### PR TITLE
Only triggering a submit-event when a message has been entered

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
@@ -72,14 +72,15 @@ function genComponentConf() {
             dispatchEvent(this.$element[0], 'input', payload);
         }
         submit() {
-            const payload = {
-                value: this.value(),
-                valid: this.valid(),
-            };
-            this.onSubmit(payload);
-            dispatchEvent(this.$element[0], 'submit', payload);
+            const value = this.value();
+            const valid = this.valid();
+            if(value && valid) {
+                const payload = { value, valid };
+                this.onSubmit(payload);
+                dispatchEvent(this.$element[0], 'submit', payload);
 
-            this.medium.clear(); // clear text
+                this.medium.clear(); // clear text
+            }
         }
         charactersLeft() {
             return this.maxChars - this.value().length;


### PR DESCRIPTION
The other events, even though this.value() was empty, were
dispatched and showed up in the chat and on the node. For
some reason they had the previously cleared value still set
as content.

Resolves #710 