### PR TITLE
Fix too many emails

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import won.owner.service.impl.URIService;
+import won.protocol.model.ConnectionState;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.utils.mail.WonMailSender;
@@ -24,15 +25,16 @@ public class WonOwnerMailSender {
   @Autowired
   LinkedDataSource linkedDataSource;
 
-  private static final String OWNER_REMOTE_NEED_LINK = "/#/post/visitor/info/?theirUri=";
-  private static final String OWNER_CONNECTION_LINK = "/#/post/visitor/messages/?myUri=<>&theirUri=";
-  private static final String OWNER_LOCAL_NEED_LINK = "/#/post/owner/info?myUri=";
+  private static final String OWNER_REMOTE_NEED_LINK = "/#post/?postUri=";
+  private static final String OWNER_CONNECTION_LINK = "&connectionUri=";
+  private static final String OWNER_LOCAL_NEED_LINK = "/#/post/?postUri=%s&connectionType=%s";
 
   private static final String NOTIFICATION_END = "\n\n\n" +
     "Sincerely yours,\nOwner application team" +
     "\n\n\n\n" +
     "You have received this email because you are subscribed to getting " +
-    "notifications for your posting. If you received this email in error please click on the link below." +
+    "notifications for your posting. If you think we should not have sent you this email, please click on the link " +
+    "below." +
     "\n" +
     "\n\n" +
     "This is an automatic email, please do not reply." ;
@@ -49,9 +51,9 @@ public class WonOwnerMailSender {
     " <span>Owner application team</span>" +
     "</p>";
 
-  private static final String SUBJECT_CONVERSATION_MESSAGE = "You have received a new Conversation Message";
-  private static final String SUBJECT_CONNECT = "You have received a new Conversation Request";
-  private static final String SUBJECT_MATCH = "You have received a new Match";
+  private static final String SUBJECT_CONVERSATION_MESSAGE = "new message";
+  private static final String SUBJECT_CONNECT = "new conversation request";
+  private static final String SUBJECT_MATCH = "new match";
 
 
   @Autowired
@@ -90,105 +92,11 @@ public class WonOwnerMailSender {
 
   }
 
-  @Deprecated
-  /**
-   * @deprecated as composes email with link to the old GUI
-   */
-  public void sendNotificationMessage(String toEmail, String messageType, String receiverNeed) {
 
-    String subject = "You received a new " + messageType;
-    String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
 
-    // the public link is used temporarily, see TODO comments below
-    String publicLink = uriService.getOwnerProtocolOwnerURI() + "/#/post-detail?need=" + receiverNeed;
-    // TODO when we implement login in context functionality, we should send here the link that
-    // would point to the private link page of the corresponding need, the would in turn redirect
-    // to sign-in dialog, and after user signs in, would display that need private link page
-
-    String text = "Dear user," +
-      "\n\n" +
-      "You have received a new " +
-      messageType +
-      " for your posting " +
-      publicLink +
-      ". Please visit " +
-      ownerAppLink +
-      " to view it in detail." +
-      "\n\n\n" +
-      "Sincerely yours,\nOwner application team" +
-      "\n\n\n\n" +
-      "You have received this email because you have subscribed to getting " +
-      messageType +
-      " notifications for your posting " +
-      publicLink +
-      ". If you received this email in error please click on the link below." +
-      "\n" +
-      //TODO implement the link that should do something that makes sense..."
-      "\n\n" +
-      "This is an automatic email, please do not reply.";
-
-    logger.info("sending " + subject + " to " + toEmail);
-
-    this.wonMailSender.sendTextMessage(toEmail, subject, text);
-
-  }
-
-  public void sendHintNotificationMessage(String toEmail, String localNeed, String remoteNeed) {
-
-    String subject = "You have received a new Match";
-    String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
-
-    String linkLocalNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_LOCAL_NEED_LINK + localNeed;
-    String linkMatch = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
-    // TODO implement login in context functionality for the linked from the email owner interface
-
-    String text = "Dear User," +
-      "\n\n" +
-      subject +
-      " for your posting " +
-      linkLocalNeed +
-      ". Please visit " +
-      linkMatch +
-      " to view it in detail." +
-      NOTIFICATION_END
-      ;
-
-    logger.info("sending " + subject + " to " + toEmail);
-
-    this.wonMailSender.sendTextMessage(toEmail, subject, text);
-
-  }
-
-  public void sendConversationNotificationMessage(String toEmail, String msgType, String localNeed, String
-    remoteNeed) {
-
-    String subject = "You have received a new Conversation " + msgType;
-    String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
-
-    String linkLocalNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_LOCAL_NEED_LINK + localNeed;
-    String linkConnection = uriService.getOwnerProtocolOwnerURI() + OWNER_CONNECTION_LINK.replaceAll("<>", localNeed)
-      + remoteNeed;
-    // TODO implement login in context functionality for the linked from the email owner interface
-
-    String text = "Dear User," +
-      "\n\n" +
-      subject +
-      " for your posting " +
-      linkLocalNeed +
-      ". Please visit " +
-      linkConnection +
-      " to view it in detail." +
-      NOTIFICATION_END
-      ;
-
-    logger.info("sending " + subject + " to " + toEmail);
-
-    this.wonMailSender.sendTextMessage(toEmail, subject, text);
-
-  }
 
   public void sendConversationNotificationHtmlMessage(String toEmail, String localNeed, String
-    remoteNeed, String textMsg) {
+    remoteNeed, String localConnection, String textMsg) {
 
 
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
@@ -196,15 +104,15 @@ public class WonOwnerMailSender {
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
-    String linkConnection = ownerAppLink + OWNER_CONNECTION_LINK.replaceAll("<>", localNeed)
-      + remoteNeed;
+    String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,localNeed, localConnection, ConnectionState.CONNECTED.getURI().toString());
+
     // TODO implement login in context functionality for the linked from the email owner interface
 
     String body =
     "<div>" +
       NOTIFICATION_START_HTML +
-      "<p>The person behind '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
-      "   has send <a href=\"" + linkLocalNeed + "\">you</a> a message. They wrote:" +
+      "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
+      "   sent <a href=\"" + linkLocalNeed + "\">you</a> a message. They wrote:" +
       "</p>" +
       "<p style=\"border-left:thick solid #808080;\">" +
       "   <span style=\"margin-left:5px;color:#808080;\">" + textMsg + "</span>" +
@@ -222,15 +130,16 @@ public class WonOwnerMailSender {
 
 
   public void sendConnectNotificationHtmlMessage(String toEmail, String localNeed, String
-    remoteNeed, String textMsg) {
+    remoteNeed, String localConnection, String textMsg) {
 
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
-    String linkConnection = ownerAppLink + OWNER_CONNECTION_LINK.replaceAll("<>", localNeed)
-      + remoteNeed;
+    String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,
+                                                         localNeed, localConnection, ConnectionState.REQUEST_RECEIVED.getURI()
+                                                                                                      .toString());
     // TODO implement login in context functionality for the linked from the email owner interface
 
     String theyWrote = "</p>";
@@ -245,7 +154,7 @@ public class WonOwnerMailSender {
     String body =
       "<div>" +
         NOTIFICATION_START_HTML +
-        "<p>The person behind '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
+        "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
         "   wants to contact <a href=\"" + linkLocalNeed + "\">you</a>. " +
         theyWrote +
         "<p><a href=\"" + linkConnection + "\">[Click here to pick up the conversation]</a></p>" +
@@ -259,21 +168,61 @@ public class WonOwnerMailSender {
 
   }
 
-  public void sendHintNotificationMessageHtml(String toEmail, String localNeed, String remoteNeed) {
+  public void sendCloseNotificationHtmlMessage(String toEmail, String localNeed, String
+    remoteNeed, String localConnection, String textMsg) {
 
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
-    String linkConnection = ownerAppLink + OWNER_CONNECTION_LINK.replaceAll("<>", localNeed)
-      + remoteNeed;
+    String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,
+                                                         localNeed, localConnection, ConnectionState.CLOSED.getURI()
+                                                                                                                     .toString());
+    // TODO implement login in context functionality for the linked from the email owner interface
+
+    String theyWrote = "</p>";
+    if (textMsg != null) {
+      theyWrote = "They wrote:" +
+        "</p>" +
+        "<p style=\"border-left:thick solid #808080;\">" +
+        "   <span style=\"margin-left:5px;color:#808080;\">" + textMsg + "</span>" +
+        "</p>";
+    }
+
+    String body =
+      "<div>" +
+        NOTIFICATION_START_HTML +
+        "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
+        "   closed the connection to <a href=\"" + linkLocalNeed + "\">you</a>. " +
+        theyWrote +
+        "<p><a href=\"" + linkConnection + "\">[Click here to view the conversation]</a></p>" +
+        NOTIFICATION_END_HTML +
+        "</div>";
+
+
+    logger.debug("sending " + SUBJECT_CONNECT + " to " + toEmail);
+
+    this.wonMailSender.sendHtmlMessage(toEmail, SUBJECT_CONNECT, body);
+
+  }
+
+
+  public void sendHintNotificationMessageHtml(String toEmail, String localNeed, String remoteNeed, String localConnection) {
+
+    String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
+    Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
+    String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
+    String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
+    String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
+    String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK, localNeed, localConnection,
+                                                         ConnectionState.SUGGESTED.getURI().toString());
     // TODO implement login in context functionality for the linked from the email owner interface
 
     String body =
       "<div>" +
         NOTIFICATION_START_HTML +
-        "<p>The post '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
+        "<p>The posting '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
         "   might be interesting for <a href=\"" + linkLocalNeed + "\">you</a>. " +
         "</p>" +
         "<p><a href=\"" + linkConnection + "\">[Click here to request a conversation]</a></p>" +

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -54,6 +54,7 @@ public class WonOwnerMailSender {
   private static final String SUBJECT_CONVERSATION_MESSAGE = "new message";
   private static final String SUBJECT_CONNECT = "new conversation request";
   private static final String SUBJECT_MATCH = "new match";
+  private static final String SUBJECT_CLOSE = "conversation closed";
 
 
   @Autowired
@@ -102,6 +103,8 @@ public class WonOwnerMailSender {
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
+    Dataset localNeedDataset =  linkedDataSource.getDataForResource(URI.create(localNeed));
+    String localNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(localNeedDataset, URI.create(localNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
     String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,localNeed, localConnection, ConnectionState.CONNECTED.getURI().toString());
@@ -112,7 +115,9 @@ public class WonOwnerMailSender {
     "<div>" +
       NOTIFICATION_START_HTML +
       "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
-      "   sent <a href=\"" + linkLocalNeed + "\">you</a> a message. They wrote:" +
+      "   sent you a message via " +
+      "your posting <a href=\"" + linkLocalNeed + "\">"+ localNeedTitle+ "</a>. " +
+      "They wrote:" +
       "</p>" +
       "<p style=\"border-left:thick solid #808080;\">" +
       "   <span style=\"margin-left:5px;color:#808080;\">" + textMsg + "</span>" +
@@ -135,6 +140,8 @@ public class WonOwnerMailSender {
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
+    Dataset localNeedDataset =  linkedDataSource.getDataForResource(URI.create(localNeed));
+    String localNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(localNeedDataset, URI.create(localNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
     String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,
@@ -155,7 +162,8 @@ public class WonOwnerMailSender {
       "<div>" +
         NOTIFICATION_START_HTML +
         "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
-        "   wants to contact <a href=\"" + linkLocalNeed + "\">you</a>. " +
+        "   wants to start a conversation with " +
+        "you via your posting <a href=\"" + linkLocalNeed + "\">"+ localNeedTitle+ "</a>. " +
         theyWrote +
         "<p><a href=\"" + linkConnection + "\">[Click here to pick up the conversation]</a></p>" +
         NOTIFICATION_END_HTML +
@@ -174,6 +182,8 @@ public class WonOwnerMailSender {
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
+    Dataset localNeedDataset =  linkedDataSource.getDataForResource(URI.create(localNeed));
+    String localNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(localNeedDataset, URI.create(localNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
     String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,
@@ -194,16 +204,17 @@ public class WonOwnerMailSender {
       "<div>" +
         NOTIFICATION_START_HTML +
         "<p>The owner of '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
-        "   closed the connection to <a href=\"" + linkLocalNeed + "\">you</a>. " +
+        "   closed the conversation with " +
+        "your posting <a href=\"" + linkLocalNeed + "\">"+ localNeedTitle+ "</a>. " +
         theyWrote +
         "<p><a href=\"" + linkConnection + "\">[Click here to view the conversation]</a></p>" +
         NOTIFICATION_END_HTML +
         "</div>";
 
 
-    logger.debug("sending " + SUBJECT_CONNECT + " to " + toEmail);
+    logger.debug("sending " + SUBJECT_CLOSE + " to " + toEmail);
 
-    this.wonMailSender.sendHtmlMessage(toEmail, SUBJECT_CONNECT, body);
+    this.wonMailSender.sendHtmlMessage(toEmail, SUBJECT_CLOSE, body);
 
   }
 
@@ -213,6 +224,8 @@ public class WonOwnerMailSender {
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     String remoteNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(needDataset, URI.create(remoteNeed));
+    Dataset localNeedDataset =  linkedDataSource.getDataForResource(URI.create(localNeed));
+    String localNeedTitle = WonRdfUtils.NeedUtils.getNeedTitle(localNeedDataset, URI.create(localNeed));
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
     String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK, localNeed, localConnection,
@@ -223,7 +236,8 @@ public class WonOwnerMailSender {
       "<div>" +
         NOTIFICATION_START_HTML +
         "<p>The posting '<a href=\"" + linkRemoteNeed + "\">" + remoteNeedTitle + "</a>'" +
-        "   might be interesting for <a href=\"" + linkLocalNeed + "\">you</a>. " +
+        "   might be interesting for "+
+        "your posting <a href=\"" + linkLocalNeed + "\">"+ localNeedTitle+ "</a>. " +
         "</p>" +
         "<p><a href=\"" + linkConnection + "\">[Click here to request a conversation]</a></p>" +
         NOTIFICATION_END_HTML +

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -26,8 +26,8 @@ public class WonOwnerMailSender {
   LinkedDataSource linkedDataSource;
 
   private static final String OWNER_REMOTE_NEED_LINK = "/#post/?postUri=";
-  private static final String OWNER_CONNECTION_LINK = "&connectionUri=";
-  private static final String OWNER_LOCAL_NEED_LINK = "/#/post/?postUri=%s&connectionType=%s";
+  private static final String OWNER_CONNECTION_LINK = "/#post/?postUri=%s&connectionUri=%s&connectionType=%s";
+  private static final String OWNER_LOCAL_NEED_LINK = "/#/post/?postUri=";
 
   private static final String NOTIFICATION_END = "\n\n\n" +
     "Sincerely yours,\nOwner application team" +


### PR DESCRIPTION
A few changes to the way the owner app sends emails:
* emails are only sent when no websocket session is found
* text was improved 
* links were improved

Not all the links work, though, as it is currently unclear how to link directly into a conversation - so this link doesn't work completely, but it gets you to the post view at least.

How to test:
* deploy to integration-test
* use two user accounts with real email addresses
* create two needs that will be matched, one in each account
* log out quickly with account A after creating the need
* check that you got the hint email of account A
* go to account B, request contact on the hint
* check that you got the open email in account A
* log in with A, accept the conversation, send a message
* reply with B then log out
* reply with A
* check that you got the message email for B
* close the connection with A
* check that you got the close email for B

fixes #661 
fixes #646 