### PR TITLE
Minor bugfix

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
@@ -69,11 +69,12 @@ angular.module('won.owner').factory('wonService', function (
                 eventData.matchCounterpartURI = won.getSafeJsonLdValue(eventData.framedMessage[won.WON.hasMatchCounterpart]);
                 //add some properties to the eventData so as to make them easily accessible to consumers
                 //of the hint event
-                if (eventData.matchCounterpartURI != null) {
-                    //load the data of the need the hint is about, if required
-                    //linkedDataService.ensureLoaded(eventData.uri);
-                    linkedDataService.ensureLoaded(eventData.matchCounterpartURI);
-                }
+            // below is commented as it seems to cause to hint event data loaded/displayed
+                //if (eventData.matchCounterpartURI != null) {
+                //    //load the data of the need the hint is about, if required
+                //    //linkedDataService.ensureLoaded(eventData.uri);
+                //    linkedDataService.ensureLoaded(eventData.matchCounterpartURI);
+                //}
                 $log.debug("Broadcasting angular event " + eventData.eventType);
                 $rootScope.$broadcast(eventData.eventType, eventData);
             });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won-service.js
@@ -69,7 +69,7 @@ angular.module('won.owner').factory('wonService', function (
                 eventData.matchCounterpartURI = won.getSafeJsonLdValue(eventData.framedMessage[won.WON.hasMatchCounterpart]);
                 //add some properties to the eventData so as to make them easily accessible to consumers
                 //of the hint event
-            // below is commented as it seems to cause to hint event data loaded/displayed
+            // below is commented as it seems to cause no hint event data loaded/displayed
                 //if (eventData.matchCounterpartURI != null) {
                 //    //load the data of the need the hint is about, if required
                 //    //linkedDataService.ensureLoaded(eventData.uri);


### PR DESCRIPTION
Hints not displayed bugfix.

Note: another reason for hints not displayed is when the hint has matched need that is under the same user account. This is intended. Therefore, when testing current matcher, use different account (or private user) after each published need. 