### PR TITLE
Feat session handling fixes

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -24,7 +24,8 @@ const initialState = Immutable.fromJS({
 });
 export function messagesReducer(messages = initialState, action = {}) {
     switch(action.type) {
-
+        case actionTypes.logout:
+            return initialState;
         case actionTypes.drafts.publish:
             return messages.setIn(
                 ['enqueued', action.payload.eventUri],


### PR DESCRIPTION
This change will introduce heartbeat checks, heartbeats are sent by the server yet up until this point we simply ignored them on the client side.

now we have a method that will process a received heartbeat by setting a var (in this case the missedHeartbeat counter) back to 0. Furthermore we added a method that checks how many heartbeats have been missed in a certain interval (in our case every 30 seconds) and if the missedHeartbeat counter is bigger than 3 we will dispatch a logout event to clear our state.

How to test: after the server has lost or closed the session the heartbeats will not get sent over the websocket anymore and thus increasing the missedHeartbeat counter every interval check (so the logout should occur roughly 2minutes after the session is lost)

This Pull Request hopefully fixes the following issues:

fix #583 
fix #561 
fix #625