### PR TITLE
Removed connectionsDeprecated from state.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -6,6 +6,8 @@ import  won from '../won-es6';
 import { actionTypes, actionCreators, getConnectionRelatedData, messageTypeToEventType  } from './actions';
 import { getEventData,setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
 
+import { selectAllByConnections } from '../selectors';
+
 import {
     checkHttpStatus,
 } from '../utils';
@@ -54,7 +56,8 @@ export function connectionsLoad(needUris) {
 export function connectionsOpen(connectionData,message) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
+        const eventData = selectAllByConnections(state).get(connectionData.connection.uri).toJS(); // TODO avoid toJS;
+        //let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -72,7 +75,8 @@ export function connectionsOpen(connectionData,message) {
 export function connectionsConnect(connectionData,message) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
+        const eventData = selectAllByConnections(state).get(connectionData.connection.uri).toJS(); // TODO avoid toJS;
+        //let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -90,7 +94,8 @@ export function connectionsConnect(connectionData,message) {
 export function connectionsClose(connectionData) {
     return (dispatch, getState) => {
         const state = getState();
-        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
+        const eventData = selectAllByConnections(state).get(connectionData.connection.uri);// TODO avoid toJS
+        //let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {
@@ -111,7 +116,8 @@ export function connectionsRate(connectionData,rating) {
         console.log(rating);
 
         const state = getState();
-        let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
+        const eventData = selectAllByConnections(state).get(connectionData.connection.uri);// TODO avoid toJS
+        //let eventData = state.getIn(['connections', 'connectionsDeprecated', connectionData.connection.uri])
         let messageData = null;
         let deferred = Q.defer()
         won.getConnection(eventData.connection.uri).then(connection=> {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
@@ -6,6 +6,7 @@ import requestItemLineModule from '../request-item-line';
 import openRequestModule from '../open-request';
 import { attach,mapToMatches } from '../../utils';
 import { actionCreators }  from '../../actions/actions';
+import { selectAllByConnections } from '../../selectors';
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
 
 class IncomingRequestsController {
@@ -17,17 +18,19 @@ class IncomingRequestsController {
         this.ownerSelection = 2; //ONLY NECESSARY FOR VIEW WITH NEED
 
         const selectFromState = (state)=>{
+            const connectionsDeprecated = selectAllByConnections(state).toJS(); //TODO plz don't do `.toJS()`. every time an ng-binding somewhere cries.
+
             if(state.getIn(['router', 'currentParams', 'myUri']) === undefined) {
                 return {
-                    incomingRequests: Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    incomingRequests: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestReceived && state.getIn(['events', conn.connection.uri]) !== undefined) {
                                 return true
                             }
                         }),
-                    incomingRequestsOfNeed: mapToMatches(Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    incomingRequestsOfNeed: mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestReceived) {
                                 return true
@@ -38,15 +41,15 @@ class IncomingRequestsController {
                 const postId = decodeURIComponent(state.getIn(['router', 'currentParams', 'myUri']));
                 return {
                     post: state.getIn(['needs','ownNeeds', postId]).toJS(),
-                    incomingRequests: Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    incomingRequests: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestReceived && state.getIn(['events', conn.connection.uri]) !== undefined && conn.ownNeed.uri === postId) {
                                 return true
                             }
                         }),
-                    incomingRequestsOfNeed: mapToMatches(Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    incomingRequestsOfNeed: mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestReceived && conn.ownNeed.uri === postId) {
                                 return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
@@ -10,6 +10,7 @@ import sendRequestModule from '../send-request';
 import { attach,mapToMatches} from '../../utils';
 import { labels } from '../../won-label-utils';
 import { actionCreators }  from '../../actions/actions';
+import { selectAllByConnections } from '../../selectors';
 
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
 class OverviewMatchesController {
@@ -24,18 +25,21 @@ class OverviewMatchesController {
 
         this.viewType = 0;
 
-        const selectFromState = (state)=>{
+        const selectFromState = (state) => {
+
+            const connectionsDeprecated = selectAllByConnections(state).toJS(); //TODO plz don't do `.toJS()`. every time an ng-binding somewhere cries.
+
             if(state.getIn(['router', 'currentParams', 'myUri']) === undefined){
                 return {
-                    matches: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    matches: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Suggested){
                                 return true
                             }
                         }),
-                    matchesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    matchesOfNeed:mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Suggested){
                                 return true
@@ -46,15 +50,15 @@ class OverviewMatchesController {
                 const postId = decodeURIComponent(state.getIn(['router', 'currentParams', 'myUri']));
                 return {
                     post: state.getIn(['needs','ownNeeds', postId]).toJS(),
-                    matches: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    matches: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated)
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Suggested && conn.ownNeed.uri === postId){
                                 return true
                             }
                         }),
-                    matchesOfNeed:mapToMatches(Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    matchesOfNeed:mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Suggested && conn.ownNeed.uri === postId){
                                 return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-sent-requests/overview-sent-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-sent-requests/overview-sent-requests.js
@@ -9,6 +9,7 @@ import requestItemLineModule from '../request-item-line';
 import openRequestModule from '../open-request';
 import { attach,mapToMatches } from '../../utils';
 import { actionCreators }  from '../../actions/actions';
+import { selectAllByConnections } from '../../selectors';
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
 
 class SentRequestsController {
@@ -20,17 +21,20 @@ class SentRequestsController {
         this.ownerSelection = 3; //ONLY NECESSARY FOR VIEW WITH NEED
 
         const selectFromState = (state)=>{
+
+            const connectionsDeprecated = selectAllByConnections(state).toJS(); //TODO plz don't do `.toJS()`. every time an ng-binding somewhere cries.
+
             if(state.getIn(['router', 'currentParams', 'myUri']) === undefined) {
                 return {
-                    sentRequests: Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    sentRequests: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestSent && state.getIn(['events', conn.connection.uri]) !== undefined) {
                                 return true
                             }
                         }),
-                    sentRequestsOfNeed: mapToMatches(Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    sentRequestsOfNeed: mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestSent) {
                                 return true
@@ -41,15 +45,15 @@ class SentRequestsController {
                 const postId = decodeURIComponent(state.getIn(['router', 'currentParams', 'myUri']));
                 return {
                     post: state.getIn(['needs','ownNeeds', postId]).toJS(),
-                    sentRequests: Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    sentRequests: Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestSent && state.getIn(['events', conn.connection.uri]) !== undefined && conn.ownNeed.uri === postId) {
                                 return true
                             }
                         }),
-                    sentRequestsOfNeed: mapToMatches(Object.keys(state.getIn(['connections', 'connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections', 'connectionsDeprecated']).toJS()[key])
+                    sentRequestsOfNeed: mapToMatches(Object.keys(connectionsDeprecated)
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=> {
                             if (conn.connection.hasConnectionState === won.WON.RequestSent && conn.ownNeed.uri === postId) {
                                 return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
@@ -6,8 +6,11 @@
 import angular from 'angular';
 import { attach } from '../utils';
 import { actionCreators }  from '../actions/actions';
-import {    selectUnreadCountsByType,
-            selectUnreadEventsByNeed } from '../selectors';
+import {
+    selectUnreadCountsByType,
+    selectUnreadEventsByNeed,
+    selectAllByConnections,
+} from '../selectors';
 import won from '../won-es6';
 
 
@@ -62,7 +65,7 @@ function genComponentConf() {
                 const unreadCounts = selectUnreadCountsByType(state);
                 const nrOfNeedsWithUnread = selectUnreadEventsByNeed(state).size;
                 const ownNeeds = state.getIn(["needs", "ownNeeds"]);
-                const connectionsDeprecated = state.getIn(['connections','connectionsDeprecated']).toJS();
+                const connectionsDeprecated = selectAllByConnections(state).toJS();
 
                 return {
                     hasPosts: ownNeeds && ownNeeds.size > 0,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -5,7 +5,7 @@ import squareImageModule from '../components/square-image';
 import { attach,mapToMatches } from '../utils';
 import won from '../won-es6';
 import { labels } from '../won-label-utils';
-import { selectUnreadEventsByNeedAndType } from '../selectors';
+import { selectUnreadEventsByNeedAndType, selectAllByConnections } from '../selectors';
 import { actionCreators }  from '../actions/actions';
 
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
@@ -78,31 +78,40 @@ function genComponentConf() {
 
             const selectFromState = (state)=>{
                 const unreadCounts = selectUnreadEventsByNeedAndType(state);
+                const connectionsDeprecated = selectAllByConnections(state).toJS(); //TODO plz don't do `.toJS()`. every time an ng-binding somewhere cries.
 
                 return {
-                    hasIncomingRequests: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    hasIncomingRequests: state.getIn(['connections', 'connections'])
+                        .filter(conn =>
+                            conn.get('hasConnectionState') === won.WON.RequestReceived
+                            && conn.get('belongsToNeed') === this.item.uri
+                        ).size > 0,
+
+                    /*
+                    hasIncomingRequests: Object.keys(connectionsDeprecated) //TODO immutable maps have a `.filter(...)` https://facebook.github.io/immutable-js/docs/
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.RequestReceived && conn.ownNeed.uri === this.item.uri){
                                 return true
                             }
                         }).length > 0,
-                    hasSentRequests: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    */
+                    hasSentRequests: Object.keys(connectionsDeprecated) //TODO immutable maps have a `.filter(...)` https://facebook.github.io/immutable-js/docs/
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.RequestSent && conn.ownNeed.uri === this.item.uri){
                                 return true
                             }
                         }).length > 0,
-                    hasMatches: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    hasMatches: Object.keys(connectionsDeprecated) //TODO immutable maps have a `.filter(...)` https://facebook.github.io/immutable-js/docs/
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Suggested && conn.ownNeed.uri === this.item.uri){
                                 return true
                             }
                         }).length > 0,
-                    hasMessages: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                        .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                    hasMessages: Object.keys(connectionsDeprecated) //TODO immutable maps have a `.filter(...)` https://facebook.github.io/immutable-js/docs/
+                        .map(key => connectionsDeprecated[key])
                         .filter(conn=>{
                             if(conn.connection.hasConnectionState===won.WON.Connected && conn.ownNeed.uri === this.item.uri){
                                 return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-messages/post-owner-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-owner-messages/post-owner-messages.js
@@ -12,6 +12,7 @@ import won from '../../won-es6';
 import { actionCreators }  from '../../actions/actions';
 import needConnectionMessageLineModule from '../connection-message-item-line';
 import openConversationModule from '../open-conversation';
+import { selectAllByConnections } from '../../selectors';
 
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
 class Controller {
@@ -23,10 +24,12 @@ class Controller {
 
         const selectFromState = (state)=>{
             const postId = decodeURIComponent(state.getIn(['router', 'currentParams', 'myUri']));
+            const connectionsDeprecated = selectAllByConnections(state).toJS(); //TODO plz don't do `.toJS()`. every time an ng-binding somewhere cries.
+
             return {
                 post: state.getIn(['needs','ownNeeds', postId]).toJS(),
-                conversations: Object.keys(state.getIn(['connections','connectionsDeprecated']).toJS())
-                    .map(key=>state.getIn(['connections','connectionsDeprecated']).toJS()[key])
+                conversations: Object.keys(connectionsDeprecated)
+                    .map(key => connectionsDeprecated[key])
                     .filter(conn=>{
                         if(conn.connection.hasConnectionState===won.WON.Connected && conn.ownNeed.uri === postId){
                             return true

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -13,7 +13,7 @@ const initialState = Immutable.fromJS({
     isFetching: false,
     didInvalidate: false,
     connectionsDeprecated: {},//don't use data from this map
-    connections: {},
+    //connections: {},
 })
 export default function(state = initialState, action = {}) {
     switch(action.type) {
@@ -44,7 +44,9 @@ function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
 
     return state
         .setIn(['connections', connection.get('uri')], connection)
+        /*
         .setIn( //TODO deletme, deprecated state-structure
             ['connectionsDeprecated',connectionWithRelatedData.connection.uri],
             connectionWithRelatedData);
+            */
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -12,8 +12,8 @@ import won from '../won-es6';
 const initialState = Immutable.fromJS({
     isFetching: false,
     didInvalidate: false,
-    connectionsDeprecated: {},//don't use data from this map
-    //connections: {},
+    //connectionsDeprecated: {},//don't use data from this map
+    connections: {},
 })
 export default function(state = initialState, action = {}) {
     switch(action.type) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -67,10 +67,48 @@ export const selectUnreadCountsByType = createSelector(
 
 
 
-const selectConnections = state => state.getIn(['connections','connectionsDeprecated']);
+const selectConnectionsDeprecated = state => state.getIn(['connections','connectionsDeprecated']);
 export const selectConnectionsByNeed = createSelector(
-    selectConnections,
+    selectConnectionsDeprecated,
     connections => connections
         .map(cnct => Immutable.fromJS(cnct)) //TODO this is a workaround. atm connections aren't ImmutableJS-objects
         .groupBy(cnct => cnct.getIn(['ownNeed', 'uri']))
-)
+);
+
+
+/**
+ * selects a map of `connectionUri -> { connection, events, ownNeed, remoteNeed }`
+ * - thus: everything a connection has direct references to. Use this selector
+ * when you're needing connection-centric data (e.g. for a view with a strong
+ * focus on the connection)
+ *
+ * NOTE: the app-state used to have events and needs stored in this fashion.
+ * Thus, this selector is also used to allow older code to use the new
+ * state-structure with minimal changes.
+ */
+export const selectAllByConnections = createSelector(
+    state => state, //reselect's createSelector always needs a dependency
+    state => state
+        .getIn(['connections', 'connections'])
+        .map(connection => allByConnection(connection)(state))
+);
+const allByConnection = (connection) => (state) => {
+    const ownNeedUri = connection.get('belongsToNeed');
+    const ownNeed = state.getIn(['needs', 'ownNeeds', ownNeedUri]);
+
+    const remoteNeedUri = connection.get('hasRemoteNeed');
+    const remoteNeed = state.getIn(['needs', 'theirNeeds', remoteNeedUri]);
+
+    const events = connection
+        .get('hasEvents')
+        .map(eventUri => state.getIn(['events', 'events', eventUri]));
+
+    return Immutable.Map({ connection, events, ownNeed, remoteNeed });
+};
+const allByConnectionUri = (connectionUri)  => {
+    const connection = state.getIn(['connections', 'connections', connectionUri]);
+    return allByConnection(connection);
+};
+
+window.selectAllByConnections4dbg = selectAllByConnections;
+window.allByConnection4db = allByConnection;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -66,15 +66,6 @@ export const selectUnreadCountsByType = createSelector(
 )
 
 
-//TODO there's certainly more elegant ways to implement this selector than first grouping by connection then by need
-export const selectConnectionsByNeed = createSelector(
-    selectAllByConnections,
-    connections => connections
-        .map(cnct => Immutable.fromJS(cnct)) //TODO this is a workaround. atm connections aren't ImmutableJS-objects
-        .groupBy(cnct => cnct.getIn(['ownNeed', 'uri']))
-);
-
-
 /**
  * selects a map of `connectionUri -> { connection, events, ownNeed, remoteNeed }`
  * - thus: everything a connection has direct references to. Use this selector
@@ -108,6 +99,16 @@ const allByConnectionUri = (connectionUri)  => {
     const connection = state.getIn(['connections', 'connections', connectionUri]);
     return allByConnection(connection);
 };
+
+//TODO there's certainly more elegant ways to implement this selector than first grouping by connection then by need
+export const selectConnectionsByNeed = createSelector(
+    selectAllByConnections,
+        connections => connections
+        .map(cnct => Immutable.fromJS(cnct)) //TODO this is a workaround. atm connections aren't ImmutableJS-objects
+        .groupBy(cnct => cnct.getIn(['ownNeed', 'uri']))
+);
+
+
 
 window.selectAllByConnections4dbg = selectAllByConnections;
 window.allByConnection4db = allByConnection;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -66,7 +66,7 @@ export const selectUnreadCountsByType = createSelector(
 )
 
 
-
+//TODO there's certainly more elegant ways to implement this selector than first grouping by connection then by need
 export const selectConnectionsByNeed = createSelector(
     selectAllByConnections,
     connections => connections

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -67,9 +67,8 @@ export const selectUnreadCountsByType = createSelector(
 
 
 
-const selectConnectionsDeprecated = state => state.getIn(['connections','connectionsDeprecated']);
 export const selectConnectionsByNeed = createSelector(
-    selectConnectionsDeprecated,
+    selectAllByConnections,
     connections => connections
         .map(cnct => Immutable.fromJS(cnct)) //TODO this is a workaround. atm connections aren't ImmutableJS-objects
         .groupBy(cnct => cnct.getIn(['ownNeed', 'uri']))


### PR DESCRIPTION
There's now a memoized selector function `selectAllByConnections` to get the structure that used to be in `state.getIn(['connections', 'connections'])`.  I've ported all occurances of the later i've found to that selector.

Most of these updated snippet's are copy-pasta code anyway and should be extracted into functions in `selectors.js` anyway, but i've had enough refactoring for a while 

Btw, immutablejs-maps have a `.filter(...)` on their own - there's no need to copy(!) their contents into vanilla-js objects by calling `.toJS()`. I've updated one occurance in `owner-title-bar.js` as example:

``` javascript
 hasIncomingRequests: state.getIn(['connections', 'connections'])
                        .filter(conn =>
                            conn.get('hasConnectionState') === won.WON.RequestReceived
                           && conn.get('belongsToNeed') === this.item.uri
                        ).size > 0,
```

When you do something along those lines, add a function in `selectors.js` with similiar code and then use that in your components/views.

So. I'll go and work on the feed now. 