### PR TITLE
Added security test bots

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/action/BaseEventBotAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/action/BaseEventBotAction.java
@@ -21,8 +21,9 @@ import org.javasimon.Split;
 import org.javasimon.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import won.bot.framework.events.event.Event;
 import won.bot.framework.events.EventListenerContext;
+import won.bot.framework.events.event.Event;
+import won.bot.framework.events.event.impl.ErrorEvent;
 
 /**
  *
@@ -55,7 +56,7 @@ public abstract class BaseEventBotAction implements EventBotAction
           doRun(event);
           split.stop();
         } catch (Exception e) {
-          logger.warn("could not run action {}", stopwatchName, e);
+          eventListenerContext.getEventBus().publish(new ErrorEvent(e));
           split.stop(EXCEPTION_TAG);
         } catch (Throwable t) {
           logger.warn("could not run action {}", stopwatchName, t);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/ErrorEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/ErrorEvent.java
@@ -17,27 +17,16 @@
 package won.bot.framework.events.event.impl;
 
 import won.bot.framework.events.event.BaseEvent;
-import won.bot.framework.events.listener.EventListener;
 
 /**
  * Event to be published when an error occurs.
  */
 public class ErrorEvent extends BaseEvent
 {
-  private EventListener listenerInError;
   private Throwable throwable;
 
-  public ErrorEvent(final EventListener listenerInError, final Throwable throwable) {
-    this.listenerInError = listenerInError;
+  public ErrorEvent(final Throwable throwable) {
     this.throwable = throwable;
-  }
-
-  public EventListener getListenerInError() {
-    return listenerInError;
-  }
-
-  public void setListenerInError(final EventListener listenerInError) {
-    this.listenerInError = listenerInError;
   }
 
   public Throwable getThrowable() {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestFailedEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestFailedEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.framework.events.event.impl;
+
+import won.bot.framework.bot.Bot;
+
+/**
+ * Indicates the failure of an integration test.
+ */
+public class TestFailedEvent extends TestFinishedEvent {
+  private String message;
+
+  public TestFailedEvent(Bot bot, String message) {
+    super(bot);
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestFinishedEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestFinishedEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.framework.events.event.impl;
+
+import won.bot.framework.bot.Bot;
+import won.bot.framework.events.event.BaseEvent;
+
+/**
+ * Base class for TestPassedEvent and TestFailedEvent.
+ */
+public abstract class TestFinishedEvent extends BaseEvent {
+  protected Bot bot;
+
+  public TestFinishedEvent(Bot bot) {
+    this.bot = bot;
+  }
+
+  public Bot getBot() {
+    return bot;
+  }
+
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestPassedEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/event/impl/TestPassedEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.framework.events.event.impl;
+
+import won.bot.framework.bot.Bot;
+
+/**
+ * Indicates that an integration test succeeded.
+ */
+public class TestPassedEvent extends TestFinishedEvent {
+  public TestPassedEvent(Bot bot) {
+    super(bot);
+  }
+
+}
+

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/listener/BaseEventListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/listener/BaseEventListener.java
@@ -86,7 +86,7 @@ public abstract class BaseEventListener implements EventListener
       if (unsubscribeOnException) {
         context.getEventBus().unsubscribe(this);
       }
-      context.getEventBus().publish(new ErrorEvent(this,e));
+      context.getEventBus().publish(new ErrorEvent(e));
       countThrowable(e);
     } finally {
       noteTimeExecuting(startTime);

--- a/webofneeds/won-bot/src/test/java/won/bot/ContextExposingBot.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/ContextExposingBot.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot;
+
+import won.bot.framework.events.EventListenerContext;
+
+/**
+ *
+ */
+public interface ContextExposingBot {
+  public EventListenerContext getExposedEventListenerContext();
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/IntegrationtestBot.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/IntegrationtestBot.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot;
+
+import won.bot.framework.bot.base.EventBot;
+import won.bot.framework.events.EventListenerContext;
+
+/**
+ * Base bot for integration tests.
+ */
+public class IntegrationtestBot extends EventBot implements ContextExposingBot {
+  @Override
+  public EventListenerContext getExposedEventListenerContext() {
+    return getEventListenerContext();
+  }
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.concurrent.SettableListenableFuture;
+import won.bot.IntegrationtestBot;
+import won.bot.framework.bot.base.TriggeredBot;
+import won.bot.framework.events.EventListenerContext;
+import won.bot.framework.events.action.BaseEventBotAction;
+import won.bot.framework.events.action.EventBotAction;
+import won.bot.framework.events.event.Event;
+import won.bot.framework.events.event.impl.ErrorEvent;
+import won.bot.framework.events.event.impl.TestFailedEvent;
+import won.bot.framework.events.event.impl.TestFinishedEvent;
+import won.bot.framework.events.event.impl.TestPassedEvent;
+import won.bot.framework.events.listener.impl.ActionOnEventListener;
+import won.bot.framework.manager.BotManager;
+import won.bot.integrationtest.security.DelayedDuplicateMessageSendingConversationBot;
+import won.bot.integrationtest.security.DuplicateMessageSendingConversationBot;
+import won.bot.integrationtest.security.DuplicateMessageURIFailureBot;
+import won.bot.integrationtest.security.DuplicateNeedURIFailureBot;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration test.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+public class SecurityBotTests
+{
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+
+    @Autowired
+    private BotManager botManager;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    public void testDuplicateNeedUri() throws Exception {
+      runBot(DuplicateNeedURIFailureBot.class);
+    }
+
+    @Test
+    public void testDuplicateMessageUriInCreate() throws Exception {
+      runBot(DuplicateMessageURIFailureBot.class);
+    }
+
+    @Test
+    public void testDuplicateMessageSendingConversationBot() throws Exception{
+      runBot(DuplicateMessageSendingConversationBot.class);
+    }
+
+    @Test
+    public void testDelayedDuplicateMessageSendingConversationBot() throws Exception{
+      runBot(DelayedDuplicateMessageSendingConversationBot.class);
+    }
+
+  private void runBot(Class botClass) throws ExecutionException, InterruptedException {
+    IntegrationtestBot bot = null;
+    //create a bot instance and auto-wire it
+    AutowireCapableBeanFactory beanFactory = applicationContext.getAutowireCapableBeanFactory();
+    bot = (IntegrationtestBot) beanFactory.autowire(botClass, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false);
+    Object botBean = beanFactory.initializeBean(bot, "theBot");
+    bot = (IntegrationtestBot) botBean;
+    //the bot also needs a trigger so its act() method is called regularly.
+    // (there is no trigger bean in the context)
+      PeriodicTrigger trigger = new PeriodicTrigger(500, TimeUnit.MILLISECONDS);
+      trigger.setInitialDelay(100);
+      ((TriggeredBot) bot).setTrigger(trigger);
+
+    //adding the bot to the bot manager will cause it to be initialized.
+    //at that point, the trigger starts.
+    botManager.addBot(bot);
+
+    final SettableListenableFuture<TestFinishedEvent> futureTestResult = new SettableListenableFuture();
+
+    final EventListenerContext ctx = bot.getExposedEventListenerContext();
+    //action for setting the future when we get a test result
+    EventBotAction setFutureAction = new SetFutureAction(ctx, futureTestResult);
+    //action for setting the future when an error occurs
+    EventBotAction setFutureFromErrorAction = new SetFutureFromErrorEventAction(ctx, futureTestResult, bot);
+    //add a listener for test success
+    ctx.getEventBus().subscribe(TestPassedEvent.class, new ActionOnEventListener(ctx, setFutureAction));
+    //add a listener for test failure
+    ctx.getEventBus().subscribe(TestFailedEvent.class, new ActionOnEventListener(ctx, setFutureAction));
+    //add a listener for errors
+    ctx.getEventBus().subscribe(ErrorEvent.class, new ActionOnEventListener(ctx, setFutureFromErrorAction));
+
+    //wait for the result
+    TestFinishedEvent result = futureTestResult.get();
+    if (result instanceof TestFailedEvent){
+      Assert.fail(((TestFailedEvent) result).getMessage());
+    }
+  }
+
+
+  private class SetFutureAction extends BaseEventBotAction
+  {
+    private SettableListenableFuture<TestFinishedEvent> futureTestResult;
+
+    private SetFutureAction(EventListenerContext eventListenerContext, SettableListenableFuture<TestFinishedEvent> futureTestResult) {
+      super(eventListenerContext);
+      this.futureTestResult = futureTestResult;
+    }
+
+    @Override
+    protected void doRun(Event event) throws Exception {
+      if (event instanceof TestFinishedEvent) {
+        futureTestResult.set((TestFinishedEvent) event);
+      } else {
+        logger.warn("cannot handle event {}", event);
+      }
+    }
+
+  }
+
+  private class SetFutureFromErrorEventAction extends BaseEventBotAction
+  {
+    private SettableListenableFuture<TestFinishedEvent> futureTestResult;
+    private IntegrationtestBot bot;
+
+    private SetFutureFromErrorEventAction(EventListenerContext eventListenerContext, SettableListenableFuture<TestFinishedEvent> futureTestResult, IntegrationtestBot bot) {
+      super(eventListenerContext);
+      this.futureTestResult = futureTestResult;
+      this.bot = bot;
+    }
+
+    @Override
+    protected void doRun(Event event) throws Exception {
+      if (event instanceof ErrorEvent) {
+
+        StringBuilder message = new StringBuilder();
+        getMessageFromCauses(message, ((ErrorEvent) event).getThrowable());
+        futureTestResult.set(new TestFailedEvent(bot,message.toString()));
+      } else {
+        logger.warn("cannot handle event {}", event);
+      }
+    }
+  }
+
+  private void getMessageFromCauses(StringBuilder stringBuilder, Throwable throwable){
+    if (throwable == null) return;
+    stringBuilder.append(throwable.getMessage());
+    Throwable cause = throwable.getCause();
+    if (cause != null){
+      stringBuilder.append(" -- Cause: ");
+      getMessageFromCauses(stringBuilder, cause);
+    }
+  }
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/BaseEventListenerContextDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/BaseEventListenerContextDecorator.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package won.bot.impl.failsim;
+package won.bot.integrationtest.failsim;
 
 import org.springframework.scheduling.TaskScheduler;
 import won.bot.framework.bot.BotContext;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/ConstantNewEventURIDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/ConstantNewEventURIDecorator.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package won.bot.impl.failsim;
+package won.bot.integrationtest.failsim;
 
 import won.bot.framework.events.EventListenerContext;
 import won.protocol.service.WonNodeInformationService;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/ConstantNewNeedURIDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/ConstantNewNeedURIDecorator.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package won.bot.impl.failsim;
+package won.bot.integrationtest.failsim;
 
 import won.bot.framework.events.EventListenerContext;
 import won.protocol.service.WonNodeInformationService;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DelayedDuplicateMessageSenderDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DelayedDuplicateMessageSenderDecorator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest.failsim;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.bot.framework.events.EventListenerContext;
+import won.protocol.message.WonMessage;
+import won.protocol.message.sender.WonMessageSender;
+import won.protocol.message.sender.exception.WonMessageSenderException;
+
+/**
+ * Decorates the EventListenerContext such that the bot sends each message twice.
+ */
+public class DelayedDuplicateMessageSenderDecorator extends BaseEventListenerContextDecorator {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private long delay = 100;
+  public DelayedDuplicateMessageSenderDecorator(EventListenerContext delegate) {
+    super(delegate);
+  }
+
+  public DelayedDuplicateMessageSenderDecorator(EventListenerContext delegate, long delay) {
+    super(delegate);
+    this.delay = delay;
+  }
+
+  @Override
+  public WonMessageSender getWonMessageSender() {
+    final WonMessageSender delegate = super.getWonMessageSender();
+    return new WonMessageSender() {
+      @Override
+      public void sendWonMessage(WonMessage message) throws WonMessageSenderException {
+        delegate.sendWonMessage(message);
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException e) {
+          logger.warn("caught while waiting the delay time before sending duplicate message",e);
+        }
+        delegate.sendWonMessage(message);
+      }
+    };
+  }
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DuplicateMessageSenderDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DuplicateMessageSenderDecorator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest.failsim;
+
+import won.bot.framework.events.EventListenerContext;
+import won.protocol.message.WonMessage;
+import won.protocol.message.sender.WonMessageSender;
+import won.protocol.message.sender.exception.WonMessageSenderException;
+
+/**
+ * Decorates the EventListenerContext such that the bot sends each message twice.
+ */
+public class DuplicateMessageSenderDecorator extends BaseEventListenerContextDecorator {
+  public DuplicateMessageSenderDecorator(EventListenerContext delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public WonMessageSender getWonMessageSender() {
+    final WonMessageSender delegate = super.getWonMessageSender();
+    return new WonMessageSender() {
+      @Override
+      public void sendWonMessage(WonMessage message) throws WonMessageSenderException {
+        delegate.sendWonMessage(message);
+        delegate.sendWonMessage(message);
+      }
+    };
+  }
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DelayedDuplicateMessageSendingConversationBot.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DelayedDuplicateMessageSendingConversationBot.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest.security;
+
+import won.bot.framework.events.EventListenerContext;
+import won.bot.integrationtest.failsim.BaseEventListenerContextDecorator;
+import won.bot.integrationtest.failsim.DelayedDuplicateMessageSenderDecorator;
+
+/**
+ * User: fkleedorfer
+ * Date: 03.05.15
+ */
+public class DelayedDuplicateMessageSendingConversationBot extends DuplicateMessageSendingConversationBot {
+
+  @Override
+  protected BaseEventListenerContextDecorator getDuplicateMessageSenderDecorator(EventListenerContext eventListenerContext) {
+    return new DelayedDuplicateMessageSenderDecorator(eventListenerContext, 1000);
+  }
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DuplicateMessageSendingConversationBot.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DuplicateMessageSendingConversationBot.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest.security;
+
+import won.bot.IntegrationtestBot;
+import won.bot.framework.events.EventListenerContext;
+import won.bot.framework.events.action.BaseEventBotAction;
+import won.bot.framework.events.action.impl.*;
+import won.bot.framework.events.bus.EventBus;
+import won.bot.framework.events.event.Event;
+import won.bot.framework.events.event.impl.*;
+import won.bot.framework.events.listener.BaseEventListener;
+import won.bot.framework.events.listener.EventListener;
+import won.bot.framework.events.listener.impl.ActionOnEventListener;
+import won.bot.framework.events.listener.impl.ActionOnceAfterNEventsListener;
+import won.bot.framework.events.listener.impl.AutomaticMessageResponderListener;
+import won.bot.integrationtest.failsim.BaseEventListenerContextDecorator;
+import won.bot.integrationtest.failsim.DuplicateMessageSenderDecorator;
+import won.protocol.model.FacetType;
+import won.protocol.util.WonRdfUtils;
+
+/**
+ *
+ */
+public class DuplicateMessageSendingConversationBot extends IntegrationtestBot
+{
+
+  private static final int NO_OF_NEEDS = 2;
+  private static final int NO_OF_MESSAGES = 10;
+  private static final long MILLIS_BETWEEN_MESSAGES = 100;
+    private static final String NAME_NEEDS = "needs";
+
+
+  @Override
+  protected void initializeEventListeners()
+  {
+    EventListenerContext ctx = getDuplicateMessageSenderDecorator(getEventListenerContext());
+    final EventBus bus = getEventBus();
+
+    //we're not expecting any failure messages in this test:
+    bus.subscribe(
+            FailureResponseEvent.class,
+            new ActionOnEventListener(
+                    ctx,
+                    new BaseEventBotAction(ctx){
+                        @Override
+                        protected void doRun(Event event) throws Exception {
+                          FailureResponseEvent failureResponseEvent = (FailureResponseEvent)event;
+                          bus.publish(new TestFailedEvent(
+                                  DuplicateMessageSendingConversationBot.this,
+                                  "Message failed: "  + failureResponseEvent.getOriginalMessageURI()
+                                          + ": " + WonRdfUtils.MessageUtils.getTextMessage(failureResponseEvent.getFailureMessage())));
+                        }
+                      }));
+
+    //create needs every trigger execution until 2 needs are created
+
+    bus.subscribe(ActEvent.class,new ActionOnEventListener(
+            ctx,
+            new CreateNeedWithFacetsAction(ctx,NAME_NEEDS),
+            NO_OF_NEEDS
+        ));
+
+    //connect needs
+    bus.subscribe(NeedCreatedEvent.class, new ActionOnceAfterNEventsListener(ctx,"needConnector",
+            NO_OF_NEEDS * 2, new ConnectFromListToListAction(ctx,NAME_NEEDS,NAME_NEEDS,FacetType.OwnerFacet.getURI(),FacetType.OwnerFacet.getURI(), MILLIS_BETWEEN_MESSAGES)));
+
+    //add a listener that is informed of the connect/open events and that auto-opens
+    //subscribe it to:
+    // * connect events - so it responds with open
+    // * open events - so it responds with open (if the open received was the first open, and we still need to accept the connection)
+    bus.subscribe(ConnectFromOtherNeedEvent.class, new ActionOnEventListener(ctx, new OpenConnectionAction(ctx)));
+
+    //add a listener that auto-responds to messages by a message
+    //after 10 messages, it unsubscribes from all events
+    //subscribe it to:
+    // * message events - so it responds
+    // * open events - so it initiates the chain reaction of responses
+    BaseEventListener autoResponder = new AutomaticMessageResponderListener(ctx, NO_OF_MESSAGES, MILLIS_BETWEEN_MESSAGES);
+    bus.subscribe(OpenFromOtherNeedEvent.class, autoResponder);
+    bus.subscribe(MessageFromOtherNeedEvent.class, autoResponder);
+
+    //add a listener that closes the connection after it has seen 10 messages
+    bus.subscribe( MessageFromOtherNeedEvent.class, new ActionOnceAfterNEventsListener(
+            ctx,
+            NO_OF_MESSAGES, new CloseConnectionAction(ctx)
+      ));
+    //add a listener that closes the connection when a failureEvent occurs
+    EventListener onFailureConnectionCloser = new ActionOnEventListener(ctx, new CloseConnectionAction(ctx));
+    bus.subscribe(FailureResponseEvent.class, onFailureConnectionCloser);
+
+    //add a listener that auto-responds to a close message with a deactivation of both needs.
+    //subscribe it to:
+    // * close events
+
+    bus.subscribe(CloseFromOtherNeedEvent.class,
+            new ActionOnEventListener(ctx,
+                    new MultipleActions(ctx,
+                      new DeactivateAllNeedsAction(ctx),
+                      new PublishEventAction(ctx, new TestPassedEvent(this)))
+                            ,1));
+
+    //add a listener that counts two NeedDeactivatedEvents and then tells the
+    //framework that the bot's work is done
+    bus.subscribe(NeedDeactivatedEvent.class, new ActionOnceAfterNEventsListener(
+            ctx,
+            NO_OF_NEEDS, new SignalWorkDoneAction(ctx)
+          ));
+  }
+
+  protected BaseEventListenerContextDecorator getDuplicateMessageSenderDecorator(EventListenerContext eventListenerContext) {
+    return new DuplicateMessageSenderDecorator(eventListenerContext);
+  }
+
+
+}

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DuplicateNeedURIFailureBot.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/security/DuplicateNeedURIFailureBot.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.integrationtest.security;
+
+import won.bot.IntegrationtestBot;
+import won.bot.framework.events.EventListenerContext;
+import won.bot.framework.events.action.impl.*;
+import won.bot.framework.events.bus.EventBus;
+import won.bot.framework.events.event.NeedCreationFailedEvent;
+import won.bot.framework.events.event.impl.*;
+import won.bot.framework.events.listener.impl.ActionOnEventListener;
+import won.bot.framework.events.listener.impl.ActionOnFirstNEventsListener;
+import won.bot.framework.events.listener.impl.ActionOnceAfterNEventsListener;
+import won.bot.integrationtest.failsim.ConstantNewNeedURIDecorator;
+
+/**
+ *
+ */
+public class DuplicateNeedURIFailureBot extends IntegrationtestBot
+{
+  private static final String NAME_NEEDS = "needs";
+
+  @Override
+  protected void initializeEventListeners()
+  {
+    EventListenerContext ctx = getEventListenerContext();
+    EventBus bus = getEventBus();
+
+    //create needs every trigger execution until 2 needs are created
+
+    bus.subscribe(
+            ActEvent.class,
+            new ActionOnEventListener(
+              ctx,
+              new CreateNeedWithFacetsAction(
+                //use a decorator that will cause the same need URI to be used in each create message
+                new ConstantNewNeedURIDecorator(ctx, "constantNeedURI" + System.currentTimeMillis()),NAME_NEEDS),
+              2));
+
+    //log error if we can create 2 needs
+    bus.subscribe(
+            NeedCreatedEvent.class,
+            new ActionOnceAfterNEventsListener(
+              ctx, 2,
+              new MultipleActions(ctx,
+                new LogErrorAction(ctx,
+                        "Should not have been able to create 2 needs with identical URI"),
+                new PublishEventAction(ctx, new TestFailedEvent(this,"Should not have been able to create 2 needs with identical URI")))));
+
+    //log success if we could create 1 need
+    bus.subscribe(
+            NeedCreatedEvent.class,
+            new ActionOnFirstNEventsListener(
+                    ctx, 1,
+                    new MultipleActions(ctx,
+                            new LogAction(ctx, "Good: could create one need"),
+                            new PublishEventAction(ctx,new SuccessEvent()))));
+
+    //log success if we got an error for 2nd need
+    bus.subscribe(
+            NeedCreationFailedEvent.class,
+            new ActionOnFirstNEventsListener(
+                    ctx, 1,
+                      new MultipleActions(ctx,
+                        new LogAction(ctx, "Good: need creation failed for 2nd need."),
+                        new PublishEventAction(ctx,new SuccessEvent()))));
+
+    //when we have 2 SuccessEvents, we're done. Deacivate the needs and signal we're finished
+    bus.subscribe(
+            SuccessEvent.class,
+            new ActionOnceAfterNEventsListener(ctx,2,
+              new MultipleActions(ctx,
+                new LogAction(ctx,"Test passed."),
+                new PublishEventAction(ctx, new TestPassedEvent(this)),
+                new DeactivateAllNeedsAction(ctx))));
+
+    //when we have a FailureEvent, we're done, too. Deacivate the needs and signal we're finished
+    bus.subscribe(
+            TestFailedEvent.class,
+            new ActionOnceAfterNEventsListener(ctx,1,
+                    new MultipleActions(ctx,
+                            new LogAction(ctx,"Test failed."),
+                            new DeactivateAllNeedsAction(ctx))));
+
+
+    //wait for the needDeactivated event, then say we're done.
+    bus.subscribe(
+            NeedDeactivatedEvent.class, new ActionOnceAfterNEventsListener(
+            ctx, 1, new SignalWorkDoneAction(ctx, this)));
+
+
+    //TODO: fix: bot runs forever even if test fails.
+    //TODO: fix: need 1 is not deactivated if test fails.
+  }
+
+
+}

--- a/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/KeyForNewNeedAddingProcessor.java
+++ b/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/KeyForNewNeedAddingProcessor.java
@@ -47,20 +47,14 @@ public class KeyForNewNeedAddingProcessor implements WonMessageProcessor
         // generate and add need's public key to the need content
         if (cryptoService.getPrivateKey(needUri) == null) {
           cryptoService.createNewKeyPair(needUri);
-          PublicKey pubKey = cryptoService.getPublicKey(needUri);
-          WonKeysReaderWriter keyWriter = new WonKeysReaderWriter();
-          String contentName = message.getContentGraphURIs().get(0);
-          Model contentModel = msgDataset.getNamedModel(contentName);
-          keyWriter.writeToModel(contentModel, contentModel.createResource(needUri), pubKey);
-        } else {
-          //something is wrong, there should exist no key for the need that have just been created
-          throw new WonMessageProcessingException("Failed to generate key for need " + needUri + ", " +
-                                                    "key already exist!");
         }
+        PublicKey pubKey = cryptoService.getPublicKey(needUri);
+        WonKeysReaderWriter keyWriter = new WonKeysReaderWriter();
+        String contentName = message.getContentGraphURIs().get(0);
+        Model contentModel = msgDataset.getNamedModel(contentName);
+        keyWriter.writeToModel(contentModel, contentModel.createResource(needUri), pubKey);
       }
     } catch (Exception e) {
-      //TODO proper exceptions
-      e.printStackTrace();
       throw new WonMessageProcessingException("Failed to add key for need in message " + message.getMessageURI()
                                                                                                 .toString());
     }

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
@@ -38,6 +38,7 @@ import won.protocol.message.sender.WonMessageSender;
 import won.protocol.model.WonNode;
 import won.protocol.repository.WonNodeRepository;
 import won.protocol.util.DataAccessUtils;
+import won.protocol.util.RdfUtils;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -89,6 +90,10 @@ public class OwnerWonMessageSenderJMSBased
 
       // TODO check if there is a better place for applying signing logic
       wonMessage = doSigningOnOwner(wonMessage);
+
+      if (logger.isDebugEnabled()){
+        logger.debug("sending this message: {}", RdfUtils.writeDatasetToString(wonMessage.getCompleteDataset(), Lang.TRIG));
+      }
 
       // ToDo (FS): change it to won node URI and create method in the MessageEvent class
       URI wonNodeUri = wonMessage.getSenderNodeURI();


### PR DESCRIPTION
Four bots are implemented, the class ```won.bot.integrationtest.SecurityBotTests``` is their junit test class. The bots communicate with the junit test through special events (TestFailedEvent, TestPassedEvent, ErrorEvent) that the test class reacts to using Assert.fail(message) if appropriate. This communication structure makes it necessary for the bots to expose their EventListenerContext, otherwise the test code would not be able to register event listeners for these, normally bot-internal, events.