### PR TITLE
Refac login and pageload

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -15,13 +15,13 @@
 	<http pattern="/style" security="none"/>
 	<http auto-config="true" use-expressions="true" entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint">
         <intercept-url pattern="/msg" access="isAnonymous()"/>
-        <intercept-url pattern="/rest/users/" access="isAnonymous()"/>
+        <intercept-url pattern="/rest/users/" access="permitAll()"/>
         <intercept-url pattern="/rest/users/private" access="isAnonymous()"/>
         <intercept-url pattern="/rest/users/ping/" access="permitAll()"/>
-		<intercept-url pattern="/rest/users/signout" access="isAuthenticated()"/>
+		<intercept-url pattern="/rest/users/signout" access="permitAll()"/>
         <intercept-url pattern="/rest/users/isSignedIn" access="permitAll()"/>
         <intercept-url pattern="/rest/users/isSignedInRole" access="permitAll()"/>
-        <intercept-url pattern="/rest/users/signin" access="isAnonymous()"/>
+        <intercept-url pattern="/rest/users/signin" access="permitAll()"/>
         <intercept-url pattern="/rest/users/email" access="isAuthenticated()"/>
         <intercept-url pattern="/rest/users/settings" access="isAuthenticated()"/>
         <intercept-url pattern="/rest/needs/drafts/*" access="hasRole('ROLE_ACCOUNT')"/>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -34,14 +34,16 @@ export function accountLogin(username, password) {
             })
         )
         .then(() => {
-            dispatch(actionCreators.user__loggedIn({loggedIn: true, email: username}));
             dispatch(actionCreators.messages__requestWsReset_Hack());
             dispatch(actionCreators.router__stateGo("feed"));
         })
         .catch(error => {
             //TODO load data of non-owned need!!!
-            dispatch(actionCreators.user__loggedIn({loggedIn: false}));
-            dispatch(actionCreators.user__loginFailed({loginError: "No such username/password combination registered."}))
+            dispatch({
+                type: actionTypes.login,
+                payload: Immutable.fromJS({loggedIn: false})
+            })
+            dispatch(actionCreators.loginFailed({loginError: "No such username/password combination registered."}))
         })
 }
 
@@ -58,20 +60,20 @@ export function accountLogout() {
         }).then(checkHttpStatus)
         .then(response => {
             return response.json()
-        }).then(
-            data => {
+        }).then(data =>
+            dispatch({
+                type: actionTypes.logout,
+                payload: Immutable.fromJS({loggedIn: false})
+            })
+        )
+        .then(() => {
             dispatch(actionCreators.messages__requestWsReset_Hack());
-            dispatch(actionCreators.user__loggedIn({loggedIn: false}));
-            dispatch(actionCreators.needs__clean({needs: {}}));
-            dispatch(actionCreators.posts__clean({}));
-            dispatch(actionCreators.connections__reset({}))
             dispatch(actionCreators.router__stateGo("landingpage"));
-        }
-        ).catch(
+        })
+        .catch(
             //TODO: PRINT ERROR MESSAGE AND CHANGE STATE ACCORDINGLY
             error => {
                 console.log(error);
-                dispatch(actionCreators.user__loggedIn({loggedIn: true}))
             }
         )
 }
@@ -98,6 +100,6 @@ export function accountRegister(username, password) {
         ).catch(
             //TODO: PRINT MORE SPECIFIC ERROR MESSAGE, already registered/password to short etc.
                 error =>
-                    dispatch(actionCreators.user__registerFailed({registerError: "Registration failed"}))
+                    dispatch(actionCreators.registerFailed({registerError: "Registration failed"}))
         )
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -4,7 +4,7 @@
 
 import  won from '../won-es6';
 import { actionTypes, actionCreators } from './actions';
