### PR TITLE
improved labels describing the connection state in the feed view

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -75,7 +75,7 @@ function genComponentConf() {
                             </div>
                         </div>
 
-                        <div class="fmil__item__description__message">Placeholder. This is a {{ cnct.getIn(['connection', 'hasConnectionState']) }}</div>
+                        <div class="fmil__item__description__message">{{ self.getTextForConnectionState(cnct.getIn(['connection', 'hasConnectionState'])) }}</div>
                     </div>
                 </div>
                 <div class="fmil__more clickable"
@@ -107,7 +107,7 @@ function genComponentConf() {
                 </div>
             </div>
             `;
-
+    
     class Controller {
         constructor() {
             attach(this, serviceDependencies, arguments);
@@ -149,6 +149,13 @@ function genComponentConf() {
         }
         unreadRequestsCount() {
             return this.unreadXCount(won.EVENT.CONNECT_RECEIVED)
+        }
+        getTextForConnectionState(state){
+            let stateText = this.labels.connectionState[state];
+            if (!stateText) {
+                stateText = "unknown connection state";
+            }
+            return stateText;
         }
     }
     Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -1,12 +1,20 @@
 ;
 import won from './won-es6';
+import {deepFreeze} from './utils';
 
-export const labels = Object.freeze({
+export const labels = deepFreeze({
     type: {
         [won.WON.BasicNeedTypeDemandCompacted]: 'I want to have something',
         [won.WON.BasicNeedTypeSupplyCompacted]: 'I offer something',
         [won.WON.BasicNeedTypeDotogetherCompacted]: 'I want to do something together',
         [won.WON.BasicNeedTypeCritiqueCompacted]: 'I want to change something',
+    },
+    connectionState: {
+        [won.WON.Suggested]: 'Conversation suggested. You can send a request.',
+        [won.WON.RequestSent]: 'Conversation requested by you. Close the connection if not interested.',
+        [won.WON.RequestReceived]: 'Conversation requested. You can accept or deny this request.',
+        [won.WON.Connected]: 'Conversation open. You can exchange messages with your counterpart.',
+        [won.WON.Closed]: 'Conversation closed. You can reopen it.',
     }
 });
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -11,7 +11,7 @@ export const labels = deepFreeze({
     },
     connectionState: {
         [won.WON.Suggested]: 'Conversation suggested. You can send a request.',
-        [won.WON.RequestSent]: 'Conversation requested by you. Close the connection if not interested.',
+        [won.WON.RequestSent]: 'Conversation requested by you. Close the connection if no longer interested.',
         [won.WON.RequestReceived]: 'Conversation requested. You can accept or deny this request.',
         [won.WON.Connected]: 'Conversation open. You can exchange messages with your counterpart.',
         [won.WON.Closed]: 'Conversation closed. You can reopen it.',


### PR DESCRIPTION
Test by running the debugbot and look a the feed after creating a need. Keep an eye on the descriptions as you move your connections through connected/closed states.
fixes #718 