### PR TITLE
Feat deeper ld

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/events/action/impl/CreateEchoNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/events/action/impl/CreateEchoNeedWithFacetsAction.java
@@ -18,8 +18,6 @@ package won.bot.framework.events.action.impl;
 
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.sparql.path.Path;
-import com.hp.hpl.jena.sparql.path.PathParser;
 import org.apache.commons.lang3.StringUtils;
 import won.bot.framework.events.EventListenerContext;
 import won.bot.framework.events.action.EventBotActionUtils;
@@ -32,7 +30,6 @@ import won.bot.framework.events.listener.EventListener;
 import won.protocol.message.WonMessage;
 import won.protocol.model.BasicNeedType;
 import won.protocol.service.WonNodeInformationService;
-import won.protocol.util.DefaultPrefixUtils;
 import won.protocol.util.NeedModelBuilder;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
@@ -63,9 +60,7 @@ public class CreateEchoNeedWithFacetsAction extends AbstractCreateNeedAction
         }
         final URI reactingToNeedUri = ((NeedCreatedEventForMatcher) event).getNeedURI();
         final Dataset needDataset = ((NeedCreatedEventForMatcher)event).getNeedData();
-        final NeedModelBuilder inBuilder = new NeedModelBuilder();
-        Path titlePath = PathParser.parse("won:hasContent/dc:title", DefaultPrefixUtils.getDefaultPrefixes());
-        String titleString = RdfUtils.getStringPropertyForPropertyPath(needDataset, reactingToNeedUri, titlePath);
+        String titleString = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, reactingToNeedUri);
         if (titleString != null){
           replyText = titleString;
         } else {

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -148,6 +148,15 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("messageType") WonMessageType messageType,
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
+  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
+    "   and (msg.messageType = :messageType)) " +
+    "group by msg.parentURI")
+  Slice<URI> getConnectionURIByLatestActivity(
+    @Param("need") URI needURI,
+    @Param("messageType") WonMessageType messageType, Pageable pageable);
+
 
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -17,6 +17,7 @@
 package won.protocol.service;
 
 import com.hp.hpl.jena.query.Dataset;
+import org.springframework.context.NoSuchMessageException;
 import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchNeedException;
 import won.protocol.message.WonMessageType;
@@ -235,12 +236,24 @@ public interface LinkedDataService
   public Dataset getNeedDataset(final URI needUri) throws NoSuchNeedException;
 
   /**
+   * Returns a dataset describing the need with the specified URI.
+   * @param needUri
+   * @param deep - include need's connections datasets and each connection's events' datasets
+   * @param deepLayerSize - number of connections and events to include in the deep need dataset
+   * @return
+   * @throws NoSuchNeedException
+   */
+  public Dataset getNeedDataset(final URI needUri, final boolean deep, final Integer deepLayerSize)  throws
+    NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException;
+
+  /**
    * Returns a model describing the connection with the specified URI.
    * @param connectionUri
    * @return
    * @throws NoSuchConnectionException
    */
-  public Dataset getConnectionDataset(final URI connectionUri, boolean includeEventData) throws NoSuchConnectionException;
+  public Dataset getConnectionDataset(final URI connectionUri, boolean includeEventContainer) throws
+    NoSuchConnectionException;
 
   /**
    * Returns a dataset containing all event uris belonging to the specified connection.
@@ -250,6 +263,14 @@ public interface LinkedDataService
    */
   public Dataset listConnectionEventURIs(final URI connectionUri) throws NoSuchConnectionException;
 
+  /**
+   * Returns a dataset containing all event uris belonging to the specified connection.
+   * @param connectionUri
+   * @param deep - include events dataset
+   * @return
+   * @throws NoSuchConnectionException
+   */
+  public Dataset listConnectionEventURIs(final URI connectionUri, final boolean deep) throws NoSuchConnectionException;
 
 
   /**

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -90,7 +90,7 @@ public interface NeedInformationService {
      *
      * @param page the page number
      * @param preferredSize preferred number of members per page or null; null => use default
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, if null - current state
      *
      * @return a slice connection URIs.
      */
