### PR TITLE
Fix visitorsviewloading + simple access managment

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -138,7 +138,8 @@ const actionHierarchy = {
     router: {
         stateGo,
         stateReload,
-        stateTransitionTo
+        stateTransitionTo,
+        accessedNonLoadedPost: INJ_DEFAULT, //dispatched in configRouting.js
     },
     posts:{
         load:INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -139,6 +139,7 @@ const actionHierarchy = {
         stateGo,
         stateReload,
         stateTransitionTo,
+        back: stateBack,
         accessedNonLoadedPost: INJ_DEFAULT, //dispatched in configRouting.js
     },
     posts:{
@@ -370,5 +371,22 @@ export function needsClose(needUri) {
             // go back to overview
             dispatch(actionCreators.router__stateGo('overviewPosts'))
         )
+    }
+}
+
+/**
+ * Action-Creator that goes back in the browser history
+ * without leaving the app.
+ * @param dispatch
+ * @param getState
+ */
+function stateBack() {
+    return (dispatch, getState) => {
+        const hasPreviousState = !!getState().getIn(['router', 'prevState', 'name']);
+        if (hasPreviousState) {
+            history.back();
+        } else {
+            dispatch(actionCreators.router__stateGo('landingpage'));
+        }
     }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -56,6 +56,11 @@ function loadingWhileSignedOut(dispatch, getState) {
                     payload: publicData
                 })
         );
+    } else {
+        dispatch({
+            type: actionTypes.initialPageLoad,
+            payload: Immutable.Map()
+        })
     }
 
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -3,9 +3,9 @@
  */
 
 import  won from '../won-es6';
-import { actionTypes, actionCreators } from './actions';
 import Immutable from 'immutable';
