### PR TITLE
User mail subscription

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -20,7 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.BotContext;
 import won.bot.framework.eventbot.EventListenerContext;
+import won.bot.framework.eventbot.action.impl.mail.model.SubscribeStatus;
 import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
+import won.bot.framework.eventbot.action.impl.mail.receive.MailContentExtractor;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.SuccessResponseEvent;
@@ -181,7 +183,7 @@ public class EventBotActionUtils
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         mimeMessage.writeTo(os);
-        botContext.addToListMap(USER_CACHED_MAILS_COLLECTION, mimeMessage.getFrom().toString(), os.toByteArray());
+        botContext.addToListMap(USER_CACHED_MAILS_COLLECTION, MailContentExtractor.getMailSender(mimeMessage), os.toByteArray());
     }
 
     public static Collection<MimeMessage> loadCachedMailsForMailAddress(BotContext botContext, String mailAddress)
@@ -202,5 +204,16 @@ public class EventBotActionUtils
 
     public static void removeCachedMailsForMailAddress(BotContext botContext, String mailAddress) {
         botContext.dropCollection(mailAddress);
+    }
+
+    public static void setSubscribeStatusForMailAddress(
+      BotContext botContext, String mailAddress, SubscribeStatus status) {
+        botContext.saveToObjectMap(USER_SUBSCRIBE_COLLECTION, mailAddress, status);
+    }
+
+    public static SubscribeStatus getSubscribeStatusForMailAddress(BotContext botContext, String mailAddress) {
+
+        String status = (String) botContext.loadFromObjectMap(USER_SUBSCRIBE_COLLECTION, mailAddress);
+        return (status != null) ? SubscribeStatus.valueOf(status) : SubscribeStatus.NO_RESPONSE;
     }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/model/ActionType.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/model/ActionType.java
