### PR TITLE
Fix message processing and reaction ordering

### DIFF
--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageProcessor.java
@@ -8,7 +8,13 @@ import java.lang.annotation.Target;
 /**
  * Identifies the annotated class as a message processor used to implement the obligatory
  * behavior for the specified message type and direction.
+ *
+ * Implementing classes may not generate and send new messages as this might cause ordering inconsistencies if new
+ * messages are sent before the current message has been processed completely. If new messages are to be sent,
+ * this is to be done in a FixedMessageReactionProcessor.
+ *
  * This implementation is always executed before the corresponding FacetMessageProcessor.
+ *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageReactionProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies the annotated class as a message processor used to react to messages by sending new ones *after* the
+ * original message has been processed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FixedMessageReactionProcessor
+{
+  String direction();
+  String messageType();
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/HintFeedbackMessageFromOwnerOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/HintFeedbackMessageFromOwnerOwnerFacetImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.facet.ownerFacet;
+
+import org.apache.camel.Exchange;
+import org.springframework.stereotype.Component;
+import won.node.camel.processor.AbstractFromOwnerCamelProcessor;
+import won.node.camel.processor.annotation.DefaultFacetMessageProcessor;
+import won.node.camel.processor.annotation.FacetMessageProcessor;
+import won.protocol.vocabulary.WON;
+import won.protocol.vocabulary.WONMSG;
+
+/**
+ * User: syim
+ * Date: 05.03.2015
+ */
+@Component
+@DefaultFacetMessageProcessor(direction=WONMSG.TYPE_FROM_OWNER_STRING,messageType = WONMSG
+  .TYPE_HINT_FEEDBACK_STRING)
+@FacetMessageProcessor(facetType = WON.OWNER_FACET_STRING,direction=WONMSG.TYPE_FROM_OWNER_STRING,messageType =
+  WONMSG.TYPE_HINT_FEEDBACK_STRING)
+public class HintFeedbackMessageFromOwnerOwnerFacetImpl extends AbstractFromOwnerCamelProcessor
+{
+  @Override
+  public void process(final Exchange exchange) {
+    logger.debug("default facet implementation, not doing anything");
+  }
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageProcessor.java
@@ -36,8 +36,6 @@ public class ActivateNeedMessageProcessor extends AbstractCamelProcessor
     need.setState(NeedState.ACTIVE);
     logger.debug("Setting Need State: " + need.getState());
     needRepository.save(need);
-    //TODO: shouldn't we send a dedicated message?
-    matcherProtocolMatcherClient.needActivated(need.getNeedURI(), wonMessage);
   }
 
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageReactionProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.fixed;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.springframework.stereotype.Component;
+import won.node.camel.processor.AbstractCamelProcessor;
+import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
+import won.protocol.message.WonMessage;
+import won.protocol.message.processor.camel.WonCamelConstants;
+import won.protocol.vocabulary.WONMSG;
+
+import java.net.URI;
+
+/**
+ * User: syim
+ * Date: 02.03.2015
+ */
+@Component
+@FixedMessageReactionProcessor(
+        direction = WONMSG.TYPE_FROM_OWNER_STRING,
+        messageType = WONMSG.TYPE_ACTIVATE_STRING)
+public class ActivateNeedMessageReactionProcessor extends AbstractCamelProcessor
+{
+
+
+  public void process(Exchange exchange) throws Exception {
+    Message message = exchange.getIn();
+    WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
+    URI receiverNeedURI = wonMessage.getReceiverNeedURI();
+    if (receiverNeedURI == null) throw new IllegalArgumentException("receiverNeedURI is not set");
+    matcherProtocolMatcherClient.needActivated(receiverNeedURI, wonMessage);
+  }
+
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageReactionProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.fixed;
+
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.springframework.stereotype.Service;
+import won.node.camel.processor.AbstractCamelProcessor;
+import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
+import won.protocol.exception.NoSuchNeedException;
+import won.protocol.message.WonMessage;
+import won.protocol.message.WonMessageBuilder;
+import won.protocol.message.WonMessageDirection;
+import won.protocol.message.processor.camel.WonCamelConstants;
+import won.protocol.model.Need;
+import won.protocol.util.WonRdfUtils;
+import won.protocol.vocabulary.WONMSG;
+
+import java.net.URI;
+
+/**
+ * Reacts to a CREATE message, informing matchers of the newly created need.
+ */
+@Service
+@FixedMessageReactionProcessor(direction= WONMSG.TYPE_FROM_OWNER_STRING,messageType = WONMSG.TYPE_CREATE_STRING)
+public class CreateNeedMessageReactionProcessor extends AbstractCamelProcessor
+{
+
+
+  @Override
+  public void process(final Exchange exchange) throws Exception {
+    Message message = exchange.getIn();
+    WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
+    Dataset needContent = wonMessage.getMessageContent();
+    URI needUri = getNeedURIFromWonMessage(needContent);
+    if (needUri == null){
+      logger.warn("could not obtain needURI from message " + wonMessage.getMessageURI());
+      return;
+    }
+    Need need = needRepository.findOneByNeedURI(needUri);
+    try {
+      WonMessage newNeedNotificationMessage = makeNeedCreatedMessageForMatcher(need);
+      matcherProtocolMatcherClient.needCreated(needUri, ModelFactory.createDefaultModel(),
+      newNeedNotificationMessage);
+    } catch (Exception e) {
+      logger.warn("could not create NeedCreatedNotification", e);
+    }
+  }
+
+
+  private WonMessage makeNeedCreatedMessageForMatcher(final Need need) throws NoSuchNeedException {
+    Dataset needDataset = linkedDataService.getNeedDataset(need.getNeedURI());
+    return WonMessageBuilder
+      .setMessagePropertiesForNeedCreatedNotification(wonNodeInformationService.generateEventURI(),
+                                                      need.getNeedURI(), need.getWonNodeURI())
+      .setWonMessageDirection(WonMessageDirection.FROM_EXTERNAL)
+      .build(needDataset);
+  }
+
+  private URI getNeedURIFromWonMessage(final Dataset wonMessage) {
+    URI needURI;
+    needURI = WonRdfUtils.NeedUtils.getNeedURI(wonMessage);
+    if (needURI == null) {
+      throw new IllegalArgumentException("at least one RDF node must be of type won:Need");
+    }
+    return needURI;
+  }
+
+
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageProcessor.java
@@ -7,20 +7,14 @@ import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
-import won.protocol.message.WonMessageBuilder;
-import won.protocol.message.WonMessageDirection;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
-import won.protocol.model.Connection;
-import won.protocol.model.ConnectionState;
 import won.protocol.model.Need;
 import won.protocol.model.NeedState;
 import won.protocol.util.DataAccessUtils;
-import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 
 import java.net.URI;
-import java.util.Collection;
 
 /**
  * User: syim
@@ -40,36 +34,6 @@ public class DeactivateNeedMessageProcessor extends AbstractCamelProcessor
     Need need = DataAccessUtils.loadNeed(needRepository, receiverNeedURI);
     need.setState(NeedState.INACTIVE);
     need = needRepository.save(need);
-
-
-    //close all connections
-    Collection<Connection> conns = connectionRepository.getConnectionsByNeedURIAndNotInState(need.getNeedURI
-      (), ConnectionState.CLOSED);
-    for (Connection con: conns) {
-      closeConnection(need, con);
-    }
-    matcherProtocolMatcherClient.needDeactivated(need.getNeedURI(), wonMessage);
-  }
-
-  public void closeConnection(final Need need, final Connection con) {
-    URI remoteWonNode = WonLinkedDataUtils.getWonNodeURIForNeedOrConnectionURI(con.getRemoteNeedURI(),
-      linkedDataSource);
-
-    //send close from system to each connection
-    //the close message is directed at our local connection. It will
-    //be routed to the owner and forwarded to to remote connection
-    URI messageURI = wonNodeInformationService.generateEventURI();
-    WonMessage message = WonMessageBuilder
-      .setMessagePropertiesForClose(messageURI,
-                                    WonMessageDirection.FROM_SYSTEM,
-                                    con.getConnectionURI(),
-                                    con.getNeedURI(),
-                                    need.getWonNodeURI(),
-                                    con.getConnectionURI(),
-                                    con.getNeedURI(),
-                                    need.getWonNodeURI(), "Closed because Need was deactivated").build();
-
-    sendSystemMessage(message);
   }
 
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageReactionProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.fixed;
+
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import won.node.camel.processor.AbstractCamelProcessor;
+import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
+import won.protocol.message.WonMessage;
+import won.protocol.message.WonMessageBuilder;
+import won.protocol.message.WonMessageDirection;
+import won.protocol.message.processor.camel.WonCamelConstants;
+import won.protocol.message.processor.exception.WonMessageProcessingException;
+import won.protocol.model.Connection;
+import won.protocol.model.ConnectionState;
+import won.protocol.model.Need;
+import won.protocol.util.DataAccessUtils;
+import won.protocol.vocabulary.WONMSG;
+
+import java.net.URI;
+import java.util.Collection;
+
+/**
+ *
+ */
+@Component
+@FixedMessageReactionProcessor(direction= WONMSG.TYPE_FROM_OWNER_STRING,messageType = WONMSG.TYPE_DEACTIVATE_STRING)
+public class DeactivateNeedMessageReactionProcessor extends AbstractCamelProcessor
+{
+  Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  public void process(final Exchange exchange) throws Exception {
+    WonMessage wonMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
+    URI receiverNeedURI = wonMessage.getReceiverNeedURI();
+    logger.debug("DEACTIVATING need. needURI:{}", receiverNeedURI);
+    if (receiverNeedURI == null) throw new WonMessageProcessingException("receiverNeedURI is not set");
+    Need need = DataAccessUtils.loadNeed(needRepository, receiverNeedURI);
+    matcherProtocolMatcherClient.needDeactivated(need.getNeedURI(), wonMessage);
+    //close all connections
+    Collection<Connection> conns = connectionRepository.getConnectionsByNeedURIAndNotInState(need.getNeedURI
+      (), ConnectionState.CLOSED);
+    for (Connection con: conns) {
+      closeConnection(need, con);
+    }
+
+  }
+
+  public void closeConnection(final Need need, final Connection con) {
+    //send close from system to each connection
+    //the close message is directed at our local connection. It will
+    //be routed to the owner and forwarded to to remote connection
+    URI messageURI = wonNodeInformationService.generateEventURI();
+    WonMessage message = WonMessageBuilder
+      .setMessagePropertiesForClose(messageURI,
+                                    WonMessageDirection.FROM_SYSTEM,
+                                    con.getConnectionURI(),
+                                    con.getNeedURI(),
+                                    need.getWonNodeURI(),
+                                    con.getConnectionURI(),
+                                    con.getNeedURI(),
+                                    need.getWonNodeURI(), "Closed because Need was deactivated").build();
+
+    sendSystemMessage(message);
+  }
+
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
@@ -1,4 +1,20 @@
-package won.node.camel.processor.fixed;
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.node.camel.processor.general;
 
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Model;

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
@@ -162,7 +162,7 @@
   <!-- processor for checking if message event, create need, or create connection uri is already in use -->
   <bean name="uriInUseChecker" class="won.protocol.message.processor.camel.WonMessageProcessorCamelAdapter">
     <constructor-arg>
-      <bean class="won.node.camel.processor.fixed.UriAlreadyUsedCheckingWonMessageProcessor"/>
+      <bean class="won.node.camel.processor.general.UriAlreadyUsedCheckingWonMessageProcessor"/>
     </constructor-arg>
   </bean>
   <!-- processor for checking well-formedness of messages -->
@@ -191,7 +191,14 @@
     </constructor-arg>
   </bean>
   <!-- routing logic for wonMessages, computing which message-type specific processor -->
-  <bean name="messageTypeSlip" class="won.node.camel.processor.general.MessageTypeSlipComputer"/>
+  <bean name="fixedMessageProcessorSlip" class="won.node.camel.processor.general.MessageTypeSlipComputer">
+    <constructor-arg value="won.node.camel.processor.annotation.FixedMessageProcessor" />
+  </bean>
+  <!-- routing logic for wonMessages, computing which message-type specific processor -->
+  <bean name="fixedMessageReactionProcessorSlip" class="won.node.camel.processor.general.MessageTypeSlipComputer">
+    <constructor-arg value="won.node.camel.processor.annotation.FixedMessageReactionProcessor" />
+    <constructor-arg name="allowNoMatchingProcessor" value="true" />
+  </bean>
   <!-- routing logic for wonMessages, computing which facet-specific processor to use -->
   <bean name="facetTypeSlip" class="won.node.camel.processor.general.FacetTypeSlipComputer"/>
 </beans>


### PR DESCRIPTION
What to test:
* create a need - the GUI will react much faster now because success/failure messages arrive instantly
* generally afflicted actions are activate, deactivate, create
* a bug was fixed regarding hintFeedback - there should not be any failuremessages in response to such a message any more (I think, however, that these messages were swallowed prior to this PR because of wrong message ordering)
fixes #595 