### PR TITLE
implemented developer data links

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
@@ -122,10 +122,11 @@ public class BridgeForLinkedDataController {
       copyResponseBody(originalResponse, response);
       // close response output stream
     } else {
+      copyResponseBody(originalResponse, response);
       response.setStatus(HttpStatus.SC_BAD_GATEWAY);
-      response.getOutputStream().print("The nodes' response was of type " + originalResponseMediaType
+      /*response.getOutputStream().print("The nodes' response was of type " + originalResponseMediaType
               + ". For security reasons the owner-server only forwards responses of the following types " +
-              RDFMediaType.rdfMediaTypes.toString());
+              RDFMediaType.rdfMediaTypes.toString());*/
     };
     response.getOutputStream().flush();
     response.getOutputStream().close();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
@@ -98,6 +98,7 @@ function genComponentConf() {
                     ng-click="self.closeRequest()">Decline</button>
                 <button class="won-button--filled red" ng-click="self.openRequest(self.message)">Accept</button>
             </div>
+            <a ng-show="self.debugmode" class="debuglink" target="_blank" href="{{self.connectionUri}}">[CONNDATA]</a>
         </div>
     `;
 
@@ -138,8 +139,7 @@ function genComponentConf() {
                         connectMsg.get('hasTextMessage') ||
                         connectMsg.getIn(['hasCorrespondingRemoteMessage', 'hasTextMessage'])
                     ),
-
-
+                    debugmode: won.debugmode,
                 }
             };
             const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -72,7 +72,9 @@ function genComponentConf() {
                         (show)
                     </a>
                 </p>
-
+                <p ng-show="self.debugmode">
+                    <a class="debuglink" target="_blank" href="{{self.post.get('@id')}}">[DATA]</a>
+                </p>
                 <div class="post-info__mapmount" id="post-info__mapmount"></div>
             </div>
         </div>
@@ -118,6 +120,7 @@ function genComponentConf() {
                         selectLastUpdateTime(state),
                         post && post.get('dct:created')
                     ),
+                    debugmode: won.debugmode
                 }
             };
             const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
@@ -102,6 +102,7 @@ function genComponentConf() {
                      <span class="pil__indicators__item__caption"></span>
                 </div>
             </div>
+            <a class="debuglink" ng-show="self.debugmode" target="_blank" href="{{self.needUri}}"> [DATA]</a>
     `;
 
     class Controller {
@@ -137,6 +138,7 @@ function genComponentConf() {
                             conn.getIn(['connection', 'hasConnectionState']) === won.WON.Suggested
                         ).size > 0,
                     WON: won.WON,
+                    debugmode: won.debugmode,
                     ownNeed: need,
                     unreadCounts,
                 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -81,6 +81,8 @@ function genComponentConf() {
                             class="pm__content__message__content__time">
                                 {{ message.get('humanReadableTimestamp') }}
                         </div>
+                        <a ng-show="self.debugmode && message.get('hasSenderNeed') == self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_self" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasSenderNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
+                        <a ng-show="self.debugmode && message.get('hasSenderNeed') != self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_self" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasReceiverNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
                     </div>
             </div>
         </div>
@@ -137,6 +139,7 @@ function genComponentConf() {
                     connectionData: selectAllByConnections(state).get(connectionUri),
                     chatMessages: chatMessages && chatMessages.toArray(), //toArray needed as ng-repeat won't work otherwise :|
                     state4dbg: state,
+                    debugmode: won.debugmode
                 }
             };
 
@@ -144,6 +147,13 @@ function genComponentConf() {
             this.$scope.$on('$destroy', disconnect);
 
             this.snapToBottom();
+        }
+
+        encodeParam(param) {
+            var encoded = encodeURIComponent(param);
+            console.log("encoding: ",param);
+            console.log("encoded: ",encoded)
+            return encoded;
         }
 
         snapToBottom() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -81,8 +81,8 @@ function genComponentConf() {
                             class="pm__content__message__content__time">
                                 {{ message.get('humanReadableTimestamp') }}
                         </div>
-                        <a ng-show="self.debugmode && message.get('hasSenderNeed') == self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_self" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasSenderNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
-                        <a ng-show="self.debugmode && message.get('hasSenderNeed') != self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_self" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasReceiverNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
+                        <a ng-show="self.debugmode && message.get('hasSenderNeed') == self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_blank" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasSenderNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
+                        <a ng-show="self.debugmode && message.get('hasSenderNeed') != self.connectionData.getIn(['ownNeed', '@id'])" class="debuglink" target="_blank" href="/owner/rest/linked-data/?requester={{self.encodeParam(message.get('hasReceiverNeed'))}}&uri={{self.encodeParam(message.get('uri'))}}&deep=true">[MSGDATA]</a>
                     </div>
             </div>
         </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -63,6 +63,7 @@ function genComponentConf() {
                 <button class="won-button--filled black" ui-sref="{connectionUri: null}">Cancel</button>
                 <button class="won-button--filled red" ng-click="self.sendRequest(self.message)" ui-sref="{connectionUri: null}">Request Contact</button>
             </div>
+            <a ng-show="self.debugmode" class="debuglink" target="_blank" href="{{self.connectionUri}}">[CONNDATA]</a>
         </div>
     `;
 
@@ -87,6 +88,7 @@ function genComponentConf() {
                     theirCreationDate: theirNeed ?
                         relativeTime(selectLastUpdateTime(state, theirNeed.get('dct:created'))) :
                         undefined,
+                    debugmode: won.debugmode,
                 }
             };
             const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -29,6 +29,10 @@ button, input, textarea {
   font-weight: inherit;
 }
 
+.debuglink {
+  font-size: $smallFontSize;
+}
+
 body {
 
   //this font will be inherited down the cascade


### PR DESCRIPTION
Fix #822

This pullrequest inserts links (in postoverview, post-info, request and match views) to access the corresponding connection/need/event data

BE AWARE:
in order to make the rest/linked-data view accessible within the browser, i needed to alter the BridgeForLinkedDataController to accept text/html again. Unfortunately the response status needed to be something other than 200 (so i kept the bad gateway response) because the redux-ui-router would have linked me to the landingpage for some in my opinion unknown reason