@@ -102,7 +102,7 @@ public interface NeedInformationService {
      *
      * @param resumeConnURI the returned slice connections precede (in time of their latest events) this connection uri
      * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
      *
      * @return a slice of connection URIs.
      */
@@ -115,7 +115,7 @@ public interface NeedInformationService {
      *
      * @param resumeConnURI the returned slice connections follow (in time of their latest events) this connection uri
      * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
      *
      * @return a slice of connection URIs.
      */
@@ -141,7 +141,7 @@ public interface NeedInformationService {
      * @param preferredSize preferred number of members per page or null; null => use default
      * @param messageType event type that should be used for defining connection latest activity; null => all event
      *                    types
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, if null - current state
      * @return a collection of connection URIs.
      * @throws won.protocol.exception.NoSuchNeedException
      *          if needURI is not a known need URI
@@ -157,7 +157,7 @@ public interface NeedInformationService {
      * @param preferredPageSize preferred number of members per page or null; null => use default
      * @param messageType event type that should be used for defining connection latest activity; null => all event
      *                    types
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
      *
      * @return a slice of connection URIs.
      */
@@ -172,7 +172,7 @@ public interface NeedInformationService {
      * @param preferredPageSize preferred number of members per page or null; null => use default
      * @param messageType event type that should be used for defining connection latest activity; null => all event
      *                    types
-     * @param timeSpot time at which we want the list state to be fixed
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
      *
      * @return a slice of connection URIs.
      */

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -5,6 +5,8 @@ import com.hp.hpl.jena.query.*;
 import com.hp.hpl.jena.rdf.model.*;
 import com.hp.hpl.jena.rdf.model.impl.PropertyImpl;
 import com.hp.hpl.jena.rdf.model.impl.ResourceImpl;
+import com.hp.hpl.jena.sparql.path.Path;
+import com.hp.hpl.jena.sparql.path.PathParser;
 import com.hp.hpl.jena.vocabulary.RDF;
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
@@ -653,6 +655,12 @@ public class WonRdfUtils
       }
     }
 
+    public static String getNeedTitle(Dataset needDataset, URI needUri) {
+      Path titlePath = PathParser.parse("won:hasContent/dc:title", DefaultPrefixUtils.getDefaultPrefixes());
+      String titleString = RdfUtils.getStringPropertyForPropertyPath(needDataset, needUri, titlePath);
+      return titleString;
+    }
+
   }
 
   private static Model createModelWithBaseResource() {
@@ -661,4 +669,5 @@ public class WonRdfUtils
       model.createResource(model.getNsPrefixURI(""));
       return model;
     }
+
 }

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -17,6 +17,8 @@
             <!-- webID verification filter for all message (event) resources -->
             <sec:filter-chain pattern="^/(resource|data|page)/event/.+" filters="
             webIdVerificationFilter"/>
+            <sec:filter-chain pattern="^/(resource|data|page)/need/[a-zA-z0-9]+/deep.*" filters="
+            webIdVerificationFilter"/>
         </sec:filter-chain-map>
     </bean>
     <bean id="webIdVerificationFilter" class="won.cryptography.webid.WebIdVerificationFilter"/>

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -27,6 +27,7 @@ import com.hp.hpl.jena.vocabulary.RDFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.NoSuchMessageException;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
@@ -162,37 +163,56 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   public Dataset getNeedDataset(final URI needUri) throws NoSuchNeedException {
-    Need need = needInformationService.readNeed(needUri);
+  Need need = needInformationService.readNeed(needUri);
 
-    // load the dataset from storage
-    Dataset dataset = rdfStorage.loadDataset(need.getNeedURI());
-    Model metaModel = needModelMapper.toModel(need);
+  // load the dataset from storage
+  Dataset dataset = rdfStorage.loadDataset(need.getNeedURI());
+  Model metaModel = needModelMapper.toModel(need);
 
-    Resource needResource = metaModel.getResource(needUri.toString());
+  Resource needResource = metaModel.getResource(needUri.toString());
 
-    // add connections
-    Resource connectionsContainer = metaModel.createResource(need.getNeedURI().toString() + "/connections/");
-    metaModel.add(metaModel.createStatement(needResource, WON.HAS_CONNECTIONS, connectionsContainer));
+  // add connections
+  Resource connectionsContainer = metaModel.createResource(need.getNeedURI().toString() + "/connections/");
+  metaModel.add(metaModel.createStatement(needResource, WON.HAS_CONNECTIONS, connectionsContainer));
 
-    // add need event container
-    Resource needEventContainer = metaModel.createResource(need.getNeedURI().toString()+"#events", WON.EVENT_CONTAINER);
-    metaModel.add(metaModel.createStatement(needResource, WON.HAS_EVENT_CONTAINER, needEventContainer));
+  // add need event container
+  Resource needEventContainer = metaModel.createResource(need.getNeedURI().toString()+"#events", WON.EVENT_CONTAINER);
+  metaModel.add(metaModel.createStatement(needResource, WON.HAS_EVENT_CONTAINER, needEventContainer));
 
-    // add need event URIs
-    List<MessageEventPlaceholder> messageEvents = messageEventRepository.findByParentURI(needUri);
-    for (MessageEventPlaceholder messageEvent : messageEvents) {
-      metaModel.add(metaModel.createStatement(needEventContainer,
-                                      RDFS.member,
-                                      metaModel.getResource(messageEvent.getMessageURI().toString())));
+  // add need event URIs
+  List<MessageEventPlaceholder> messageEvents = messageEventRepository.findByParentURI(needUri);
+  for (MessageEventPlaceholder messageEvent : messageEvents) {
+    metaModel.add(metaModel.createStatement(needEventContainer,
+                                            RDFS.member,
+                                            metaModel.getResource(messageEvent.getMessageURI().toString())));
+  }
+
+  // add WON node link
+  needResource.addProperty(WON.HAS_WON_NODE, metaModel.createResource(this.resourceURIPrefix));
+
+  // add meta model to dataset
+  String needMetaInformationURI = uriService.createNeedSysInfoGraphURI(needUri).toString();
+  dataset.addNamedModel(needMetaInformationURI, metaModel);
+  addBaseUriAndDefaultPrefixes(dataset);
+  return dataset;
+}
+
+  @Override
+  public Dataset getNeedDataset(final URI needUri, boolean deep, Integer deepLayerSize
+                                ) throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException {
+    Dataset dataset = getNeedDataset(needUri);
+    if (deep) {
+      Slice<URI> slice = needInformationService.listConnectionURIs(needUri, 1, deepLayerSize, null, null);
+      NeedInformationService.PagedResource<Dataset, URI> connectionsResource = toContainerPage(
+        this.uriService.createConnectionsURIForNeed(needUri).toString(), slice);
+      addDeepConnectionData(connectionsResource.getContent(), slice.getContent());
+      RdfUtils.addDatasetToDataset(dataset, connectionsResource.getContent());
+      for (URI connectionUri : slice.getContent()) {
+        NeedInformationService.PagedResource<Dataset,URI> eventsResource = listConnectionEventURIs(
+          connectionUri, 1, deepLayerSize, null, true);
+        RdfUtils.addDatasetToDataset(dataset, eventsResource.getContent());
+      }
     }
-
-    // add WON node link
-    needResource.addProperty(WON.HAS_WON_NODE, metaModel.createResource(this.resourceURIPrefix));
-
-    // add meta model to dataset
-    String needMetaInformationURI = uriService.createNeedSysInfoGraphURI(needUri).toString();
-    dataset.addNamedModel(needMetaInformationURI, metaModel);
-    addBaseUriAndDefaultPrefixes(dataset);
     return dataset;
   }
 
@@ -243,13 +263,14 @@ public class LinkedDataServiceImpl implements LinkedDataService
       Resource blankNodeUriSpec = model.createResource();
       res.addProperty(WON.HAS_URI_PATTERN_SPECIFICATION, blankNodeUriSpec);
       blankNodeUriSpec.addProperty(WON.HAS_NEED_URI_PREFIX,
-        model.createLiteral(this.needResourceURIPrefix));
+                                   model.createLiteral(this.needResourceURIPrefix));
       blankNodeUriSpec.addProperty(WON.HAS_CONNECTION_URI_PREFIX,
                                    model.createLiteral(this.connectionResourceURIPrefix));
       blankNodeUriSpec.addProperty(WON.HAS_EVENT_URI_PREFIX, model.createLiteral(this.eventResourceURIPrefix));
   }
 
