### PR TITLE
added capability to query event container optionally with deep=true

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -275,44 +275,48 @@ public interface LinkedDataService
 
   /**
    * Returns paged resource containing all event uris belonging to the specified connection.
-   *
+   * If deep is true, the event dataset is added to the result.
    * @param connectionUri connection parent of the events
    * @param pageNum number of the page to be returned
    * @param preferedSize preferred number of uris per page, null means use default
    * @param messageType message type, null means all types
+   * @param deep
    * @return
    * @throws NoSuchConnectionException
    */
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(
-    final URI connectionUri, final int pageNum, Integer preferedSize, WonMessageType messageType) throws
+    final URI connectionUri, final int pageNum, Integer preferedSize, WonMessageType messageType, boolean deep) throws
     NoSuchConnectionException;
+
 
   /**
    * Returns a dataset containing all event uris belonging to the specified connection that were created after the
-   * specified event uri.
+   * specified event uri. If deep is true, the event dataset is added to the result.
    * @param connectionUri connection parent of the events
    * @param msgURI message to follow (in message creation time)
    * @param preferedSize preferred number of uris per page, null means use default
    * @param msgType message type, null means all types
+   * @param deep
    * @return
    * @throws NoSuchConnectionException
    */
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsAfter(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType) throws
+    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException;
 
   /**
    * Returns a dataset containing all event uris belonging to the specified connection that were created before the
-   * specified event uri.
+   * specified event uri. If deep is true, the event dataset is added to the result.
    * @param connectionUri connection parent of the events
    * @param msgURI message to precede (in message creation time)
    * @param preferedSize preferred number of uris per page, null means use default
    * @param msgType message type, null means all types
+   * @param deep
    * @return
    * @throws NoSuchConnectionException
    */
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsBefore(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType) throws
+    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException;
 
   public Dataset getNodeDataset();

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -216,6 +216,7 @@ public class
     @RequestParam(value="resumebefore", required=false) String beforeId,
     @RequestParam(value="resumeafter", required=false) String afterId,
     @RequestParam(value="type", required=false) String type,
