### PR TITLE
Fix duplicatepredicates

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -473,11 +473,12 @@
     won.reportError = function(message) {
         if (arguments.length == 1) {
             return function(reason) {
-                console.log(message + " reason: " + reason);
+                console.log(message, " reason: ", reason);
             }
-        }
-        return function(reason) {
-            console.log("Error! reason: " + reason);
+        } else {
+            return function (reason) {
+                console.log("Error! reason: ", reason);
+            }
         }
     }
 


### PR DESCRIPTION
Before: when accepting a request then getting chat messages―which causes the connection-rdf to be reloaded―the connection had two triples with the predicate `hasConnectionStates` in the rdfstore which showed up as array in the state. As a result it didn't show up in the messages-tab as it wasn't registered as open.