-import { selectOpenPostUri } from '../selectors';
+import { actionTypes, actionCreators } from './actions';
+import { selectOpenPostUri, selectOpenPost } from '../selectors';
 
 import {
     checkHttpStatus,
@@ -24,31 +24,40 @@ export const pageLoadAction = () => (dispatch, getState) => {
     /* TODO the data fetched here should be baked into
     * the send html thus significantly improving the
     * initial page-load-speed.
+    * TODO fetch config data here as well
     */
-    fetch('rest/users/isSignedIn', {credentials: 'include'}) //TODO send credentials along
+    fetch('rest/users/isSignedIn', {credentials: 'include'})
     .then(checkHttpStatus)
     .then(resp => resp.json())
     /* handle data, dispatch actions */
-    .then(data =>
-        fetchDataForOwnedNeeds(data.username)
-    )
+    .then(data => loadingWhileSignedIn(dispatch, data.username))
+    /* handle: not-logged-in */
+    .catch(error => loadingWhileSignedOut(dispatch, getState));
+}
+
+function loadingWhileSignedIn(dispatch, username) {
+    fetchDataForOwnedNeeds(username)
     .then(allThatData =>
         dispatch({
             type: actionTypes.initialPageLoad,
             payload: allThatData
         })
     )
-    /* handle: not-logged-in */
-    .catch(error => {
-        const postUri = selectOpenPostUri(getState());
+}
+
+function loadingWhileSignedOut(dispatch, getState) {
+    const state = getState();
+    const postUri = selectOpenPostUri(state);
+    if(postUri && !selectOpenPost(state)) { //got an uri but no post loaded yet
         fetchDataForNonOwnedNeedOnly(postUri)
-        .then(publicData =>
-            dispatch({
-                type: actionTypes.initialPageLoad,
-                payload: publicData
-            })
+            .then(publicData =>
+                dispatch({
+                    type: actionTypes.initialPageLoad,
+                    payload: publicData
+                })
         );
-    })
+    }
+
 }
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -24,7 +24,7 @@ import {
 } from './utils';
 
 //---------- Config -----------
-import configRouting from './configRouting';
+import { configRouting, runAccessControl } from './configRouting';
 import configRedux from './configRedux';
 
 //--------- Actions -----------
@@ -122,13 +122,15 @@ app.filter('filterByNeedState', function(){
         }
     })
 
-app.config([ '$urlRouterProvider', '$stateProvider', configRouting ]);
+app.config(configRouting);
 app.run([ '$ngRedux', $ngRedux => runMessagingAgent($ngRedux) ]);
 
 
 app.run([ '$ngRedux', $ngRedux =>
     $ngRedux.dispatch(actionCreators.config__init())
 ]);
+
+app.run(runAccessControl);
 
 //check login status. TODO: this should actually be baked-in data (to avoid the extra roundtrip)
 //app.run([ '$ngRedux', $ngRedux => $ngRedux.dispatch(actionCreators.verifyLogin())]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -136,7 +136,6 @@ app.run(runAccessControl);
 //app.run([ '$ngRedux', $ngRedux => $ngRedux.dispatch(actionCreators.verifyLogin())]);
 app.run([ '$ngRedux', '$state', '$urlRouter', ($ngRedux, $uiRouterState, $urlRouter) => {
     $urlRouter.sync();
-    let foo = arguments;
     delay(0).then(() => { //to make sure the the route is synchronised and in the state.
         $ngRedux.dispatch(actionCreators.initialPageLoad())
     })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -31,7 +31,7 @@ function genComponentConf() {
                     <button class="won-button--filled red">Quit Contact</button>
                     <ul class="vtb__tabs">
                         <li ng-class="self.selection == 0? 'vtb__tabs__selected' : ''" ng-click="self.selection = 0">
-                        <a ui-sref="postVisitorMsgs({myUri: 'http://example.org/121337345'})">
+                        <a ui-sref="post({ERROR: 'Messages tab not implemented yet'})">
                             Messages
                             <span class="vtb__tabs__unread">{{self.post.get('messages').length}}</span>
                         </a></li>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -7,8 +7,7 @@
  * @param $urlRouterProvider
  * @param $stateProvider
  */
-
-export default function configRouting($urlRouterProvider, $stateProvider) {
+export const configRouting = [ '$urlRouterProvider', '$stateProvider', ($urlRouterProvider, $stateProvider) => {
     $urlRouterProvider.otherwise('/landingpage');
 
     [
@@ -56,6 +55,32 @@ export default function configRouting($urlRouterProvider, $stateProvider) {
             template: `<won-general-settings></won-general-settings>`
         })
 
+}]
+
+export const runAccessControl = [ '$rootScope', '$ngRedux', ($rootScope, $ngRedux) => {
+    $rootScope.$on('$stateChangeStart',
+        (event, toState, toParams, fromState, fromParams, options) => {
+
+            switch(toState.name) {
+                case 'post':
+                    break;
+                case 'landingpage':
+                    break;
+                default:
+                    if(!$ngRedux.getState().getIn(['user', 'loggedIn'])) {
+                        console.error(
+                            "Tried to access view that won't work" +
+                            "without logging in. Blocking route-change."
+                        );
+                        event.preventDefault();
+                    }
+            }
+
+
+        }
+    );
+
+}];
 }
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -20,8 +20,8 @@ export default function configRouting($urlRouterProvider, $stateProvider) {
         { path: '/overview/sent-requests?myUri?connectionUri', component: 'overview-sent-requests', as: 'overviewSentRequests' },
         { path: '/overview/posts', component: 'overview-posts', as: 'overviewPosts' },
         { path: '/post/?postUri?connectionUri?connectionType?layout', component: 'post', as: 'post' },
-        { path: '/post/visitor/info/?myUri?theirUri', component: 'post-visitor', as: 'postVisitor' },
-        { path: '/post/visitor/messages/?myUri?theirUri', component: 'post-visitor-msgs', as: 'postVisitorMsgs' },
+        //{ path: '/post/visitor/info/?myUri?theirUri', component: 'post-visitor', as: 'postVisitor' },
+        //{ path: '/post/visitor/messages/?myUri?theirUri', component: 'post-visitor-msgs', as: 'postVisitorMsgs' },
 
     ].forEach( ({path, component, as}) => {
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -35,6 +35,13 @@ export default function(allNeeds = initialState, action = {}) {
                 .mergeIn(['ownNeeds'], ownNeeds)
                 .mergeIn(['theirNeeds'], theirNeeds);
 
+        case actionTypes.router.accessedNonLoadedPost:
+            const theirNeed = action.payload.get('theirNeed');
+            return allNeeds.setIn(
+                ['theirNeeds', theirNeed.get('uri')],
+                theirNeed
+            );
+
         case actionTypes.needs.fetch:
             //TODO needs supplied by this action don't have a list of already associated connections
             return action.payload.reduce(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -49,22 +49,26 @@ const reducers = {
     // contains the Date.now() of the last action
     lastUpdateTime: (state = Date.now(), action = {}) => Date.now(),
 
-    config: createReducer(
-        //initial state
-        Immutable.Map(),
+    initialLoadFinished: (state = false, action = {}) =>
+        state || action.type === actionTypes.initialPageLoad,
 
-        //handlers
-        {
-            [actionTypes.config.update]: (state, { payload }) =>
+
+    //config: createReducer(
+    config: (config = Immutable.Map(), action = {}) => {
+        switch(action.type) {
+
+            case actionTypes.config.update:
                 /*
                  * `.merge` assumes a flat config-object. should the config
                  * become nested, use `mergeDeep` instead or use a
                  * custom merging-function (or more fine-grained actions)
                  */
-                state.merge(payload)
-        }
+                return config.merge(action.payload);
 
-    ),
+            default:
+                return config;
+        }
+    },
 }
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -173,10 +173,7 @@ export const selectOpenPostUri = createSelector(
         const encodedPostUri =
             state.getIn(['router', 'currentParams', 'postUri']) ||
             state.getIn(['router', 'currentParams', 'myUri']); //deprecated parameter
-        if(!encodedPostUri)
-            return undefined;
-        else
-            return decodeURIComponent(encodedPostUri);
+        return decodeUriComponentProperly(encodedPostUri);
     }
 );
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -7,11 +7,11 @@ import Immutable from 'immutable';
 import { decodeUriComponentProperly } from './utils';
 import { relativeTime } from './won-label-utils';
 
-const selectConnections = state => state.getIn(['connections']);
-const selectEvents = state => state.getIn(['events', 'events']);
-const selectOwnNeeds = state => state.getIn(['needs', 'ownNeeds']);
-const selectTheirNeeds = state => state.getIn(['needs', 'theirNeeds']);
-const selectLastUpdateTime = state => state.get('lastUpdateTime');
+export const selectConnections = state => state.getIn(['connections']);
+export const selectEvents = state => state.getIn(['events', 'events']);
+export const selectOwnNeeds = state => state.getIn(['needs', 'ownNeeds']);
+export const selectTheirNeeds = state => state.getIn(['needs', 'theirNeeds']);
+export const selectLastUpdateTime = state => state.get('lastUpdateTime');
 
 export const selectUnreadEventUris = state => state
     .getIn(['events', 'unreadEventUris']);


### PR DESCRIPTION
When you pasted a uri for the post-view while the page already was loaded (thus after the `initialPageLoad` action was created and dispatched) the need wouldn't get loaded. The assumption before was that pasting and entering always triggers a page-reload. However when the base-url matches, the browser only "jumps" to the new fragment-identifier, without reloading and thus without triggering `initialPageLoad`. 

This patch adds a listener to route-changes and causes the post to be loaded if the user would run into an unitialized post-view.

This branch also include simple access managment.

Check the following behaviours:

* once logged in and once logged out do:
  * reload on posts-overview
  * while on some other view (e.g. landing-page): paste link to posts-overview
  * reload on post-detail view
  * while on some other view (e.g. landing-page):paste link to post-detail view
* log-out on posts-overview
* log-out on posts-view (probably still redirects incorrectly)

you should always have data in those views and when you try accessing the overview while logged out you should land on the last page you were on or the landing page if this is the first in the app you accessed.