### PR TITLE
@ld-bridge: filtering out responses that would have been a huge same-origin security leak

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/rest/RDFMediaType.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/RDFMediaType.java
@@ -18,6 +18,12 @@ package won.protocol.rest;
 
 import org.springframework.http.MediaType;
 
+import javax.print.attribute.standard.Media;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * User: fkleedorfer
  * Date: 28.11.12
@@ -32,4 +38,28 @@ public class RDFMediaType
   public static final MediaType APPLICATION_TRIG = new MediaType("application", "trig");
   public static final MediaType APPLICATION_JSONLD = new MediaType("application", "ld+json");
   public static final MediaType APPLICATION_NQUADS = new MediaType("application", "n-quads");
+
+
+  public static final Set<MediaType> rdfMediaTypes;
+  static {
+
+    HashSet<MediaType> types = new HashSet<MediaType>(
+      Arrays.asList(new MediaType[]{
+        TEXT_TURTLE,
+        APPLICATION_RDF_XML,
+        APPLICATION_X_TURTLE,
+        TEXT_RDF_N3,
+        APPLICATION_JSON,
+        APPLICATION_TRIG,
+        APPLICATION_JSONLD,
+        APPLICATION_NQUADS
+      })
+    );
+    rdfMediaTypes = Collections.unmodifiableSet(types);
+
+  }
+
+  public static boolean isRDFMediaType(MediaType mediaType) {
+      return rdfMediaTypes.contains(mediaType);
+  }
 }


### PR DESCRIPTION
At the linked data bridge: if you get a link like  <https://www.matchat.org/owner/rest/linked-data/?uri=http:%2F%2Fevil.com%2F> the server would just pass through the html and any javascript contained therein, thus undermining any protection against cross-origin requests. If you'd click such a link, an attacker could hijack your session.