### PR TITLE
Feat close need on taken

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -49,12 +49,13 @@ import java.util.Properties;
  * User: fkleedorfer
  * Date: 02.02.14
  */
-public class EventBotActionUtils
-{
+public class EventBotActionUtils {
     private static final Logger logger = LoggerFactory.getLogger(EventBotActionUtils.class);
 
-    private static final String USER_SUBSCRIBE_COLLECTION = "user_subscribe_status";
-    private static final String USER_CACHED_MAILS_COLLECTION = "user_cached_mails";
+    private static final String MAIL_USER_SUBSCRIBE_COLLECTION = "user_subscribe_status";
+    private static final String MAIL_USER_CACHED_MAILS_COLLECTION = "user_cached_mails";
+    private static final String MAIL_URIMIMEMESSAGERELATIONS_NAME = "uriMimeMessageRelations";
+    private static final String MAIL_MAILIDURIRELATIONS_NAME = "mailIdUriRelations";
 
     public static void rememberInList(EventListenerContext ctx, URI uri, String uriListName) {
         if (uriListName != null && uriListName.trim().length() > 0){
@@ -78,119 +79,52 @@ public class EventBotActionUtils
         }
     }
 
-    /**
-    * Creates a listener that waits for the response to the specified message. If a SuccessResponse is received,
-    * the successCallback is executed, if a FailureResponse is received, the failureCallback is executed.
-    * @param outgoingMessage
-    * @param successCallback
-    * @param failureCallback
-    * @param context
-    * @return
-    */
-    public static EventListener makeAndSubscribeResponseListener(final WonMessage outgoingMessage,
-        final EventListener successCallback, final EventListener failureCallback, EventListenerContext context) {
-
-        //create an event listener that processes the response to the wonMessage we're about to send
-        EventListener listener = new ActionOnEventListener(context,
-            new AcceptOnceFilter(OriginalMessageUriResponseEventFilter.forWonMessage(outgoingMessage)),
-            new BaseEventBotAction(context)
-            {
-                @Override
-                protected void doRun(final Event event) throws Exception {
-                    if (event instanceof SuccessResponseEvent) {
-                        successCallback.onEvent(event);
-                    } else  if (event instanceof FailureResponseEvent){
-                        failureCallback.onEvent(event);
-                    }
-                }
-            }
-        );
-        context.getEventBus().subscribe(SuccessResponseEvent.class, listener);
-        context.getEventBus().subscribe(FailureResponseEvent.class, listener);
-        return listener;
-    }
-
-
-    /**
-    * Creates a listener that waits for the remote response to the specified message. If a SuccessResponse is received,
-    * the successCallback is executed, if a FailureResponse is received, the failureCallback is executed.
-    * @param outgoingMessage
-    * @param successCallback
-    * @param failureCallback
-    * @param context
-    * @return
-    */
-    public static EventListener makeAndSubscribeRemoteResponseListener(final WonMessage outgoingMessage,
-        final EventListener successCallback, final EventListener failureCallback, EventListenerContext context) {
-
-        //create an event listener that processes the remote response to the wonMessage we're about to send
-        EventListener listener = new ActionOnEventListener(context,
-            new AcceptOnceFilter(OriginalMessageUriRemoteResponseEventFilter.forWonMessage(outgoingMessage)),
-            new BaseEventBotAction(context)
-            {
-                @Override
-                protected void doRun(final Event event) throws Exception {
-                    if (event instanceof SuccessResponseEvent) {
-                        successCallback.onEvent(event);
-                    } else  if (event instanceof FailureResponseEvent){
-                        failureCallback.onEvent(event);
-                    }
-                }
-            }
-        );
-        context.getEventBus().subscribe(SuccessResponseEvent.class, listener);
-        context.getEventBus().subscribe(FailureResponseEvent.class, listener);
-        return listener;
-    }
-
+    //************************************************ Mail2WonBot Context Methods *************************************
     //Util Methods to Get/Remove/Add Uri -> MimeMessage Relation
-    public static void removeUriMimeMessageRelation(EventListenerContext context, String mapName, URI needURI) {
-        context.getBotContext().removeFromObjectMap(mapName, needURI.toString());
+    public static void removeUriMimeMessageRelation(EventListenerContext context, URI needURI) {
+        context.getBotContext().removeFromObjectMap(MAIL_URIMIMEMESSAGERELATIONS_NAME, needURI.toString());
     }
 
-    public static MimeMessage getMimeMessageForURI(EventListenerContext context, String mapName, URI uri)
-      throws MessagingException {
+    public static MimeMessage getMimeMessageForURI(EventListenerContext context, URI uri) throws MessagingException {
 
         // use the empty default session here for reconstructing the mime message
-        byte[] byteMsg = (byte[]) context.getBotContext().loadFromObjectMap(mapName, uri.toString());
+        byte[] byteMsg = (byte[]) context.getBotContext().loadFromObjectMap(MAIL_URIMIMEMESSAGERELATIONS_NAME, uri.toString());
         ByteArrayInputStream is = new ByteArrayInputStream(byteMsg);
         return new MimeMessage(Session.getDefaultInstance(new Properties(), null), is);
     }
 
-    public static void addUriMimeMessageRelation(EventListenerContext context, String mapName, URI needURI, MimeMessage mimeMessage)
+    public static void addUriMimeMessageRelation(EventListenerContext context, URI needURI, MimeMessage mimeMessage)
       throws IOException, MessagingException {
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         mimeMessage.writeTo(os);
-        context.getBotContext().saveToObjectMap(mapName, needURI.toString(), os.toByteArray());
+        context.getBotContext().saveToObjectMap(MAIL_URIMIMEMESSAGERELATIONS_NAME, needURI.toString(), os.toByteArray());
     }
 
     //Util Methods to Get/Remove/Add MailId -> URI Relation
-    public static void removeMailIdWonURIRelation(EventListenerContext context, String mapName, String mailId) {
-        context.getBotContext().removeFromObjectMap(mapName, mailId);
+    public static void removeMailIdWonURIRelation(EventListenerContext context, String mailId) {
+        context.getBotContext().removeFromObjectMap(MAIL_MAILIDURIRELATIONS_NAME, mailId);
     }
 
-    public static WonURI getWonURIForMailId(EventListenerContext context, String mapName, String mailId) {
-        return (WonURI) context.getBotContext().loadFromObjectMap(mapName, mailId);
+    public static WonURI getWonURIForMailId(EventListenerContext context, String mailId) {
+        return (WonURI) context.getBotContext().loadFromObjectMap(MAIL_MAILIDURIRELATIONS_NAME, mailId);
     }
 
-    public static void addMailIdWonURIRelation(EventListenerContext context, String mapName, String mailId, WonURI uri) {
-        context.getBotContext().saveToObjectMap(mapName, mailId, uri);
+    public static void addMailIdWonURIRelation(EventListenerContext context, String mailId, WonURI uri) {
+        context.getBotContext().saveToObjectMap(MAIL_MAILIDURIRELATIONS_NAME, mailId, uri);
     }
 
-    public static void addCachedMailsForMailAddress(BotContext botContext, MimeMessage mimeMessage)
-      throws IOException, MessagingException {
-
+    public static void addCachedMailsForMailAddress(BotContext botContext, MimeMessage mimeMessage) throws IOException, MessagingException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         mimeMessage.writeTo(os);
-        botContext.addToListMap(USER_CACHED_MAILS_COLLECTION, MailContentExtractor.getMailSender(mimeMessage), os.toByteArray());
+        botContext.addToListMap(MAIL_USER_CACHED_MAILS_COLLECTION, MailContentExtractor.getMailSender(mimeMessage), os.toByteArray());
     }
 
     public static Collection<MimeMessage> loadCachedMailsForMailAddress(BotContext botContext, String mailAddress)
       throws MessagingException {
 
         List<MimeMessage> mimeMessages = new LinkedList<>();
-        List<Object> objectList = botContext.loadFromListMap(USER_CACHED_MAILS_COLLECTION, mailAddress);
+        List<Object> objectList = botContext.loadFromListMap(MAIL_USER_CACHED_MAILS_COLLECTION, mailAddress);
         for (Object o : objectList) {
 
             // use the empty default session here for reconstructing the mime message
@@ -208,15 +142,16 @@ public class EventBotActionUtils
 
     public static void setSubscribeStatusForMailAddress(
       BotContext botContext, String mailAddress, SubscribeStatus status) {
-        botContext.saveToObjectMap(USER_SUBSCRIBE_COLLECTION, mailAddress, status);
+        botContext.saveToObjectMap(MAIL_USER_SUBSCRIBE_COLLECTION, mailAddress, status);
     }
 
     public static SubscribeStatus getSubscribeStatusForMailAddress(BotContext botContext, String mailAddress) {
 
-        String status = (String) botContext.loadFromObjectMap(USER_SUBSCRIBE_COLLECTION, mailAddress);
+        String status = (String) botContext.loadFromObjectMap(MAIL_USER_SUBSCRIBE_COLLECTION, mailAddress);
         return (status != null) ? SubscribeStatus.valueOf(status) : SubscribeStatus.NO_RESPONSE;
     }
 
+    //************************************************ TelegramBot Context Methods *************************************
     public static void addChatIdWonURIRelation(EventListenerContext context, String mapName, Long chatId, WonURI uri) {
         context.getBotContext().saveToObjectMap(mapName, chatId.toString(), uri);
     }
@@ -234,5 +169,75 @@ public class EventBotActionUtils
 
     public static WonURI getWonURIForMessageId(EventListenerContext context, String mapName, Integer messageId) {
         return (WonURI) context.getBotContext().loadFromObjectMap(mapName, messageId.toString());
+    }
+
+    //************************************************ EventListener ***************************************************
+    /**
+     * Creates a listener that waits for the response to the specified message. If a SuccessResponse is received,
+     * the successCallback is executed, if a FailureResponse is received, the failureCallback is executed.
+     * @param outgoingMessage
+     * @param successCallback
+     * @param failureCallback
+     * @param context
+     * @return
+     */
+    public static EventListener makeAndSubscribeResponseListener(final WonMessage outgoingMessage,
+                                                                 final EventListener successCallback,
+                                                                 final EventListener failureCallback,
+                                                                 EventListenerContext context) {
+
+        //create an event listener that processes the response to the wonMessage we're about to send
+        EventListener listener = new ActionOnEventListener(context,
+                new AcceptOnceFilter(OriginalMessageUriResponseEventFilter.forWonMessage(outgoingMessage)),
+                new BaseEventBotAction(context)
+                {
+                    @Override
+                    protected void doRun(final Event event) throws Exception {
+                        if (event instanceof SuccessResponseEvent) {
+                            successCallback.onEvent(event);
+                        } else  if (event instanceof FailureResponseEvent){
+                            failureCallback.onEvent(event);
+                        }
+                    }
+                }
+        );
+        context.getEventBus().subscribe(SuccessResponseEvent.class, listener);
+        context.getEventBus().subscribe(FailureResponseEvent.class, listener);
+        return listener;
+    }
+
+
+    /**
+     * Creates a listener that waits for the remote response to the specified message. If a SuccessResponse is received,
+     * the successCallback is executed, if a FailureResponse is received, the failureCallback is executed.
+     * @param outgoingMessage
+     * @param successCallback
+     * @param failureCallback
+     * @param context
+     * @return
+     */
+    public static EventListener makeAndSubscribeRemoteResponseListener(final WonMessage outgoingMessage,
+                                                                       final EventListener successCallback,
+                                                                       final EventListener failureCallback,
+                                                                       EventListenerContext context) {
+
+        //create an event listener that processes the remote response to the wonMessage we're about to send
+        EventListener listener = new ActionOnEventListener(context,
+                new AcceptOnceFilter(OriginalMessageUriRemoteResponseEventFilter.forWonMessage(outgoingMessage)),
+                new BaseEventBotAction(context)
+                {
+                    @Override
+                    protected void doRun(final Event event) throws Exception {
+                        if (event instanceof SuccessResponseEvent) {
+                            successCallback.onEvent(event);
+                        } else  if (event instanceof FailureResponseEvent){
+                            failureCallback.onEvent(event);
+                        }
+                    }
+                }
+        );
+        context.getEventBus().subscribe(SuccessResponseEvent.class, listener);
+        context.getEventBus().subscribe(FailureResponseEvent.class, listener);
+        return listener;
     }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -56,6 +56,7 @@ public class EventBotActionUtils {
     private static final String MAIL_USER_CACHED_MAILS_COLLECTION = "user_cached_mails";
     private static final String MAIL_URIMIMEMESSAGERELATIONS_NAME = "uriMimeMessageRelations";
     private static final String MAIL_MAILIDURIRELATIONS_NAME = "mailIdUriRelations";
+    private static final String MAIL_MAILADRESSURIRELATIONS_NAME = "mailAdressUriRelations";
 
     public static void rememberInList(EventListenerContext ctx, URI uri, String uriListName) {
         if (uriListName != null && uriListName.trim().length() > 0){
@@ -86,7 +87,6 @@ public class EventBotActionUtils {
     }
 
     public static MimeMessage getMimeMessageForURI(EventListenerContext context, URI uri) throws MessagingException {
-
         // use the empty default session here for reconstructing the mime message
         byte[] byteMsg = (byte[]) context.getBotContext().loadFromObjectMap(MAIL_URIMIMEMESSAGERELATIONS_NAME, uri.toString());
         ByteArrayInputStream is = new ByteArrayInputStream(byteMsg);
@@ -114,15 +114,29 @@ public class EventBotActionUtils {
         context.getBotContext().saveToObjectMap(MAIL_MAILIDURIRELATIONS_NAME, mailId, uri);
     }
 
+    //Util Methods to Get/Remove/Add MailId -> URI Relation
+    public static List<WonURI> getWonURIsForMailAddress(EventListenerContext context, String mailAddress) {
+        List<WonURI> uriList = new LinkedList<>();
+        List<Object> objectList = context.getBotContext().loadFromListMap(MAIL_MAILADRESSURIRELATIONS_NAME, mailAddress);
+
+        for(Object o : objectList){
+            uriList.add((WonURI) o);
+        }
+
+        return uriList;
+    }
+
+    public static void addMailAddressWonURIRelation(EventListenerContext context, String mailAddress, WonURI uri) {
+        context.getBotContext().addToListMap(MAIL_MAILADRESSURIRELATIONS_NAME, mailAddress, uri);
+    }
+
     public static void addCachedMailsForMailAddress(BotContext botContext, MimeMessage mimeMessage) throws IOException, MessagingException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         mimeMessage.writeTo(os);
         botContext.addToListMap(MAIL_USER_CACHED_MAILS_COLLECTION, MailContentExtractor.getMailSender(mimeMessage), os.toByteArray());
     }
 
-    public static Collection<MimeMessage> loadCachedMailsForMailAddress(BotContext botContext, String mailAddress)
-      throws MessagingException {
-
+    public static Collection<MimeMessage> loadCachedMailsForMailAddress(BotContext botContext, String mailAddress) throws MessagingException {
         List<MimeMessage> mimeMessages = new LinkedList<>();
         List<Object> objectList = botContext.loadFromListMap(MAIL_USER_CACHED_MAILS_COLLECTION, mailAddress);
         for (Object o : objectList) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -161,8 +161,8 @@ public class EventBotActionUtils {
 
     public static SubscribeStatus getSubscribeStatusForMailAddress(BotContext botContext, String mailAddress) {
 
-        String status = (String) botContext.loadFromObjectMap(MAIL_USER_SUBSCRIBE_COLLECTION, mailAddress);
-        return (status != null) ? SubscribeStatus.valueOf(status) : SubscribeStatus.NO_RESPONSE;
+        SubscribeStatus status = (SubscribeStatus) botContext.loadFromObjectMap(MAIL_USER_SUBSCRIBE_COLLECTION, mailAddress);
+        return (status != null) ? SubscribeStatus.valueOf(status.name()) : SubscribeStatus.NO_RESPONSE;
     }
 
     //************************************************ TelegramBot Context Methods *************************************

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateNeedFromMailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateNeedFromMailAction.java
@@ -4,6 +4,8 @@ import com.hp.hpl.jena.rdf.model.Model;
 import org.apache.commons.lang3.StringUtils;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
+import won.bot.framework.eventbot.action.impl.mail.model.UriType;
+import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
 import won.bot.framework.eventbot.action.impl.needlifecycle.AbstractCreateNeedAction;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.mail.CreateNeedFromMailEvent;
@@ -87,6 +89,7 @@ public class CreateNeedFromMailAction extends AbstractCreateNeedAction {
                     public void onEvent(Event event) throws Exception {
                         logger.debug("need creation successful, new need URI is {}", needURI);
                         String sender = MailContentExtractor.getFromAddressString(EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), needURI));
+                        EventBotActionUtils.addMailAddressWonURIRelation(getEventListenerContext(), sender, new WonURI(needURI, UriType.NEED));
                         logger.debug("created need was from sender: " + sender);
                     }
                 };

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateNeedFromMailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateNeedFromMailAction.java
@@ -27,15 +27,14 @@ import java.util.Arrays;
  * Created by fsuda on 30.09.2016.
  */
 public class CreateNeedFromMailAction extends AbstractCreateNeedAction {
-    private String uriMimeMessageRelationsName;
+    private static final String MAIL_NEEDSLIST_NAME = "mailNeeds";
     private MailContentExtractor mailContentExtractor;
 
-    public CreateNeedFromMailAction(EventListenerContext eventListenerContext, String uriListName,
-                                    MailContentExtractor mailContentExtractor, String uriMimeMessageRelationsName,
+    public CreateNeedFromMailAction(EventListenerContext eventListenerContext,
+                                    MailContentExtractor mailContentExtractor,
                                     URI... facets) {
 
-        super(eventListenerContext, uriListName);
-        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
+        super(eventListenerContext, MAIL_NEEDSLIST_NAME);
         this.mailContentExtractor = mailContentExtractor;
 
         if (facets == null || facets.length == 0) {
@@ -80,14 +79,14 @@ public class CreateNeedFromMailAction extends AbstractCreateNeedAction {
                 WonMessage createNeedMessage = createWonMessage(wonNodeInformationService, needURI, wonNodeUri,
                                                                 model, isUsedForTesting, isDoNotMatch);
                 EventBotActionUtils.rememberInList(ctx, needURI, uriListName);
-                EventBotActionUtils.addUriMimeMessageRelation(ctx, uriMimeMessageRelationsName, needURI, message);
+                EventBotActionUtils.addUriMimeMessageRelation(ctx, needURI, message);
 
                 EventListener successCallback = new EventListener()
                 {
                     @Override
                     public void onEvent(Event event) throws Exception {
                         logger.debug("need creation successful, new need URI is {}", needURI);
-                        String sender = MailContentExtractor.getFromAddressString(EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, needURI));
+                        String sender = MailContentExtractor.getFromAddressString(EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), needURI));
                         logger.debug("created need was from sender: " + sender);
                     }
                 };
@@ -99,7 +98,7 @@ public class CreateNeedFromMailAction extends AbstractCreateNeedAction {
                         String textMessage = WonRdfUtils.MessageUtils.getTextMessage(((FailureResponseEvent) event).getFailureMessage());
                         logger.debug("need creation failed for need URI {}, original message URI {}: {}", new Object[]{needURI, ((FailureResponseEvent) event).getOriginalMessageURI(), textMessage});
                         EventBotActionUtils.removeFromList(getEventListenerContext(), needURI, uriListName);
-                        EventBotActionUtils.removeUriMimeMessageRelation(getEventListenerContext(), uriMimeMessageRelationsName, needURI);
+                        EventBotActionUtils.removeUriMimeMessageRelation(getEventListenerContext(), needURI);
                     }
                 };
                 EventBotActionUtils.makeAndSubscribeResponseListener(createNeedMessage, successCallback, failureCallback, getEventListenerContext());

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -9,6 +9,7 @@ import won.bot.framework.eventbot.action.impl.mail.model.SubscribeStatus;
 import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
+import won.bot.framework.eventbot.event.impl.command.DeactivateNeedCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.SendTextMessageOnConnectionEvent;
 import won.bot.framework.eventbot.event.impl.mail.CloseConnectionEvent;
 import won.bot.framework.eventbot.event.impl.mail.MailCommandEvent;
@@ -71,7 +72,7 @@ public class MailCommandAction extends BaseEventBotAction {
                  as a previously created need by the user*/
                 URI needUri = retrieveCorrespondingNeedUriFromMailByTitle(message);
                 if(needUri != null) {
-                    bus.publish(new NeedDeactivatedEvent(needUri));
+                    bus.publish(new DeactivateNeedCommandEvent(needUri));
                 }
                 break;
             case NO_ACTION:
@@ -140,7 +141,7 @@ public class MailCommandAction extends BaseEventBotAction {
                     bus.publish(new SendTextMessageOnConnectionEvent(mailContentExtractor.getTextMessage(message), wonUri.getUri()));
                     break;
                 case CLOSE_NEED:
-                    bus.publish(new NeedDeactivatedEvent(needUri));
+                    bus.publish(new DeactivateNeedCommandEvent(needUri));
                     break;
                 case NO_ACTION:
                 default:

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -30,16 +30,10 @@ import static jdk.nashorn.internal.runtime.regexp.joni.Config.log;
  * Created by fsuda on 18.10.2016.
  */
 public class MailCommandAction extends BaseEventBotAction {
-
-    private String mailIdUriRelationsName;
-    private String uriMimeMessageRelationsName;
     private MailContentExtractor mailContentExtractor;
 
-    public MailCommandAction(EventListenerContext eventListenerContext, String mailIdUriRelationsName,
-                             String uriMimeMessageRelationsName, MailContentExtractor mailContentExtractor) {
+    public MailCommandAction(EventListenerContext eventListenerContext, MailContentExtractor mailContentExtractor) {
         super(eventListenerContext);
-        this.mailIdUriRelationsName = mailIdUriRelationsName;
-        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
         this.mailContentExtractor = mailContentExtractor;
     }
 
@@ -86,7 +80,7 @@ public class MailCommandAction extends BaseEventBotAction {
 
         EventBus bus = getEventListenerContext().getEventBus();
         try{
-            WonURI wonUri = EventBotActionUtils.getWonURIForMailId(getEventListenerContext(), mailIdUriRelationsName, referenceId);
+            WonURI wonUri = EventBotActionUtils.getWonURIForMailId(getEventListenerContext(), referenceId);
 
             if(wonUri == null){
                 throw new NullPointerException("No corresponding wonUri found");
@@ -104,7 +98,7 @@ public class MailCommandAction extends BaseEventBotAction {
                     break;
             }
 
-            MimeMessage originalMessage = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, needUri); //TODO: SET MAPNAME TO THE CORRECT ONE DIRECTLY FROM Mail2WonBot
+            MimeMessage originalMessage = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), needUri);
 
             if(originalMessage == null) {
                 throw new NullPointerException("no originalmessage found");

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -1,11 +1,13 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
+import com.hp.hpl.jena.query.Dataset;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
 import won.bot.framework.eventbot.action.impl.mail.model.ActionType;
 import won.bot.framework.eventbot.action.impl.mail.model.SubscribeStatus;
 import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
+import won.bot.framework.eventbot.action.impl.mail.send.WonMimeMessage;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.command.SendTextMessageOnConnectionEvent;
@@ -17,7 +19,12 @@ import won.protocol.util.WonRdfUtils;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import javax.naming.AuthenticationException;
 import java.io.IOException;
+import java.net.URI;
+import java.security.AccessControlException;
+
+import static jdk.nashorn.internal.runtime.regexp.joni.Config.log;
 
 /**
  * Created by fsuda on 18.10.2016.
@@ -25,12 +32,14 @@ import java.io.IOException;
 public class MailCommandAction extends BaseEventBotAction {
 
     private String mailIdUriRelationsName;
+    private String uriMimeMessageRelationsName;
     private MailContentExtractor mailContentExtractor;
 
     public MailCommandAction(EventListenerContext eventListenerContext, String mailIdUriRelationsName,
-                             MailContentExtractor mailContentExtractor) {
+                             String uriMimeMessageRelationsName, MailContentExtractor mailContentExtractor) {
         super(eventListenerContext);
         this.mailIdUriRelationsName = mailIdUriRelationsName;
+        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
         this.mailContentExtractor = mailContentExtractor;
     }
 
@@ -78,7 +87,38 @@ public class MailCommandAction extends BaseEventBotAction {
         EventBus bus = getEventListenerContext().getEventBus();
         try{
             WonURI wonUri = EventBotActionUtils.getWonURIForMailId(getEventListenerContext(), mailIdUriRelationsName, referenceId);
-            assert wonUri != null;
+
+            if(wonUri == null){
+                throw new NullPointerException("No corresponding wonUri found");
+            }
+
+            URI needUri;
+            switch(wonUri.getType()){
+                case CONNECTION:
+                    Dataset connectionRDF = getEventListenerContext().getLinkedDataSource().getDataForResource(wonUri.getUri());
+                    needUri = WonRdfUtils.NeedUtils.getLocalNeedURIFromConnection(connectionRDF, wonUri.getUri());
+                    break;
+                case NEED:
+                default:
+                    needUri = wonUri.getUri();
+                    break;
+            }
+
+            MimeMessage originalMessage = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, needUri); //TODO: SET MAPNAME TO THE CORRECT ONE DIRECTLY FROM Mail2WonBot
+
+            if(originalMessage == null) {
+                throw new NullPointerException("no originalmessage found");
+            }
+
+            logger.debug("Validate mailorigin with originalmail:");
+            logger.debug("Command Message Sender: "+message.getFrom());
+            logger.debug("Original Message Sender: "+originalMessage.getFrom());
+
+            if(!message.getFrom()[0].equals(originalMessage.getFrom()[0])) {
+                throw new AccessControlException("Sender of original and command mail are not equal");
+            }else{
+                logger.debug("Sender of original and command mail are not equal, continue with command processing");
+            }
 
             ActionType actionType = determineAction(getEventListenerContext(), message, wonUri);
             logger.debug("Executing " + actionType + " on uri: " + wonUri.getUri() + " of type " + wonUri.getType());
@@ -105,8 +145,10 @@ public class MailCommandAction extends BaseEventBotAction {
                     logger.error("No command was given or assumed");
                     break;
             }
-        }catch(Exception e){
-            logger.error("no reply mail was set or found");
+        }catch (AccessControlException ace){
+            logger.error("ACCESS RESTRICTION: sender of original and command mail are not equal, command will be blocked");
+        } catch(Exception e){
+            logger.error("no reply mail was set or found: "+e.getMessage());
         }
     }
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -45,9 +45,11 @@ public class MailCommandAction extends BaseEventBotAction {
             MimeMessage message = ((MailCommandEvent) event).getMessage();
             String referenceId = MailContentExtractor.getMailReference(message);
 
+            WonURI wonUri = EventBotActionUtils.getWonURIForMailId(getEventListenerContext(), referenceId);
+
             // determine if the mail is referring to some other mail/need/connection or not
-            if (referenceId != null) {
-                processReferenceMailCommands(message, referenceId);
+            if(wonUri != null){
+                processReferenceMailCommands(message, wonUri);
             } else {
                 processNonReferenceMailCommand(message);
             }
@@ -83,12 +85,10 @@ public class MailCommandAction extends BaseEventBotAction {
         }
     }
 
-    private void processReferenceMailCommands(MimeMessage message, String referenceId) {
+    private void processReferenceMailCommands(MimeMessage message, WonURI wonUri) {
 
         EventBus bus = getEventListenerContext().getEventBus();
         try{
-            WonURI wonUri = EventBotActionUtils.getWonURIForMailId(getEventListenerContext(), referenceId);
-
             if(wonUri == null){
                 throw new NullPointerException("No corresponding wonUri found");
             }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailContentExtractor.java
@@ -50,6 +50,7 @@ public class MailContentExtractor
   private Pattern cmdConnectPattern;
   private Pattern cmdSubscribePattern;
   private Pattern cmdUnsubscribePattern;
+  private Pattern cmdTakenPattern;
 
   public static String getMailReference(MimeMessage message) throws MessagingException {
 
@@ -153,16 +154,18 @@ public class MailContentExtractor
     this.cmdUnsubscribePattern = cmdUnsubscribePattern;
   }
 
+  public void setCmdTakenPattern(final Pattern cmdTakenPattern) {
+    this.cmdTakenPattern = cmdTakenPattern;
+  }
+
   public boolean isCreateNeedMail(MimeMessage messsage) throws MessagingException {
     return getBasicNeedType(messsage) != null;
   }
 
   public boolean isCommandMail(MimeMessage message) throws IOException, MessagingException {
-
     // command mail is either an answer mail (with reference) to a previous mail (e.g. message, implicit connect) or an
     // explicitly set action command (e.g. subscribe, unsubscribe, close need)
-    return getMailReference(message) != null ||
-      (getMailAction(message) != null && !ActionType.NO_ACTION.equals(getMailAction(message)));
+    return getMailReference(message) != null || (getMailAction(message) != null && !ActionType.NO_ACTION.equals(getMailAction(message)));
   }
 
   public ActionType getMailAction(MimeMessage message) throws IOException, MessagingException {
@@ -175,6 +178,8 @@ public class MailContentExtractor
       return ActionType.CLOSE_CONNECTION;
     } else if (cmdConnectPattern.matcher(message.getSubject()).matches()) {
       return ActionType.OPEN_CONNECTION;
+    } else if(cmdTakenPattern.matcher(message.getSubject()).matches()){
+      return ActionType.CLOSE_NEED;
     } else {
       return ActionType.NO_ACTION;
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
@@ -19,15 +19,11 @@ import java.net.URI;
  * Created by fsuda on 03.10.2016.
  */
 public class Connect2MailParserAction extends BaseEventBotAction {
-    private String uriMimeMessageRelationsName;
-    private String mailIdUriRelationsName;
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 
-    public Connect2MailParserAction(WonMimeMessageGenerator mailGenerator, String uriMimeMessageRelationsName, String mailIdUriRelationsName, MessageChannel sendChannel) {
+    public Connect2MailParserAction(WonMimeMessageGenerator mailGenerator, MessageChannel sendChannel) {
         super(mailGenerator.getEventListenerContext());
-        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
-        this.mailIdUriRelationsName = mailIdUriRelationsName;
         this.sendChannel = sendChannel;
         this.mailGenerator = mailGenerator;
     }
@@ -40,13 +36,13 @@ public class Connect2MailParserAction extends BaseEventBotAction {
             URI responseTo = con.getNeedURI();
             URI remoteNeedUri = con.getRemoteNeedURI();
 
-            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, responseTo);
+            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), responseTo);
             logger.debug(
               "Someone issued a connect for URI: " + responseTo + " sending a mail to the creator: " + MailContentExtractor
                 .getFromAddressString(originalMail));
 
             WonMimeMessage answerMessage = mailGenerator.createConnectMail(originalMail, remoteNeedUri);
-            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), mailIdUriRelationsName, answerMessage.getMessageID(), new WonURI(con.getConnectionURI(), UriType.CONNECTION));
+            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), answerMessage.getMessageID(), new WonURI(con.getConnectionURI(), UriType.CONNECTION));
 
             sendChannel.send(new GenericMessage<>(answerMessage));
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
@@ -20,15 +20,11 @@ import java.net.URI;
  * Created by fsuda on 03.10.2016.
  */
 public class Hint2MailParserAction extends BaseEventBotAction {
-    private String uriMimeMessageRelationsName;
-    private String mailIdUriRelationsName;
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 
-    public Hint2MailParserAction(WonMimeMessageGenerator mailGenerator, String uriMimeMessageRelationsName, String mailIdUriRelationsName, MessageChannel sendChannel) {
+    public Hint2MailParserAction(WonMimeMessageGenerator mailGenerator, MessageChannel sendChannel) {
         super(mailGenerator.getEventListenerContext());
-        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
-        this.mailIdUriRelationsName = mailIdUriRelationsName;
         this.sendChannel = sendChannel;
         this.mailGenerator = mailGenerator;
     }
@@ -42,13 +38,13 @@ public class Hint2MailParserAction extends BaseEventBotAction {
             URI responseTo = match.getFromNeed();
             URI remoteNeedUri = match.getToNeed();
 
-            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, responseTo);
+            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), responseTo);
             logger.debug(
               "Found a hint for URI: " + responseTo + " sending a mail to the creator: " + MailContentExtractor
                 .getFromAddressString(originalMail));
 
             WonMimeMessage answerMessage = mailGenerator.createHintMail(originalMail, remoteNeedUri);
-            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), mailIdUriRelationsName, answerMessage.getMessageID(), new WonURI(message.getReceiverURI(), UriType.CONNECTION));
+            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), answerMessage.getMessageID(), new WonURI(message.getReceiverURI(), UriType.CONNECTION));
 
             sendChannel.send(new GenericMessage<>(answerMessage));
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
@@ -22,15 +22,11 @@ import java.net.URI;
  * Created by fsuda on 18.10.2016.
  */
 public class Message2MailAction extends BaseEventBotAction {
-    private String uriMimeMessageRelationsName;
-    private String mailIdUriRelationsName;
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 
-    public Message2MailAction(WonMimeMessageGenerator mailGenerator, String uriMimeMessageRelationsName, String mailIdUriRelationsName, MessageChannel sendChannel) {
+    public Message2MailAction(WonMimeMessageGenerator mailGenerator, MessageChannel sendChannel) {
         super(mailGenerator.getEventListenerContext());
-        this.mailIdUriRelationsName = mailIdUriRelationsName;
-        this.uriMimeMessageRelationsName = uriMimeMessageRelationsName;
         this.sendChannel = sendChannel;
         this.mailGenerator = mailGenerator;
     }
@@ -43,11 +39,11 @@ public class Message2MailAction extends BaseEventBotAction {
             URI responseTo = con.getNeedURI();
             URI remoteNeedUri = con.getRemoteNeedURI();
 
-            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), uriMimeMessageRelationsName, responseTo);
+            MimeMessage originalMail = EventBotActionUtils.getMimeMessageForURI(getEventListenerContext(), responseTo);
             logger.debug("Someone sent a message for URI: " + responseTo + " sending a mail to the creator: " + MailContentExtractor.getFromAddressString(originalMail));
 
             WonMimeMessage answerMessage = mailGenerator.createMessageMail(originalMail, responseTo, remoteNeedUri, con.getConnectionURI());
-            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), mailIdUriRelationsName, answerMessage.getMessageID(), new WonURI(con.getConnectionURI(), UriType.CONNECTION));
+            EventBotActionUtils.addMailIdWonURIRelation(getEventListenerContext(), answerMessage.getMessageID(), new WonURI(con.getConnectionURI(), UriType.CONNECTION));
 
             sendChannel.send(new GenericMessage<>(answerMessage));
         }else{

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -212,8 +212,6 @@ public class WonMimeMessageGenerator {
         Dataset baseDataSet = eventListenerContext.getLinkedDataSource().getDataForResource(connectionUri);
         Dataset eventDataSet = eventListenerContext.getLinkedDataSource().getDataForResource(URI.create(connectionUri.toString()+"/events?deep=true"), requesterUri);
 
-        RDFDataMgr.write(System.out, eventDataSet, Lang.TRIG);
-
         RdfUtils.addDatasetToDataset(baseDataSet, eventDataSet);
 
         try {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/DeactivateNeedCommandEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/DeactivateNeedCommandEvent.java
@@ -1,0 +1,16 @@
+package won.bot.framework.eventbot.event.impl.command;
+
+import won.bot.framework.eventbot.event.BaseEvent;
+import won.bot.framework.eventbot.event.BaseNeedSpecificEvent;
+import won.bot.framework.eventbot.event.NeedSpecificEvent;
+
+import java.net.URI;
+
+/**
+ * Created by fsuda on 24.02.2017.
+ */
+public class DeactivateNeedCommandEvent extends BaseNeedSpecificEvent implements NeedSpecificEvent {
+    public DeactivateNeedCommandEvent(URI needURI) {
+        super(needURI);
+    }
+}

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
@@ -25,10 +25,6 @@ import javax.mail.internet.MimeMessage;
  * Created by fsuda on 27.09.2016.
  */
 public class Mail2WonBot extends EventBot{
-    private static final String NAME_NEEDS = "mailNeeds";
-    private static final String URIMIMEMESSAGERELATIONS_NAME = "uriMimeMessageRelations";
-    private static final String MAILIDURIRELATIONS_NAME = "mailIdUriRelations";
-
     @Autowired
     private MessageChannel receiveEmailChannel;
 
@@ -62,7 +58,7 @@ public class Mail2WonBot extends EventBot{
         new ActionOnEventListener(
                 ctx,
                 "CreateNeedFromMailEvent",
-                new CreateNeedFromMailAction(ctx, NAME_NEEDS, mailContentExtractor, URIMIMEMESSAGERELATIONS_NAME)
+                new CreateNeedFromMailAction(ctx, mailContentExtractor)
 
         ));
 
@@ -77,7 +73,7 @@ public class Mail2WonBot extends EventBot{
         new ActionOnEventListener(
                 ctx,
                 "MailCommandEvent",
-                new MailCommandAction(ctx, MAILIDURIRELATIONS_NAME, URIMIMEMESSAGERELATIONS_NAME, mailContentExtractor)
+                new MailCommandAction(ctx, mailContentExtractor)
         ));
 
         bus.subscribe(SendTextMessageOnConnectionEvent.class,
@@ -109,21 +105,21 @@ public class Mail2WonBot extends EventBot{
         new ActionOnEventListener(
                 ctx,
                 "HintReceived",
-                new Hint2MailParserAction(mailGenerator, URIMIMEMESSAGERELATIONS_NAME, MAILIDURIRELATIONS_NAME, sendEmailChannel)
+                new Hint2MailParserAction(mailGenerator, sendEmailChannel)
         ));
 
         bus.subscribe(ConnectFromOtherNeedEvent.class,
         new ActionOnEventListener(
                 ctx,
                 "ConnectReceived",
-                new Connect2MailParserAction(mailGenerator, URIMIMEMESSAGERELATIONS_NAME, MAILIDURIRELATIONS_NAME, sendEmailChannel)
+                new Connect2MailParserAction(mailGenerator, sendEmailChannel)
         ));
 
         bus.subscribe(MessageFromOtherNeedEvent.class,
         new ActionOnEventListener(
                 ctx,
                 "ReceivedTextMessage",
-                new Message2MailAction(mailGenerator, URIMIMEMESSAGERELATIONS_NAME, MAILIDURIRELATIONS_NAME, sendEmailChannel)
+                new Message2MailAction(mailGenerator, sendEmailChannel)
         ));
     }
 

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
@@ -77,7 +77,7 @@ public class Mail2WonBot extends EventBot{
         new ActionOnEventListener(
                 ctx,
                 "MailCommandEvent",
-                new MailCommandAction(ctx, MAILIDURIRELATIONS_NAME, mailContentExtractor)
+                new MailCommandAction(ctx, MAILIDURIRELATIONS_NAME, URIMIMEMESSAGERELATIONS_NAME, mailContentExtractor)
         ));
 
         bus.subscribe(SendTextMessageOnConnectionEvent.class,

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
@@ -11,6 +11,7 @@ import won.bot.framework.eventbot.action.impl.wonmessage.CloseConnectionUriActio
 import won.bot.framework.eventbot.action.impl.wonmessage.OpenConnectionUriAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendMessageOnConnectionAction;
 import won.bot.framework.eventbot.bus.EventBus;
+import won.bot.framework.eventbot.event.impl.command.DeactivateNeedCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.SendTextMessageOnConnectionEvent;
 import won.bot.framework.eventbot.event.impl.mail.*;
 import won.bot.framework.eventbot.event.impl.needlifecycle.NeedDeactivatedEvent;
@@ -92,7 +93,7 @@ public class Mail2WonBot extends EventBot{
                 new CloseConnectionUriAction(ctx)
         ));
 
-        bus.subscribe(NeedDeactivatedEvent.class,
+        bus.subscribe(DeactivateNeedCommandEvent.class,
         new ActionOnEventListener(
                 ctx,
                 "DeactivateNeedEvent",

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Mail2WonBot.java
@@ -6,12 +6,14 @@ import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.impl.mail.receive.*;
 import won.bot.framework.eventbot.action.impl.mail.send.*;
+import won.bot.framework.eventbot.action.impl.needlifecycle.DeactivateNeedAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.CloseConnectionUriAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.OpenConnectionUriAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendMessageOnConnectionAction;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.impl.command.SendTextMessageOnConnectionEvent;
 import won.bot.framework.eventbot.event.impl.mail.*;
+import won.bot.framework.eventbot.event.impl.needlifecycle.NeedDeactivatedEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherNeedEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.HintFromMatcherEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherNeedEvent;
@@ -88,6 +90,13 @@ public class Mail2WonBot extends EventBot{
                 ctx,
                 "CloseCommandEvent",
                 new CloseConnectionUriAction(ctx)
+        ));
+
+        bus.subscribe(NeedDeactivatedEvent.class,
+        new ActionOnEventListener(
+                ctx,
+                "DeactivateNeedEvent",
+                new DeactivateNeedAction(ctx)
         ));
 
         bus.subscribe(OpenConnectionEvent.class,

--- a/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
+++ b/webofneeds/won-bot/src/main/resources/mail-templates/welcome-mail.vm
@@ -2,7 +2,7 @@ Dear mailing list user,
 
 this is an automatic response from the $mailbotName to the following email you sent.
 
-#parse('mail-templates/inc/quoted-mail.vm')
-
 publish all my requests in this mailing list to matchat.org: <mailto:$mailbotEmailAddress?subject=subscribe>
 do not publish my requests on this mailinglist and ignore mails from $mailbotName in the future: <mailto:$mailbotEmailAddress?subject=unsubscribe>
+
+#parse('mail-templates/inc/quoted-mail.vm')

--- a/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
@@ -68,6 +68,11 @@
                 <constructor-arg value=".*?\[DEBUG\].*?" />
             </bean>
         </property>
+        <property name="cmdTakenPattern">
+            <bean id="cmdTakenPattern" class="java.util.regex.Pattern" factory-method="compile">
+                <constructor-arg value=".*?\[TAKEN\].*?" />
+            </bean>
+        </property>
         <property name="doNotMatchPattern">
             <bean id="doNotMatchPattern" class="java.util.regex.Pattern" factory-method="compile">
                 <constructor-arg value=".*?\[NO_MATCH\].*?" />

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -730,6 +730,13 @@ public class WonRdfUtils
       return titleString;
     }
 
+    public static boolean isNeedActive(Dataset needDataset, URI needUri) {
+      Path titlePath = PathParser.parse("won:isInState", DefaultPrefixUtils.getDefaultPrefixes());
+
+      URI uri = RdfUtils.getURIPropertyForPropertyPath(needDataset, needUri, titlePath);
+      return uri.equals(URI.create("http://purl.org/webofneeds/model#Active"));
+    }
+
     /**
      * Checks if the need has set a certain flag set
      *


### PR DESCRIPTION
implemented the possibility to close an open need via an e-mail that matches a takenCmdPattern (currently set to [TAKEN]) in the subject line, the mailbot will then crawl through all the created needs of that e-mail adress and close the first open need that matches the title e.g "[WANT] testneed" will be closed when the same e-mail adress sends a "[TAKEN] testneed" e-mail