### PR TITLE
Fix consistent events - accepting incoming requests working

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -50,7 +50,7 @@ import {
     entries,
 } from '../utils';
 import { hierarchy2Creators } from './action-utils';
-import { getEventData,setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
+import { getEventsFromMessage,setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
 import {
     buildCreateMessage,
     buildCloseNeedMessage

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -4,7 +4,7 @@
 
 import  won from '../won-es6';
 import { actionTypes, actionCreators, getConnectionRelatedData, messageTypeToEventType  } from './actions';
-import { getEventData,setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
+import { getEventsFromMessage,setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
 
 import { selectAllByConnections } from '../selectors';
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -159,15 +159,15 @@ export function connectMessageReceived(event) {
             .then(() => {
                 won.getConnectionWithOwnAndRemoteNeed(event.hasReceiverNeed, event.hasSenderNeed).then(connectionData=> {
                     //TODO refactor
-                    event.unreadUri = connectionData.uri;
-                    dispatch(actionCreators.events__addUnreadEventUri(event));
-
                     getConnectionRelatedData(event.hasReceiverNeed, event.hasSenderNeed, connectionData.uri)
-                    .then(data =>
-                        dispatch({
-                            type: actionTypes.messages.connectMessageReceived,
-                            payload: data
-                        })
+                    .then(data => {
+                            event.unreadUri = connectionData.uri;
+                            data.receivedEvent = event;
+                            dispatch({
+                                type: actionTypes.messages.connectMessageReceived,
+                                payload: data
+                            });
+                        }
                     );
                 })
 
@@ -190,14 +190,14 @@ export function hintMessageReceived(event) {
                 console.log('going to crawl connection related data');//deletme
 
                 getConnectionRelatedData(needUri, event.hasMatchCounterpart, event.hasReceiver)
-                .then(data =>
-                    dispatch({
-                        type: actionTypes.messages.hintMessageReceived,
-                        payload: data
-                    })
+                .then(data => {
+                        data.receivedEvent = event;
+                        dispatch({
+                            type: actionTypes.messages.hintMessageReceived,
+                            payload: data
+                        });
+                    }
                 );
-
-                dispatch(actionCreators.events__addUnreadEventUri(event));
 
                 // /add some properties to the eventData so as to make them easily accessible to consumers
                 //of the hint event

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -151,18 +151,18 @@ export function successfulCreate(event) {
     }
 }
 
-export function connectMessageReceived(data) {
+export function connectMessageReceived(event) {
     return dispatch=> {
-        data.eventType = messageTypeToEventType[data.hasMessageType].eventType;
+        event.eventType = messageTypeToEventType[event.hasMessageType].eventType;
         //TODO data.hasReceiver, the connectionUri is undefined in the response message
-        won.invalidateCacheForNewConnection(data.hasReceiver, data.hasReceiverNeed)
+        won.invalidateCacheForNewConnection(event.hasReceiver, event.hasReceiverNeed)
             .then(() => {
-                won.getConnectionWithOwnAndRemoteNeed(data.hasReceiverNeed, data.hasSenderNeed).then(connectionData=> {
+                won.getConnectionWithOwnAndRemoteNeed(event.hasReceiverNeed, event.hasSenderNeed).then(connectionData=> {
                     //TODO refactor
-                    data.unreadUri = connectionData.uri;
-                    dispatch(actionCreators.events__addUnreadEventUri(data));
+                    event.unreadUri = connectionData.uri;
+                    dispatch(actionCreators.events__addUnreadEventUri(event));
 
-                    getConnectionRelatedData(data.hasReceiverNeed, data.hasSenderNeed, connectionData.uri)
+                    getConnectionRelatedData(event.hasReceiverNeed, event.hasSenderNeed, connectionData.uri)
                     .then(data =>
                         dispatch({
                             type: actionTypes.messages.connectMessageReceived,
@@ -175,21 +175,21 @@ export function connectMessageReceived(data) {
     }
 }
 
-export function hintMessageReceived(data) {
+export function hintMessageReceived(event) {
     return dispatch=> {
-        data.eventType = messageTypeToEventType[data.hasMessageType].eventType;
-        won.invalidateCacheForNewConnection(data.hasReceiver, data.hasReceiverNeed)
+        event.eventType = messageTypeToEventType[event.hasMessageType].eventType;
+        won.invalidateCacheForNewConnection(event.hasReceiver, event.hasReceiverNeed)
             .then(() => {
-                let needUri = data.hasReceiverNeed;
+                let needUri = event.hasReceiverNeed;
                 let match = {}
 
-                data.unreadUri = data.hasReceiver;
-                data.matchScore = data.framedMessage[won.WON.hasMatchScoreCompacted];
-                data.matchCounterpartURI = won.getSafeJsonLdValue(data.framedMessage[won.WON.hasMatchCounterpart]);
+                event.unreadUri = event.hasReceiver;
+                event.matchScore = event.framedMessage[won.WON.hasMatchScoreCompacted];
+                event.matchCounterpartURI = won.getSafeJsonLdValue(event.framedMessage[won.WON.hasMatchCounterpart]);
 
                 console.log('going to crawl connection related data');//deletme
 
-                getConnectionRelatedData(needUri, data.hasMatchCounterpart, data.hasReceiver)
+                getConnectionRelatedData(needUri, event.hasMatchCounterpart, event.hasReceiver)
                 .then(data =>
                     dispatch({
                         type: actionTypes.messages.hintMessageReceived,
@@ -197,7 +197,7 @@ export function hintMessageReceived(data) {
                     })
                 );
 
-                dispatch(actionCreators.events__addUnreadEventUri(data));
+                dispatch(actionCreators.events__addUnreadEventUri(event));
 
                 // /add some properties to the eventData so as to make them easily accessible to consumers
                 //of the hint event

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
@@ -85,10 +85,10 @@ function genComponentConf() {
         input () {
             console.log('got input in dynamic textfeld ', this.getText());
             if(!this.displayingPlaceholder) {
-                const newVal = this.getText();
-                if(newVal !== this.getUnsanitizedText()) {
+                if(this.getText() !== this.getUnsanitizedText()) {
                     this.sanitize();
                 }
+                const newVal = this.getText().trim();
                 //make sure the text field contains the sanitized text (so user sees what they're posting)
                 //this.setText(newVal);
 
@@ -139,13 +139,13 @@ function genComponentConf() {
             this.setText(this.getText());
         }
         getUnsanitizedText() {
-            return this.textField().innerHTML;
+            return this.textField().textContent;
         }
         getText() {
             //sanitize input
-            return this.$sanitize(this.textField().innerHTML)
-                .replace(/<(?:.|\n)*?>/gm, '') //strip html tags
-                .trim();
+            return this.$sanitize(this.getUnsanitizedText())
+                .replace(/<(?:.|\n)*?>/gm, ''); //strip html tags
+
         }
         setText(txt) {
             this.textField().innerHTML = txt

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
@@ -33,21 +33,25 @@ function genComponentConf() {
             console.log('dynamic-textfield.js : in ctrl', this, this.$element)
             */
 
+            window.dtf4dbg = this;
 
             this.displayingPlaceholder = true;
             this.value = '';
 
-            this.textFieldNg().bind('keydown',e => this.onKeydown(e))
+            this.textFieldNg().bind('keydown',e => this.onKeydown(e)) //prevent enter
+                              .bind('keyup', () => this.input()) // handle title changes
                               .bind('focus', (e) => this.onFocus(e))
                               .bind('blur', (e) => this.onBlur(e))
-                              .bind('keyup drop paste', () => this.input())
-            //this.textField().addEventListener('keyup', () => this.input());
-            //this.textField().addEventListener('drop', () => this.input());
-            //this.textField().addEventListener('paste', () => this.input());
-
-            //don't want the default input event to bubble and leak into this directives event-stream
+                            /*
+                              .bind('drop paste', (e) => {
+                                  e.stopPropagation();
+                                  this.sanitize();
+                                  return this.input();
+                              })
+                              */
+                              //don't want the default input event to bubble and leak into this directives event-stream
                               .bind('input', (e) => e.stopPropagation());
-            //this.textField().addEventListener('input', (e) => e.stopPropagation());
+
 
             /*
             *   TODO
@@ -79,10 +83,14 @@ function genComponentConf() {
             }
         }
         input () {
+            console.log('got input in dynamic textfeld ', this.getText());
             if(!this.displayingPlaceholder) {
                 const newVal = this.getText();
+                if(newVal !== this.getUnsanitizedText()) {
+                    this.sanitize();
+                }
                 //make sure the text field contains the sanitized text (so user sees what they're posting)
-                this.setText(newVal);
+                //this.setText(newVal);
 
                 //compare with previous value, if different
                 if(this.value !== newVal) {
@@ -126,6 +134,12 @@ function genComponentConf() {
         }
         textField() {
             return this.textFieldNg()[0];
+        }
+        sanitize() {
+            this.setText(this.getText());
+        }
+        getUnsanitizedText() {
+            return this.textField().innerHTML;
         }
         getText() {
             //sanitize input

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
@@ -85,9 +85,10 @@ function genComponentConf() {
         input () {
             console.log('got input in dynamic textfeld ', this.getText());
             if(!this.displayingPlaceholder) {
-                if(this.getText() !== this.getUnsanitizedText()) {
-                    this.sanitize();
-                }
+                if(this.getUnsanitizedText() !== this.getText() ||
+                    this.textField().innerHTML.contains('<br>.')) { //also supress line breaks inside the text in copy-pasted text
+                        this.setText(this.getText()); //sanitize
+                    }
                 const newVal = this.getText().trim();
                 //make sure the text field contains the sanitized text (so user sees what they're posting)
                 //this.setText(newVal);
@@ -135,15 +136,14 @@ function genComponentConf() {
         textField() {
             return this.textFieldNg()[0];
         }
-        sanitize() {
-            this.setText(this.getText());
-        }
         getUnsanitizedText() {
             return this.textField().textContent;
         }
         getText() {
             //sanitize input
-            return this.$sanitize(this.getUnsanitizedText())
+            //return this.$sanitize(this.getUnsanitizedText())
+            return this.getUnsanitizedText()
+                .replace(/<br>/gm, ' ')
                 .replace(/<(?:.|\n)*?>/gm, ''); //strip html tags
 
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/dynamic-textfield.js
@@ -86,7 +86,7 @@ function genComponentConf() {
             console.log('got input in dynamic textfeld ', this.getText());
             if(!this.displayingPlaceholder) {
                 if(this.getUnsanitizedText() !== this.getText() ||
-                    this.textField().innerHTML.contains('<br>.')) { //also supress line breaks inside the text in copy-pasted text
+                    this.textField().innerHTML.match(/<br>./)) { //also supress line breaks inside the text in copy-pasted text
                         this.setText(this.getText()); //sanitize
                     }
                 const newVal = this.getText().trim();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/request-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/request-item-line.js
@@ -6,6 +6,8 @@ import { labels } from '../won-label-utils';
 import {attach} from '../utils.js';
 import { actionCreators }  from '../actions/actions';
 
+import { selectUnreadEvents } from '../selectors';
+
 const serviceDependencies = ['$q', '$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
@@ -57,7 +59,7 @@ function genComponentConf() {
             const selectFromState = (state)=>{
 
                 return {
-                    unreadUris: state.getIn(['events','unreadEventUris'])
+                    unreadUris: selectUnreadEvents(state)
                 };
             }
             this.labels = labels;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -20,16 +20,8 @@ export default function(state = initialState, action = {}) {
             const allPreviousEvents = action.payload.get('events');
             return state.mergeIn(['events'], allPreviousEvents);
 
-        case actionTypes.events.addUnreadEventUri:
-            //TODO this should only store the URI
-            return state.setIn(
-                ['unreadEventUris',action.payload.unreadUri],
-                Immutable.fromJS(action.payload)
-            );
-
         case actionTypes.events.read:
             return state.deleteIn(['unreadEventUris', action.payload]);
-
 
         /**
          * @deprecated this is a legacy action
@@ -42,8 +34,12 @@ export default function(state = initialState, action = {}) {
 
         case actionTypes.messages.connectMessageReceived:
         case actionTypes.messages.hintMessageReceived:
-            return storeConnectionRelatedData(state, action.payload);
-
+            const event = action.payload.receivedEvent;
+            const updatedState = state.setIn(
+                ['unreadEventUris', event.unreadUri],
+                Immutable.fromJS(event)
+            );
+            return storeConnectionRelatedData(updatedState, action.payload);
 
         default:
             return state;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -34,9 +34,11 @@ export default function(state = initialState, action = {}) {
 
         case actionTypes.messages.connectMessageReceived:
         case actionTypes.messages.hintMessageReceived:
-            const event = action.payload.receivedEvent;
+            //const event = action.payload.receivedEvent;
+            const event = action.payload.events[action.payload.receivedEvent];
+            event.unreadUri = action.payload.updatedConnection;
             const updatedState = state.setIn(
-                ['unreadEventUris', event.unreadUri],
+                ['unreadEventUris', action.payload.updatedConnection],
                 Immutable.fromJS(event)
             );
             return storeConnectionRelatedData(updatedState, action.payload);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -10,8 +10,7 @@ import won from '../won-es6';
 
 const initialState = Immutable.fromJS({
     events: {},
-    unreadEventUris:{},
-})
+}).set('unreadEventUris', Immutable.Set());
 
 export default function(state = initialState, action = {}) {
     switch(action.type) {
@@ -21,7 +20,8 @@ export default function(state = initialState, action = {}) {
             return state.mergeIn(['events'], allPreviousEvents);
 
         case actionTypes.events.read:
-            return state.deleteIn(['unreadEventUris', action.payload]);
+            return state.update('unreadEventUris',
+                    unread => unread.remove(action.payload));
 
         /**
          * @deprecated this is a legacy action
@@ -37,11 +37,8 @@ export default function(state = initialState, action = {}) {
             //TODO events should be an object too
             const event = action.payload.events.filter(e => e.uri === action.payload.receivedEvent)[0];
             event.unreadUri = action.payload.updatedConnection;
-            const updatedState = state.setIn(
-                ['unreadEventUris', action.payload.updatedConnection],
-                Immutable.fromJS(event)
-            //Immutable.fromJS({uri: event.uri})
-            );
+
+            const updatedState = state.update('unreadEventUris', unread => unread.add(event.uri));
             return storeConnectionRelatedData(updatedState, action.payload);
 
         default:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -34,12 +34,13 @@ export default function(state = initialState, action = {}) {
 
         case actionTypes.messages.connectMessageReceived:
         case actionTypes.messages.hintMessageReceived:
-            //const event = action.payload.receivedEvent;
-            const event = action.payload.events[action.payload.receivedEvent];
+            //TODO events should be an object too
+            const event = action.payload.events.filter(e => e.uri === action.payload.receivedEvent)[0];
             event.unreadUri = action.payload.updatedConnection;
             const updatedState = state.setIn(
                 ['unreadEventUris', action.payload.updatedConnection],
                 Immutable.fromJS(event)
+            //Immutable.fromJS({uri: event.uri})
             );
             return storeConnectionRelatedData(updatedState, action.payload);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -20,7 +20,7 @@ window.selectUnreadUris4dbg =  selectUnreadEventUris;
 
 //TODO the earlier unreadEvents was organised by need-uri!
 
-export const selectUnreadEventsRework = createSelector(
+export const selectUnreadEvents = createSelector(
     selectEvents, selectUnreadEventUris,
     (events, unreadEventUris) =>
         unreadEventUris.map(eventUri => events.get(eventUri))
@@ -30,7 +30,7 @@ export const selectUnreadEventsRework = createSelector(
  * @deprecated
  * @param state
  */
-export const selectUnreadEvents = state => state.getIn(['events', 'unreadEventUris']);
+export const selectUnreadEventsDeprecated = state => state.getIn(['events', 'unreadEventUris']);
 
 //const selectUnreadEvents = state => state.getIn(['events', 'unreadEventUris']);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -11,12 +11,7 @@ const selectConnections = state => state.getIn(['connections']);
 const selectEvents = state => state.getIn(['events', 'events']);
 
 export const selectUnreadEventUris = state => state
-    .getIn(['events', 'unreadEventUris'])
-    //TODO unreadEventUris should just be this set of strings in the first place (to avoid saving redundant data)
-    .map(event => event.get('uri'))
-    .toSet();
-
-window.selectUnreadUris4dbg =  selectUnreadEventUris;
+    .getIn(['events', 'unreadEventUris']);
 
 //TODO the earlier unreadEvents was organised by need-uri!
 
@@ -25,12 +20,6 @@ export const selectUnreadEvents = createSelector(
     (events, unreadEventUris) =>
         unreadEventUris.map(eventUri => events.get(eventUri))
 );
-
-/**
- * @deprecated
- * @param state
- */
-export const selectUnreadEventsDeprecated = state => state.getIn(['events', 'unreadEventUris']);
 
 //const selectUnreadEvents = state => state.getIn(['events', 'unreadEventUris']);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -7,7 +7,7 @@ import Immutable from 'immutable';
 
 
 //TODO update to reflect simplfied state (drop one 'connections')
-const selectConnections = state => state.getIn(['connections', 'connections']);
+const selectConnections = state => state.getIn(['connections']);
 const selectEvents = state => state.getIn(['events', 'events']);
 
 export const selectUnreadEventUris = state => state

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -477,6 +477,33 @@ export function urisToLookupMap(uris, asyncLookupFunction) {
 }
 
 /**
+ * Maps an asynchronous function over the values of an object or
+ * the elements of an array. It returns a promise with the result,
+ * when all applications of the asyncFunction have finished.
+ * @param object
+ * @param asyncFunction
+ * @return {*}
+ */
+export function mapJoin(object, asyncFunction) {
+    if(is('Array', object)) {
+        const promises = object.map(el => asyncFunction(el));
+        return Promise.all(promises);
+    } else if(is('Object', object)){
+        const keys = Object.keys(object);
+        const promises = keys.map(k => asyncFunction(object[k]));
+        return Promise.all(promises).then(results => {
+            const acc = {};
+            results.forEach((result, i) => {
+                acc[keys[i]] = result;
+            });
+            return acc;
+        });
+    } else {
+        return undefined;
+    }
+}
+
+/**
  * Stable method of determining the type
  * taken from http://bonsaiden.github.io/JavaScript-Garden/
  * @param type

--- a/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
@@ -7,14 +7,25 @@ var rename = require('gulp-rename');
 var autoprefixer = require('gulp-autoprefixer');
 var svgSprite = require('gulp-svg-sprite');
 var sassImportOnce = require('node-sass-import-once');
+var gulp_jspm = require('gulp-jspm');
+var sourcemaps = require('gulp-sourcemaps');
 
 
 gulp.task('default', ['build']);
-gulp.task('build', ['sass', 'iconsprite']);
-gulp.task('watch', ['sass', 'iconsprite'], function() {
+gulp.task('build', ['bundlejs', 'sass', 'iconsprite']);
+gulp.task('watch', ['bundlejs', 'sass', 'iconsprite'], function() {
+    gulp.watch('./app/**/*.js', ['bundlejs']);
     gulp.watch('./style/**/*.scss', ['sass']);
     gulp.watch('./style/**/_*.scss', ['sass']);
     gulp.watch('./images/won-icons/**/*.svg', ['iconsprite']);
+});
+
+gulp.task('bundlejs', function(){
+    return gulp.src('app/app_jspm.js')
+        .pipe(sourcemaps.init())
+        .pipe(gulp_jspm())
+        .pipe(sourcemaps.write('.'))
+        .pipe(gulp.dest('./generated/'));
 });
 
 gulp.task('sass', function(done) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -11,9 +11,11 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-jspm": "^0.5.7",
     "gulp-minify-css": "^1.2.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.1.0",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-svg-sprite": "^1.2.16",
     "jspm": "^0.16.15",
     "jspm-bower-endpoint": "^0.3.2",

--- a/webofneeds/won-owner-webapp/src/main/webapp/rework.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/rework.html
@@ -60,9 +60,16 @@
 
         <script src="./jspm_packages/system.js"></script>
         <script src="./jspm_config.js"></script>
+
+        <!--
+        this line loads the bundled app. comment it out if you want
+        jspm to dynamically load and compile the sources at runtime.
+        this makes for easier debugging, as you get seperate
+        source files in the dev-tools' source explorer.
+        -->
+        <script src="./generated/app_jspm.bundle.js"></script>
+
         <script>
-            //console.log(System);
-            //System.import('app/app')
             System.import('./app/app_jspm')
                     .catch(console.error.bind(console));
         </script>


### PR DESCRIPTION
There was a bug that―for incoming connection requests―`unreadEvents[cnctUri].uri` didn’t match any uri in the list of own events. The message handling was just using the first successful framing result―essentially yielding the remote counterpart of the own event, which of course had a different uri. A selector function in the feed-view was crashing as a result, while trying to access properties of an undefined event.

The code is now returning the correct event. What’s more, all events now also contain have property with their counterpart attached, as you can see in the state. Especially for incoming requests, this counterpart holds valuable information.