### PR TITLE
Fixed hanging conversations

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1065,7 +1065,7 @@ const rdfstore = window.rdfstore;
      * @return {*} the data of all connection-nodes referenced by that need
      */
     won.getConnectionsOfNeed = (needUri, requesterWebId = needUri) =>
-        won.getConnectionUrisOfNeed(needUri)
+        won.getConnectionUrisOfNeed(needUri, requesterWebId)
         .then(connectionUris =>
             urisToLookupMap(
                 connectionUris,
@@ -1077,25 +1077,11 @@ const rdfstore = window.rdfstore;
     /*
      * Loads all URIs of a need's connections.
      */
-    won.getConnectionUrisOfNeed = (needUri) =>
-        won.getNode(needUri)
-            .then(need =>
-                won.getNode(need.hasConnections)
-            )
-            .then(connectionContainer => {
-                /*
-                 * if there's only a single rdfs:member in the event
-                 * container, getNode will not return an array, so we
-                 * need to make sure it's one from here on out.
-                 */
-                return is('String', connectionContainer.member) ?
-                    [connectionContainer.member] :
-                    connectionContainer.member
-            })
-            .catch(error => {
-                error.message = "Failed to fetch connection uris for need <" + needUri + "> because of:\n" + error.message;
-                throw(error);
-            });
+    won.getConnectionUrisOfNeed = (needUri, requesterWebId) =>
+        won.executeCrawlableQuery(won.queries["getAllConnectionUrisOfNeed"], needUri, requesterWebId)
+            .then(
+                (result) =>  result.map( x => x.connection.value));
+
 
     /**
      *


### PR DESCRIPTION
Single conversations no longer hang and the null OID message is gone.
Replaced old promise-hell implementation with crawlable query implementation - that fixed it.

fixes #651 
fixes #691 