### PR TITLE
Feat closeonpartnerclose fixes#610

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -70,6 +70,7 @@ export function accountLogout() {
             })
         )
         .then(() => {
+            won.clearStore();
             dispatch(actionCreators.messages__requestWsReset_Hack());
             dispatch(actionCreators.router__stateGo("landingpage"));
         })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -109,6 +109,13 @@ export function successfulCloseConnection(event) {
                 type: actionTypes.messages.close.success,
                 payload: event
             });
+        } else {
+            //when a connection is closed by the node (e.g. when you close/deactivate a need all its corresponding connections will be closed)
+            console.log("close the connection because the need closed");
+            dispatch({
+                type: actionTypes.messages.close.success,
+                payload: event
+            })
         }
     }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -111,7 +111,6 @@ export function successfulCloseConnection(event) {
             });
         } else {
             //when a connection is closed by the node (e.g. when you close/deactivate a need all its corresponding connections will be closed)
-            console.log("close the connection because the need closed");
             dispatch({
                 type: actionTypes.messages.close.success,
                 payload: event

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -87,6 +87,152 @@ export function runMessagingAgent(redux) {
 
     };
 
+
+    /**
+     * The messageProcessingArray encapsulates all currently implemented message handlers with their respective redux dispatch
+     * events, to process another message you add another anonymous function that checks on the necessary message properties/values
+     * and dispatches the needed redux action/event
+     */
+    const messageProcessingArray = [
+        function (events) {
+            const msgFromExternal = events['msg:FromExternal'];
+
+            /* Other clients or matcher initiated stuff: */
+            if(msgFromExternal && msgFromExternal.hasMessageType === won.WONMSG.hintMessageCompacted) {
+                redux.dispatch(actionCreators.messages__hintMessageReceived(msgFromExternal));
+                return true;
+            } else {
+                return false;
+            }
+        },
+        function (events) {
+            const msgFromExternal = events['msg:FromExternal'];
+            const msgFromOwner = events['msg:FromOwner'];
+
+            /* Other clients or matcher initiated stuff: */
+            if(msgFromExternal && msgFromOwner && msgFromOwner.hasMessageType === won.WONMSG.connectMessageCompacted) {
+                redux.dispatch(actionCreators.messages__connectMessageReceived(events));
+                return true;
+            } else {
+                return false;
+            }
+        },
+        function (events) {
+            const msgFromExternal = events['msg:FromExternal'];
+            const msgFromOwner = events['msg:FromOwner'];
+
+            /* Other clients or matcher initiated stuff: */
+            if(msgFromExternal && msgFromOwner && msgFromOwner.hasMessageType === won.WONMSG.connectionMessageCompacted) {
+                redux.dispatch(actionCreators.messages__connectionMessageReceived(events));
+                return true;
+            } else {
+                return false;
+            }
+        },
+        function (events) {
+            const msgFromExternal = events['msg:FromExternal'];
+            const msgFromOwner = events['msg:FromOwner'];
+
+            if(msgFromExternal && msgFromOwner && msgFromOwner.hasMessageType === won.WONMSG.closeMessageCompacted) {
+                redux.dispatch(actionCreators.messages__close__success(msgFromOwner));
+                return true;
+            } else {
+                return false;
+            }
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.createMessageCompacted){
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
+                    redux.dispatch(actionCreators.messages__create__success(msgFromSystem));
+                //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
+                //    redux.dispatch(actionCreators.messages__create__failure(event));
+                return true;
+            } else {
+                return false;
+            }
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.connectMessageCompacted){
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
+                    redux.dispatch(actionCreators.messages__connect__success(msgFromSystem));
+                //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
+                //  redux.dispatch(actionCreators.messages__open__failure(event));
+                return true;
+            }else{
+                return false;
+            }
+
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.connectionMessageCompacted){
+                var eventUri = msgFromSystem.isRemoteResponseTo || msgFromSystem.isResponseTo;
+                var connectionUri = msgFromSystem.hasReceiver;
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted) {
+                    if (msgFromSystem.isRemoteResponseTo) {
+                        // got the second success-response (from the remote-node) - 2nd ACK
+                        redux.dispatch(actionCreators.messages__chatMessage__successRemote({ events }));
+                    } else {
+                        // got the first success-response (from our own node) - 1st ACK
+                        redux.dispatch(actionCreators.messages__chatMessage__successOwn({ events }));
+                    }
+                } else if(msgFromSystem.hasMessageType === won.WONMSG.failureResponseCompacted) {
+                    redux.dispatch(actionCreators.messages__chatMessage__failure({ events }));
+                }
+                return true;
+            }else{
+                return false;
+            }
+
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.openMessageCompacted){
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
+                    redux.dispatch(actionCreators.messages__open__success(msgFromSystem));
+                //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
+                //  redux.dispatch(actionCreators.messages__open__failure(event));
+                return true;
+            }else{
+                return false;
+            }
+
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.closeMessageCompacted){
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted) //JUMP HERE AND ONLY HERE WHEN CLOSE MESSAGES COME IN!
+                    redux.dispatch(actionCreators.messages__close__success(msgFromSystem));
+                //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
+                //  redux.dispatch(actionCreators.messages__close__failure(event));
+                return true;
+            }else{
+                return false;
+            }
+
+        },
+        function (events) {
+            const msgFromSystem = events['msg:FromSystem'];
+
+            if(msgFromSystem && msgFromSystem.isResponseToMessageType === won.WONMSG.closeNeedMessageCompacted){
+                if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
+                    redux.dispatch(actionCreators.messages__closeNeed__success(msgFromSystem));
+                else if (msgFromSystem.hasMessageType === won.WONMSG.failureResponseCompacted)
+                    redux.dispatch(actionCreators.messages__closeNeed__failure(msgFromSystem));
+                return true;
+            }else{
+                return false;
+            }
+        }
+    ];
+
     function onMessage(receivedMsg) {
         const data = JSON.parse(receivedMsg.data);
 
@@ -94,105 +240,18 @@ export function runMessagingAgent(redux) {
         getEventsFromMessage(data).then(events => {
             console.log('onMessage - events: ', events);
 
-            /* Other clients or matcher initiated stuff: */
-            const msgFromExternal = events['msg:FromExternal'];
-            const msgFromSystem = events['msg:FromSystem'];
+            var messageProcessed = false;
 
-            if(msgFromExternal) {
-                const msgFromOwner = events['msg:FromOwner'];
-
-                switch (msgFromExternal.hasMessageType){
-                    case won.WONMSG.hintMessageCompacted:
-                        redux.dispatch(actionCreators.messages__hintMessageReceived(msgFromExternal));
-                        break;
-                    default:
-                        console.warn("MESSAGE PROCESSING IS NOT IMPLEMENTED FOR THIS CASE: ",events);
-                        break;
-                }
-
-                if(msgFromOwner){
-                    switch (msgFromOwner.hasMessageType) {
-                        case won.WONMSG.connectMessageCompacted:
-                            redux.dispatch(actionCreators.messages__connectMessageReceived(events));
-                            break;
-                        case won.WONMSG.connectionMessageCompacted:
-                            redux.dispatch(actionCreators.messages__connectionMessageReceived(events));
-                            break;
-                        case won.WONMSG.closeMessageCompacted:
-                            console.log("REMOTE CONNECTION CLOSE");
-                            redux.dispatch(actionCreators.messages__close__success(msgFromOwner));
-                            break;
-                        default:
-                            console.warn("MESSAGE PROCESSING IS NOT IMPLEMENTED FOR THIS CASE: ",events);
-                            break;
-                    }
-                }
+            for(var i = 0; i < messageProcessingArray.length; i++) {
+                messageProcessed = messageProcessed || messageProcessingArray[i](events);
             }
-            /* responses to own actions: */
-            if(msgFromSystem) {
-                switch (msgFromSystem.isResponseToMessageType) {
-                    case won.WONMSG.createMessageCompacted:
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
-                            redux.dispatch(actionCreators.messages__create__success(msgFromSystem));
-                        //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
-                        //    redux.dispatch(actionCreators.messages__create__failure(event));
-                        break;
 
-                    case won.WONMSG.connectMessageCompacted:
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
-                            redux.dispatch(actionCreators.messages__connect__success(msgFromSystem));
-                        //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
-                        //  redux.dispatch(actionCreators.messages__open__failure(event));
-                        break;
-
-                    case won.WONMSG.connectionMessageCompacted:
-                        var eventUri = msgFromSystem.isRemoteResponseTo || msgFromSystem.isResponseTo;
-                        var connectionUri = msgFromSystem.hasReceiver;
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted) {
-                            if (msgFromSystem.isRemoteResponseTo) {
-                                // got the second success-response (from the remote-node) - 2nd ACK
-                                redux.dispatch(actionCreators.messages__chatMessage__successRemote({ events }));
-                            } else {
-                                // got the first success-response (from our own node) - 1st ACK
-                                redux.dispatch(actionCreators.messages__chatMessage__successOwn({ events }));
-                            }
-                        } else if(msgFromSystem.hasMessageType === won.WONMSG.failureResponseCompacted) {
-                            redux.dispatch(actionCreators.messages__chatMessage__failure({ events }));
-                        }
-                        break;
-
-                    case won.WONMSG.openMessageCompacted:
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
-                            redux.dispatch(actionCreators.messages__open__success(msgFromSystem));
-                        //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
-                        //  redux.dispatch(actionCreators.messages__open__failure(event));
-                        break;
-
-                    case won.WONMSG.closeMessageCompacted:
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted) //JUMP HERE AND ONLY HERE WHEN CLOSE MESSAGES COME IN!
-                            redux.dispatch(actionCreators.messages__close__success(msgFromSystem));
-                        //else if(event.hasMessageType === won.WONMSG.failureResponseCompacted)
-                        //  redux.dispatch(actionCreators.messages__close__failure(event));
-                        break;
-
-                    case won.WONMSG.closeNeedMessageCompacted:
-                        if (msgFromSystem.hasMessageType === won.WONMSG.successResponseCompacted)
-                            redux.dispatch(actionCreators.messages__closeNeed__success(msgFromSystem));
-                        else if (msgFromSystem.hasMessageType === won.WONMSG.failureResponseCompacted)
-                            redux.dispatch(actionCreators.messages__closeNeed__failure(msgFromSystem));
-                        break;
-
-                    case won.WONMSG.connectionMessageCompacted:
-                        //TODO handle succesful posting
-                        break;
-                    default:
-                        console.warn("MESSAGE PROCESSING IS NOT IMPLEMENTED FOR THIS CASE: ",events);
-                        break;
-                }
+            if(!messageProcessed){
+                console.warn("MESSAGE WAS PROCESSED DUE TO MISSING IMPLEMENTATION: ", events);
             }
         })
-
     };
+
     function onError(e) {
         console.error('websocket error: ', e);
         this.close();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -71,8 +71,7 @@ const rdfstore = window.rdfstore;
 
     var privateData = {};
 
-    won.ld_reset = function() {
-        privateData = {};
+    won.clearStore = function () {
         //create an rdfstore-js based store as a cache for rdf data.
         privateData.store =  rdfstore.create();
         window.store4dbg = privateData.store; //TODO deletme
@@ -88,7 +87,7 @@ const rdfstore = window.rdfstore;
     }
     const CACHE_ITEM_STATE = { OK: 1, DIRTY: 2, UNRESOLVABLE: 3, FETCHING: 4};
 
-    won.ld_reset();
+    won.clearStore();
 
 
     var createNameNodeInStore = function(uri){
@@ -268,7 +267,6 @@ const rdfstore = window.rdfstore;
         }
 
     };
-
 
     /**
      * We got the rdf but didn't know the uri of the resource
@@ -762,7 +760,7 @@ const rdfstore = window.rdfstore;
 
     function loadFromOwnServerIntoCache(uri, requesterWebId, deep, layerSize) {
         return new Promise((resolve, reject) => {
-            //console.log("linkeddata-service-won.js: fetching:        " + uri);
+            console.log("linkeddata-service-won.js: fetching:        " + uri);
 
             let requestUri = queryString(uri, requesterWebId, deep, layerSize);
             const find = '%3A';

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -215,6 +215,7 @@
     won.WONMSG.closeNeedSentMessageCompacted = won.WONMSG.prefix +":DeactivateSentMessage";
     won.WONMSG.hintMessage = won.WONMSG.baseUri + "HintMessage";
     won.WONMSG.hintMessageCompacted = won.WONMSG.prefix + ":HintMessage";
+    won.WONMSG.hintFeedbackMessageCompacted = won.WONMSG.prefix + ":HintFeedbackMessage";
     won.WONMSG.connectMessage = won.WONMSG.baseUri + "ConnectMessage";
     won.WONMSG.connectMessageCompacted = won.WONMSG.prefix + ":ConnectMessage";
     won.WONMSG.connectSentMessage = won.WONMSG.baseUri + "ConnectSentMessage";


### PR DESCRIPTION
WARN: Despite the title this PullRequest does not handle a user-close of a connection yet (# 569)

fixes #610 -> GUI should react to a partner close:
Testing:
1) Create new need
2) Connect with the DebugBot Request
3) type "close"
result -> you should receive a message that will close this connection (message should disappear from the gui)

1) Create new need
2) Close Post
result -> you should receive messages that close the respective connections -> the messages are marked as #Closed in the state (visible via console)