### PR TITLE
added lastNeedsSeenMatcher app

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/app/LastSeenNeedsMatcherApp.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/app/LastSeenNeedsMatcherApp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package won.bot.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * App for EchoBot
+ */
+public class LastSeenNeedsMatcherApp
+{
+    public static void main(String[] args) throws Exception {
+        SpringApplication app = new SpringApplication(
+                new Object[]{"classpath:/spring/app/lastSeenNeedsMatcherApp.xml"}
+        );
+        app.setWebEnvironment(false);
+        ConfigurableApplicationContext applicationContext =  app.run(args);
+        //Thread.sleep(5*60*1000);
+        //app.exit(applicationContext);
+    }
+
+}

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!--
+       context that combines bot definitions with runner context
+    -->
+    <!-- the runner -->
+    <import resource="classpath:/spring/app/botRunner.xml" />
+    <!-- the bots to run -->
+    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
+
+
+</beans>


### PR DESCRIPTION
This bot matches the two needs it has seen last, sending a hint to the newer need. Useful for testing ownerapp-to-ownerapp without a functioning matcher