### PR TITLE
Feat feed

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -17,7 +17,8 @@ export function accountVerifyLogin() {
             /* handle data, dispatch actions */
             .then(data => {
                 dispatch(actionCreators.user__loggedIn({loggedIn: true, email: data.username}));
-                dispatch(actionCreators.retrieveNeedUris());
+                dispatch(actionCreators.load()); //TODO should be part of the login if only called together
+                dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
             })
             /* handle: not-logged-in */
             .catch(error =>
@@ -44,7 +45,8 @@ export function accountLogin(username, password) {
                 data => {
                 dispatch(actionCreators.user__loggedIn({loggedIn: true, email: username}));
                 dispatch(actionCreators.messages__requestWsReset_Hack());
-                dispatch(actionCreators.retrieveNeedUris());
+                dispatch(actionCreators.load()); //TODO should be part of the login if only called together
+                dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
                 //dispatch(actionCreators.posts__load());
                 dispatch(actionCreators.router__stateGo("feed"));
             }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -54,7 +54,7 @@ export function connectionsLoad(needUris) {
 export function connectionsOpen(connectionData,message) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connections', connectionData.connection.uri])
+        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -72,7 +72,7 @@ export function connectionsOpen(connectionData,message) {
 export function connectionsConnect(connectionData,message) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connections', connectionData.connection.uri])
+        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -90,7 +90,7 @@ export function connectionsConnect(connectionData,message) {
 export function connectionsClose(connectionData) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connections', connectionData.connection.uri])
+        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -111,7 +111,7 @@ export function connectionsRate(connectionData,rating) {
         console.log(rating);
 
         const state = getState();
-        let eventData = state.getIn(['connections', 'connections', connectionData.connection.uri])
+        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
@@ -20,15 +20,15 @@ class IncomingRequestsController {
         const selectFromState = (state)=>{
 
             return {
-                incomingRequests: Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                incomingRequests: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived && state.getIn(['events',conn.connection.uri]) !== undefined){
                             return true
                         }
                     }),
-                incomingRequestsOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                incomingRequestsOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived){
                             return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
@@ -26,15 +26,15 @@ class OverviewMatchesController {
         const selectFromState = (state)=>{
 
             return {
-                matches: Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                matches: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.Suggested){
                             return true
                         }
                     }),
-                matchesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                matchesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.Suggested){
                             return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.js
@@ -49,8 +49,9 @@ class OverviewPostsController {
 
 
 
+            const ownNeeds = state.getIn(["needs", "ownNeeds"]);
             return {
-                posts: state.getIn(["needs", "ownNeeds"]).toJS(),
+                posts: ownNeeds? ownNeeds.toJS() : {}, //TODO pass in the immutablejs-object directly
                 unreadEvents,
                 unreadCounts: selectUnreadCountsByNeedAndType(state),
                 //unreadMatchEventsOfNeed: unseenMatchesCounts,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-matches/post-owner-matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-matches/post-owner-matches.js
@@ -53,15 +53,15 @@ class Controller {
         const selectFromState = (state)=>{
 
             return {
-                 messages: Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                 messages: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived && state.getIn(['events',conn.connection.uri]) !== undefined){
                             return true
                         }
                     }),
-                messagesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                messagesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived){
                             return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-messages/post-owner-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-messages/post-owner-messages.js
@@ -53,15 +53,15 @@ class Controller {
         const selectFromState = (state)=>{
 
             return {
-                 messages: Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                 messages: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived && state.getIn(['events',conn.connection.uri]) !== undefined){
                             return true
                         }
                     }),
-                messagesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connections']).toJS())
-                    .map(key=>state.getIn(['connections','connections']).toJS()[key])
+                messagesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
+                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.RequestReceived){
                             return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -12,11 +12,17 @@ import won from '../won-es6';
 const initialState = Immutable.fromJS({
     isFetching: false,
     didInvalidate: false,
-    connections: Immutable.Map(),
+    connectionsDeprecated: Immutable.Map(),
 
 })
 export default function(state = initialState, action = {}) {
     switch(action.type) {
+        /*
+        case actionTypes.load:
+            const allPreviousConnections = action.payload.get('connections');
+            return state.mergeIn(['connections'], allPreviousConnections);
+            */
+
         case actionTypes.connections.load:
             return action.payload.reduce(
                 (updatedState, connectionWithRelatedData) =>
@@ -37,6 +43,6 @@ export default function(state = initialState, action = {}) {
 }
 function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
     return state.setIn(
-        ['connections',connectionWithRelatedData.connection.uri],
+        ['connectionsDeprecated',connectionWithRelatedData.connection.uri],
         connectionWithRelatedData);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -12,16 +12,14 @@ import won from '../won-es6';
 const initialState = Immutable.fromJS({
     isFetching: false,
     didInvalidate: false,
-    connectionsDeprecated: Immutable.Map(),
-
+    connectionsDeprecated: {},//don't use data from this map
+    connections: {},
 })
 export default function(state = initialState, action = {}) {
     switch(action.type) {
-        /*
         case actionTypes.load:
             const allPreviousConnections = action.payload.get('connections');
             return state.mergeIn(['connections'], allPreviousConnections);
-            */
 
         case actionTypes.connections.load:
             return action.payload.reduce(
@@ -42,7 +40,11 @@ export default function(state = initialState, action = {}) {
     }
 }
 function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
-    return state.setIn(
-        ['connectionsDeprecated',connectionWithRelatedData.connection.uri],
-        connectionWithRelatedData);
+    const connection = Immutable.fromJS(connectionWithRelatedData.connection);
+
+    return state
+        .setIn(['connections', connection.get('uri')], connection)
+        .setIn( //TODO deletme, deprecated state-structure
+            ['connectionsDeprecated',connectionWithRelatedData.connection.uri],
+            connectionWithRelatedData);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -9,28 +9,59 @@ import { combineReducersStable } from '../redux-utils';
 import won from '../won-es6';
 
 const initialState = Immutable.fromJS({
-        /*
-    unreadEventsByNeedByType: {},
-    unreadEventsByTypeByNeed:{ <needUri>:
-        'hint': {count: 0, timestamp: new Date().getTime() },
-        'connect': {count: 0, timestamp: new Date().getTime()},
-        'message': {count: 0, timestamp: new Date().getTime()},
-        'close': {count: 0, timestamp: new Date().getTime()},
-        'created': {count: 0, timestamp: new Date().getTime()}
-    },
-    */
-    unreadEventUris:{}
+    events: {},
+    unreadEventUris:{},
 })
-export default createReducer(
-    initialState,
-    {
 
-        [actionTypes.events.addUnreadEventUri]:(state,action)=>{
-            return state.setIn(['unreadEventUris',action.payload.unreadUri],Immutable.fromJS(action.payload))
-        },
-        [actionTypes.events.read]:(state,action) => state.deleteIn(['unreadEventUris', action.payload])
+export default function(state = initialState, action = {}) {
+    switch(action.type) {
+
+        case actionTypes.load:
+            const allPreviousEvents = action.payload.get('events');
+            return state.mergeIn(['events'], allPreviousEvents);
+
+        case actionTypes.events.addUnreadEventUri:
+            //TODO this should only store the URI
+            return state.setIn(
+                ['unreadEventUris',action.payload.unreadUri],
+                Immutable.fromJS(action.payload)
+            );
+
+        case actionTypes.events.read:
+            return state.deleteIn(['unreadEventUris', action.payload]);
+
+
+        /**
+         * @deprecated this is a legacy action
+         */
+        case actionTypes.connections.load:
+            return action.payload.reduce(
+                (updatedState, connectionWithRelatedData) =>
+                    storeConnectionRelatedData(updatedState, connectionWithRelatedData),
+                state);
+
+        case actionTypes.messages.connectMessageReceived:
+        case actionTypes.messages.hintMessageReceived:
+        case actionTypes.messages.openResponseReceived:
+            return storeConnectionRelatedData(state, action.payload);
+
+
+        default:
+            return state;
     }
-)
+}
+function storeConnectionRelatedData(state, connectionWithRelatedData) {
+    return connectionWithRelatedData.events.reduce(
+
+        (updatedState, event) =>
+            updatedState.getIn(['events', event.uri]) ?
+                updatedState : // we already know this one. no need to trigger re-rendering
+                updatedState.setIn(['events', event.uri], event) // add the event
+
+        , state // start with the original state
+    );
+}
+
 var createOrUpdateUnreadEntry = function(needURI, eventData, unreadEntry){
 
     if(unreadEntry == null || typeof unreadEntry === 'undefined'){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -56,7 +56,7 @@ function storeConnectionRelatedData(state, connectionWithRelatedData) {
         (updatedState, event) =>
             updatedState.getIn(['events', event.uri]) ?
                 updatedState : // we already know this one. no need to trigger re-rendering
-                updatedState.setIn(['events', event.uri], event) // add the event
+                updatedState.setIn(['events', event.uri], Immutable.fromJS(event)) // add the event
 
         , state // start with the original state
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -13,10 +13,10 @@ const initialState = Immutable.fromJS({
     isFetching: false,
     didInvalidate: false,
     ownNeeds: {},
-    othersNeeds: {},
+    theirNeeds: {},
 });
 
-export default function(state = initialState, action = {}) {
+export default function(allNeeds = initialState, action = {}) {
     switch(action.type) {
         case actionTypes.needs.clean:
             return initialState;
@@ -25,28 +25,36 @@ export default function(state = initialState, action = {}) {
             console.log('reducers.js: failed receive needlist action');
             return Immutable.fromJS({error: error});
 
+        case actionTypes.load:
+            const ownNeeds = action.payload.get('ownNeeds');
+            const theirNeeds = action.payload.get('theirNeeds');
+            return allNeeds
+                .mergeIn(['ownNeeds'], ownNeeds)
+                .mergeIn(['theirNeeds'], theirNeeds);
+
         case actionTypes.needs.fetch:
+            //TODO needs supplied by this action don't have a list of already associated connections
             return action.payload.reduce(
                 (updatedState, ownNeed) => setIfNew(updatedState, ['ownNeeds', ownNeed.uri], ownNeed),
-                state
+                allNeeds
             );
 
         case actionTypes.needs.received:
             const ownNeed = action.payload;
-            return setIfNew(state, ['ownNeeds', ownNeed.uri], ownNeed)
+            return setIfNew(allNeeds, ['ownNeeds', ownNeed.uri], ownNeed)
 
         case actionTypes.connections.load:
             return action.payload.reduce(
                 (updatedState, connectionWithRelatedData) =>
                     storeConnectionAndRelatedData(updatedState, connectionWithRelatedData),
-                state);
+                allNeeds);
 
         case actionTypes.messages.connectMessageReceived:
         case actionTypes.messages.hintMessageReceived:
-            return storeConnectionAndRelatedData(state, action.payload);
+            return storeConnectionAndRelatedData(allNeeds, action.payload);
 
         default:
-            return state;
+            return allNeeds;
     }
 }
 
@@ -54,13 +62,13 @@ function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
     const {ownNeed, remoteNeed, connection} = connectionWithRelatedData;
     //guarantee that own need is in the state
     const stateWithOwnNeed = setIfNew(state, ['ownNeeds', ownNeed.uri], ownNeed);
-    const stateWithBothNeeds = setIfNew(stateWithOwnNeed, ['othersNeeds', remoteNeed.uri], remoteNeed);
+    const stateWithBothNeeds = setIfNew(stateWithOwnNeed, ['theirNeeds', remoteNeed.uri], remoteNeed);
 
     /* TODO | what if we get the connection while not online?
      * TODO | doing this here doesn't guarantee synchronicity with the rdf
      * TODO | unless we fetch all connections onLoad and onLogin
      */
-    return stateWithBothNeeds.updateIn(['ownNeeds', ownNeed.uri, 'connections'], connections => connections?
+    return stateWithBothNeeds.updateIn(['ownNeeds', ownNeed.uri, 'hasConnections'], connections => connections?
             connections.push(connection.uri) :
             Immutable.List([connection.uri]) // first connection -> new List
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -61,8 +61,15 @@ export default function(allNeeds = initialState, action = {}) {
 function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
     const {ownNeed, remoteNeed, connection} = connectionWithRelatedData;
     //guarantee that own need is in the state
-    const stateWithOwnNeed = setIfNew(state, ['ownNeeds', ownNeed.uri], ownNeed);
-    const stateWithBothNeeds = setIfNew(stateWithOwnNeed, ['theirNeeds', remoteNeed.uri], remoteNeed);
+    const stateWithOwnNeed = setIfNew(
+        state,
+        ['ownNeeds', ownNeed.uri],
+        Immutable.fromJS(ownNeed));
+
+    const stateWithBothNeeds = setIfNew(
+        stateWithOwnNeed,
+        ['theirNeeds', remoteNeed.uri],
+        Immutable.fromJS(remoteNeed));
 
     /* TODO | what if we get the connection while not online?
      * TODO | doing this here doesn't guarantee synchronicity with the rdf

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -23,7 +23,7 @@ export default function(allNeeds = initialState, action = {}) {
 
         case actionTypes.needs.failed:
             console.log('reducers.js: failed receive needlist action');
-            return Immutable.fromJS({error: error});
+            return Immutable.fromJS({error: action.payload.error});
 
         case actionTypes.load:
             const ownNeeds = action.payload.get('ownNeeds');

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -67,7 +67,7 @@ export const selectUnreadCountsByType = createSelector(
 
 
 
-const selectConnections = state => state.getIn(['connections','connections']);
+const selectConnections = state => state.getIn(['connections','connectionsDeprecated']);
 export const selectConnectionsByNeed = createSelector(
     selectConnections,
     connections => connections

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -491,6 +491,7 @@ const rdfstore = window.rdfstore;
     won.addJsonLdData = function(uri, data) {
         console.log("linkeddata-service-won.js: storing jsonld data for uri: " + uri);
         privateData.store.load("application/ld+json", data, function (success, results) {
+            //privateData.store.load("application/ld+json", data, function (success, results) {
             console.log("linkeddata-service-won.js: added jsonld data to rdf store, success: " + success);
             if (success) {
                 cacheItemMarkAccessed(uri);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -644,18 +644,6 @@ const rdfstore = window.rdfstore;
     };
 
     /**
-     * Saves the specified jsonld structure in the triple store with the specified default graph URI.
-     * @param graphURI used if no graph URI is specified in the jsonld
-     * @param jsonld the data
-     */
-    won.storeJsonLdGraph = function(graphURI, jsonld) {
-        if (typeof graphURI === 'undefined' || graphURI == null  ){
-            throw {message : "storeJsonLdGraph: graphURI must not be null"};
-        }
-        privateData.store.load("application/ld+json", jsonld, graphURI, function (success, results) {});
-    }
-
-    /**
      * Loads the default data of the need with the specified URI into a js object.
      * @return the object or null if no data is found for that URI in the local datastore
      */

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1025,7 +1025,6 @@ const rdfstore = window.rdfstore;
             .then(eventUris => won.urisToLookupMap(eventUris,
                     eventUri => won.getNode(eventUri, requesterWebId))
             )
-            .catch(e => `Could not get all events of connection ${connectionUri}. Reason: ${e}`);
     };
 
     /**
@@ -1044,7 +1043,6 @@ const rdfstore = window.rdfstore;
             .then(connection => connection.hasEventContainer)
             .then(eventContainerUri => won.getNodeWithAttributes(eventContainerUri, requesterWebId))
             .then(eventContainer => eventContainer.member)
-            .catch(e => `Could not get all events of connection ${connectionUri}. Reason: ${e}`);
     }
 
 


### PR DESCRIPTION
old connections-object collection is renamed as Deprecated

i tried to keep the old state structure as much as possible

important lookups (you'll need these when writing selectors):
```
state.getIn(['needs', 'ownNeeds', needUri, 'hasConnections']) // -> connectionUris
state.getIn(['needs', 'theirNeeds', needUri, 'hasConnections']) // -> connectionUris
state.getIn(['events', 'events', eventUri, 'hasReceiver']) // -> connectionUri
state.getIn(['events', 'events', eventUri, 'hasReceiverNeed']) // -> needUri
state.getIn(['connections', 'connections', connectionUri, 'belongsToNeed']) // -> needUri
state.getIn(['connections', 'connections', connectionUri, 'hasEvents']) // -> eventUris
```
when using `unreadEvents` try to just use the `.uri`-field and lookup the actual event in `['events', 'events']`

I still need to remove anything using `connectionsDeprecated` and remove the superfluos load-actions. but the state is in the form it can remain in for now, imo.

As usual, don't delete the branch after merging, plz :)