-  public Dataset getConnectionDataset(final URI connectionUri, final boolean includeEventData) throws NoSuchConnectionException
+  public Dataset getConnectionDataset(final URI connectionUri, final boolean includeEventContainer) throws
+    NoSuchConnectionException
   {
     Connection connection = needInformationService.readConnection(connectionUri);
 
@@ -268,11 +289,10 @@ public class LinkedDataServiceImpl implements LinkedDataService
     // add WON node link
     connectionResource.addProperty(WON.HAS_WON_NODE, model.createResource(this.resourceURIPrefix));
 
-    if (includeEventData) {
+    if (includeEventContainer) {
       //create event container and attach it to the member
       Resource eventContainer = model.createResource(connection.getConnectionURI().toString()+"/events");
       connectionResource.addProperty(WON.HAS_EVENT_CONTAINER, eventContainer);
-      connectionResource.addProperty(WON.HAS_REMOTE_NEED, model.createResource(connection.getRemoteNeedURI().toString()));
       addAdditionalData(model, connection.getConnectionURI(), connectionResource);
     }
 
@@ -384,6 +404,13 @@ public class LinkedDataServiceImpl implements LinkedDataService
   public Dataset listConnectionEventURIs(final URI connectionUri) throws
     NoSuchConnectionException
   {
+    return  listConnectionEventURIs(connectionUri, false);
+  }
+
+  @Override
+  public Dataset listConnectionEventURIs(final URI connectionUri, boolean deep) throws
+    NoSuchConnectionException
+  {
 
     Model model = ModelFactory.createDefaultModel();
     setNsPrefixes(model);
@@ -393,12 +420,19 @@ public class LinkedDataServiceImpl implements LinkedDataService
                                                    WON.EVENT_CONTAINER);
     // add the events with the new format (only the URI, no content)
     List<MessageEventPlaceholder> connectionEvents = messageEventRepository.findByParentURI(connectionUri);
+    Dataset eventsContainerDataset = newDatasetWithNamedModel(createDataGraphUri(eventContainer), model);
+    addBaseUriAndDefaultPrefixes(eventsContainerDataset);
     for (MessageEventPlaceholder event : connectionEvents) {
       model.add(model.createStatement(eventContainer,
                                       RDFS.member,
                                       model.getResource(event.getMessageURI().toString())));
+      if (deep) {
+        Dataset eventDataset = getDatasetForUri(event.getMessageURI());
+        RdfUtils.addDatasetToDataset(eventsContainerDataset, eventDataset);
+      }
     }
-    return addBaseUriAndDefaultPrefixes(newDatasetWithNamedModel(createDataGraphUri(eventContainer), model));
+
+    return eventsContainerDataset;
   }
 
 
@@ -410,6 +444,23 @@ public class LinkedDataServiceImpl implements LinkedDataService
     Slice<URI> slice = needInformationService.listConnectionEventURIs(connectionUri, pageNum,
                                                                       preferedSize, msgType);
     return toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
+  }
+
+  public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(final URI connectionUri, final int
+    pageNum, Integer preferedSize, WonMessageType msgType, boolean deep) throws
+    NoSuchConnectionException
+  {
+    Slice<URI> slice = needInformationService.listConnectionEventURIs(connectionUri, pageNum,
+                                                                      preferedSize, msgType);
+    NeedInformationService.PagedResource<Dataset,URI> containerPage = toContainerPage(
+      this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
+    if (deep) {
+      for (URI eventUri : slice.getContent()) {
+        Dataset eventDataset = getDatasetForUri(eventUri);
+        RdfUtils.addDatasetToDataset(containerPage.getContent(), eventDataset);
+      }
+    }
+    return containerPage;
   }
 
   @Override
@@ -571,7 +622,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
     //add the connection model for each connection URI
     for (URI connectionURI : connectionURIs) {
       Dataset connectionDataset =
-        getConnectionDataset(connectionURI, false); //do not include event data
+        getConnectionDataset(connectionURI, true);
       RdfUtils.addDatasetToDataset(dataset, connectionDataset);
     }
   }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -140,9 +140,15 @@ public class NeedInformationServiceImpl implements NeedInformationService
   {
     int pageSize = getPageSize(preferedPageSize);
     int pageNum = page - 1;
-    Slice<URI> slice = connectionRepository.getConnectionURIByLatestActivity(
-      timeSpot,
-      new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+    Slice<URI> slice;
+    if (timeSpot == null) {
+      slice = connectionRepository.getConnectionURIByLatestActivity(
+        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+    } else {
+      slice = connectionRepository.getConnectionURIByLatestActivity(
+        timeSpot,
+        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+    }
     return slice;
   }
 
@@ -182,13 +188,19 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     int pageSize = getPageSize(preferedPageSize);
     int pageNum = page - 1;
+    PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)");
     if (messageType == null) {
-      slice = connectionRepository.getConnectionURIByLatestActivity(needURI, timeSpot, new PageRequest(
-        pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+      if (timeSpot == null) {
+        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, pageRequest);
+      } else {
+        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, timeSpot, pageRequest);
+      }
     } else {
-      slice = connectionRepository.getConnectionURIByLatestActivity(
-        needURI, messageType, timeSpot, new PageRequest(
-          pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+      if (timeSpot == null) {
+        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, messageType, pageRequest);
+      } else {
+        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, messageType, timeSpot, pageRequest);
+      }
     }
     return slice;
   }

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -199,30 +199,32 @@ public class WonWebSocketHandler
       return;
     }
 
