### PR TITLE
improved cache headers and landingpage config in owner application

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -5,14 +5,8 @@
              xmlns:beans="http://www.springframework.org/schema/beans" xmlns:benas="http://www.springframework.org/schema/beans"
              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
-	<http pattern="/favicon.ico" security="none"/>
-	<http pattern="/app" security="none"/>
-	<http pattern="/bower_components" security="none"/>
-	<http pattern="/fonts" security="none"/>
-	<http pattern="/images" security="none"/>
-	<http pattern="/old" security="none"/>
-	<http pattern="/scripts" security="none"/>
-	<http pattern="/style" security="none"/>
+
+
 	<!-- special config for linked data brige: we want no caching headers added  -->
 	<http use-expressions="true" pattern="/rest/linked-data/**"
 		  entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint" security-context-repository-ref="securityContextRepository">
@@ -26,6 +20,23 @@
 		<intercept-url pattern="/**" access="denyAll" />
 		<custom-filter ref="sessionRepositoryFilter" before="FIRST" />
 	</http>
+
+	<http use-expressions="true"
+		  pattern="(/generated/.+|/images/.+|/favicon.ico|/app/.+|bower_components/.+|/fonts/.+|/scripts/.+|/style/.+|/index.html|/appConfig/.+|/jspm_packages/.+|/jspm_config.js)"
+		  request-matcher="regex"
+		  entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint"
+		   security-context-repository-ref="securityContextRepository">
+		<!--
+			This is static stuff, which may change, but usually doesn't.
+			If it changes, we want clients to notice the change via If-None-Match Etag validation.
+			We accept that users only check these resources once a day
+		-->
+		<headers >
+			<header name="Cache-Control" value="max-age=86400" />
+		</headers>
+		<intercept-url pattern=".*" access="permitAll()" />
+	</http>
+
 	<http use-expressions="true" entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint"
 		  security-context-repository-ref="securityContextRepository">
         <intercept-url pattern="/msg" access="isAnonymous()"/>

--- a/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/web.xml
@@ -74,7 +74,6 @@
     <!-- GENERAL -->
 
     <welcome-file-list>
-        <welcome-file>index.jsp</welcome-file>
 	    <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -1,4 +1,4 @@
-<%--
+<!--
   ~ Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,11 +12,7 @@
   ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
-  --%>
-
-<!DOCTYPE HTML>
-<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt" %>
-<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
+  -->
 <html>
 <head>
     <meta charset="UTF-8">
@@ -27,29 +23,6 @@
 </head>
 <body>
 <section ui-view></section>
-
-<!-- <debug-navigation>
-<div style="position: fixed;
-                    z-index: 200;
-                    bottom: 0px; left: 0px; right: 0px;
-                    background-color: lightgray;
-                    border-top: 1px solid black;">
-    debug navigation: |
-    <a ui-sref="landingpage">landingpage</a> |
-    <a ui-sref="createNeed({draftId: 0})">create-need</a> |
-    <a ui-sref="feed">feed</a> |
-    <a ui-sref="settings.general">settings</a> |
-    <a ui-sref="overviewMatches">matches</a> |
-    <a ui-sref="overviewIncomingRequests">incoming-requests</a> |
-    <a ui-sref="overviewPosts">posts</a> |
-    <a ui-sref="postVisitor({myUri: 'http://example.org/121337345', theirUri: 'http://example.org/97172311'})">visitor-info</a> |
-    <a ui-sref="postVisitorMsgs({myUri: 'http://example.org/121337345', theirUri: 'http://example.org/97172311'})">visitor-convo</a> |
-    <a ui-sref="postInfo({myUri: 'http://example.org/121337345'})">owner-info</a> |
-    <a ui-sref="postMatches({myUri: 'http://example.org/121337345'})">owner-matches</a> |
-    <a ui-sref="postRequests({myUri: 'http://example.org/121337345'})">owner-requests</a> |
-    <a ui-sref="postConversations({myUri: 'http://example.org/121337345'})">owner-convos</a>
-</div>
-<!-- </debug-navigation> -->
 
 <!-- TODO make sure to only show the svgs once angular has finished rendering -->
 


### PR DESCRIPTION
improved caching headers in owner application to allow for client side caching of static resources

How to test: open the owner application, inspect the network information in the browser. After the first page view, almost all resources should cause a 304 not modified response upon page reload. 
If the page is requested again (via entering the url again), most resources should be served from the cache directly.