### PR TITLE
Feat deepld clientside

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -47,7 +47,6 @@ export function accountLogin(username, password) {
                 dispatch(actionCreators.messages__requestWsReset_Hack());
                 dispatch(actionCreators.load()); //TODO should be part of the login if only called together
                 dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
-                //dispatch(actionCreators.posts__load());
                 dispatch(actionCreators.router__stateGo("feed"));
             }
         ).catch(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -81,7 +81,7 @@ export function configInit() {
                 const defaultNodeUri = `${location.protocol}://${location.host}/won/resource`;
                 console.info(
                     'Failed to fetch default node uri at the relative path `',
-                    relativePathToConfig,
+                    'appConfig/getDefaultWonNodeUri',
                     '` (is the API endpoint there up and reachable?) -> falling back to the default ',
                     defaultNodeUri
                 );
@@ -95,19 +95,18 @@ export function configInit() {
 export function needsFetch(data) {
     return dispatch => {
         const needUris = data.needs;
-        const needLookups = needUris.map(needUri => won.getNeed(needUri));
-        Promise.all(needLookups).then(needs => {
+        const allLoadedPromise = Promise.all(
+            needUris.map(uri =>
+                won.ensureLoaded(uri, uri, deep = true))
+        ).then(() => Promise.all(
+            needUris.map(needUri =>
+                won.getNeed(needUri))
+        )).then(needs => {
             console.log("linked data fetched for needs: ", needs );
             dispatch({ type: actionTypes.needs.fetch, payload: needs });
+            //TODO get rid of this multiple dispatching here (always push looping back into the reducer)
+            dispatch(actionCreators.connections__load(needUris));
         });
-
-        //TODO get rid of this multiple dispatching here (always push looping back into the reducer)
-        dispatch(actionCreators.connections__load(needUris));
-        /*
-         needUris.forEach(needUri => {
-         dispatch(actionCreators.connections__load(needUri));
-         });
-         */
     }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -143,6 +143,8 @@ export function runMessagingAgent(redux) {
         console.error('websocket error: ', e);
         this.close();
     };
+
+    let reconnectAttempts = 0;
     function onClose(e) {
         if(e.wasClean){
             console.log('websocket closed.');
@@ -152,14 +154,20 @@ export function runMessagingAgent(redux) {
         if(unsubscribeWatch && typeof unsubscribeWatch === 'function')
             unsubscribeWatch();
 
-        if (e.code === 1011) {
+        if (e.code === 1011 || reconnectAttempts > 5) {
             console.log('either your session timed out or you encountered an unexpected server condition. \n', e.reason);
+        } else if (reconnectAttempts > 1) {
+            setTimeout(() => {
+                ws = newSock();
+                reconnectAttempts++;
+            }, 2000);
         } else {
             // posting anonymously creates a new session for each post
             // thus we need to reconnect here
             // TODO reconnect only on next message instead of straight away <-- bad idea, prevents push notifications
             // TODO add a delay if first reconnect fails
             ws = newSock();
+            reconnectAttempts++;
         }
     };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -57,7 +57,11 @@ const rdfstore = window.rdfstore;
             requestUri = requestUri + '/deep';
         }
         if (layerSize) {
-            requestUri = requestUri + '&layer-size=' + layerSize;
+            /*
+             * the ? is because this parameter is still part of the`uri`-parameter
+             * that is passed on to the node.
+             */
+            requestUri = requestUri + '?layer-size=' + layerSize;
         }
         if (requesterWebId) {
             requestUri = requestUri + '&requester=' + encodeURIComponent(requesterWebId);


### PR DESCRIPTION
With this all rdf-resources get fetched in one go at page startup. There's only one caveats though: As we don't have the uris of the connections and events from the outset, we can't set their cache-state to pending or lock requests to them. So there's the possibility, that up to 3 request-slots are blocked with unnecessary requests that are subsumed by the deep triple set. We'd need to either lock the whole store or make the locking mechanism aware of our data-structure (so it doesn't lock other needs), to even partially address this.