### PR TITLE
Feat do not match

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugNeedWithFacetsAction.java
@@ -59,12 +59,9 @@ public class CreateDebugNeedWithFacetsAction extends AbstractCreateNeedAction
   private boolean isInitialForHint;
   private boolean isInitialForConnect;
 
-  public CreateDebugNeedWithFacetsAction(EventListenerContext eventListenerContext, String uriListName, URI... facets) {
-    super(eventListenerContext, uriListName, facets);
-  }
-
-  public CreateDebugNeedWithFacetsAction(EventListenerContext eventListenerContext, URI... facets) {
-    super(eventListenerContext, facets);
+  public CreateDebugNeedWithFacetsAction(final EventListenerContext eventListenerContext, final String uriListName,
+                                         final boolean usedForTesting, final boolean doNotMatch, final URI... facets) {
+    super(eventListenerContext, uriListName, usedForTesting, doNotMatch, facets);
   }
 
   @Override

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
@@ -25,6 +25,7 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.model.FacetType;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.RdfUtils;
+import won.protocol.vocabulary.WON;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -38,12 +39,23 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
 
   protected List<URI> facets;
   protected String uriListName;
+  //indicates if the won:DoNotMatch flag is to be set
+  protected boolean usedForTesting;
+  protected boolean doNotMatch;
 
   /**
    * Creates a need with the specified facets.
    * If no facet is specified, the ownerFacet will be used.
    */
   public AbstractCreateNeedAction(EventListenerContext eventListenerContext, String uriListName, URI... facets) {
+    this(eventListenerContext, uriListName, true, true, facets);
+  }
+
+  /**
+   * Creates a need with the specified facets.
+   * If no facet is specified, the ownerFacet will be used.
+   */
+  public AbstractCreateNeedAction(EventListenerContext eventListenerContext, String uriListName, final boolean usedForTesting, final boolean doNotMatch, URI... facets) {
     super(eventListenerContext);
     if (facets == null || facets.length == 0) {
       //add the default facet if none is present.
@@ -53,6 +65,8 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
       this.facets = Arrays.asList(facets);
     }
     this.uriListName = uriListName;
+    this.doNotMatch = doNotMatch;
+    this.usedForTesting = usedForTesting;
   }
 
   /**
@@ -68,6 +82,12 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
                                         Model needModel)
           throws WonMessageBuilderException {
 
+    if (doNotMatch){
+      needModel.getResource(needURI.toString()).addProperty(WON.HAS_FLAG, WON.DO_NOT_MATCH);
+    }
+    if (usedForTesting){
+      needModel.getResource(needURI.toString()).addProperty(WON.HAS_FLAG, WON.USED_FOR_TESTING);
+    }
     RdfUtils.replaceBaseURI(needModel, needURI.toString());
 
     return WonMessageBuilder.setMessagePropertiesForCreate(
@@ -77,5 +97,13 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
                     wonNodeURI)
             .addContent(needModel, null)
             .build();
+  }
+
+  public void setUsedForTesting(final boolean usedForTesting) {
+    this.usedForTesting = usedForTesting;
+  }
+
+  public void setDoNotMatch(final boolean doNotMatch) {
+    this.doNotMatch = doNotMatch;
   }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
@@ -45,10 +45,10 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
 
   /**
    * Creates a need with the specified facets.
-   * If no facet is specified, the ownerFacet will be used.
+   * If no facet is specified, the ownerFacet will be used, Flag 'UsedForTesting' will be set.
    */
   public AbstractCreateNeedAction(EventListenerContext eventListenerContext, String uriListName, URI... facets) {
-    this(eventListenerContext, uriListName, true, true, facets);
+    this(eventListenerContext, uriListName, true, false, facets);
   }
 
   /**

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateNeedWithFacetsAction.java
@@ -43,6 +43,11 @@ public class CreateNeedWithFacetsAction extends AbstractCreateNeedAction
     super(eventListenerContext, uriListName, facets);
   }
 
+  public CreateNeedWithFacetsAction(final EventListenerContext eventListenerContext, final String uriListName,
+                                    final boolean usedForTesting, final boolean doNotMatch, final URI... facets) {
+    super(eventListenerContext, uriListName, usedForTesting, doNotMatch, facets);
+  }
+
   public CreateNeedWithFacetsAction(EventListenerContext eventListenerContext, URI... facets) {
     super(eventListenerContext, facets);
   }

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
@@ -85,7 +85,8 @@ public class DebugBot extends EventBot
     bus.subscribe(ActEvent.class, this.matcherRegistrator);
 
     //create the echo need for debug initial connect - if we're not reacting to the creation of our own echo need.
-    CreateDebugNeedWithFacetsAction needForInitialConnectAction = new CreateDebugNeedWithFacetsAction(ctx, NAME_NEEDS);
+    CreateDebugNeedWithFacetsAction needForInitialConnectAction =
+      new CreateDebugNeedWithFacetsAction(ctx,NAME_NEEDS,true,true);
     needForInitialConnectAction.setIsInitialForConnect(true);
 
     ActionOnEventListener initialConnector = new ActionOnEventListener(
@@ -96,7 +97,7 @@ public class DebugBot extends EventBot
     bus.subscribe(NeedCreatedEventForMatcher.class, initialConnector);
 
     //create the echo need for debug initial hint - if we're not reacting to the creation of our own echo need.
-    CreateDebugNeedWithFacetsAction initialHinter = new CreateDebugNeedWithFacetsAction(ctx, NAME_NEEDS);
+    CreateDebugNeedWithFacetsAction initialHinter = new CreateDebugNeedWithFacetsAction(ctx, NAME_NEEDS, true, true);
     initialHinter.setIsInitialForHint(true);
     ActionOnEventListener needForInitialHintListener = new ActionOnEventListener(
       ctx, new NotFilter(new NeedUriInNamedListFilter(ctx, NAME_NEEDS)), initialHinter);
@@ -170,7 +171,7 @@ public class DebugBot extends EventBot
     // events)
     needCreator = new ActionOnEventListener(
       ctx,
-      new CreateDebugNeedWithFacetsAction(ctx,NAME_NEEDS)
+      new CreateDebugNeedWithFacetsAction(ctx,NAME_NEEDS, true, true)
     );
     bus.subscribe(HintDebugCommandEvent.class, needCreator);
     bus.subscribe(ConnectDebugCommandEvent.class, needCreator);

--- a/webofneeds/won-core/src/main/java/won/protocol/util/NeedBuilder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/NeedBuilder.java
@@ -111,6 +111,10 @@ public interface NeedBuilder<T>
 
   public NeedBuilder<T> setState(String stateURI);
 
+  public NeedBuilder<T> setDoNotMatch(boolean doNotMatch);
+
+  public NeedBuilder<T> setUsedForTesting(boolean usedForTesting);
+
   /**
    * Set RDF content in Turtle format.
    *

--- a/webofneeds/won-core/src/main/java/won/protocol/util/NeedBuilderBase.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/NeedBuilderBase.java
@@ -71,13 +71,15 @@ public abstract class NeedBuilderBase<T> implements NeedBuilder<T>
   private String availableAtLocationLongitudeString;
   private String availableAtLocationRegion;
   private Model contentDescription;
-
+  private boolean doNotMatch;
+  private boolean usedForTesting = false;
 
   //pattern for finding hashtags in title and description
   private static final Pattern PATTERN_HASHTAG = Pattern.compile("#\\w+");
 
   private static final String PRICE_SEPARATOR = "-";
   private static final String DATE_SEPARATOR = "/";
+
 
   @Override
   public <O> void copyValuesToBuilder(final NeedBuilder<O> otherNeedBuilder)
@@ -619,6 +621,24 @@ public abstract class NeedBuilderBase<T> implements NeedBuilder<T>
     this.stateURI = null;
     this.stateNS = null;
     this.stateURIString = stateURI;
+    return this;
+  }
+
+  public boolean isDoNotMatch() {
+    return doNotMatch;
+  }
+
+  public NeedBuilder<T> setDoNotMatch(final boolean doNotMatch) {
+    this.doNotMatch = doNotMatch;
+    return this;
+  }
+
+  public boolean isUsedForTesting(){
+    return usedForTesting;
+  }
+
+  public NeedBuilder<T> setUsedForTesting(boolean usedForTesting) {
+    this.usedForTesting = usedForTesting;
     return this;
   }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/NeedModelBuilder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/NeedModelBuilder.java
@@ -78,6 +78,8 @@ public class NeedModelBuilder extends NeedBuilderBase<Model>
     if (needModality != null) {
       copyValuesFromNeedModality(needModality);
     }
+    this.setDoNotMatch(needResource.hasProperty(WON.HAS_FLAG, WON.DO_NOT_MATCH));
+    this.setUsedForTesting(needResource.hasProperty(WON.HAS_FLAG, WON.USED_FOR_TESTING));
   }
 
   private void copyValuesFromNeedModality(final Resource needModality)
@@ -274,6 +276,12 @@ public class NeedModelBuilder extends NeedBuilderBase<Model>
     addNeedContent(needModel, needResource);
     // need modalities
     addNeedModality(needModel, needResource);
+    if (isDoNotMatch()){
+      needResource.addProperty(WON.HAS_FLAG, WON.DO_NOT_MATCH);
+    }
+    if (isUsedForTesting()){
+      needResource.addProperty(WON.HAS_FLAG, WON.USED_FOR_TESTING);
+    }
     return needModel;
   }
 

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -158,7 +158,17 @@ public class WON
   public static final Resource CONNECTION_STATE_CONNECTED = m.createResource(ConnectionState.CONNECTED.getURI().toString());
   public static final Resource CONNECTION_STATE_CLOSED = m.createResource(ConnectionState.CLOSED.getURI().toString());
 
+  //adds a flag to a need
+  public static final Property HAS_FLAG = m.createProperty(BASE_URI+"hasFlag");
+
+  //the doNotMatch flag: need does not want matching
+  public static final Resource DO_NOT_MATCH = m.createResource(BASE_URI+"DoNotMatch");
+
+  //the usedForTesting flag: need is not a real need, only match with other needs flagged with usedForTesting
+  public static final Resource USED_FOR_TESTING= m.createResource(BASE_URI+"UsedForTesting");
+
   public static final Property HAS_GRAPH = m.createProperty(BASE_URI,"hasGraph");
+
 
   //search result model
   public static final Resource Match = m.createResource(BASE_URI + "Match");

--- a/webofneeds/won-vocab/src/main/resources/ontology/won_ontology_v1.0.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won_ontology_v1.0.ttl
@@ -153,6 +153,16 @@ xsd:duration rdf:type rdfs:Datatype .
             
             rdfs:range :NeedContent .
 
+###  http://purl.org/webofneeds/model#hasContent
+
+:hasFlag rdf:type owl:ObjectProperty ;
+
+            rdfs:comment "Flags for the Need"@en ;
+
+            rdfs:isDefinedBy <http://purl.org/webofneeds/model> ;
+
+            rdfs:domain :Need.
+
 
 
 ###  http://purl.org/webofneeds/model#hasContentDescription
@@ -734,7 +744,15 @@ gr:QuantitativeValue rdf:type owl:Class .
                
                rdfs:isDefinedBy <http://purl.org/webofneeds/model> .
 
+###  http://purl.org/webofneeds/model#DoNotMatch
 
+:DoNotMatch rdfs:comment "Flag indicating the need should not be matched. It should not receive hints nor should other needs receive hints pointing them to this one."@en ;
+               rdfs:isDefinedBy <http://purl.org/webofneeds/model> .
+
+###  http://purl.org/webofneeds/model#UsedForTesting
+
+:UsedForTesting rdfs:comment "Flag indicating the need has been created for testing purposes. It should only be matched with other needs flagged with UsedForTesting. The flag is intended to separate real-world needs from those generated for testing the system, so that users aren't spammed or misled.."@en ;
+               rdfs:isDefinedBy <http://purl.org/webofneeds/model> .
 
 ###  http://purl.org/webofneeds/model#Connection
 


### PR DESCRIPTION
This PR adds two functionalities, which are achieved by adding flags to a need and the matching services respecting the flags.

# DoNotMatch
When a need is flagged with DoNotMatch, it is not supposed to receive any hints, nor are other needs supposed to receive hints about it.
# UsedForTesting
When a need is flagged with UsedForTesting, it is may only be sent hints to other needs that have this flag.
# RDF
The PR adds a new property, `won:hasFlag`, and two Resources, `won:DoNotMatch` and `won:UsedForTesting`, the intended use is on the need resource:
```
[need] won:hasFlag [flag]
```

