### PR TITLE
Bugfix msg sender node

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
@@ -362,7 +362,7 @@ public class EventBot extends TriggeredBot
           //only react to an ErrorEvent
           if (! done) {
             //make sure we send only one WorkDoneEvent
-            logger.warn("saw an ErrorEvent, stopping the bot by publishing a WorkDoneEvent");
+            logger.warn("saw an ErrorEvent, stopping the bot by publishing a WorkDoneEvent", ((ErrorEvent) event).getThrowable());
             getEventListenerContext().getEventBus().publish(new WorkDoneEvent(EventBot.this));
           }
           setDoneAndUnsubscribe();

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/NeedBasedCamelConfiguratorImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/NeedBasedCamelConfiguratorImpl.java
@@ -49,14 +49,15 @@ public abstract class NeedBasedCamelConfiguratorImpl implements NeedProtocolCame
     private Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
-    public synchronized String configureCamelEndpointForNeedUri(URI brokerUri, String needProtocolQueueName){
+    public synchronized String configureCamelEndpointForNeedUri(URI wonNodeURI, URI brokerUri, String
+      needProtocolQueueName){
         String brokerComponentName = setupBrokerComponentName(brokerUri);
         if (!brokerComponentName.contains("brokerUri")){
           addCamelComponentForWonNodeBroker(brokerUri, brokerComponentName);
         }
         String endpoint = brokerComponentName+":queue:"+needProtocolQueueName;
-        endpointMap.put(brokerUri,endpoint);
-        logger.info("endpoint of wonNodeURI {} is {}",brokerUri,endpointMap.get(brokerUri));
+        endpointMap.put(wonNodeURI,endpoint);
+        logger.info("endpoint of wonNodeURI {} is {}", wonNodeURI, endpointMap.get(brokerUri));
         return endpoint;
     }
 

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/NeedBasedCamelConfiguratorImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/NeedBasedCamelConfiguratorImpl.java
@@ -112,8 +112,8 @@ public abstract class NeedBasedCamelConfiguratorImpl implements NeedProtocolCame
 
 
     @Override
-    public String getEndpoint(URI brokerUri) {
-        return  endpointMap.get(brokerUri);
+    public String getEndpoint(URI nodeUri) {
+        return  endpointMap.get(nodeUri);
     }
     public void setComponentName(String componentName) {
         this.componentName = componentName;

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/NeedProtocolCamelConfigurator.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/NeedProtocolCamelConfigurator.java
@@ -26,7 +26,7 @@ import java.net.URI;
  */
 public interface NeedProtocolCamelConfigurator extends CamelConfigurator {
 
-    public String configureCamelEndpointForNeedUri(URI brokerUri, String needProtocolQueueName);
+    public String configureCamelEndpointForNeedUri(URI wonNodeUri, URI brokerUri, String needProtocolQueueName);
     public void addCamelComponentForWonNodeBroker(URI brokerUri,String brokerComponentName);
 
 

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/OwnerProtocolCommunicationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/OwnerProtocolCommunicationService.java
@@ -25,7 +25,7 @@ import java.net.URI;
  * Date: 25.02.14
  */
 public interface OwnerProtocolCommunicationService extends ProtocolCommunicationService {
-    public CamelConfiguration configureCamelEndpoint(URI wonNodeUri) throws Exception;
+    public CamelConfiguration configureCamelEndpoint(URI wonNodeUri, String ownerId) throws Exception;
     public URI  getWonNodeUriWithConnectionUri(URI connectionUri) throws NoSuchConnectionException;
     public URI  getWonNodeUriWithNeedUri(URI needUri) throws NoSuchConnectionException;
 

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
@@ -372,6 +372,7 @@ public class WonMessageBuilder
       .setWonMessageDirection(WonMessageDirection.FROM_OWNER)
       .setWonMessageType(WonMessageType.DEACTIVATE)
       .setSenderNeedURI(localNeed)
+      .setSenderNodeURI(localWonNode)
       .setReceiverNeedURI(localNeed)
       .setReceiverNodeURI(localWonNode)
       .setSentTimestampToNow();
@@ -415,9 +416,9 @@ public class WonMessageBuilder
       .setWonMessageDirection(WonMessageDirection.FROM_OWNER)
       .setWonMessageType(WonMessageType.CREATE_NEED)
       .setSenderNeedURI(needURI)
+      .setSenderNodeURI(wonNodeURI)
       .setReceiverNodeURI(wonNodeURI)
       .setSentTimestampToNow();
-
     return this;
   }
 
@@ -595,11 +596,6 @@ public class WonMessageBuilder
         .setSenderNodeURI(originalMessage.getSenderNodeURI())
         .setSenderNeedURI(originalMessage.getSenderNeedURI())
         .setSenderURI(originalMessage.getSenderURI());
-      if (originalMessage.getSenderNodeURI() == null) {
-        // special case for e.g. create message where there is no sender node uri specified
-        // in this case it should be send to the receiver node uri
-        this.setSenderNodeURI(originalMessage.getReceiverNodeURI());
-      }
     }
     this
       .setReceiverNeedURI(originalMessage.getSenderNeedURI())

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
@@ -70,7 +70,7 @@ public class UriConsistencyCheckingWonMessageProcessor implements WonMessageProc
     checkCreateMsgNeedURI(message, ownNodeInfo);
 
     // Specified sender-receiverNeed/Connection must conform to sender-receiverNode URI pattern
-    checkSenders(senderNodeInfo, receiverNodeInfo, message);
+    checkSenders(senderNodeInfo, message);
     checkReceivers(receiverNodeInfo, message);
 
     // Check that my node is sender or receiver node URI, depending on the message direction
@@ -91,15 +91,9 @@ public class UriConsistencyCheckingWonMessageProcessor implements WonMessageProc
                          message.getReceiverURI(), null);
   }
 
-  private void checkSenders(final WonNodeInfo senderNodeInfo, final WonNodeInfo receiverNodeInfo, final WonMessage message) {
-
-    // special case for e.g. create_message that has only sender need and receiver node
-    if (message.getSenderNodeURI() == null) {
-      checkNodeConformance(receiverNodeInfo, message.getSenderNeedURI(), null, null);
-    } else { // common case
-      checkNodeConformance(senderNodeInfo, message.getSenderNeedURI(),
+  private void checkSenders(final WonNodeInfo senderNodeInfo, final WonMessage message) {
+    checkNodeConformance(senderNodeInfo, message.getSenderNeedURI(),
                            message.getSenderURI(), null);
-    }
   }
 
   private void checkDirection(final WonMessage message, final URI ownNode) {
@@ -116,13 +110,9 @@ public class UriConsistencyCheckingWonMessageProcessor implements WonMessageProc
         }
         break;
       case FROM_OWNER:
-        // my node should be a sender node; if sender node is not specified - then the receiver node
-        node = senderNode;
-        if (senderNode == null) {
-          node = receiverNode;
-        }
-        if (!ownNode.equals(node)) {
-          throw new UriNodePathException(node);
+        // my node should be a sender node
+        if (!ownNode.equals(senderNode)) {
+          throw new UriNodePathException(senderNode);
         }
         break;
       case FROM_SYSTEM:

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
@@ -47,13 +47,17 @@ public class UriConsistencyCheckingWonMessageProcessor implements WonMessageProc
     if (receiverNode != null) {
       receiverNodeInfo = wonNodeInformationService.getWonNodeInformation(receiverNode);
     }
-    URI ownNode = wonNodeInformationService.getDefaultWonNodeURI();
+
     WonNodeInfo ownNodeInfo = null;
-    if (ownNode.equals(senderNode)) {
+
+    URI msgUri = message.getMessageURI();
+
+    if (msgUri.getScheme().equals(senderNode.getScheme()) && msgUri.getAuthority().equals(senderNode.getAuthority())) {
       ownNodeInfo = senderNodeInfo;
-    } else if (ownNode.equals(receiverNode)) {
+    } else if (msgUri.getScheme().equals(receiverNode.getScheme()) && msgUri.getAuthority().equals(receiverNode.getAuthority())) {
       ownNodeInfo = receiverNodeInfo;
     }
+    URI ownNode = URI.create(ownNodeInfo.getWonNodeURI());
 
 
     // do checks for consistency between these nodes and message direction, as well as needs,

--- a/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
@@ -42,21 +42,21 @@ public class MatcherProtocolCommunicationServiceImpl implements MatcherProtocolC
   private Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @Override
-  public synchronized CamelConfiguration configureCamelEndpoint(URI needUri, String startingEndpoint) throws Exception {
+  public synchronized CamelConfiguration configureCamelEndpoint(URI nodeUri, String startingEndpoint) throws Exception {
     String matcherProtocolQueueName;
     CamelConfiguration camelConfiguration = new CamelConfiguration();
 
-    URI needBrokerUri =activeMQService.getBrokerEndpoint(needUri);
+    URI needBrokerUri =activeMQService.getBrokerEndpoint(nodeUri);
 
 
     if (matcherProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(needBrokerUri)!=null){
-      if (matcherProtocolCamelConfigurator.getEndpoint(needBrokerUri)!=null)
+      if (matcherProtocolCamelConfigurator.getEndpoint(nodeUri)!=null)
       {
-        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.getEndpoint(needBrokerUri));
+        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.getEndpoint(nodeUri));
       } else {
         matcherProtocolCamelConfigurator.addRouteForEndpoint(startingEndpoint,needBrokerUri);
-        matcherProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(needUri);
-        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(needUri,
+        matcherProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(nodeUri);
+        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(nodeUri,
                                                                                                          needBrokerUri,
                                                                                                          matcherProtocolQueueName));
       }
@@ -64,7 +64,7 @@ public class MatcherProtocolCommunicationServiceImpl implements MatcherProtocolC
 
     } else{
 
-      URI resourceUri = needUri;
+      URI resourceUri = nodeUri;
       URI brokerUri = needBrokerUri;
 
       matcherProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(resourceUri);

--- a/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
@@ -56,7 +56,8 @@ public class MatcherProtocolCommunicationServiceImpl implements MatcherProtocolC
       } else {
         matcherProtocolCamelConfigurator.addRouteForEndpoint(startingEndpoint,needBrokerUri);
         matcherProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(needUri);
-        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(needBrokerUri,
+        camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(needUri,
+                                                                                                         needBrokerUri,
                                                                                                          matcherProtocolQueueName));
       }
       camelConfiguration.setBrokerComponentName(matcherProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(needBrokerUri));
@@ -67,7 +68,9 @@ public class MatcherProtocolCommunicationServiceImpl implements MatcherProtocolC
       URI brokerUri = needBrokerUri;
 
       matcherProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(resourceUri);
-      camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(brokerUri,matcherProtocolQueueName));
+      camelConfiguration.setEndpoint(matcherProtocolCamelConfigurator.configureCamelEndpointForNeedUri(resourceUri,
+                                                                                                       brokerUri,
+                                                                                                       matcherProtocolQueueName));
       matcherProtocolCamelConfigurator.addRouteForEndpoint(startingEndpoint,brokerUri);
       camelConfiguration.setBrokerComponentName(matcherProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(brokerUri));
       ActiveMQComponent activeMQComponent = (ActiveMQComponent)matcherProtocolCamelConfigurator.getCamelContext().getComponent(matcherProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(brokerUri));

--- a/webofneeds/won-node/src/main/java/won/node/camel/NeedProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/NeedProtocolCommunicationServiceImpl.java
@@ -62,7 +62,7 @@ public class NeedProtocolCommunicationServiceImpl implements NeedProtocolCommuni
 
             needProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(resourceUri);
             camelConfiguration.setEndpoint(
-              needProtocolCamelConfigurator.configureCamelEndpointForNeedUri(brokerUri, needProtocolQueueName));
+              needProtocolCamelConfigurator.configureCamelEndpointForNeedUri(resourceUri, brokerUri, needProtocolQueueName));
             camelConfiguration.setBrokerComponentName(needProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(brokerUri));
             ActiveMQComponent activeMQComponent = (ActiveMQComponent)needProtocolCamelConfigurator.getCamelContext().getComponent(needProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(brokerUri));
             logger.info("ActiveMQ Service Status : {}",activeMQComponent.getStatus().toString());

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/NeedProtocolOutgoingMessagesProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/NeedProtocolOutgoingMessagesProcessor.java
@@ -53,7 +53,11 @@ public class NeedProtocolOutgoingMessagesProcessor implements Processor {
       //add a camel endpoint for the remote won node
       needProtocolCommunicationService.configureCamelEndpoint(wonMessage.getReceiverNodeURI());
       //send the message to that endpoint
-      messageService.sendInOnlyMessage(null, null, wonMessage, wonMessage.getReceiverNodeURI().toString());
+      String ep = needProtocolCommunicationService.getProtocolCamelConfigurator().getEndpoint(wonMessage
+                                                                                              .getReceiverNodeURI());
+      //messageService.sendInOnlyMessage(null, null, wonMessage, wonMessage.getReceiverNodeURI().toString());
+      String msgBody = RdfUtils.writeDatasetToString(wonMessage.getCompleteDataset(), WonCamelConstants.RDF_LANGUAGE_FOR_MESSAGE);
+      messageService.sendInOnlyMessage(null, null, msgBody, ep);
     }
 
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
@@ -69,6 +69,7 @@
                 'msg:hasMessageType': { '@id': args.msgType },
                 'msg:hasContent': nonEnvelopeGraphIds.map(function(graphId) {return {'@id': graphId} }),
                 'msg:hasReceiverNode': { '@id': args.receiverNode },
+                'msg:hasSenderNode': { '@id': args.senderNode },
                 'msg:hasSenderNeed': { '@id': args.publishedContentUri },
                 'msg:hasAttachment': attachmentBlankNodes.map(function(n) {return {'@id' : n['@id']} }),
             },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
@@ -469,6 +469,7 @@ angular.module('won.owner').factory('wonService', function (
         var msgUri = wonNodeUri + '/event/' + utilService.getRandomPosInt(); //mandatory
         var msgJson = won.buildMessageRdf(contentRdf, {
             receiverNode : wonNodeUri, //mandatory
+            senderNode : wonNodeUri, //mandatory
             msgType : won.WONMSG.createMessage, //mandatory
             publishedContentUri: publishedContentUri, //mandatory
             msgUri: msgUri,

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCommunicationServiceImpl.java
@@ -55,7 +55,8 @@ public class OwnerProtocolCommunicationServiceImpl implements OwnerProtocolCommu
 
     Logger logger = LoggerFactory.getLogger(this.getClass());
     @Override
-    public final synchronized CamelConfiguration configureCamelEndpoint(URI wonNodeUri) throws Exception {
+    public final synchronized CamelConfiguration configureCamelEndpoint(URI wonNodeUri, String ownerId) throws
+      Exception {
         CamelConfiguration camelConfiguration = new CamelConfiguration();
         URI brokerURI;
         String ownerProtocolQueueName;
@@ -63,8 +64,8 @@ public class OwnerProtocolCommunicationServiceImpl implements OwnerProtocolCommu
         //OwnerProtocolCamelConfigurator ownerProtocolCamelConfigurator = camelConfiguratorFactory.createCamelConfigurator(methodName);
         logger.debug("configuring camel endpoint");
         if (ownerProtocolCamelConfigurator.getBrokerComponent(wonNodeUri)!=null && ownerProtocolCamelConfigurator
-          .getEndpoint(wonNodeUri)!=null){
-            logger.debug("wonNode known");
+          .getEndpoint(wonNodeUri)!=null && !wonNodeList.isEmpty()){
+          logger.debug("wonNode known");
             WonNode wonNode = wonNodeList.get(0);
             brokerURI = wonNode.getBrokerURI();
             camelConfiguration.setEndpoint(wonNode.getOwnerProtocolEndpoint());
@@ -77,16 +78,19 @@ public class OwnerProtocolCommunicationServiceImpl implements OwnerProtocolCommu
         } else{  //if unknown wonNode
             logger.debug("wonNode unknown");
             brokerURI = activeMQService.getBrokerEndpoint(wonNodeUri);
-            camelConfiguration.setBrokerComponentName(ownerProtocolCamelConfigurator.addCamelComponentForWonNodeBroker(wonNodeUri,brokerURI,null));
+            camelConfiguration.setBrokerComponentName(ownerProtocolCamelConfigurator
+                                                        .addCamelComponentForWonNodeBroker(wonNodeUri,brokerURI, ownerId));
 
             //TODO: brokerURI gets the node information already. so requesting node information again for queuename would be duplicate
             ownerProtocolQueueName = activeMQService.getProtocolQueueNameWithResource(wonNodeUri);
-            camelConfiguration.setEndpoint(ownerProtocolCamelConfigurator.configureCamelEndpointForNodeURI(wonNodeUri, brokerURI, ownerProtocolQueueName));
+            camelConfiguration.setEndpoint(ownerProtocolCamelConfigurator.configureCamelEndpointForNodeURI
+              (wonNodeUri, brokerURI, ownerProtocolQueueName));
             ownerProtocolCamelConfigurator.addRouteForEndpoint(null, wonNodeUri);
         }
 
         return camelConfiguration;
     }
+
     @Override
     public synchronized URI  getWonNodeUriWithConnectionUri(URI connectionUri) throws NoSuchConnectionException {
         //TODO: make this more efficient

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
@@ -98,8 +98,11 @@ public class OwnerWonMessageSenderJMSBased
       // ToDo (FS): change it to won node URI and create method in the MessageEvent class
       URI wonNodeUri = wonMessage.getSenderNodeURI();
 
-      if (wonNodeUri == null)
-        wonNodeUri = defaultNodeURI;
+      if (wonNodeUri == null){
+        //obtain the sender won node from the sender need
+          throw new IllegalStateException("a message needs a SenderNodeUri otherwise we can't determine the won node " +
+                                            "via which to send it");
+      }
 
       List<WonNode> wonNodeList = wonNodeRepository.findByWonNodeURI(wonNodeUri);
       String ownerApplicationId;
@@ -166,7 +169,6 @@ public class OwnerWonMessageSenderJMSBased
               String ownerApplicationId = register(defaultNodeURI);
               configureRemoteEndpointsForOwnerApplication(ownerApplicationId, ownerProtocolCommunicationServiceImpl
                 .getProtocolCamelConfigurator().getEndpoint(defaultNodeURI));
-
             } catch (Exception e) {
               logger.warn("Could not register with default won node {}", defaultNodeURI, e);
             }


### PR DESCRIPTION
Works again: a need from node on server X is able to connect to another need on server Y. For example, the EchoBotApp and SimpleToNeedConversationTest both work when given a list of two different node source uris.