@@ -4,10 +4,13 @@ package won.bot.framework.eventbot.action.impl.mail.model;
  * Created by fsuda on 18.10.2016.
  */
 public enum ActionType {
+
     CLOSE_CONNECTION,
     CLOSE_NEED,
     OPEN_CONNECTION,
     IMPLICIT_OPEN_CONNECTION,
     SENDMESSAGE,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
     NO_ACTION
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/model/SubscribeStatus.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/model/SubscribeStatus.java
@@ -1,0 +1,11 @@
+package won.bot.framework.eventbot.action.impl.mail.model;
+
+/**
+ * Created by hfriedrich on 17.11.2016.
+ */
+public enum SubscribeStatus
+{
+  SUBSCRIBED,
+  UNSUBSCRIBED,
+  NO_RESPONSE
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
@@ -1,5 +1,6 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
+import won.bot.framework.eventbot.action.impl.mail.model.ActionType;
 import won.protocol.model.BasicNeedType;
 
 import javax.mail.Address;
@@ -44,9 +45,57 @@ public class MailContentExtractor
   // check if the need created from the mail should be not matched with other needs
   private Pattern doNotMatchPattern;
 
-  // check if this is a command mail of type close or connect
+  // check if this is a command mail of different action types
   private Pattern cmdClosePattern;
   private Pattern cmdConnectPattern;
+  private Pattern cmdSubscribePattern;
+  private Pattern cmdUnsubscribePattern;
+
+  public static String getMailReference(MimeMessage message) throws MessagingException {
+
+    // first search the mail reference is in the in-reply-to header in case user answered a mail
+    // e.g. in case of messages, implicit connect
+    String[] replyTo = message.getHeader("In-Reply-To");
+    if (replyTo != null && replyTo.length > 0) {
+      return replyTo[0];
+    }
+
+    // second search the mail reference in the subject written by predefined mailto links
+    // e.g. in case of close need
+    Pattern referenceMailPattern = Pattern.compile("Message-Id: <(.+)>");
+    Matcher m = referenceMailPattern.matcher(message.getSubject());
+    return m.find() ? m.group(1) : null;
+  }
+
+  public static String getMailText(MimeMessage message) throws MessagingException, IOException {
+
+    if (message.isMimeType("text/plain")) {
+      return message.getContent().toString();
+    } else if (message.isMimeType("multipart/*")) {
+      return getMailTextFromMultiPart((MimeMultipart) message.getContent());
+    }
+
+    return null;
+  }
+
+  private static String getMailTextFromMultiPart(MimeMultipart mm) throws MessagingException, IOException {
+
+    for (int i = 0; i < mm.getCount(); i++) {
+      BodyPart part = mm.getBodyPart(i);
+      if (part.isMimeType("text/plain")) {
+        return part.getContent().toString();
+      } else if (part.isMimeType("multipart/*")) {
+        return getMailTextFromMultiPart((MimeMultipart) part.getContent());
+      }
+    }
+    return null;
+  }
+
+  public static String getMailSender(MimeMessage message) throws MessagingException {
+
+    Address[] froms = message.getFrom();
+    return (froms == null ? null : ((InternetAddress) froms[0]).getAddress());
+  }
 
   public void setDemandTypePattern(final Pattern demandTypePattern) {
     this.demandTypePattern = demandTypePattern;
@@ -96,12 +145,39 @@ public class MailContentExtractor
     this.cmdConnectPattern = cmdConnectPattern;
   }
 
-  public boolean isCmdClose(MimeMessage message) throws IOException, MessagingException {
-    return cmdClosePattern.matcher(getMailText(message)).matches();
+  public void setCmdSubscribePattern(final Pattern cmdSubscribePattern) {
+    this.cmdSubscribePattern = cmdSubscribePattern;
   }
 
-  public boolean isCmdConnect(MimeMessage message) throws IOException, MessagingException {
-    return cmdConnectPattern.matcher(getMailText(message)).matches();
+  public void setCmdUnsubscribePattern(final Pattern cmdUnsubscribePattern) {
+    this.cmdUnsubscribePattern = cmdUnsubscribePattern;
+  }
+
+  public boolean isCreateNeedMail(MimeMessage messsage) throws MessagingException {
+    return getBasicNeedType(messsage) != null;
+  }
+
+  public boolean isCommandMail(MimeMessage message) throws IOException, MessagingException {
+
+    // command mail is either an answer mail (with reference) to a previous mail (e.g. message, implicit connect) or an
+    // explicitly set action command (e.g. subscribe, unsubscribe, close need)
+    return getMailReference(message) != null ||
+      (getMailAction(message) != null && !ActionType.NO_ACTION.equals(getMailAction(message)));
+  }
+
+  public ActionType getMailAction(MimeMessage message) throws IOException, MessagingException {
+
+    if (cmdSubscribePattern.matcher(message.getSubject()).matches()) {
+      return ActionType.SUBSCRIBE;
+    } else if (cmdUnsubscribePattern.matcher(message.getSubject()).matches()) {
+      return ActionType.UNSUBSCRIBE;
+    } else if (cmdClosePattern.matcher(message.getSubject()).matches()) {
+      return ActionType.CLOSE_CONNECTION;
+    } else if (cmdConnectPattern.matcher(message.getSubject()).matches()) {
+      return ActionType.OPEN_CONNECTION;
+    } else {
+      return ActionType.NO_ACTION;
+    }
   }
 
   public boolean isDoNotMatch(MimeMessage message) throws MessagingException {
@@ -115,35 +191,7 @@ public class MailContentExtractor
   public String getTitle(MimeMessage message) throws MessagingException {
 
     Matcher m = titleExtractionPattern.matcher(message.getSubject());
-    if (m.find()) {
-      return m.group().trim();
-    }
-
-    return null;
-  }
-
-  public static String getMailText(MimeMessage message) throws MessagingException, IOException {
-
-    if (message.isMimeType("text/plain")) {
-      return message.getContent().toString();
-    } else if (message.isMimeType("multipart/*")) {
-      return getMailTextFromMultiPart((MimeMultipart) message.getContent());
-    }
-
-    return null;
-  }
-
-  private static String getMailTextFromMultiPart(MimeMultipart mm) throws MessagingException, IOException {
-
-    for (int i = 0; i < mm.getCount(); i++) {
-      BodyPart part = mm.getBodyPart(i);
-      if (part.isMimeType("text/plain")) {
-        return part.getContent().toString();
-      } else if (part.isMimeType("multipart/*")) {
-        return getMailTextFromMultiPart((MimeMultipart) part.getContent());
-      }
-    }
-    return null;
+    return m.find() ? m.group() : null;
   }
 
   public String getDescription(MimeMessage message) throws MessagingException, IOException {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
@@ -62,7 +62,7 @@ public class MailContentExtractor
 
     // second search the mail reference in the subject written by predefined mailto links
     // e.g. in case of close need
-    Pattern referenceMailPattern = Pattern.compile("Message-Id: <(.+)>");
+    Pattern referenceMailPattern = Pattern.compile("Message-Id_(.+)");
     Matcher m = referenceMailPattern.matcher(message.getSubject());
     return m.find() ? m.group(1) : null;
   }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
@@ -1,15 +1,20 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
+import won.bot.framework.bot.context.BotContext;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
+import won.bot.framework.eventbot.action.EventBotActionUtils;
+import won.bot.framework.eventbot.action.impl.mail.model.SubscribeStatus;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.mail.CreateNeedFromMailEvent;
 import won.bot.framework.eventbot.event.impl.mail.MailCommandEvent;
 import won.bot.framework.eventbot.event.impl.mail.MailReceivedEvent;
+import won.bot.framework.eventbot.event.impl.mail.WelcomeMailEvent;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import java.io.IOException;
 
 /**
  * Created by fsuda on 30.09.2016.
@@ -27,20 +32,51 @@ public class MailParserAction extends BaseEventBotAction {
         if(event instanceof MailReceivedEvent){
             EventBus bus = getEventListenerContext().getEventBus();
             MimeMessage message = ((MailReceivedEvent) event).getMessage();
+            String senderMailAddress = MailContentExtractor.getMailSender(message);
 
             try {
-                if (mailContentExtractor.getBasicNeedType(message) != null) {
-                    logger.debug("received a create mail publishing the CreateNeedFromMail event");
-                    bus.publish(new CreateNeedFromMailEvent(message));
-                } else if (MailCommandAction.isCommandMail(message)) {
+                if (mailContentExtractor.isCreateNeedMail(message)) {
+                    processCreateNeedMail(message);
+                } else if (mailContentExtractor.isCommandMail(message)) {
+
                     logger.debug("received a command mail publishing the MailCommand event");
                     bus.publish(new MailCommandEvent(message));
+
                 } else {
-                    logger.warn("unknown mail with subject '{}', no further processing required", message.getSubject());
+                    logger.warn("unknown mail from user '{}' with subject '{}', no further processing required",
+                                senderMailAddress, message.getSubject());
                 }
             } catch (MessagingException me) {
                 logger.error("Messaging exception occurred while processing MimeMessage: {}", me);
+                logger.warn("mail from user '{}' with subject '{}' could not be processed",
+                            senderMailAddress, message.getSubject());
             }
+        }
+    }
+
+    private void processCreateNeedMail(MimeMessage message) throws MessagingException, IOException {
+
+        EventBus bus = getEventListenerContext().getEventBus();
+        BotContext botContext = getEventListenerContext().getBotContext();
+        String senderMailAddress = MailContentExtractor.getMailSender(message);
+        SubscribeStatus subscribeStatus =
+          EventBotActionUtils.getSubscribeStatusForMailAddress(botContext, senderMailAddress);
+
+        // depending of the user has subscribed/unsubscribed (via mailto links) his mails will be
+        // published as needs, discarded or cached
+        if (SubscribeStatus.SUBSCRIBED.equals(subscribeStatus)) {
+            logger.info("received a create mail from subscribed user '{}' with subject '{}' so publish as need",
+                        senderMailAddress, message.getSubject());
+            bus.publish(new CreateNeedFromMailEvent(message));
+        } else if (SubscribeStatus.UNSUBSCRIBED.equals(subscribeStatus)) {
+            logger.info("received mail from unsubscribed user '{}' so discard mail with subject '{}'",
+                        senderMailAddress, message.getSubject());
+        } else {
+            logger.info(
+              "received a create mail from new user '{}' with subject '{}' so cache it and send welcome mail",
+              senderMailAddress, message.getSubject());
+            EventBotActionUtils.addCachedMailsForMailAddress(botContext, message);
+            bus.publish(new WelcomeMailEvent(message));
         }
     }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WelcomeMailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WelcomeMailAction.java
@@ -1,0 +1,31 @@
+package won.bot.framework.eventbot.action.impl.mail.send;
+
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
+import won.bot.framework.eventbot.action.BaseEventBotAction;
+import won.bot.framework.eventbot.event.Event;
+import won.bot.framework.eventbot.event.impl.mail.WelcomeMailEvent;
+
+/**
+ * Created by hfriedrich on 16.11.2016.
+ */
+public class WelcomeMailAction extends BaseEventBotAction
+{
+  private MessageChannel sendChannel;
+  private WonMimeMessageGenerator mailGenerator;
+
+  public WelcomeMailAction(WonMimeMessageGenerator mailGenerator, MessageChannel sendChannel) {
+
+    super(mailGenerator.getEventListenerContext());
+    this.sendChannel = sendChannel;
+    this.mailGenerator = mailGenerator;
+  }
+
+  @Override
+  protected void doRun(final Event event) throws Exception {
+    if(event instanceof WelcomeMailEvent){
+      WonMimeMessage welcomeMessage = mailGenerator.createWelcomeMail(((WelcomeMailEvent) event).getMessage());
+      sendChannel.send(new GenericMessage<>(welcomeMessage));
+    }
+  }
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessage.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessage.java
@@ -17,6 +17,19 @@ public class WonMimeMessage extends MimeMessage {
         super(mimeMessage);
     }
 
+    public void setMessageId(String messageId) throws MessagingException {
+
+        if (messageId.startsWith("<") && messageId.endsWith(">")) {
+            this.setHeader("Message-ID", messageId);
+        } else {
+            this.setHeader("Message-ID", "<" + messageId + ">");
+        }
+    }
+
+    public String getMessageIdHeader() throws MessagingException {
+        return getHeader("Message-Id")[0];
+    }
+
     @Override
     public void updateMessageID() throws MessagingException {
         if(getHeader("Message-Id") == null) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -85,7 +85,7 @@ public class WonMimeMessageGenerator {
     public WonMimeMessage createWelcomeMail(MimeMessage msgToRespondTo) throws IOException, MessagingException {
 
         VelocityContext velocityContext = new VelocityContext();
-        putQuotedMessage(velocityContext, msgToRespondTo);
+        putQuotedMail(velocityContext, msgToRespondTo);
         velocityContext.put("mailbotEmailAddress", sentFrom);
         velocityContext.put("mailbotName", sentFromName);
         StringWriter writer = new StringWriter();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -82,6 +82,24 @@ public class WonMimeMessageGenerator {
         return generateWonMimeMessage(msgToRespondTo, writer.toString(), remoteNeedUri);
     }
 
+    public WonMimeMessage createWelcomeMail(MimeMessage msgToRespondTo) throws IOException, MessagingException {
+
+        VelocityContext velocityContext = new VelocityContext();
+        putQuotedMessage(velocityContext, msgToRespondTo);
+        velocityContext.put("mailbotEmailAddress", sentFrom);
+        velocityContext.put("mailbotName", sentFromName);
+        StringWriter writer = new StringWriter();
+        velocityEngine.getTemplate("mail-templates/welcome-mail.vm").merge(velocityContext, writer);
+
+        MimeMessage answerMessage = (MimeMessage) msgToRespondTo.reply(false);
+        answerMessage.setFrom(new InternetAddress(sentFrom, sentFromName));
+        answerMessage.setText(writer.toString());
+        WonMimeMessage wonAnswerMessage = new WonMimeMessage(answerMessage);
+        wonAnswerMessage.updateMessageID();
+
+        return wonAnswerMessage;
+    }
+
     /**
      * Creates the DefaultContext and fills in all relevant Infos which are used in every Mail, in our Case this is the NeedInfo and the quoted Original Message
      * @param msgToRespondTo Message that the new Mail is in ResponseTo (to extract the mailtext)

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -2,6 +2,7 @@ package won.bot.framework.eventbot.action.impl.mail.send;
 
 import com.hp.hpl.jena.query.*;
 import com.hp.hpl.jena.tdb.TDB;
+import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.slf4j.Logger;
@@ -21,7 +22,10 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.*;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This Class is used to generate all Mails that are going to be sent via the Mail2WonBot
@@ -54,32 +58,25 @@ public class WonMimeMessageGenerator {
      * Creates Response Message that is sent when a need tries to connect with another need
      */
     public WonMimeMessage createConnectMail(MimeMessage msgToRespondTo, URI remoteNeedUri) throws MessagingException, IOException {
+
         VelocityContext velocityContext = putDefaultContent(msgToRespondTo, remoteNeedUri);
-
-        StringWriter writer = new StringWriter();
-
-        velocityEngine.getTemplate("mail-templates/connect-mail.vm").merge(velocityContext, writer);
-        return generateWonMimeMessage(msgToRespondTo, writer.toString(), remoteNeedUri);
+        return generateWonMimeMessage(msgToRespondTo, velocityEngine.getTemplate("mail-templates/connect-mail.vm"),
+                                      velocityContext, remoteNeedUri);
     }
 
     public WonMimeMessage createHintMail(MimeMessage msgToRespondTo, URI remoteNeedUri) throws MessagingException, IOException {
+
         VelocityContext velocityContext = putDefaultContent(msgToRespondTo, remoteNeedUri);
-
-        StringWriter writer = new StringWriter();
-
-        velocityEngine.getTemplate("mail-templates/hint-mail.vm").merge(velocityContext, writer);
-        return generateWonMimeMessage(msgToRespondTo, writer.toString(), remoteNeedUri);
+        return generateWonMimeMessage(msgToRespondTo, velocityEngine.getTemplate("mail-templates/hint-mail.vm"),
+                                      velocityContext, remoteNeedUri);
     }
 
     public WonMimeMessage createMessageMail(MimeMessage msgToRespondTo, URI requesterId, URI remoteNeedUri, URI connectionUri) throws MessagingException, IOException {
+
         VelocityContext velocityContext = putDefaultContent(msgToRespondTo, remoteNeedUri);
-
         putMessages(velocityContext, connectionUri, requesterId);
-
-        StringWriter writer = new StringWriter();
-
-        velocityEngine.getTemplate("mail-templates/message-mail.vm").merge(velocityContext, writer);
-        return generateWonMimeMessage(msgToRespondTo, writer.toString(), remoteNeedUri);
+        return generateWonMimeMessage(msgToRespondTo, velocityEngine.getTemplate("mail-templates/message-mail.vm"),
+                                      velocityContext, remoteNeedUri);
     }
 
     public WonMimeMessage createWelcomeMail(MimeMessage msgToRespondTo) throws IOException, MessagingException {
@@ -117,20 +114,35 @@ public class WonMimeMessageGenerator {
         return velocityContext;
     }
 
-    private WonMimeMessage generateWonMimeMessage(MimeMessage msgToRespondTo, String mailBody, URI remoteNeedUri)
+    private WonMimeMessage generateWonMimeMessage(
+      MimeMessage msgToRespondTo, Template template, VelocityContext velocityContext, URI remoteNeedUri)
       throws MessagingException, UnsupportedEncodingException {
+
         Dataset remoteNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(remoteNeedUri);
 
         MimeMessage answerMessage = (MimeMessage) msgToRespondTo.reply(false);
         answerMessage.setFrom(new InternetAddress(sentFrom, sentFromName));
-        answerMessage.setText(mailBody);
-        answerMessage.setSubject(answerMessage.getSubject() + " <-> ["+ BasicNeedType.fromURI(WonRdfUtils.NeedUtils.getBasicNeedType(remoteNeedRDF))+"] " +  WonRdfUtils.NeedUtils.getNeedTitle(remoteNeedRDF));
+        answerMessage.setText("");
+        answerMessage.setSubject(answerMessage.getSubject() + " <-> [" + BasicNeedType
+          .fromURI(WonRdfUtils.NeedUtils.getBasicNeedType(remoteNeedRDF)) + "] " + WonRdfUtils.NeedUtils
+          .getNeedTitle(remoteNeedRDF));
 
         //We need to create an instance of our own MimeMessage Implementation in order to have the Unique Message Id set before sending
         WonMimeMessage wonAnswerMessage = new WonMimeMessage(answerMessage);
         wonAnswerMessage.updateMessageID();
+        String messageId = wonAnswerMessage.getMessageID();
 
-        return  wonAnswerMessage;
+        // put variables (e.g. Message-Id) for the footer into the context and create mail body using the template
+        putCommandFooter(velocityContext, wonAnswerMessage);
+        StringWriter writer = new StringWriter();
+        template.merge(velocityContext, writer);
+        answerMessage.setText(writer.toString());
+
+        // create a new won mime message with the right body and message id set
+        wonAnswerMessage = new WonMimeMessage(answerMessage);
+        wonAnswerMessage.setMessageId(messageId);
+
+        return wonAnswerMessage;
     }
 
     /**
@@ -141,12 +153,29 @@ public class WonMimeMessageGenerator {
     private void putRemoteNeedInfo(VelocityContext velocityContext, URI remoteNeedUri) {
         Dataset remoteNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(remoteNeedUri);
 
-        velocityContext.put("remoteNeedTitle", WonRdfUtils.NeedUtils.getNeedTitle(remoteNeedRDF).replaceAll("\\n", "\n" + QUOTE_CHAR));
-        velocityContext.put("remoteNeedDescription", WonRdfUtils.NeedUtils.getNeedDescription(remoteNeedRDF).replaceAll("\\n", "\n" + QUOTE_CHAR));
+        velocityContext.put("remoteNeedTitle",
+                            WonRdfUtils.NeedUtils.getNeedTitle(remoteNeedRDF).replaceAll("\\n", "\n" + QUOTE_CHAR));
+        velocityContext.put("remoteNeedDescription", WonRdfUtils.NeedUtils.getNeedDescription(remoteNeedRDF)
+                                                                          .replaceAll("\\n", "\n" + QUOTE_CHAR));
 
         List<String> tags = WonRdfUtils.NeedUtils.getTags(remoteNeedRDF);
         velocityContext.put("remoteNeedTags", tags.size() > 0 ? tags : null);
         velocityContext.put("remoteNeedUri", remoteNeedUri);
+    }
+
+    /**
+     * Responsible for filling inc/footer.vm template
+     *
+     * @param velocityContext
+     * @param message
+     * @throws MessagingException
+     */
+    private void putCommandFooter(VelocityContext velocityContext, WonMimeMessage message)
+      throws MessagingException, UnsupportedEncodingException {
+
+        velocityContext.put("mailbotEmailAddress", sentFrom);
+        velocityContext.put("mailbotName", sentFromName);
+        velocityContext.put("mailReference", URLEncoder.encode(message.getMessageIdHeader(), "UTF-8"));
     }
 
     /**

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/mail/SubscribeUnsubscribeEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/mail/SubscribeUnsubscribeEvent.java
@@ -1,0 +1,29 @@
+package won.bot.framework.eventbot.event.impl.mail;
+
+import won.bot.framework.eventbot.action.impl.mail.model.SubscribeStatus;
+import won.bot.framework.eventbot.event.BaseEvent;
+
+import javax.mail.internet.MimeMessage;
+
+/**
+ * Created by hfriedrich on 16.11.2016.
+ */
+public class SubscribeUnsubscribeEvent extends BaseEvent
+{
+  private final MimeMessage message;
+  private final SubscribeStatus subscribeStatus;
+
+  public SubscribeUnsubscribeEvent(MimeMessage message, SubscribeStatus subscribeStatus) {
+
+    this.message = message;
+    this.subscribeStatus = subscribeStatus;
+  }
+
+  public MimeMessage getMessage() {
+    return message;
+  }
+
+  public SubscribeStatus getSubscribeStatus() {
+    return subscribeStatus;
+  }
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/mail/WelcomeMailEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/mail/WelcomeMailEvent.java
@@ -1,0 +1,22 @@
+package won.bot.framework.eventbot.event.impl.mail;
+
+import won.bot.framework.eventbot.event.BaseEvent;
+
+import javax.mail.internet.MimeMessage;
+
+/**
+ * Created by hfriedrich on 16.11.2016.
+ */
+public class WelcomeMailEvent  extends BaseEvent
+{
+  private final MimeMessage message;
+
+  public WelcomeMailEvent(MimeMessage message) {
+    this.message = message;
+  }
+
+  public MimeMessage getMessage() {
+    return message;
+  }
+}
+

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
@@ -1,18 +1,11 @@
 package won.bot.impl;
 
-import org.apache.velocity.app.VelocityEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
-import won.bot.framework.eventbot.action.impl.mail.receive.CreateNeedFromMailAction;
-import won.bot.framework.eventbot.action.impl.mail.receive.MailCommandAction;
-import won.bot.framework.eventbot.action.impl.mail.receive.MailContentExtractor;
-import won.bot.framework.eventbot.action.impl.mail.receive.MailParserAction;
-import won.bot.framework.eventbot.action.impl.mail.send.Connect2MailParserAction;
-import won.bot.framework.eventbot.action.impl.mail.send.Hint2MailParserAction;
-import won.bot.framework.eventbot.action.impl.mail.send.Message2MailAction;
-import won.bot.framework.eventbot.action.impl.mail.send.WonMimeMessageGenerator;
+import won.bot.framework.eventbot.action.impl.mail.receive.*;
+import won.bot.framework.eventbot.action.impl.mail.send.*;
 import won.bot.framework.eventbot.action.impl.wonmessage.CloseConnectionUriAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.OpenConnectionUriAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendMessageOnConnectionAction;
@@ -73,6 +66,13 @@ public class Mail2WonBot extends EventBot{
 
         ));
 
+        bus.subscribe(WelcomeMailEvent.class, new ActionOnEventListener(
+          ctx,
+          "WelcomeMailAction",
+          new WelcomeMailAction(mailGenerator, sendEmailChannel)
+
+        ));
+
         bus.subscribe(MailCommandEvent.class,
         new ActionOnEventListener(
                 ctx,
@@ -100,6 +100,9 @@ public class Mail2WonBot extends EventBot{
                 "OpenCommandEvent",
                 new OpenConnectionUriAction(ctx)
         ));
+
+      bus.subscribe(SubscribeUnsubscribeEvent.class,
+                    new ActionOnEventListener(ctx, "SubscribeUnsubscribeEvent", new SubscribeUnsubscribeAction(ctx)));
 
         //WON initiated Events
         bus.subscribe(HintFromMatcherEvent.class,

--- a/webofneeds/won-bot/src/main/resources/mail-templates/connect-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/connect-mail.vm
@@ -3,3 +3,5 @@ Someone wants to connect with you:
 #parse('mail-templates/inc/remote-need-info.vm')
 
 #parse('mail-templates/inc/quoted-mail.vm')
+
+#parse('mail-templates/inc/footer.vm')

--- a/webofneeds/won-bot/src/main/resources/mail-templates/hint-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/hint-mail.vm
@@ -3,3 +3,5 @@ We found a Match for you:
 #parse('mail-templates/inc/remote-need-info.vm')
 
 #parse('mail-templates/inc/quoted-mail.vm')
+
+#parse('mail-templates/inc/footer.vm')

--- a/webofneeds/won-bot/src/main/resources/mail-templates/inc/footer.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/inc/footer.vm
@@ -1,0 +1,3 @@
+---
+close this request and do not receive mails for it anymore:<mailto:$mailbotEmailAddress?subject=close_Message-Id_$mailReference>
+do not publish my requests on this mailinglist and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>

--- a/webofneeds/won-bot/src/main/resources/mail-templates/message-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/message-mail.vm
@@ -3,3 +3,5 @@
 #parse('mail-templates/inc/remote-need-info.vm')
 
 #parse('mail-templates/inc/quoted-mail.vm')
+
+#parse('mail-templates/inc/footer.vm')

--- a/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
@@ -1,0 +1,8 @@
+Dear mailing list user,
+
+this is an automatic response from the $mailbotName to the following email you sent.
+
+#parse('mail-templates/inc/quoted-message.vm')
+
+publish all my mails in this mailing list to matchat.org: <mailto:$mailbotEmailAddress?subject=subscribe>
+do not publish my mails and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>

--- a/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
@@ -5,4 +5,4 @@ this is an automatic response from the $mailbotName to the following email you s
 #parse('mail-templates/inc/quoted-mail.vm')
 
 publish all my requests in this mailing list to matchat.org: <mailto:$mailbotEmailAddress?subject=subscribe>
-do not publish requests and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>
+do not publish my requests on this mailinglist and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>

--- a/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
@@ -2,7 +2,7 @@ Dear mailing list user,
 
 this is an automatic response from the $mailbotName to the following email you sent.
 
-#parse('mail-templates/inc/quoted-message.vm')
+#parse('mail-templates/inc/quoted-mail.vm')
 
-publish all my mails in this mailing list to matchat.org: <mailto:$mailbotEmailAddress?subject=subscribe>
-do not publish my mails and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>
+publish all my requests in this mailing list to matchat.org: <mailto:$mailbotEmailAddress?subject=subscribe>
+do not publish requests and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>

--- a/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
@@ -83,5 +83,15 @@
                 <constructor-arg value="(?si)^connect.*" />
             </bean>
         </property>
+        <property name="cmdSubscribePattern">
+            <bean id="cmdSubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
+                <constructor-arg value="(?si)^subscribe.*" />
+            </bean>
+        </property>
+        <property name="cmdUnsubscribePattern">
+            <bean id="cmdUnsubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
+                <constructor-arg value="(?si)^unsubscribe.*" />
+            </bean>
+        </property>
     </bean>
 </beans>


### PR DESCRIPTION
* fixes #882, fixes #889 

* added functionality for the user to subscribe/unsubscribe to the mail bot, meaning publish all my future needs / ignore mail bot in future (opt-in/opt-out)
* created first draft of welcome mail that is sent in response to mails on the mailinglist if user has not subscribed or unsubscribed yet 
* added footer to hint/connect/message mails to send and close event using mailto links (close need functionality is not yet implemented)