+    String textMsg = WonRdfUtils.MessageUtils.getTextMessage(wonMessage);
+
     try {
       switch (wonMessage.getMessageType()) {
         case OPEN:
           if (userNeed.isConversations()) {
-            emailSender.sendConversationNotificationMessage(
-              user.getEmail(), "Message", needUri.toString(), wonMessage.getSenderNeedURI().toString());
+            emailSender.sendConversationNotificationHtmlMessage(
+              user.getEmail(), needUri.toString(), wonMessage.getSenderNeedURI().toString(), textMsg);
           }
           return;
         case CONNECTION_MESSAGE:
           if (userNeed.isConversations()) {
-            emailSender.sendConversationNotificationMessage(
-              user.getEmail(), "Message", needUri.toString(), wonMessage.getSenderNeedURI().toString());
+            emailSender.sendConversationNotificationHtmlMessage(
+              user.getEmail(), needUri.toString(), wonMessage.getSenderNeedURI().toString(), textMsg);
           }
           return;
         case CONNECT:
           if (userNeed.isRequests()) {
-            emailSender.sendConversationNotificationMessage(
-              user.getEmail(), "Request", needUri.toString(), wonMessage.getSenderNeedURI().toString());
+            emailSender.sendConnectNotificationHtmlMessage(
+              user.getEmail(), needUri.toString(), wonMessage.getSenderNeedURI().toString(), textMsg);
           }
           return;
         case HINT_MESSAGE:
           if (userNeed.isMatches()) {
             String remoteNeedUri = WonRdfUtils.MessageUtils.toMatch(wonMessage).getToNeed().toString();
-            emailSender.sendHintNotificationMessage(user.getEmail(), needUri.toString(), remoteNeedUri);
+            emailSender.sendHintNotificationMessageHtml(user.getEmail(), needUri.toString(), remoteNeedUri);
           }
           return;
         //TODO close message can be of either type depending of state of the connection...

--- a/webofneeds/won-utils/won-utils-mail/src/main/java/won/utils/mail/WonMailSender.java
+++ b/webofneeds/won-utils/won-utils-mail/src/main/java/won/utils/mail/WonMailSender.java
@@ -1,7 +1,13 @@
 package won.utils.mail;
 
-import org.springframework.mail.MailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.internet.MimeMessage;
 
 /**
  * User: ypanchenko
@@ -10,10 +16,12 @@ import org.springframework.mail.SimpleMailMessage;
 public class WonMailSender
 {
 
-  private MailSender mailSender;
+  private JavaMailSender mailSender;
   private SimpleMailMessage templateMessage;
 
-  public void setMailSender(MailSender mailSender) {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  public void setMailSender(JavaMailSender mailSender) {
     this.mailSender = mailSender;
   }
 
@@ -26,7 +34,26 @@ public class WonMailSender
     msg.setSubject(subject);
     msg.setTo(toEmail);
     msg.setText(text);
-    mailSender.send(msg);
+    try{
+      mailSender.send(msg);
+    } catch (MailException ex) {
+      logger.warn(ex.getMessage());
+    }
+  }
+
+  public void sendHtmlMessage(String toEmail, String subject, String htmlBody) {
+
+    MimeMessage msg = mailSender.createMimeMessage();
+    try{
+      MimeMessageHelper helper = new MimeMessageHelper(msg, true);
+      helper.setFrom(this.templateMessage.getFrom());
+      helper.setSubject(subject);
+      helper.setTo(toEmail);
+      helper.setText(htmlBody, true);
+      mailSender.send(msg);
+    } catch (Exception ex) {
+      logger.warn(ex.getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
Implemented #444 in a following way:

extended with connections and events need data is accessed via separate URL, - need resource URI plus 'deep' path fragment. Optionally, so that limited number of events and connections are returned, one can specify the size of the connections/events layer.

Example URL:
	https://example.com:8443/won/resource/need/1693454629993447400/deep?layer-size=5
This returns need resource description, plus 5 (latest by their events) connections resource descriptions, plus for each connection 5 latest events resource descriptions.
	
From the Owner client-side the requests should be done via the owner server linked data bridge (because of the webid proving - the need deep data includes confidential events data), for example:

https://example.com:8443/owner/rest/linked-data/?uri=https://example.com:8443/won/resource/need/1693454629993447400/deep?layer-size=5&requester=https://example.com:8443/won/resource/need/1693454629993447400