### PR TITLE
Fix sorting chatmessages

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -181,7 +181,7 @@ const actionHierarchy = {
             //TODO failure: messages.failedConnect
         },
         chatMessage: {
-            success: INJ_DEFAULT,
+            success: messages.successfulChatMessage,
             failure: INJ_DEFAULT
         },
         closeNeed: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -181,8 +181,10 @@ const actionHierarchy = {
             //TODO failure: messages.failedConnect
         },
         chatMessage: {
-            success: messages.successfulChatMessage,
-            failure: INJ_DEFAULT
+            //success: messages.successfulChatMessage,
+            successRemote: INJ_DEFAULT, //2nd successResponse
+            successOwn: INJ_DEFAULT, //1st successResponse
+            failure: INJ_DEFAULT,
         },
         closeNeed: {
             success: messages.successfulCloseNeed,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -65,37 +65,6 @@ export function failedCloseNeed(event) {
     }
 }
 
-export function successfulChatMessage({eventUri, connectionUri}) {
-    return (dispatch, getState) => {
-        // invalidate cache
-        const requesterId = getState().getIn(['connections', connectionUri, 'belongsToNeed']);
-        console.log('successfulChatMessage: ', eventUri, connectionUri);
-        won.invalidateCacheForNewMessage(connectionUri)
-        .then(() =>
-            Promise.all([
-                won.getConnection(connectionUri, requesterId),
-                won.getEventsOfConnection(connectionUri, requesterId)
-            ])
-        ).then( ([connection, events]) => {
-            console.log('successfulChatMessage: ', connection, events);
-
-            dispatch({
-                type: actionTypes.messages.chatMessage.success,
-                payload: {
-                    eventUri,
-                    events,
-                    connectionUri,
-                    connection,
-                }
-            })
-        });
-        // reload connection
-        // dispatch event as it's seen by the owner
-
-    }
-}
-
-
         /*
          hasReceiverNeed: "https://192.168.124.53:8443/won/resource/need/1741189480636743700"
          hasSenderNeed: "https://192.168.124.53:8443/won/resource/need/1741189480636743700"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -65,6 +65,37 @@ export function failedCloseNeed(event) {
     }
 }
 
+export function successfulChatMessage({eventUri, connectionUri}) {
+    return (dispatch, getState) => {
+        // invalidate cache
+        const requesterId = getState().getIn(['connections', connectionUri, 'belongsToNeed']);
+        console.log('successfulChatMessage: ', eventUri, connectionUri);
+        won.invalidateCacheForNewMessage(connectionUri)
+        .then(() =>
+            Promise.all([
+                won.getConnection(connectionUri, requesterId),
+                won.getEventsOfConnection(connectionUri, requesterId)
+            ])
+        ).then( ([connection, events]) => {
+            console.log('successfulChatMessage: ', connection, events);
+
+            dispatch({
+                type: actionTypes.messages.chatMessage.success,
+                payload: {
+                    eventUri,
+                    events,
+                    connectionUri,
+                    connection,
+                }
+            })
+        });
+        // reload connection
+        // dispatch event as it's seen by the owner
+
+    }
+}
+
+
         /*
          hasReceiverNeed: "https://192.168.124.53:8443/won/resource/need/1741189480636743700"
          hasSenderNeed: "https://192.168.124.53:8443/won/resource/need/1741189480636743700"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -4,7 +4,7 @@ import angular from 'angular';
 import Immutable from 'immutable';
 import squareImageModule from './square-image';
 import dynamicTextFieldModule from './dynamic-textfield';
-import { attach } from '../utils.js'
+import { attach, is } from '../utils.js'
 import { actionCreators }  from '../actions/actions';
 import { labels, relativeTime } from '../won-label-utils';
 import { selectAllByConnections, selectOpenConnectionUri } from '../selectors';
@@ -40,7 +40,7 @@ function genComponentConf() {
                         ng-show="message.hasSenderNeed != self.connectionData.getIn(['ownNeed', 'uri'])">
                     </won-square-image>
                     <div class="pm__content__message__content">
-                        <div class="pm__content__message__content__text">{{ message.hasTextMessage }}</div>
+                        <div class="pm__content__message__content__text">{{ message.hasTextMessage }}{{ message.unconfirmed }}</div>
                         <div class="pm__content__message__content__time">{{ message.humanReadableTimestamp }}</div>
                     </div>
             </div>
@@ -127,7 +127,10 @@ function selectChatMessages(state) {
             .filter(event => {
                 if (event.get('hasTextMessage')) return true;
                 else {
-                    const remote = event.get('hasCorrespondingRemoteMessage');
+                    let remote = event.get('hasCorrespondingRemoteMessage');
+                    if(is('String', remote)) {
+                        remote = state.getIn(['events', 'events', remote]);
+                    }
                     return remote && remote.get('hasTextMessage');
                 }
             }).map(event => {
@@ -142,6 +145,24 @@ function selectChatMessages(state) {
             .sort((event1, event2) =>
                 selectTimestamp(event1) - selectTimestamp(event2)
             )
+            /*
+             * sort so the latest, optimistic/unconfirmed
+             * messages are always at the bottom.
+             */
+            .sort((event1, event2) => {
+                const u1 = event1.get('unconfirmed');
+                const u2 = event2.get('unconfirmed');
+
+                if(u1 && !u2) {
+                  return 1;
+                }
+                else if (!u1 && u2) {
+                    return -1;
+                }
+                else {
+                    return 0;
+                }
+            })
 
             /* add a nice relative timestamp */
             .map(event => event.set(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -40,8 +40,19 @@ function genComponentConf() {
                         ng-show="message.hasSenderNeed != self.connectionData.getIn(['ownNeed', 'uri'])">
                     </won-square-image>
                     <div class="pm__content__message__content">
-                        <div class="pm__content__message__content__text">{{ message.hasTextMessage }}{{ message.unconfirmed }}</div>
-                        <div class="pm__content__message__content__time">{{ message.humanReadableTimestamp }}</div>
+                        <div class="pm__content__message__content__text">
+                            {{ message.hasTextMessage }}
+                        </div>
+                        <div
+                            ng-show="message.unconfirmed"
+                            class="pm__content__message__content__time">
+                                Pending‥
+                        </div>
+                        <div
+                            ng-hide="message.unconfirmed"
+                            class="pm__content__message__content__time">
+                                {{ message.humanReadableTimestamp }}
+                        </div>
                     </div>
             </div>
         </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -67,6 +67,7 @@ function genComponentConf() {
                 const connectionUri = selectOpenConnectionUri(state);
                 const chatMessages = selectChatMessages(state);
                 return {
+                    lastUpdateTime: state.get('lastUpdateTime'),
                     connectionData: selectAllByConnections(state).get(connectionUri),
                     chatMessages: chatMessages && chatMessages.toJS(), //toJS needed as ng-repeat won't work otherwise :|
                     state4dbg: state,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -133,12 +133,16 @@ export function runMessagingAgent(redux) {
                     case won.WONMSG.connectionMessageCompacted:
                         var eventUri = msgFromSystem.isRemoteResponseTo || msgFromSystem.isResponseTo;
                         var connectionUri = msgFromSystem.hasReceiver;
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted
-                            && msgFromSystem.isRemoteResponseTo) {
-                                // got the second success-response (from the remote-node)
-                                redux.dispatch(actionCreators.messages__chatMessage__success({eventUri, connectionUri}));
+                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted) {
+                            if (msgFromSystem.isRemoteResponseTo) {
+                                // got the second success-response (from the remote-node) - 2nd ACK
+                                redux.dispatch(actionCreators.messages__chatMessage__successRemote({ events }));
+                            } else {
+                                // got the first success-response (from our own node) - 1st ACK
+                                redux.dispatch(actionCreators.messages__chatMessage__successOwn({ events }));
+                            }
                         } else if(msgFromSystem.hasMessageType === won.WONMSG.failureResponseCompacted) {
-                            redux.dispatch(actionCreators.messages__chatMessage__failure({ eventUri, connectionUri }));
+                            redux.dispatch(actionCreators.messages__chatMessage__failure({ events }));
                         }
                         break;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -35,18 +35,14 @@ export default function(connections = initialState, action = {}) {
             }
 
         case actionTypes.messages.connect.success:
-            var eventUri = action.payload.uri;
             var connectionUri = action.payload.hasReceiver;
-            return connections
+            return storeEventUris(connections, connectionUri, [action.payload.uri])
                 .setIn([connectionUri, 'hasConnectionState'], won.WON.RequestSent)
-                .updateIn([connectionUri, 'hasEvents'], events => events.add(eventUri));
 
         case actionTypes.messages.close.success:
-            var eventUri = action.payload.uri;
             var connectionUri = action.payload.hasReceiver;
-            return connections
-                .setIn([connectionUri, 'hasConnectionState'], won.WON.Closed)
-                .updateIn([connectionUri, 'hasEvents'], events => events.add(eventUri));
+            return storeEventUris(connections, connectionUri, [action.payload.uri])
+                .setIn([connectionUri, 'hasConnectionState'], won.WON.Closed);
 
         case actionTypes.connections.sendChatMessage:
             var eventUri = action.payload.eventUri;
@@ -66,10 +62,20 @@ export default function(connections = initialState, action = {}) {
                 eventUris => eventUris.remove(action.payload.eventUri)
             );
 
-        case actionTypes.messages.chatMessage.success:
-            var updatedConnection = Immutable.fromJS(action.payload.connection);
-            var connectionUri = updatedConnection.get('uri');
-            return state.mergeDeepIn([connectionUri], updatedConnection);
+        case actionTypes.messages.chatMessage.successOwn:
+            var msgFromOwner = action.payload.events['msg:FromSystem'];
+            var connectionUri = msgFromOwner.hasReceiver;
+            return storeEventUris(connections, connectionUri, [msgFromOwner.uri]);
+
+        case actionTypes.messages.chatMessage.successRemote:
+            var eventOnOwnNode = action.payload.events['msg:FromExternal'];
+            var msgFromOwner = action.payload.events['msg:FromSystem'];
+            var connectionUri = msgFromOwner.hasReceiver;
+            return storeEventUris(
+                connections,
+                connectionUri,
+                [msgFromOwner.uri, eventOnOwnNode.uri]
+            );
 
         case actionTypes.messages.connectionMessageReceived:
         case actionTypes.messages.connectMessageReceived:
@@ -83,6 +89,15 @@ export default function(connections = initialState, action = {}) {
             return connections;
     }
 }
+
+function storeEventUris(connections, connectionUri, eventUris) {
+    return connections.updateIn(
+        [connectionUri, 'hasEvents'],
+        events => events.merge(eventUris)
+    );
+}
+
+
 function storeConnectionAndRelatedData(state, connectionWithRelatedData) {
     console.log("STORING CONNECTION AND RELATED DATA");
     console.log(connectionWithRelatedData);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -61,10 +61,15 @@ export default function(connections = initialState, action = {}) {
                 connections);
 
         case actionTypes.messages.chatMessage.failure:
-            return state.updateIn(
-                ['connections', action.payload.connectionUri, 'hasEvents'],
+            return connections.updateIn(
+                [action.payload.connectionUri, 'hasEvents'],
                 eventUris => eventUris.remove(action.payload.eventUri)
             );
+
+        case actionTypes.messages.chatMessage.success:
+            var updatedConnection = Immutable.fromJS(action.payload.connection);
+            var connectionUri = updatedConnection.get('uri');
+            return state.mergeDeepIn([connectionUri], updatedConnection);
 
         case actionTypes.messages.connectionMessageReceived:
         case actionTypes.messages.connectMessageReceived:


### PR DESCRIPTION
With this patch all chat-messages should use the owner-server's timestamps and thus sort correctly. as As @quasarchimaere suggested, pending messages now have a boolean flag, that allows displaying them at the very bottom.

See extended chat-messages for more information.