### PR TITLE
use different mail addresses for master and int mail bot deployments

### DIFF
--- a/webofneeds/won-docker/deploy/int_satsrv06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satsrv06/docker-compose.yml
@@ -61,7 +61,14 @@ services:
       - "botContext.mongodb.host=satsrv06.researchstudio.at"
       - "botContext.mongodb.port=27017"
       - "botContext.mongodb.database=int_bot"
+      - "mailbot.email.user=mail2won.int"
+      - "mailbot.email.address=mail2won.int@gmail.com"
+      - "mailbot.email.name=Web of Needs Integration Test Mail Bot"
       - "mailbot.email.password=$mailinglist_passwd"
+      - "mailbot.email.imap.host=imap.gmail.com"
+      - "mailbot.email.imap.port=993"
+      - "mailbot.email.smtp.host=smtp.gmail.com"
+      - "mailbot.email.smtp.port=587"
     depends_on:
       - nginx
       - mongodb

--- a/webofneeds/won-docker/deploy/master_satsrv06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/master_satsrv06/docker-compose.yml
@@ -47,7 +47,14 @@ services:
       - "botContext.mongodb.host=satsrv06.researchstudio.at"
       - "botContext.mongodb.port=27018"
       - "botContext.mongodb.database=master_bot"
+      - "mailbot.email.user=won-internal"
+      - "mailbot.email.address=won-internal@researchstudio.at"
+      - "mailbot.email.name=Web of Needs Master Mail Bot"
       - "mailbot.email.password=$mailinglist_passwd"
+      - "mailbot.email.imap.host=imap.researchstudio.at"
+      - "mailbot.email.imap.port=993"
+      - "mailbot.email.smtp.host=smtp.researchstudio.at"
+      - "mailbot.email.smtp.port=587"
     depends_on:
       - mongodb
 


### PR DESCRIPTION
use the follwing mail addresses for the mail bot now:
* master: won-internal@researchstudio.at
* int: mail2won.int@gmail.com
* already tested in integration-test