+    @RequestParam(value="deep", required=false, defaultValue = "false") boolean deep,
     Model model, HttpServletResponse response) {
 
     try {
@@ -227,12 +228,12 @@ public class
 
       if (page == null && beforeId == null && afterId == null) {
         // all events, does not support type filtering for clients that do not support paging
-        rdfDataset = linkedDataService.listConnectionEventURIs(connectionURI);
+        rdfDataset = linkedDataService.listConnectionEventURIs(connectionURI, deep);
 
       } else if (page != null) {
         // a page having particular page number is requested
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIs
-          (connectionURI, page, null, msgType);
+          (connectionURI, page, null, msgType, deep);
         rdfDataset = resource.getContent();
 
       } else if (beforeId != null) {
@@ -240,7 +241,7 @@ public class
 
         URI referenceEvent = uriService.createEventURIForId(beforeId);
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIsBefore
-          (connectionURI, referenceEvent, null, msgType);
+          (connectionURI, referenceEvent, null, msgType, deep);
         rdfDataset = resource.getContent();
 
       }  else {
@@ -248,7 +249,7 @@ public class
 
         URI referenceEvent = uriService.createEventURIForId(afterId);
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIsAfter
-          (connectionURI, referenceEvent, null, msgType);
+          (connectionURI, referenceEvent, null, msgType, deep);
         rdfDataset = resource.getContent();
 
       }
@@ -880,7 +881,8 @@ public class
     @RequestParam(value="p", required=false) Integer page,
     @RequestParam(value="resumebefore", required=false) String beforeId,
     @RequestParam(value="resumeafter", required=false) String afterId,
-    @RequestParam(value="type", required=false) String type) {
+    @RequestParam(value="type", required=false) String type,
+    @RequestParam(value="deep", required = false, defaultValue = "false") boolean deep) {
 
     logger.debug("readConnection() called");
     Dataset rdfDataset = null;
@@ -896,11 +898,11 @@ public class
       if (preferedSize == null) {
         // client doesn't not support paging - return all members; does not support type filtering for clients that do
         // not support paging
-        rdfDataset = linkedDataService.listConnectionEventURIs(connectionUri);
+        rdfDataset = linkedDataService.listConnectionEventURIs(connectionUri, deep);
       } else  if (page == null && beforeId == null && afterId == null) {
         // client supports paging but didn't specify which page to return - return page with latest events
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIs
-          (connectionUri, 1, preferedSize, msgType);
+          (connectionUri, 1, preferedSize, msgType, deep);
         rdfDataset = resource.getContent();
         addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
 
@@ -908,7 +910,7 @@ public class
         // a page having particular page number is requested
 
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIs
-          (connectionUri, page, preferedSize, msgType);
+          (connectionUri, page, preferedSize, msgType, deep);
         rdfDataset = resource.getContent();
         addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, page, passableMap);
 
@@ -917,7 +919,7 @@ public class
 
         URI referenceEvent = uriService.createEventURIForId(beforeId);
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIsBefore
-          (connectionUri, referenceEvent, preferedSize, msgType);
+          (connectionUri, referenceEvent, preferedSize, msgType, deep);
         rdfDataset = resource.getContent();
         addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
 
@@ -926,7 +928,7 @@ public class
 
         URI referenceEvent = uriService.createEventURIForId(afterId);
         NeedInformationService.PagedResource<Dataset,URI> resource = linkedDataService.listConnectionEventURIsAfter
-          (connectionUri, referenceEvent, preferedSize, msgType);
+          (connectionUri, referenceEvent, preferedSize, msgType, deep);
         rdfDataset = resource.getContent();
         addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
 

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -435,17 +435,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
     return eventsContainerDataset;
   }
 
-
   @Override
-  public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(final URI connectionUri, final int
-    pageNum, Integer preferedSize, WonMessageType msgType) throws
-    NoSuchConnectionException
-  {
-    Slice<URI> slice = needInformationService.listConnectionEventURIs(connectionUri, pageNum,
-                                                                      preferedSize, msgType);
-    return toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
-  }
-
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(final URI connectionUri, final int
     pageNum, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
@@ -454,35 +444,35 @@ public class LinkedDataServiceImpl implements LinkedDataService
                                                                       preferedSize, msgType);
     NeedInformationService.PagedResource<Dataset,URI> containerPage = toContainerPage(
       this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
-    if (deep) {
-      for (URI eventUri : slice.getContent()) {
-        Dataset eventDataset = getDatasetForUri(eventUri);
-        RdfUtils.addDatasetToDataset(containerPage.getContent(), eventDataset);
-      }
-    }
+    if (deep) addEventData(slice, containerPage);
     return containerPage;
   }
 
+
+
   @Override
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsAfter(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType) throws
+    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
   {
     Slice<URI> slice = needInformationService.listConnectionEventURIsAfter(
       connectionUri, msgURI, preferedSize, msgType);
-    return toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
+    NeedInformationService.PagedResource<Dataset,URI> containerPage = toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
+    if (deep) addEventData(slice, containerPage);
+    return containerPage;
   }
 
   @Override
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsBefore(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType) throws
+    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
   {
 
     Slice<URI> slice = needInformationService.listConnectionEventURIsBefore(
       connectionUri, msgURI, preferedSize, msgType);
-    return toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
-
+    NeedInformationService.PagedResource<Dataset,URI> containerPage = toContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice);
+    if (deep) addEventData(slice, containerPage);
+    return containerPage;
   }
 
   @Override
@@ -518,6 +508,13 @@ public class LinkedDataServiceImpl implements LinkedDataService
       //RdfUtils.replaceBaseResource(additionalDataModel, additionalData);
       model.add(model.createStatement(targetResource, WON.HAS_ADDITIONAL_DATA, additionalData));
       model.add(additionalDataModel);
+    }
+  }
+
+  public void addEventData(final Slice<URI> slice, final NeedInformationService.PagedResource<Dataset, URI> containerPage) {
+    for (URI eventUri : slice.getContent()) {
+      Dataset eventDataset = getDatasetForUri(eventUri);
+      RdfUtils.addDatasetToDataset(containerPage.getContent(), eventDataset);
     }
   }
 


### PR DESCRIPTION
adding `deep=true` in the HTTP request for an event container causes the events' datasets to be included in the response

fixes #746 
