### PR TITLE
Fix clear state #607

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/drafts-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/drafts-reducer.js
@@ -8,12 +8,18 @@ import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
 import { combineReducersStable } from '../redux-utils';
 
+const initialState = Immutable.fromJS({});
+
+
 export const draftsReducer = createReducer(
     //initial state
     Immutable.Map(),
 
     //handlers
     {
+        [actionTypes.logout]: () => {
+            return initialState;
+        },
         /**
          * @param {*} draftId : the draft that's type has changed
          * @param {string} type : the short-hand won-type (e.g. `'won:Demand'`)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -14,7 +14,9 @@ const initialState = Immutable.fromJS({
 
 export default function(state = initialState, action = {}) {
     switch(action.type) {
-
+        case actionTypes.logout:
+            return initialState;
+        
         case actionTypes.initialPageLoad:
         case actionTypes.login:
             const allPreviousEvents = action.payload.get('events');


### PR DESCRIPTION
fixes #607 

after a logout the state for events: and drafts: (see console output) should be wiped -> before all the events and drafts where still in the state and another login had data from an old session