### PR TITLE
Fixed bug in selector used by "show more".

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -8,6 +8,7 @@ import won from './won-es6';
 import {
     decodeUriComponentProperly,
     msStringToDate,
+    is,
 } from './utils';
 
 import {
@@ -36,6 +37,7 @@ export const selectRemoteEvents = createSelector(
             .toList()
             .map(e => {
                 let remote = e.get('hasCorrespondingRemoteMessage') // select remote
+                if(is('string', remote)) remote = events.get(remote); // for those rare cases where remote is only a uri
                 if(!remote) return undefined;
                 remote = remote.set('correspondsToOwnMsg', e); //add back-reference to it
                 return remote && [remote.get('uri'), remote]


### PR DESCRIPTION
Apparently for some success-responses the corresponding-remote-message is only saved as string. This is a quick fix, that allows a selector used by the "show more"-button to deal with these without crashing.

Test: open connection, chat around a bit, click show-more -> no more exceptions. Make sure to test with the master-branch first, so you have a events on your connections that cause the exception to begin with.