-import { load } from './load-action';
+import { fetchDataForOwnedNeeds } from '../won-message-utils';
 
 import {
     checkHttpStatus,
@@ -25,7 +25,7 @@ export function accountLogin(username, password) {
             return response.json()
         })
         .then( data =>
-            load(true, username)
+            fetchDataForOwnedNeeds(username)
         )
         .then(allThatData =>
             dispatch({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -20,11 +20,11 @@ export function accountLogin(username, password) {
             },
             credentials: 'include',
             body: JSON.stringify({username: username, password: password})
-        }).then(checkHttpStatus)
-        .then(response => {
-            return response.json()
         })
-        .then( data =>
+        .then(
+            checkHttpStatus
+        )
+        .then( response =>
             fetchDataForOwnedNeeds(username)
         )
         .then(allThatData =>
@@ -57,10 +57,11 @@ export function accountLogout() {
             },
             credentials: 'include',
             body: JSON.stringify({})
-        }).then(checkHttpStatus)
-        .then(response => {
-            return response.json()
-        }).then(data =>
+        })
+        .then(
+            checkHttpStatus
+        )
+        .then(response =>
             dispatch({
                 type: actionTypes.logout,
                 payload: Immutable.fromJS({loggedIn: false})
@@ -92,11 +93,8 @@ export function accountRegister(username, password) {
         .then(
             checkHttpStatus
         )
-        .then(response =>
-            response.json()
-        )
         .then(
-                data => {
+                response => {
                     /* TODO shouldn't we already have a valid
                     * session at this point and thus just need
                     * to execute the data-fetching part of login

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -3,6 +3,7 @@
  */
 
 import  won from '../won-es6';
+import Immutable from 'immutable';
 import { actionTypes, actionCreators } from './actions';
 import { fetchDataForOwnedNeeds } from '../won-message-utils';
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -18,7 +18,7 @@ export function accountVerifyLogin() {
             .then(data => {
                 dispatch(actionCreators.user__loggedIn({loggedIn: true, email: data.username}));
                 dispatch(actionCreators.load()); //TODO should be part of the login if only called together
-                dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
+                //dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
             })
             /* handle: not-logged-in */
             .catch(error =>
@@ -46,7 +46,7 @@ export function accountLogin(username, password) {
                 dispatch(actionCreators.user__loggedIn({loggedIn: true, email: username}));
                 dispatch(actionCreators.messages__requestWsReset_Hack());
                 dispatch(actionCreators.load()); //TODO should be part of the login if only called together
-                dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
+                //dispatch(actionCreators.retrieveNeedUris());//TODO deprecated.
                 dispatch(actionCreators.router__stateGo("feed"));
             }
         ).catch(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -88,16 +88,25 @@ export function accountRegister(username, password) {
             },
             credentials: 'include',
             body: JSON.stringify({username: username, password: password})
-        }).then(checkHttpStatus)
-            .then(response => {
-                return response.json()
-            }).then(
+        })
+        .then(
+            checkHttpStatus
+        )
+        .then(response =>
+            response.json()
+        )
+        .then(
                 data => {
-                dispatch(actionCreators.login(username, password))
-                /*                    dispatch(actionCreators.user__loggedIn({loggedIn: true, email: username}));
-                 dispatch(actionCreators.router__stateGo("createNeed"));*/
-            }
-        ).catch(
+                    /* TODO shouldn't we already have a valid
+                    * session at this point and thus just need
+                    * to execute the data-fetching part of login
+                    * (the fetchDataForOwnedNeeds, redirect
+                    * and wsReset)
+                    */
+                    dispatch(actionCreators.login(username, password));
+                }
+            )
+        .catch(
             //TODO: PRINT MORE SPECIFIC ERROR MESSAGE, already registered/password to short etc.
                 error =>
                     dispatch(actionCreators.registerFailed({registerError: "Registration failed"}))

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -43,7 +43,7 @@ export function accountLogin(username, password) {
                 type: actionTypes.login,
                 payload: Immutable.fromJS({loggedIn: false})
             })
-            dispatch(actionCreators.loginFailed({loginError: "No such username/password combination registered."}))
+            dispatch(actionCreators.loginFailed({loginError: "No such username/password combination registered.", error}))
         })
 }
 
@@ -107,6 +107,6 @@ export function accountRegister(username, password) {
         .catch(
             //TODO: PRINT MORE SPECIFIC ERROR MESSAGE, already registered/password to short etc.
                 error =>
-                    dispatch(actionCreators.registerFailed({registerError: "Registration failed"}))
+                    dispatch(actionCreators.registerFailed({registerError: "Registration failed", error}))
         )
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -80,7 +80,7 @@ import {
 
 import * as messages from './messages-actions';
 
-import { loadAction, retrieveNeedUris, configInit, needsFetch } from './load-action';
+import { loadAction, configInit } from './load-action';
 import { matchesLoad } from './matches-actions';
 import { stateGo, stateReload, stateTransitionTo } from 'redux-ui-router';
 
@@ -119,7 +119,6 @@ const actionHierarchy = {
         reset:INJ_DEFAULT,
     },
     needs: {
-        fetch: needsFetch,
         received: INJ_DEFAULT,
         connectionsReceived:INJ_DEFAULT,
         clean:INJ_DEFAULT,
@@ -206,7 +205,6 @@ const actionHierarchy = {
     login: accountLogin,
     logout: accountLogout,
     register: accountRegister,
-    retrieveNeedUris: retrieveNeedUris,
     config: {
         init: configInit,
         update: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -96,11 +96,6 @@ import { stateGo, stateReload, stateTransitionTo } from 'redux-ui-router';
 const INJ_DEFAULT = 'INJECT_DEFAULT_ACTION_CREATOR';
 const actionHierarchy = {
     initialPageLoad: pageLoadAction,
-    user: {
-        loggedIn: INJ_DEFAULT,
-        loginFailed: INJ_DEFAULT,
-        registerFailed: INJ_DEFAULT
-    },
     events:{
         addUnreadEventUri:INJ_DEFAULT,
         read:INJ_DEFAULT
@@ -203,10 +198,11 @@ const actionHierarchy = {
          */
         requestWsReset_Hack: INJ_DEFAULT,
     },
-    verifyLogin: accountVerifyLogin,
     login: accountLogin,
     logout: accountLogout,
     register: accountRegister,
+    loginFailed: INJ_DEFAULT,
+    registerFailed: INJ_DEFAULT,
     config: {
         init: configInit,
         update: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -65,7 +65,6 @@ import {
     accountLogin,
     accountLogout,
     accountRegister,
-    accountVerifyLogin
 } from './account-actions';
 
 import {
@@ -80,7 +79,10 @@ import {
 
 import * as messages from './messages-actions';
 
-import { loadAction, configInit } from './load-action';
+import {
+    configInit,
+    pageLoadAction
+} from './load-action';
 import { matchesLoad } from './matches-actions';
 import { stateGo, stateReload, stateTransitionTo } from 'redux-ui-router';
 
@@ -93,7 +95,7 @@ import { stateGo, stateReload, stateTransitionTo } from 'redux-ui-router';
  */
 const INJ_DEFAULT = 'INJECT_DEFAULT_ACTION_CREATOR';
 const actionHierarchy = {
-    load: loadAction, /* triggered on pageload to cause initial crawling of linked-data and other startup tasks*/
+    initialPageLoad: pageLoadAction,
     user: {
         loggedIn: INJ_DEFAULT,
         loginFailed: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -33,10 +33,13 @@ export const loadAction = () => dispatch => {
             fetchAllAccessibleAndRelevantData(needUris))
     .then(allThatData =>
             Immutable.fromJS(allThatData)) //!!!
-    .then(allThatData =>
-            dispatch({type: actionTypes.load, payload: allThatData}))
+    .then(allThatData => {
+            dispatch({type: actionTypes.load, payload: allThatData})
+            //dispatch({ type: actionTypes.needs.fetch, payload: needs });
+    })
     .catch(error => dispatch(actionCreators.needs__failed({
-                error: "user needlist retrieval failed"
+                error: "user needlist retrieval failed",
+                e: error
             })
         )
     );
@@ -44,26 +47,6 @@ export const loadAction = () => dispatch => {
 
 
 /////////// THE ACTIONCREATORS BELOW SHOULD BE PART OF LOAD
-
-export function retrieveNeedUris() {
-    return (dispatch) => {
-        fetch('/owner/rest/needs/', {
-            method: 'get',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            credentials: 'include'
-        }).then(checkHttpStatus)
-            .then(response => {
-                return response.json()
-            }).then(
-                needs => dispatch(actionCreators.needs__fetch({needs: needs}))
-        ).catch(
-                error => dispatch(actionCreators.needs__failed({error: "user needlist retrieval failed"}))
-        )
-    }
-}
 
 /**
  * Anything that is load-once, read-only, global app-config
@@ -90,23 +73,5 @@ export function configInit() {
             .then(defaultNodeUri =>
                 dispatch(actionCreators.config__update({defaultNodeUri}))
         )
-}
-
-export function needsFetch(data) {
-    return dispatch => {
-        const needUris = data.needs;
-        const allLoadedPromise = Promise.all(
-            needUris.map(uri =>
-                won.ensureLoaded(uri, uri, deep = true))
-        ).then(() => Promise.all(
-            needUris.map(needUri =>
-                won.getNeed(needUri))
-        )).then(needs => {
-            console.log("linked data fetched for needs: ", needs );
-            dispatch({ type: actionTypes.needs.fetch, payload: needs });
-            //TODO get rid of this multiple dispatching here (always push looping back into the reducer)
-            dispatch(actionCreators.connections__load(needUris));
-        });
-    }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -25,10 +25,9 @@ export const pageLoadAction = () => dispatch => {
     .then(checkHttpStatus)
     .then(resp => resp.json())
     /* handle data, dispatch actions */
-    .then(data => {
-        dispatch(actionCreators.user__loggedIn({loggedIn: true, email: data.username}));
-        return load(dispatch, true, data.username);
-    })
+    .then(data =>
+        load(true, data.username)
+    )
     .then(allThatData =>
         dispatch({
             type: actionTypes.initialPageLoad,
@@ -38,7 +37,10 @@ export const pageLoadAction = () => dispatch => {
     /* handle: not-logged-in */
     .catch(error =>
         //TODO load data of non-owned need!!!
-        dispatch(actionCreators.user__loggedIn({loggedIn: false}))
+        dispatch({
+            type: actionTypes.initialPageLoad,
+            payload: Immutable.fromJS({loggedIn: false})
+        })
     )
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -14,7 +14,7 @@ import {
     urisToLookupMap
 } from '../utils';
 
-import { fetchAllAccessibleAndRelevantData } from '../won-message-utils';
+import { fetchDataForOwnedNeeds } from '../won-message-utils';
 
 export const pageLoadAction = () => dispatch => {
     /* TODO the data fetched here should be baked into
@@ -26,7 +26,7 @@ export const pageLoadAction = () => dispatch => {
     .then(resp => resp.json())
     /* handle data, dispatch actions */
     .then(data =>
-        load(true, data.username)
+        fetchDataForOwnedNeeds(data.username)
     )
     .then(allThatData =>
         dispatch({
@@ -44,32 +44,6 @@ export const pageLoadAction = () => dispatch => {
     )
 }
 
-export function load(loggedIn, email) {
-    return fetch('/owner/rest/needs/', {
-        method: 'get',
-        headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-        },
-        credentials: 'include'
-    })
-    .then(checkHttpStatus)
-    .then(response =>
-        response.json())
-    .then(needUris =>
-        fetchAllAccessibleAndRelevantData(needUris))
-    .then(allThatData =>
-        Immutable.fromJS(allThatData)) //!!!
-    .then(allThatData => {
-        const payload = allThatData
-            .set('loggedIn', loggedIn)
-            .set('email', email);
-        return payload;
-    })
-    .catch(error => {
-        throw({msg: 'user needlist retrieval failed', error});
-    });
-}
 
 /////////// THE ACTIONCREATORS BELOW SHOULD BE PART OF PAGELOAD
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -20,7 +20,7 @@ import {
     buildRateMessage,
     buildConnectMessage,
     isSuccessMessage,
-    fetchAllAccessibleAndRelevantData
+    fetchDataForOwnedNeeds
 } from '../won-message-utils';
 
 export function successfulCloseNeed(event) {
@@ -55,11 +55,12 @@ export function failedCloseNeed(event) {
             ).then(() =>
                 // as the need and it's connections have been marked dirty
                 // they will be reloaded on this action.
-                fetchAllAccessibleAndRelevantData([needUri])
+                fetchDataForOwnedNeeds([needUri])
+                //fetchAllAccessibleAndRelevantData([needUri])
             ).then(allThatData =>
                 dispatch({
                     type: actionTypes.messages.closeNeed.failed,
-                    payload: Immutable.fromJS(allThatData)
+                    payload: allThatData
                 })
             );
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -126,7 +126,8 @@ app.run([ '$ngRedux', $ngRedux =>
 ]);
 
 //check login status. TODO: this should actually be baked-in data (to avoid the extra roundtrip)
-app.run([ '$ngRedux', $ngRedux => $ngRedux.dispatch(actionCreators.verifyLogin())]);
+//app.run([ '$ngRedux', $ngRedux => $ngRedux.dispatch(actionCreators.verifyLogin())]);
+app.run([ '$ngRedux', $ngRedux => $ngRedux.dispatch(actionCreators.initialPageLoad())]);
 
 /*
  * this action-creator dispatches once per minute thus making

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -8,7 +8,7 @@ import { labels } from '../won-label-utils';
 import { selectUnreadEventsByNeedAndType, selectAllByConnections } from '../selectors';
 import { actionCreators }  from '../actions/actions';
 
-const serviceDependencies = ['$q', '$ngRedux', '$scope'];
+const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
         <nav class="need-tab-bar" ng-cloak ng-show="{{true}}">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -1,23 +1,30 @@
 <!-- TODO parametrize by selected tab -->
 <header>
     <won-topnav></won-topnav>
-    <won-owner-title-bar selection="self.selection">
+    <won-owner-title-bar
+            selection="self.selection"
+            ng-show="self.owningPost">
     </won-owner-title-bar>
+    <won-visitor-title-bar
+            selection="::1"
+            item="self.post"
+            ng-show="!self.owningPost">
+    </won-visitor-title-bar>
 </header>
 <main class="ownerpostcontent">
 
 
     <!-- Post info view when there's no connection-state/-type selected -->
-    <won-post-info ng-show="!self.connectionType"></won-post-info>
+    <won-post-info ng-show="!self.connectionType || !self.owningPost"></won-post-info>
 
     <!-- Matches: -->
-    <won-matches ng-show="self.showMatches"></won-matches>
+    <won-matches ng-show="self.showMatches && self.owningPost"></won-matches>
 
 
     <!-- left column for connection-typed tabs -->
     <won-connection-selection
             class="owner__messages"
-            ng-show="self.showConnectionSelection"
+            ng-show="self.showConnectionSelection && self.owningPost"
             connection-type="self.connectionType"
             selected-connection="::self.openConnection(connectionUri)"
             >
@@ -26,20 +33,26 @@
 
     <!-- right column -->
     <!-- Conversations: -->
-    <div class="post-messages" ng-show="self.showConversationDetails">
-        <div class="post-messages__inner">
-            <won-post-messages></won-post-messages>
-        </div>
+    <div
+        class="post-messages"
+        ng-show="self.showConversationDetails && self.owningPost">
+            <div class="post-messages__inner">
+                <won-post-messages></won-post-messages>
+            </div>
     </div>
 
     <!-- Incoming Requests: -->
-    <div class="post-messages" ng-show="self.showIncomingRequestDetails">
-        <won-open-request></won-open-request>
+    <div
+        class="post-messages"
+        ng-show="self.showIncomingRequestDetails && self.owningPost">
+            <won-open-request></won-open-request>
     </div>
 
     <!-- Sent Requests: -->
-    <div class="post-messages" ng-show="self.showSentRequestDetails">
-        <won-open-request></won-open-request>
+    <div
+        class="post-messages"
+        ng-show="self.showSentRequestDetails && self.owningPost">
+            <won-open-request></won-open-request>
     </div>
 
     <!-- /right column -->

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -49,7 +49,7 @@ class Controller {
             return {
                 postUri: selectOpenPostUri(state),
                 post: selectOpenPost(state),
-                postIsOwned: selectOwningOpenPost(state),
+                owningPost: selectOwningOpenPost(state),
                 connectionUri,
                 connectionType: connectionTypeInParams,
                 showConnectionSelection: !!connectionTypeInParams && connectionTypeInParams !== won.WON.Suggested,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -4,8 +4,13 @@
 ;
 
 import angular from 'angular';
+import { attach, mapToMatches, decodeUriComponentProperly } from '../utils';
+import won from '../won-es6';
 import { labels } from '../won-label-utils';
+import { selectOpenPost } from '../selectors';
+import { actionCreators }  from '../actions/actions';
 
+const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
         <nav class="visitor-title-bar">
@@ -14,10 +19,10 @@ function genComponentConf() {
                     <a ng-click="self.back()">
                         <img src="generated/icon-sprite.svg#ico36_backarrow" class="vtb__icon">
                     </a>
-                    <won-square-image title="self.item.title" src="self.item.titleImgSrc"></won-square-image>
+                    <won-square-image title="self.post.get('title')" src="self.post.get('titleImgSrc')"></won-square-image>
                     <div class="vtb__inner__left__titles">
-                        <h1 class="vtb__title">{{self.item.title}}</h1>
-                        <div class="vtb__inner__left__titles__type">{{self.labels.type[self.item.type]}}, {{self.item.creationDate}} </div>
+                        <h1 class="vtb__title">{{self.post.get('title')}}</h1>
+                        <div class="vtb__inner__left__titles__type">{{self.labels.type[self.post.get('type')]}}, {{self.post.get('creationDate')}} </div>
                     </div>
                 </div>
                 <div class="vtb__inner__right">
@@ -26,7 +31,7 @@ function genComponentConf() {
                         <li ng-class="self.selection == 0? 'vtb__tabs__selected' : ''" ng-click="self.selection = 0">
                         <a ui-sref="postVisitorMsgs({myUri: 'http://example.org/121337345'})">
                             Messages
-                            <span class="vtb__tabs__unread">{{self.item.messages.length}}</span>
+                            <span class="vtb__tabs__unread">{{self.post.get('messages').length}}</span>
                         </a></li>
                         <li ng-class="self.selection == 1? 'vtb__tabs__selected' : ''" ng-click="self.selection = 1">
                         <a ui-sref="postVisitor({myUri: 'http://example.org/121337345'})">
@@ -40,10 +45,18 @@ function genComponentConf() {
 
     class Controller {
         constructor() {
+            attach(this, serviceDependencies, arguments);
             this.labels = labels;
+            window.vtb4dbg = this;
+            const selectFromState = state => ({
+                post: selectOpenPost(state)
+            });
+            const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);
+            this.$scope.$on('$destroy', disconnect);
         }
         back() { window.history.back() }
     }
+    Controller.$inject = serviceDependencies;
 
     return {
         restrict: 'E',

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -14,7 +14,8 @@ const initialState = Immutable.fromJS({});
 export default function(connections = initialState, action = {}) {
     switch(action.type) {
         case actionTypes.messages.closeNeed.failed:
-        case actionTypes.load:
+        case actionTypes.initialPageLoad:
+        case actionTypes.login:
             const allPreviousConnections = action.payload.get('connections');
             return connections.merge(allPreviousConnections);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/connection-reducer.js
@@ -83,7 +83,8 @@ export default function(connections = initialState, action = {}) {
         case actionTypes.messages.hintMessageReceived:
             return storeConnectionAndRelatedData(connections, action.payload);
 
-        case actionTypes.connections.reset:
+        case actionTypes.logout:
+
             return initialState;
 
         default:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -15,7 +15,8 @@ const initialState = Immutable.fromJS({
 export default function(state = initialState, action = {}) {
     switch(action.type) {
 
-        case actionTypes.load:
+        case actionTypes.initialPageLoad:
+        case actionTypes.login:
             const allPreviousEvents = action.payload.get('events');
             return state.mergeIn(['events'], allPreviousEvents);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -26,7 +26,8 @@ export default function(allNeeds = initialState, action = {}) {
             console.log('reducers.js: failed receive needlist action');
             return allNeeds.update('errors', errors => errors.push(action.payload.error));
 
-        case actionTypes.load:
+        case actionTypes.initialPageLoad:
+        case actionTypes.login:
             const ownNeeds = action.payload.get('ownNeeds');
             const theirNeeds = action.payload.get('theirNeeds');
             return allNeeds

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -19,6 +19,7 @@ const initialState = Immutable.fromJS({
 
 export default function(allNeeds = initialState, action = {}) {
     switch(action.type) {
+        case actionTypes.logout:
         case actionTypes.needs.clean:
             return initialState;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/posts-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/posts-reducer.js
@@ -10,34 +10,20 @@ import { buildCreateMessage } from '../won-message-utils';
 const initialState = Immutable.fromJS({
         activePostsView: true,
         closedPostsView: true,
-        posts: []
-
 })
-export default createReducer(
-    initialState,
-    {
-        [actionTypes.posts_overview.openPostsView]:(state, {payload: {activePostsOpen}})=> {
+export default function(state = initialState, action = {}) {
+    switch(action.type) {
+        case actionTypes.posts_overview.openPostsView:
             if (state === 'undefined') {
                 return initialState
             }else{
                 return !Immutable.fromJS(initialState.openPostsView)
             }
-        },
-        [actionTypes.posts.load]: (state, {}) => {
-            //TODO use json-ld for state
-            const dummy=[{id: "121337345", title: "New ffdsalat, need furniture", creationDate: "20.11.2015", type: 1, group: "ux barcamp stuff",state:"active", requests: [{},{},{}], matches: [{},{},{}],messages: [{},{},{}], titleImgSrc: "images/someNeedTitlePic.png"},
-                {id: "121337345", title: "Clean park 1020 Vienna", creationDate: "20.11.1998", type: 4, group: "gaming",state:"active",requests: [{},{},{}], matches: [{},{},{}], messages: [{},{},{}]},
-                {id: "121337345", title: "Car sharing 1020 Vienna", creationDate: "2.3.2001", type: 2, state:"active",requests: [{},{},{}],matches: [{},{},{}],messages: [{},{},{}], titleImgSrc: "images/someNeedTitlePic.png"},
-                {id: "121337345", title: "tutu", creationDate: "7.9.2015", type: 3, group: "sat lunch group",state:"active", requests: [{},{},{}],matches: [{},{},{}],messages: [{},{},{}]},
-                {id: "121337345", title: "Local Artistry", creationDate: "20.11.2005", type: 2,state:"active",requests: [{},{},{}],matches: [{},{},{}],messages: [{},{},{}], titleImgSrc: "images/someNeedTitlePic.png"},
-                {id: "121337345", title: "Cycling Tour de France", creationDate: "1.1.2000", type: 3,state:"inactive",requests: [{},{},{}],matches: [{},{},{}],messages: [{},{},{}]},
-                {id: "121337345", title: "Cycling Tour de France", creationDate: "1.1.2000", type: 3,state:"inactive",requests: [{},{},{}],matches: [{},{},{}],messages: [{},{},{}]}]
 
-            return  state.set('posts', Immutable.fromJS(dummy));
-        },
-        [actionTypes.posts.clean]:(state,{})=>{
+        case actionTypes.logout:
             return Immutable.fromJS(initialState);
-        }
-    }
 
-)
+        default:
+            return state;
+    }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -5,16 +5,17 @@
 import { actionTypes } from '../actions/actions';
 import { repeatVar } from '../utils';
 import Immutable from 'immutable';
-import { createReducer } from 'redux-immutablejs'
+import { createReducer } from 'redux-immutablejs';
 import { combineReducersStable } from '../redux-utils';
 import { draftsReducer } from './drafts-reducer';
-import { messagesReducer } from './message-reducers'
+import { messagesReducer } from './message-reducers';
 import reduceReducers from 'reduce-reducers';
-import postsReducer from './posts-reducer'
-import needReducer from './need-reducer'
-import eventReducer from './event-reducer'
-import matchReducer from './match-reducer'
-import connectionReducer from './connection-reducer'
+import postsReducer from './posts-reducer';
+import needReducer from './need-reducer';
+import eventReducer from './event-reducer';
+import userReducer from './user-reducer';
+import matchReducer from './match-reducer';
+import connectionReducer from './connection-reducer';
 
 /*
  * this reducer attaches a 'router' object to our state that keeps the routing state.
@@ -39,31 +40,7 @@ const reducers = {
     connections:connectionReducer,
     drafts: draftsReducer,
     events: eventReducer,
-    user: createReducer(
-        //initial state
-        Immutable.Map(),
-
-        //handlers
-        {
-            [actionTypes.user.loggedIn]: (state, {payload: {loggedIn, email}}) => {
-                if(loggedIn == true){
-                    console.log('reducers.js: received successful-login action from app-server');
-                    return Immutable.fromJS({loggedIn: true, email: email});
-                }else{
-                    console.log('reducers.js: received notlogged in action from app-server');
-                    return Immutable.fromJS({loggedIn: false});
-                }
-            },
-            [actionTypes.user.loginFailed]: (state, {payload: {loginError}}) => {
-                console.log('reducers.js: received UNsuccessful-login action from app-server');
-                return Immutable.fromJS({loginError: loginError});
-            },
-            [actionTypes.user.registerFailed]: (state, {payload: {registerError}}) => {
-                console.log('reducers.js: received UNsuccessful-login action from app-server');
-                return Immutable.fromJS({registerError: registerError});
-            }
-        }
-    ),
+    user: userReducer,
     needs:needReducer,
     matches: matchReducer,
     postOverview:postsReducer,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
@@ -13,7 +13,6 @@ const initialState = Immutable.fromJS({});
 
 export default function(userData = initialState, action = {}) {
     switch(action.type) {
-        case actionTypes.user.loggedIn:
         case actionTypes.initialPageLoad:
         case actionTypes.login:
 
@@ -30,12 +29,14 @@ export default function(userData = initialState, action = {}) {
                 console.log('reducers.js: received notlogged in action from app-server');
                 return Immutable.fromJS({loggedIn: false});
             }
+        case actionTypes.logout:
+            return Immutable.fromJS({loggedIn: false});
 
-        case actionTypes.user.loginFailed:
+        case actionTypes.loginFailed:
             console.log('reducers.js: received UNsuccessful-login action from app-server');
             return Immutable.fromJS({loginError: action.payload.loginError});
 
-        case actionTypes.user.registerFailed:
+        case actionTypes.registerFailed:
             console.log('reducers.js: received UNsuccessful-login action from app-server');
             return Immutable.fromJS({registerError: action.payload.registerError});
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
@@ -14,7 +14,15 @@ const initialState = Immutable.fromJS({});
 export default function(userData = initialState, action = {}) {
     switch(action.type) {
         case actionTypes.user.loggedIn:
-            var {loggedIn, email} = action.payload
+        case actionTypes.initialPageLoad:
+        case actionTypes.login:
+
+            //because we get payload as immutablejs-map sometimes but not always
+            var immutablePayload = Immutable.fromJS(action.payload);
+
+            var loggedIn = immutablePayload.get('loggedIn');
+            var email = immutablePayload.get('email');
+
             if(loggedIn == true){
                 console.log('reducers.js: received successful-login action from app-server');
                 return Immutable.fromJS({loggedIn: true, email: email});

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
@@ -1,0 +1,37 @@
+/**
+ * Created by ksinger on 10.05.2016.
+ */
+import { actionTypes } from '../actions/actions';
+import { repeatVar } from '../utils';
+import Immutable from 'immutable';
+import { createReducer } from 'redux-immutablejs'
+import { combineReducersStable } from '../redux-utils';
+import { buildCreateMessage } from '../won-message-utils';
+import won from '../won-es6';
+
+const initialState = Immutable.fromJS({});
+
+export default function(userData = initialState, action = {}) {
+    switch(action.type) {
+        case actionTypes.user.loggedIn:
+            var {loggedIn, email} = action.payload
+            if(loggedIn == true){
+                console.log('reducers.js: received successful-login action from app-server');
+                return Immutable.fromJS({loggedIn: true, email: email});
+            }else{
+                console.log('reducers.js: received notlogged in action from app-server');
+                return Immutable.fromJS({loggedIn: false});
+            }
+
+        case actionTypes.user.loginFailed:
+            console.log('reducers.js: received UNsuccessful-login action from app-server');
+            return Immutable.fromJS({loginError: action.payload.loginError});
+
+        case actionTypes.user.registerFailed:
+            console.log('reducers.js: received UNsuccessful-login action from app-server');
+            return Immutable.fromJS({registerError: action.payload.registerError});
+
+        default:
+            return userData;
+    }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -436,7 +436,7 @@ export function mapObj(obj, f) {
 export function flatten(listOfLists) {
     return listOfLists.reduce(
         (flattendList, innerList) =>
-            flattendList.concat(innerList),
+            innerList? flattendList.concat(innerList) : [], //not concatenating `undefined`s
         [] //concat onto empty list as start
     )
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -465,7 +465,12 @@ export function flattenObj(objOfObj) {
 export function urisToLookupMap(uris, asyncLookupFunction) {
     //make sure we have an array and not a single uri.
     const urisAsArray = is('Array', uris) ? uris : [uris];
-    const asyncLookups = urisAsArray.map(uri => asyncLookupFunction(uri));
+    const asyncLookups = urisAsArray.map(uri =>
+        asyncLookupFunction(uri)
+        .catch(error => {
+            throw({msg: `failed lookup for ${uri} in utils.js:urisToLookupMap`, error, urisAsArray, uris})
+        })
+    );
     return Promise.all(asyncLookups).then( dataObjects => {
         const lookupMap = {};
         //make sure there's the same

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -3,6 +3,8 @@
  */
 
 
+import won from './won-es6';
+import Immutable from 'immutable';
 import {
     getRandomPosInt,
     checkHttpStatus,
@@ -11,8 +13,8 @@ import {
     flattenObj,
     flatten,
     entries,
+    is,
 } from './utils';
-import won from './won-es6';
 
 import jsonld from 'jsonld';
 window.jsonld4Dbg = jsonld;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -380,6 +380,14 @@ function fetchOwnedNeedUris() {
 
 window.fetchAll4dbg = fetchAllAccessibleAndRelevantData;
 function fetchAllAccessibleAndRelevantData(ownNeedUris) {
+    if(!is('Array', ownNeedUris) || ownNeedUris.length === 0 ) {
+        return Immutable.fromJS({
+            ownNeeds: {},
+            connections: {},
+            events: {},
+            theirNeeds: {},
+        });
+    }
 
     const allLoadedPromise = Promise.all(
         ownNeedUris.map(uri => won.ensureLoaded(uri, uri, deep = true))

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -9,6 +9,8 @@ import {
     mapJoin,
     urisToLookupMap,
     flattenObj,
+    flatten,
+    entries,
 } from './utils';
 import won from './won-es6';
 
@@ -347,11 +349,11 @@ export function fetchAllAccessibleAndRelevantData(ownNeedUris) {
                     flatten(connectionUrisPerNeed));
 
         const allConnectionsPromise = allConnectionUrisPromise
-            .then(connectionUris =>
+            .then(connectionUris => //delivers an obj<idx, string>
                 urisToLookupMap(connectionUris, won.getConnection));
 
         const allEventsPromise = allConnectionUrisPromise
-            .then(connectionUris =>
+            .then(connectionUris => //expects an array
                 urisToLookupMap(connectionUris, connectionUri =>
                         won.getConnection(connectionUri)
                             .then(connection =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -339,7 +339,7 @@ export function fetchDataForOwnedNeeds(emailOrNeedUris) {
     if(is('Array', emailOrNeedUris)) {
         email = undefined;
         needUrisPromise = Promise.resolve(emailOrNeedUris);
-    } else if (is('Array', emailOrNeedUris)) {
+    } else if (is('String', emailOrNeedUris)) {
         email = emailOrNeedUris;
         needUrisPromise = fetchOwnedNeedUris();
     } else {


### PR DESCRIPTION
Merge #529 first

Turns out our action-creators for login, page-load, etc were calling and being called by other action-creators in a slightly confusing mess. Also there was a distinct action dispatched for every reducer. The mess should be untangled via this branch and redundancies removed―there's one action-creator for login and one for page-load now. They get called directly, fetch all relevant data and dispatch one main action that carries the data. 

Without this, we would have needed to load need for the visitors-view at multiple places, adding even more complexity to the call-graph.