### PR TITLE
Refactoring spring xml properties

### DIFF
--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -18,26 +18,31 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml and in matcher-nodeurisource-all.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml and in matcher-nodeurisource-all.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
     <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
     <!-- all within botRunner.xml -->
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml and in matcher-nodeurisource-all.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -27,8 +27,8 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml and in matcher-nodeurisource-all.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -28,6 +28,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -25,8 +25,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -18,16 +18,21 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -35,9 +40,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -16,12 +16,16 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -25,6 +25,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -27,6 +27,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -26,7 +26,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAAtomicPC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBACC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBACC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBACC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBACC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAPC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotBAPC#.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotBAPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAPC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAPC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
@@ -16,44 +16,41 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!--
        context that combines components to provide an environment for running bots
     -->
     <!--import resource="classpath:/spring/component/linkeddatasource/owner-linkeddatasource.xml" /-->
-    <import resource="classpath:/spring/component/scheduling/scheduling.xml" />
-    <import resource="classpath:/spring/component/ownerCallback/ownerCallback.xml" />
+    <import resource="classpath:/spring/component/scheduling/scheduling.xml"/>
+    <import resource="classpath:/spring/component/ownerCallback/ownerCallback.xml"/>
     <import resource="classpath:/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml"/>
-    <import resource="classpath:/spring/component/botManager/botManager.xml" />
+    <import resource="classpath:/spring/component/botManager/botManager.xml"/>
     <!-- this introduces the email-based subsystem for generating needs to be loaded, which is not desirable for most
      applications. -->
     <!-- import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" /-->
-    <import resource="classpath:/spring/component/nodeurisource/nodeurisource-roundrobin.xml" />
-    <import resource="classpath:/spring/owner-jmsonly.xml" />
+    <import resource="classpath:/spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>
+    <import resource="classpath:/spring/owner-jmsonly.xml"/>
     <!-- monitoring -->
     <!--
     <import resource="classpath:/spring/component/monitoring/bot-monitoring-jmx.xml" />
     <import resource="classpath:/spring/component/monitoring/bot-monitoring.xml" />
     -->
-    <import resource="classpath:/spring/component/monitoring/monitoring-recorder.xml" />
+    <import resource="classpath:/spring/component/monitoring/monitoring-recorder.xml"/>
 
     <!--import resource="classpath:/spring/component/wonNodeInformationService.xml"/-->
 
     <!--import resource="classpath:/spring/matcher-jmsonly.xml"/-->
 
-    <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
+    <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml"/>
     <import resource="classpath:/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml"/>
-    <import resource="classpath:/spring/component/camel/matcher-camel.xml" />
-    <import resource="classpath:/spring/core/matcher-core.xml" />
-    <import resource="classpath:/spring/component/storage/storage.xml" />
+    <import resource="classpath:/spring/component/camel/matcher-camel.xml"/>
+    <import resource="classpath:/spring/core/matcher-core.xml"/>
+    <import resource="classpath:/spring/component/storage/storage.xml"/>
     <import resource="classpath:/spring/component/services/matcher-services.xml"/>
-    <import resource="classpath:/spring/component/linkeddatasource/matcher-linkeddatasource.xml" />
-    <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml" />
-    <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml" />
+    <import resource="classpath:/spring/component/linkeddatasource/matcher-linkeddatasource.xml"/>
+    <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml"/>
+    <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml"/>
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
@@ -21,6 +21,14 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <!--
+         Load properties but ignore unresolvable properties so that
+         they are searched in other property configuerers defined in the context
+    -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in noderurisource-roundrobin.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in matcherProtocolMatcherServiceHandler.xml -->
     <!--
        context that combines components to provide an environment for running bots
     -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
@@ -23,13 +23,6 @@
         http://www.springframework.org/schema/context/spring-context.xsd">
 
     <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in noderurisource-roundrobin.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in matcherProtocolMatcherServiceHandler.xml -->
-    <!--
        context that combines components to provide an environment for running bots
     -->
     <!--import resource="classpath:/spring/component/linkeddatasource/owner-linkeddatasource.xml" /-->

--- a/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
@@ -24,9 +24,6 @@
     <!--
        context that combines components to provide an environment for running bots
     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
-
-
     <!--import resource="classpath:/spring/component/linkeddatasource/owner-linkeddatasource.xml" /-->
     <import resource="classpath:/spring/component/scheduling/scheduling.xml" />
     <import resource="classpath:/spring/component/ownerCallback/ownerCallback.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -29,6 +29,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -26,9 +26,9 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in DebutBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in DebutBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -18,18 +18,24 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -37,9 +43,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/DebugBot.xml" />
+    <import resource="classpath:/spring/bot/DebugBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -30,6 +30,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -26,6 +26,9 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in DebutBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -28,7 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -25,9 +25,9 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in EchoBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in EchoBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -27,7 +27,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -18,17 +18,23 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +42,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/EchoBot.xml" />
+    <import resource="classpath:/spring/bot/EchoBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -16,12 +16,16 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -25,6 +25,9 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in EchoBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -26,12 +26,12 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml --><!-- was in randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml and needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -26,13 +26,16 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml --><!-- was in randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
     <import resource="classpath:/spring/bot/randomSimulatorBot.xml" />
-
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -18,17 +18,23 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml and needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml and needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,8 +42,8 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
-    <import resource="classpath:/spring/bot/randomSimulatorBot.xml" />
+    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml"/>
+    <import resource="classpath:/spring/bot/randomSimulatorBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -16,12 +16,16 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -24,14 +24,10 @@
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml and needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -25,6 +25,7 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -18,18 +18,24 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml and botContext.xml within LastSeenNeedsMatcherBot.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml and botContext.xml within LastSeenNeedsMatcherBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -37,9 +43,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
+    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -30,6 +30,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -25,12 +25,10 @@
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botContext.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml and botContext.xml within LastSeenNeedsMatcherBot.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -26,6 +26,7 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -29,6 +29,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -27,10 +27,10 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botContext.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botContext.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -27,6 +27,10 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botContext.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in LastSeenNeedsMatcherBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in Mail2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -27,6 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in Mail2WonBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -26,11 +26,10 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/Mail2WonBot.xml" />
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,7 +41,7 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/Mail2WonBot.xml" />
+    <import resource="classpath:/spring/bot/Mail2WonBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -26,6 +26,7 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -28,7 +28,12 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
-    
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -27,7 +27,8 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
-
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -18,16 +18,20 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -35,9 +39,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/MatcherBot.xml" />
+    <import resource="classpath:/spring/bot/MatcherBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -27,6 +27,9 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in needCreatorBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -25,11 +25,10 @@
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and needCreatorBot.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -27,9 +27,9 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml --><!-- was in needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -26,11 +26,10 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in needCreatorBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/needCreatorBot.xml" />
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -29,6 +29,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -30,6 +30,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -18,18 +18,24 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml and needCreatorBot.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and needCreatorBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -37,7 +43,7 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/needCreatorBot.xml" />
+    <import resource="classpath:/spring/bot/needCreatorBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/randomSimulatorBot.xml" />
+    <import resource="classpath:/spring/bot/randomSimulatorBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml --><!-- was in randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml --><!-- was in randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in randomSimulatorBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
@@ -23,6 +23,8 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+
     <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate-oncepernode.xml" />
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
 

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
@@ -17,22 +17,22 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
 
-    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate-oncepernode.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
+    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate-oncepernode.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerOwnerEmulateOncePerNode" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerOwnerEmulateOncePerNode"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerOncePerNodeBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerOncePerNodeBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
@@ -17,22 +17,22 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
 
-    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
+    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerOwnerEmulate" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerOwnerEmulate"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
@@ -23,6 +23,8 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+
     <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate.xml" />
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
 

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
@@ -22,6 +22,10 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
     <import resource="classpath:spring/component/needconsumer/needconsumer-sysout.xml" />
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
@@ -17,24 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
-    <import resource="classpath:spring/component/needconsumer/needconsumer-sysout.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
-    <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml" />
+    <import resource="classpath:spring/component/needconsumer/needconsumer-sysout.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
+    <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerSysout" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerSysout"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToSysoutBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToSysoutBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
+
+    <!--
+       context that combines bot definitions with runner context
+    -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
+    <!-- the runner -->
+    <import resource="classpath:/spring/app/botRunner.xml" />
+</beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,5 +41,5 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -27,6 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBaseSimpleReactiveBotConnecting2Needs.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -26,6 +26,7 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBaseSimpleReactiveBotConnecting2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -26,7 +26,7 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
 
     <!-- the runner -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml" />
+    <import resource="classpath:/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotGroupConversation.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotGroupConversation.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotComment.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotComment.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotComment.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotComment.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -26,11 +26,11 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotMatcher.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotMatcher.xml" />
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,7 +41,7 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotMatcher.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotMatcher.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBasedSimpleReactiveBotMatcher.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -26,11 +26,11 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml" />
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,7 +41,7 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml" />
+    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -26,8 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -16,12 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,9 +41,9 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml" />
+    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -26,6 +26,8 @@
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- was in mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -18,17 +18,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
@@ -36,7 +41,7 @@
     <!-- all within botRunner.xml -->
 
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/Telegram2WonBot.xml" />
+    <import resource="classpath:/spring/bot/Telegram2WonBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -16,12 +16,18 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
+
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -29,6 +29,11 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -27,7 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in Telegram2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -28,6 +28,7 @@
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -27,6 +27,7 @@
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- was in Telegram2WonBot.xml -->
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -32,6 +32,4 @@
     <import resource="classpath:/spring/app/botRunner.xml" />
     <!-- the bots to run -->
     <import resource="classpath:/spring/bot/Telegram2WonBot.xml" />
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
@@ -23,10 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
@@ -16,37 +16,33 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.DebugBot">
         <!-- optional property, by default one echo need per each need will be created -->
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
-        <property name="matcherUri" value="${matcher.uri}" />
+        <property name="matcherUri" value="${matcher.uri}"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
         <!--property name="ownerService" ref="ownerProtocolNeedServiceClient" /-->
         <property name="matcherProtocolNeedServiceClient" ref="matcherProtocolNeedServiceClient"/>
         <property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
-        
+
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
@@ -16,8 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
@@ -23,10 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
@@ -16,22 +16,18 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.EchoBot">
         <!-- optional property, by default one echo need per each need will be created -->
-        <property name="numberOfEchoNeedsPerNeed" value="3" />
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="numberOfEchoNeedsPerNeed" value="3"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
@@ -43,10 +39,10 @@
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
@@ -16,8 +16,17 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
@@ -22,11 +22,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />

--- a/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
@@ -16,31 +16,28 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.LastSeenNeedsMatcherBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
-        <property name="matcherUri" value="${matcher.uri}" />
+        <property name="matcherUri" value="${matcher.uri}"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
@@ -21,7 +21,11 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context.xsd">
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/> <!-- was in LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
@@ -29,11 +29,11 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/mail/mailContentExtractor.xml"/>
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/>
 
     <util:properties id="javaMailProperties">
         <prop key="mail.imap.socketFactory.class">javax.net.ssl.SSLSocketFactory</prop>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
@@ -19,15 +19,12 @@
        xmlns:mail="http://www.springframework.org/schema/integration/mail"
        xmlns:int="http://www.springframework.org/schema/integration"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/integration/mail
         http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
         http://www.springframework.org/schema/util
-        http://www.springframework.org/schema/util/spring-util.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
@@ -70,8 +67,8 @@
     <bean id="mail2wonBot" class="won.bot.impl.Mail2WonBot">
         <!-- optional property, by default one echo need per each need will be created -->
 
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="taskScheduler" ref="taskScheduler" />
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
         <property name="receiveEmailChannel" ref="receiveEmailChannel"/>
         <property name="sendEmailChannel" ref="sendEmailChannel"/>
         <property name="mailGenerator" ref="mailGenerator"/>
@@ -85,10 +82,10 @@
         <!--<property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>-->
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="60000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="60000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>
@@ -105,6 +102,7 @@
         <property name="velocityEngine" ref="velocityEngine"/>
         <property name="sentFrom" value="${mailbot.email.address}"/>
         <property name="sentFromName" value="${mailbot.email.name}"/>
-        <property name="MAX_CONVERSATION_DEPTH" value="${mailbot.max_conversation_depth}"/> <!-- 0 includes no messages at all, -1 includes all messages -->
+        <property name="MAX_CONVERSATION_DEPTH"
+                  value="${mailbot.max_conversation_depth}"/> <!-- 0 includes no messages at all, -1 includes all messages -->
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
@@ -29,8 +29,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/mail/mailContentExtractor.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
@@ -26,8 +26,6 @@
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/telegram/telegramContentExtractor.xml"/>
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/>
-
     <bean id="telegram2wonBot" class="won.bot.impl.Telegram2WonBot">
         <!-- optional property, by default one echo need per each need will be created -->
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
@@ -16,11 +16,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
@@ -29,8 +26,8 @@
     <bean id="telegram2wonBot" class="won.bot.impl.Telegram2WonBot">
         <!-- optional property, by default one echo need per each need will be created -->
 
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="taskScheduler" ref="taskScheduler" />
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
         <property name="token" value="${telegrambot.token}"/>
         <property name="botName" value="${telegrambot.botname}"/>
         <property name="telegramContentExtractor" ref="telegramContentExtractor"/>
@@ -45,10 +42,10 @@
         <!--<property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>-->
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="6002000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="6002000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
@@ -22,6 +22,8 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/telegram/telegramContentExtractor.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
@@ -22,8 +22,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/telegram/telegramContentExtractor.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
@@ -16,30 +16,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.StandardTwoPhaseCommitNoVoteBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
@@ -16,30 +16,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
@@ -16,8 +16,14 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.ConversationBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRoundRobin" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRoundRobin"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
@@ -23,8 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
@@ -16,30 +16,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
@@ -16,30 +16,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
@@ -16,33 +16,29 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
 </beans>
 
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
@@ -16,32 +16,28 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
@@ -16,30 +16,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCAdditionalParticipants">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
@@ -16,32 +16,28 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
@@ -14,34 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
@@ -14,34 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
@@ -14,34 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
@@ -14,34 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
@@ -14,34 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BACCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAPCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.CommentBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.GroupingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
@@ -14,37 +14,31 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.MatcherProtocolTestBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="matcherProtocolNeedServiceClient" ref="matcherProtocolNeedServiceClient"/>
         <property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
@@ -23,8 +23,9 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
-                                  ignore-unresolvable="true"/>
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <!--<import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>-->
     <!--<import resource="classpath:spring/component/needproducer/needproducer-trig.xml"/>-->

--- a/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
@@ -16,12 +16,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!--<import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>-->
     <!--<import resource="classpath:spring/component/needproducer/needproducer-trig.xml"/>-->
@@ -30,20 +26,20 @@
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="needCreatorBot" class="won.bot.impl.NeedCreatorBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--<property name="needProducer" ref="needProducerFromMails" />-->
         <!--<property name="needProducer" ref="needProducerFromTrig" />-->
-        <property name="needProducer" ref="needProducerMixed" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="needProducer" ref="needProducerMixed"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="${needCreatorBot.period}" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="true" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="${needCreatorBot.period}"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="true"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
@@ -23,10 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <!--<import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>-->
     <!--<import resource="classpath:spring/component/needproducer/needproducer-trig.xml"/>-->
     <import resource="classpath:spring/component/needproducer/needproducer-mixed.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
@@ -14,32 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails-nonstop.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="randomSimulatorBot" class="won.bot.impl.RandomSimulatorBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="1000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="1000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
@@ -16,8 +16,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails-nonstop.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
@@ -23,9 +23,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
-
     <import resource="classpath:spring/component/needproducer/needproducer-mails-nonstop.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>

--- a/webofneeds/won-bot/src/main/resources/spring/component/botContext/botContext.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/botContext/botContext.xml
@@ -17,11 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/data/mongo
-        http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- MongoDB config -->
     <bean id="mongoClientUri" class="com.mongodb.MongoClientURI">
@@ -36,9 +32,9 @@
 
     <!-- use this mongo converter to be able to save keys with dots -->
     <bean id="mongoConverter" class="org.springframework.data.mongodb.core.convert.MappingMongoConverter">
-        <constructor-arg index="0" ref="mongoDbFactory" />
+        <constructor-arg index="0" ref="mongoDbFactory"/>
         <constructor-arg index="1">
-            <bean class="org.springframework.data.mongodb.core.mapping.MongoMappingContext" />
+            <bean class="org.springframework.data.mongodb.core.mapping.MongoMappingContext"/>
         </constructor-arg>
 
         <!-- replace dots by '^^^' -->

--- a/webofneeds/won-bot/src/main/resources/spring/component/botManager/botManager.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/botManager/botManager.xml
@@ -17,16 +17,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="botManager" class="won.bot.framework.manager.impl.SpringAwareBotManagerImpl" >
+    <bean id="botManager" class="won.bot.framework.manager.impl.SpringAwareBotManagerImpl">
         <property name="checkWorkDoneTrigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="10" />
-                <constructor-arg name="timeUnit" value="SECONDS" />
-                <property name="fixedRate" value="true" />
-                <property name="initialDelay" value="10" />
+                <constructor-arg name="period" value="10"/>
+                <constructor-arg name="timeUnit" value="SECONDS"/>
+                <property name="fixedRate" value="true"/>
+                <property name="initialDelay" value="10"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
@@ -16,44 +16,43 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="mailExtractor" class="won.bot.framework.eventbot.action.impl.mail.receive.MailContentExtractor">
         <property name="demandTypePattern">
             <bean id="demandTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[WANT\].*" />
+                <constructor-arg value="(?si)^\[WANT\].*"/>
             </bean>
         </property>
         <property name="supplyTypePattern">
             <bean id="supplyTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[OFFER\].*" />
+                <constructor-arg value="(?si)^\[OFFER\].*"/>
             </bean>
         </property>
         <property name="doTogetherTypePattern">
             <bean id="doTogetherTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[TOGETHER\].*" />
+                <constructor-arg value="(?si)^\[TOGETHER\].*"/>
             </bean>
         </property>
         <property name="critiqueTypePattern">
             <bean id="critiqueTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[CRITIQUE\].*" />
+                <constructor-arg value="(?si)^\[CRITIQUE\].*"/>
             </bean>
         </property>
         <property name="tagExtractionPattern">
             <bean id="tagExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="[#]+[\w]+\b" />
+                <constructor-arg value="[#]+[\w]+\b"/>
             </bean>
         </property>
         <property name="textMessageExtractionPattern">
             <bean id="textMessageExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?s).+?(?=\b[^\n]*\n>)" />
+                <constructor-arg value="(?s).+?(?=\b[^\n]*\n>)"/>
             </bean>
         </property>
         <property name="descriptionExtractionPattern">
             <bean id="descriptionExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?s).*" />
+                <constructor-arg value="(?s).*"/>
             </bean>
         </property>
         <property name="titleExtractionPattern">
@@ -65,37 +64,37 @@
         </property>
         <property name="usedForTestingPattern">
             <bean id="usedForTestingPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[DEBUG\].*?" />
+                <constructor-arg value=".*?\[DEBUG\].*?"/>
             </bean>
         </property>
         <property name="cmdTakenPattern">
             <bean id="cmdTakenPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[TAKEN\].*?" />
+                <constructor-arg value=".*?\[TAKEN\].*?"/>
             </bean>
         </property>
         <property name="doNotMatchPattern">
             <bean id="doNotMatchPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[NO_MATCH\].*?" />
+                <constructor-arg value=".*?\[NO_MATCH\].*?"/>
             </bean>
         </property>
         <property name="cmdClosePattern">
             <bean id="cmdClosePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^close.*" />
+                <constructor-arg value="(?si)^close.*"/>
             </bean>
         </property>
         <property name="cmdConnectPattern">
             <bean id="cmdConnectPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^connect.*" />
+                <constructor-arg value="(?si)^connect.*"/>
             </bean>
         </property>
         <property name="cmdSubscribePattern">
             <bean id="cmdSubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^subscribe.*" />
+                <constructor-arg value="(?si)^subscribe.*"/>
             </bean>
         </property>
         <property name="cmdUnsubscribePattern">
             <bean id="cmdUnsubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^unsubscribe.*" />
+                <constructor-arg value="(?si)^unsubscribe.*"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
@@ -15,18 +15,13 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- expects a botManager and a taskScheduler bean -->
-    <bean id="matcherProtocolMatcherServiceHandler" class="won.bot.integration.BotMatcherProtocolMatcherServiceCallback" >
-        <property name="botManager" ref="botManager" />
-        <property name="taskScheduler" ref="taskScheduler" />
+    <bean id="matcherProtocolMatcherServiceHandler"
+          class="won.bot.integration.BotMatcherProtocolMatcherServiceCallback">
+        <property name="botManager" ref="botManager"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
@@ -24,11 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
     <!-- expects a botManager and a taskScheduler bean -->
     <bean id="matcherProtocolMatcherServiceHandler" class="won.bot.integration.BotMatcherProtocolMatcherServiceCallback" >
         <property name="botManager" ref="botManager" />

--- a/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring-jmx.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring-jmx.xml
@@ -17,17 +17,9 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd
-        http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean" >
+    <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean">
         <property name="callbacks">
             <list>
                 <bean class="org.javasimon.jmx.JmxRegisterCallback">

--- a/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
@@ -22,7 +22,7 @@
 
 
         http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+        http://www.springframework.org/schema/aop/spring-aop-4.1.xsd">
 
     <bean id="monitoringInterceptor" class="org.javasimon.spring.MonitoringInterceptor"/>
 

--- a/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
@@ -17,13 +17,10 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+
+
         http://www.springframework.org/schema/aop
         http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
 

--- a/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-nop.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-nop.xml
@@ -15,14 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needConsumerNop" class="won.bot.framework.component.needconsumer.impl.NopNeedConsumer" />
+    <bean id="needConsumerNop" class="won.bot.framework.component.needconsumer.impl.NopNeedConsumer"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-sysout.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-sysout.xml
@@ -15,14 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needConsumerSysout" class="won.bot.framework.component.needconsumer.impl.SysoutNeedConsumer" />
+    <bean id="needConsumerSysout" class="won.bot.framework.component.needconsumer.impl.SysoutNeedConsumer"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
@@ -24,13 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    
-
     <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
@@ -15,66 +15,65 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromMails"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
-                <bean id="supplyNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl" />
+                <bean id="supplyNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.supply}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.supply}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="demandNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl" />
+                <bean id="demandNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.demand}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.demand}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="doTogetherNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl" />
+                <bean id="doTogetherNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.doTogether}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.doTogether}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="critiqueNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl" />
+                <bean id="critiqueNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.critique}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.critique}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
@@ -84,4 +83,4 @@
         </property>
     </bean>
 
-        </beans>
+</beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
@@ -24,13 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    
-
     <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
@@ -15,66 +15,65 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromMails"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
-                <bean id="supplyNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl" />
+                <bean id="supplyNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.supply}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.supply}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="demandNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl" />
+                <bean id="demandNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.demand}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.demand}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="doTogetherNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl" />
+                <bean id="doTogetherNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.doTogether}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.doTogether}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="critiqueNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl" />
+                <bean id="critiqueNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.critique}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.critique}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
@@ -84,4 +83,4 @@
         </property>
     </bean>
 
-        </beans>
+</beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
@@ -24,14 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/>
-
-
     <bean id="needProducerMixed" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <qualifier value="default"/>
         <property name="needFactories">

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
@@ -15,14 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="needProducerMixed" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <qualifier value="default"/>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
@@ -15,16 +15,11 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needProducerFromTrig" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromTrig"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
                 <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
@@ -24,15 +24,7 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/>
-
-
-    <bean id="needProducerFromTrig"
-          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromTrig" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
                 <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
@@ -24,15 +24,7 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-
-
-    <bean id="needProducerFromTurtle"
-          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromTurtle" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
                 <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
@@ -15,16 +15,11 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needProducerFromTurtle" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromTurtle"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
                 <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
@@ -24,12 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
-
     <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource" >
         <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
@@ -15,16 +15,10 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource" >
-        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
+    <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource">
+        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
@@ -24,12 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
-
     <bean id="nodeUriSourceRoundRobin" class="won.bot.framework.component.nodeurisource.impl.RoundRobinMultiNodeUriSource" >
         <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
         <qualifier value="default" />

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
@@ -15,17 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="nodeUriSourceRoundRobin" class="won.bot.framework.component.nodeurisource.impl.RoundRobinMultiNodeUriSource" >
-        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
-        <qualifier value="default" />
+    <bean id="nodeUriSourceRoundRobin"
+          class="won.bot.framework.component.nodeurisource.impl.RoundRobinMultiNodeUriSource">
+        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}"/>
+        <qualifier value="default"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
@@ -24,11 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
     <!-- expects a botManager and a taskScheduler bean -->
     <bean id="botOwnerProtocolAdapter" class="won.bot.integration.BotOwnerCallback" >
         <property name="botManager" ref="botManager" />

--- a/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
@@ -15,19 +15,13 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- expects a botManager and a taskScheduler bean -->
-    <bean id="botOwnerProtocolAdapter" class="won.bot.integration.BotOwnerCallback" >
-        <property name="botManager" ref="botManager" />
-        <property name="taskScheduler" ref="taskScheduler" />
+    <bean id="botOwnerProtocolAdapter" class="won.bot.integration.BotOwnerCallback">
+        <property name="botManager" ref="botManager"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
     </bean>
 
     <!-- provides the bean expected by the dynamic camel route configuration in won-owner -->

--- a/webofneeds/won-bot/src/main/resources/spring/component/scheduling/scheduling.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/scheduling/scheduling.xml
@@ -15,17 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >
-    <property name="poolSize" value="15" />
-</bean>
+    <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler"
+          destroy-method="destroy">
+        <property name="poolSize" value="15"/>
+    </bean>
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/telegram/telegramContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/telegram/telegramContentExtractor.xml
@@ -16,29 +16,29 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="telegramContentExtractor" class="won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor">
+    <bean id="telegramContentExtractor"
+          class="won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor">
         <property name="demandTypePattern">
             <bean id="demandTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[WANT\].*" />
+                <constructor-arg value="(?si)^\[WANT\].*"/>
             </bean>
         </property>
         <property name="supplyTypePattern">
             <bean id="supplyTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[OFFER\].*" />
+                <constructor-arg value="(?si)^\[OFFER\].*"/>
             </bean>
         </property>
         <property name="doTogetherTypePattern">
             <bean id="doTogetherTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[TOGETHER\].*" />
+                <constructor-arg value="(?si)^\[TOGETHER\].*"/>
             </bean>
         </property>
         <property name="critiqueTypePattern">
             <bean id="critiqueTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[CRITIQUE\].*" />
+                <constructor-arg value="(?si)^\[CRITIQUE\].*"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveExitingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveExitingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveExitingTest.xml"})
 
 public class BAAtomicCCActiveExitingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveFailingBotTest.java
@@ -39,7 +39,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveFailingTest.xml"})
 
 public class BAAtomicCCActiveFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveNotComletingTest.xml"})
 
 public class BAAtomicCCActiveNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCAdditionalParticipantsBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCAdditionalParticipantsBotTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCAdditionalParticipantsTest.xml"})
 
 public class BAAtomicCCAdditionalParticipantsBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCBotTest.java
@@ -40,7 +40,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCTest.xml"})
 
 public class BAAtomicCCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingFailingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCCompletingFailingTest.xml"})
 
 public class BAAtomicCCCompletingFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCCompletingNotCompletingTest.xml"})
 
 public class BAAtomicCCCompletingNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveExitingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveExitingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveExitingTest.xml"})
 
 public class BAAtomicPCActiveExitingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveFailingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveFailingTest.xml"})
 
 public class BAAtomicPCActiveFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveNotCompletingTest.xml"})
 
 public class BAAtomicPCActiveNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCTest.xml"})
 
 public class BAAtomicPCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BACCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BACCBotTest.java
@@ -44,7 +44,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baccTest.xml"})
 
 public class BACCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAPCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAPCBotTest.java
@@ -44,7 +44,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/bapcTest.xml"})
 
 public class BAPCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
@@ -56,7 +56,7 @@ import static junit.framework.TestCase.assertTrue;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simpleCommentTest.xml"})
 public class CommentBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simple2NeedConversationTest.xml"})
 public class ConversationBotTest
 {
 

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simple2NeedGroupingTest.xml"})
 public class GroupingBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simpleMatcherTest.xml"})
 public class MatcherBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/securityBotTest.xml"})
 public class SecurityBotTests
 {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitBotTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  * Date: 14.5.14.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/standardTwoPhaseCommitTest.xml"})
 public class StandardTwoPhaseCommitBotTest {
   private static final int RUN_ONCE = 1;
   private static final long ACT_LOOP_TIMEOUT_MILLIS = 100;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitNoVoteBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitNoVoteBotTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/standardTwoPhaseCommitNoVoteTest.xml"})
 
 public class StandardTwoPhaseCommitNoVoteBotTest
 {

--- a/webofneeds/won-bot/src/test/resources/botContext.xml
+++ b/webofneeds/won-bot/src/test/resources/botContext.xml
@@ -23,7 +23,7 @@
         http://www.springframework.org/schema/data/mongo
         http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- MongoDB config -->
     <mongo:mongo id="mongo" host="localhost" port="27017"/>

--- a/webofneeds/won-bot/src/test/resources/botContext.xml
+++ b/webofneeds/won-bot/src/test/resources/botContext.xml
@@ -26,8 +26,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
-
     <!-- MongoDB config -->
     <mongo:mongo id="mongo" host="localhost" port="27017"/>
 

--- a/webofneeds/won-bot/src/test/resources/botContext.xml
+++ b/webofneeds/won-bot/src/test/resources/botContext.xml
@@ -19,8 +19,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mongo="http://www.springframework.org/schema/data/mongo"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/data/mongo
         http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd
         http://www.springframework.org/schema/context

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/KeyStoreService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/KeyStoreService.java
@@ -164,17 +164,16 @@ public class KeyStoreService
    * @param certificateChain
    * @param certificate
    * @param replace
-   * @throws IOException
    */
   private synchronized void putEntry(String alias, PrivateKey key, Certificate[] certificateChain, Certificate
-    certificate, boolean replace) throws IOException {
+    certificate, boolean replace){
 
     try {
       if (!replace && store.containsAlias(alias)) {
-        throw new IOException("Could not add new entry - key store already contains entry for " + alias);
+        return;
       }
     } catch (Exception e) {
-      throw new IOException("Could not add into the key store entry for " + alias, e);
+      throw new RuntimeException("Error checking if key with alias '"+ alias +"' is in the keystore", e);
     }
 
     try {
@@ -183,11 +182,11 @@ public class KeyStoreService
       } else if (alias != null && certificate != null) {
         store.setCertificateEntry(alias, certificate);
       } else {
-        throw new IOException("Could not add entry for " + alias + " to the key store");
+        throw new RuntimeException("Could not add entry for " + alias + " to the key store");
       }
       saveStoreToFile();
     } catch (Exception e) {
-      throw new IOException("Could not add entry for " + alias + " to the key store", e);
+      throw new RuntimeException("Could not add entry for " + alias + " to the key store", e);
     }
 
   }

--- a/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
+++ b/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
@@ -18,8 +18,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/task
         http://www.springframework.org/schema/task/spring-task-3.1.xsd">
 

--- a/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
+++ b/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
@@ -20,7 +20,7 @@
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/task
-        http://www.springframework.org/schema/task/spring-task-3.1.xsd">
+        http://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
     <!-- expects a bean 'taskScheduler', a spring task scheduler -->
     <task:scheduled-tasks scheduler="taskScheduler">

--- a/webofneeds/won-core/src/main/resources/spring/component/wonNodeInformationService.xml
+++ b/webofneeds/won-core/src/main/resources/spring/component/wonNodeInformationService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <bean id="wonNodeInformationService" class="won.protocol.service.impl.WonNodeInformationServiceImpl">
         <property name="defaultWonNodeUri" value="${uri.node.default}" />

--- a/webofneeds/won-cryptography/src/main/resources/spring/component/cryptographyServices.xml
+++ b/webofneeds/won-cryptography/src/main/resources/spring/component/cryptographyServices.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="java.security.Security.addProvider"/>

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/ehcache/spring-node-ehcache.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/ehcache/spring-node-ehcache.xml
@@ -15,8 +15,7 @@
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher-service.properties" ignore-unresolvable="true"/>
 

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
@@ -24,9 +24,7 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher-service.properties"
-                                  ignore-unresolvable="true"/>
-
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher-service.properties" ignore-unresolvable="true"/>
 
     <bean id="keyStoreService" class="won.cryptography.service.KeyStoreService" init-method="init">
         <constructor-arg type="java.lang.String" value="${keystore.location}" />

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/scheduling/matcher-service-scheduling.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/scheduling/matcher-service-scheduling.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >
     <property name="poolSize" value="15" />

--- a/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
+++ b/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->

--- a/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
+++ b/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
@@ -17,8 +17,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mixed.xml"/>
 

--- a/webofneeds/won-matcher/src/main/resources/matcherApplicationContext.xml
+++ b/webofneeds/won-matcher/src/main/resources/matcherApplicationContext.xml
@@ -5,10 +5,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
          Load properties but ignore unresolvable properties so that

--- a/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
@@ -18,8 +18,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-jmsonly.xml and matcher-core.xml and in matcher-camel.xml within matcher-jmsonly.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/><!-- was in storage.xml -->

--- a/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
@@ -16,8 +16,14 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation=
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-jmsonly.xml and matcher-core.xml and in matcher-camel.xml within matcher-jmsonly.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/><!-- was in storage.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/><!-- was in matcher-nodeurisource-all.xml within matcher-jmsonly.xml -->
 
     <!--
        context that combines bot definitions with runner context
@@ -32,7 +38,4 @@
     <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
     <import resource="classpath:/spring/component/storage/storage.xml" />
     <import resource="classpath:/spring/component/wonNodeInformationService.xml" />
-
-
-
 </beans>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
@@ -28,6 +28,5 @@
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
     <bean id="matcherCLICommandLineRunner" class="won.matcher.cli.MatcherCLI"/>
 </beans>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <bean id="matcherProtocolMatcherServiceJMSBased"
           class="won.matcher.protocol.impl.MatcherProtocolMatcherServiceImplJMSBased">
         <property name="matcherProtocolCommunicationService" ref="matcherProtocolCommunicationService"/>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
@@ -14,8 +14,6 @@
                 http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
-
     <camel:camelContext id="wonMatcherCamel">
         <camel:packageScan>
             <camel:package>won.matcher.camel.routes.fixed</camel:package>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
@@ -7,11 +7,11 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <camel:camelContext id="wonMatcherCamel">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/ehcache/spring-matcher-ehcache.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/ehcache/spring-matcher-ehcache.xml
@@ -14,14 +14,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/linkeddatasource/matcher-linkeddatasource.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/linkeddatasource/matcher-linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-matcher/src/main/resources/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- expects a bean matcherMessagingService -->
     <bean id="matcherProtocolNeedServiceClientJMSBased"

--- a/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="matcherNodeURISource" class="won.matcher.component.MatcherNodeURISourceImpl" >
         <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />

--- a/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
@@ -24,12 +24,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
-
     <bean id="matcherNodeURISource" class="won.matcher.component.MatcherNodeURISourceImpl" >
         <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
         <qualifier value="default" />

--- a/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
@@ -28,7 +28,6 @@
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!--bean id="matcherProtocolCommunicationService"
     class="won.matcher.protocol.impl.MatcherProtocolCommunicationServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
@@ -26,14 +26,6 @@
                 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
                 ">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <context:annotation-config />
 
     <!-- Defines where to search for annotated components -->

--- a/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
@@ -21,10 +21,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 ">
     <context:annotation-config />
 

--- a/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
@@ -28,7 +28,6 @@
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!--bean id="matcherProtocolCommunicationService"
     class="won.matcher.protocol.impl.MatcherProtocolCommunicationServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">

--- a/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
@@ -28,7 +28,6 @@
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!-- protocol-level services -->
     <bean id="matcherMessagingService" class="won.protocol.jms.MessagingServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
@@ -15,14 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">

--- a/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
@@ -19,8 +19,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <import resource="classpath:/spring/component/transmission/matcher-security.xml" />
     <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />

--- a/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
@@ -22,12 +22,6 @@
                "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
-
     <import resource="classpath:/spring/component/transmission/matcher-security.xml" />
     <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
     <import resource="classpath:/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml"/>
@@ -39,8 +33,4 @@
     <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml" />
     <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml" />
     <import resource="classpath:/spring/component/wonNodeInformationService.xml" />
-
-
-
-
 </beans>

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -8,7 +8,25 @@
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
                                  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
+    <!--context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/-->
+    <!--
+        Problem:
+        1. The embedded activemq broker creates a child spring context
+        2. Properties are not seen in child contexts because they are realized as bean factory post processors,
+            which do not post-process child contexts
+        3. We do not want to re-define the property file in the child context (for ease of configuration)
+        Solution:
+        1. we first define a bean template (abstract=true) for the PPC
+        2. we can define a concrete one in this context and in the child context because the
+            template is visible in the child context
+    -->
+    <bean id="abstractPropertyPlaceholderConfigurer" abstract="true" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="location" value="file:${WON_CONFIG_DIR}/node.properties" />
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+    </bean>
+    <!-- here's the concrete bean for the PPC. The same is done in the activemq.xml file -->
+    <bean id="propertyPlaceholderConfigurer" parent="abstractPropertyPlaceholderConfigurer" />
+
     <!-- was in node.xml --><!-- was in message-processors.xml within node.xml--><!-- was in activemq.xml within node-camel.xml within node.xml-->
     <!-- was in node-camel.xml within node.xml --><!-- was in jdbc-storage.xml within node.xml -->
     <!-- was in jpabased-rdf-storage.xml within node.xml --><!-- was in node-security.xml within node.xml-->

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -4,7 +4,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns:context="http://www.springframework.org/schema/context"
              xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
                                  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -2,12 +2,17 @@
 
 <beans xmlns:sec="http://www.springframework.org/schema/security"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:context="http://www.springframework.org/schema/context"
              xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
+                                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-
-    <!-- all the beans necessary for node's functioning -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
+    <!-- was in node.xml --><!-- was in message-processors.xml within node.xml--><!-- was in activemq.xml within node-camel.xml within node.xml-->
+    <!-- was in node-camel.xml within node.xml --><!-- was in jdbc-storage.xml within node.xml -->
+    <!-- was in jpabased-rdf-storage.xml within node.xml --><!-- was in node-security.xml within node.xml-->
+    <!-- was in node-core.xml within node.xml--><!-- all the beans necessary for node's functioning -->
     <import resource="classpath:/spring/node.xml"/>
 
     <!--

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -6,7 +6,7 @@
              xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
-                                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+                                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <!-- was in node.xml --><!-- was in message-processors.xml within node.xml--><!-- was in activemq.xml within node-camel.xml within node.xml-->

--- a/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
+++ b/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
@@ -21,9 +21,9 @@
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.1.xsd
        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
 

--- a/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
+++ b/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
@@ -22,7 +22,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.1.xsd
        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -28,7 +28,13 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
+
+    <!-- This bean extends the the abstract PPC bean in the parent context -->
+    <spring:bean id="propertyPlaceholderConfigurer" parent="abstractPropertyPlaceholderConfigurer" />
+
     <broker xmlns="http://activemq.apache.org/schema/core" brokerName="wonBroker" persistent="false" >
+
+
 
         <!--
             For better performances use VM cursor and small memory limit.

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -25,15 +25,6 @@
   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
   http://www.springframework.org/schema/context
   http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
-
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -24,7 +24,7 @@
         xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
   http://www.springframework.org/schema/context
-  http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+  http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -21,7 +21,7 @@
         xmlns:spring="http://www.springframework.org/schema/beans"
         xmlns:context="http://www.springframework.org/schema/context"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
   http://www.springframework.org/schema/context
   http://www.springframework.org/schema/context/spring-context-3.1.xsd">

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
@@ -23,11 +23,6 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <!--import resource="classpath:/spring/component/wonNodeInformationService.xml" /-->
     <!--import resource="classpath:/spring/component/linkeddatasource/linkeddatasource.xml"/-->
     <!--import resource="classpath:/spring/component/ehcache/spring-node-ehcache.xml"/-->

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
@@ -15,14 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--import resource="classpath:/spring/component/wonNodeInformationService.xml" /-->
     <!--import resource="classpath:/spring/component/linkeddatasource/linkeddatasource.xml"/-->
     <!--import resource="classpath:/spring/component/ehcache/spring-node-ehcache.xml"/-->

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
@@ -4,10 +4,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
@@ -11,12 +11,6 @@
 
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
     <!-- Camel configuration -->
     <!--camel:camelContext id="wonNodeCamel" trace="false"  we comment this out for testing if using the 'trace'
     attribute causes the resources for tracing to be allocated (CamelInternalProcessor$BacklogTracerAdvice with 100k

--- a/webofneeds/won-node/src/main/resources/spring/component/ehcache/spring-node-ehcache.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/ehcache/spring-node-ehcache.xml
@@ -15,8 +15,7 @@
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-node/src/main/resources/spring/component/linkeddatasource/linkeddatasource.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/linkeddatasource/linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolMatcherServiceClient/matcherProtocolMatcherServiceClient-jms.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolMatcherServiceClient/matcherProtocolMatcherServiceClient-jms.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
 

--- a/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolNeedService/matcherProtocolNeedService-jms.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolNeedService/matcherProtocolNeedService-jms.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
     <bean id="matcherProtocolNeedJMSService" class="won.node.protocol.impl.MatcherProtocolNeedServiceImplJMSBased">

--- a/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring-jmx.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring-jmx.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean" >
         <property name="callbacks">

--- a/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
@@ -22,7 +22,7 @@
 
 
         http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+        http://www.springframework.org/schema/aop/spring-aop-4.1.xsd">
 
     <bean id="monitoringInterceptor" class="org.javasimon.spring.MonitoringInterceptor"/>
 

--- a/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
@@ -18,8 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
         http://www.springframework.org/schema/aop

--- a/webofneeds/won-node/src/main/resources/spring/component/scheduling/node-scheduling.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/scheduling/node-scheduling.xml
@@ -18,8 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- required for monitoring stats recorder -->
     <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -22,10 +22,10 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
                 http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
 

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -29,13 +29,6 @@
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
                 http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
-
     <!-- Defines where to search for annotated components -->
     <context:component-scan base-package="won.node.protocol.impl" />
 

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -27,7 +27,7 @@
                 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
     <!-- Defines where to search for annotated components -->
     <context:component-scan base-package="won.node.protocol.impl" />

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -24,14 +24,6 @@
 
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
     <!--- RDF Storage -->
     <bean id="rdfStorageRef" class="won.protocol.repository.rdfstorage.impl.JpaRepositoryBasedRdfStorageServiceImpl" />
-
-    
 </beans>

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -19,10 +19,10 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--- RDF Storage -->
     <bean id="rdfStorageRef" class="won.protocol.repository.rdfstorage.impl.JpaRepositoryBasedRdfStorageServiceImpl" />

--- a/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
@@ -14,14 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- private keys and their certificates for node,
              possibly certificates of other parties-->

--- a/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
@@ -22,11 +22,6 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
 
     <!-- private keys and their certificates for node,
              possibly certificates of other parties-->

--- a/webofneeds/won-node/src/main/resources/spring/component/wonNodeInformationService-node.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/wonNodeInformationService-node.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <bean id="wonNodeInformationService" class="won.protocol.service.impl.WonNodeInformationServiceImpl">
         <property name="defaultWonNodeUri" value="${uri.node.default}" />

--- a/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
+++ b/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
@@ -25,11 +25,6 @@
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
     <!--import resource="classpath:/spring/component/security/key-services.xml" /-->
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert strings into jena models -->

--- a/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
+++ b/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
@@ -15,14 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--import resource="classpath:/spring/component/security/key-services.xml" /-->
 

--- a/webofneeds/won-node/src/main/resources/spring/node.xml
+++ b/webofneeds/won-node/src/main/resources/spring/node.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--context:component-scan base-package="won.*" /-->
     <import resource="classpath:/spring/component/camel/message-processors.xml"/>

--- a/webofneeds/won-node/src/main/resources/spring/node.xml
+++ b/webofneeds/won-node/src/main/resources/spring/node.xml
@@ -6,12 +6,6 @@
                "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in th e context
-    -->
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <!--context:component-scan base-package="won.*" /-->
     <import resource="classpath:/spring/component/camel/message-processors.xml"/>
     <import resource="classpath:/spring/component/cryptographyServices.xml" />

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
@@ -27,6 +27,7 @@
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
     <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
     <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- was in owner-mailer.xml -->
 
     <!-- owner functioning -->
     <import resource="classpath:/spring/owner-jmsonly.xml"/>

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
@@ -18,9 +18,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
 
     <!-- owner functioning -->
     <import resource="classpath:/spring/owner-jmsonly.xml"/>

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
@@ -21,7 +21,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
             http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
@@ -20,7 +20,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
@@ -16,14 +16,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- configuration with gmail smtp server, uses unsafe access and requires
     that https://www.google.com/settings/security/lesssecureapps is turned on.

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
@@ -25,12 +25,6 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
     <!-- configuration with gmail smtp server, uses unsafe access and requires
     that https://www.google.com/settings/security/lesssecureapps is turned on.
     Change this confuguration if another mail server should be used -->

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-message.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-message.xml
@@ -19,7 +19,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="ownerApplicationService" class="won.owner.service.impl.OwnerApplicationService"/>
 

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -3,7 +3,7 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns:beans="http://www.springframework.org/schema/beans" xmlns:benas="http://www.springframework.org/schema/beans"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -21,11 +21,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:websocket="http://www.springframework.org/schema/websocket"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd
+http://www.springframework.org/schema/context/spring-context-4.1.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.1.xsd
 http://www.springframework.org/schema/websocket
-http://www.springframework.org/schema/websocket/spring-websocket-4.0.xsd">
+http://www.springframework.org/schema/websocket/spring-websocket-4.1.xsd">
 
     <!--import resource="classpath:/spring/owner-jmsonly.xml"/>
     <import resource="classpath:/spring/owner-context.xml"/>

--- a/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
@@ -14,12 +14,6 @@
                 http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
     <!-- messaging beans -->
     <camel:camelContext id="wonOwnerCamel">
         <camel:packageScan>

--- a/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
@@ -7,11 +7,11 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <!-- messaging beans -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/ehcache/spring-owner-ehcache.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ehcache/spring-owner-ehcache.xml
@@ -13,14 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/ownerProtocolCommunicationService.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/ownerProtocolCommunicationService.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 
     <bean id="messagingService" class="won.protocol.jms.MessagingServiceImpl">

--- a/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/wonNodeRegistrationEventPublisher.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/wonNodeRegistrationEventPublisher.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:task="http://www.springframework.org/schema/task"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
 
     <bean id="wonNodeRegistrationEventPublisher" class="won.owner.messaging.WonNodeRegistrationEventPublisher" />
     <task:scheduled-tasks>

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
@@ -21,10 +21,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
     <context:annotation-config />

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
@@ -27,11 +27,6 @@
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
@@ -21,10 +21,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
     <context:annotation-config />

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
@@ -27,11 +27,6 @@
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -27,7 +27,7 @@
                 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
     <context:annotation-config />
 
     <!-- Defines where to search for annotated components -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -22,10 +22,10 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
                 http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
     <context:annotation-config />

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -28,14 +28,6 @@
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
                 http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <context:annotation-config />
 
     <!-- Defines where to search for annotated components -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -21,10 +21,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
     <context:annotation-config />
 

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -26,12 +26,6 @@
                 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">

--- a/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
@@ -28,9 +28,6 @@
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <bean id="clientKeyStoreService" class="won.cryptography.service.KeyStoreService" init-method="init">
         <constructor-arg type="java.lang.String" value="${keystore.location}" />
         <constructor-arg type="java.lang.String" value="${keystore.password}" />

--- a/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
@@ -15,14 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <bean id="uriService" class="won.owner.service.impl.URIService">
         <property name="ownerProtocolOwnerServiceEndpointURI" value="${uri.owner.protocol.endpoint}" />
         <property name="defaultOwnerProtocolNeedServiceEndpointURI" value="${uri.need.protocol.endpoint.default}" />

--- a/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
@@ -23,13 +23,6 @@
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <bean id="uriService" class="won.owner.service.impl.URIService">
         <property name="ownerProtocolOwnerServiceEndpointURI" value="${uri.owner.protocol.endpoint}" />
         <property name="defaultOwnerProtocolNeedServiceEndpointURI" value="${uri.need.protocol.endpoint.default}" />

--- a/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- TODO merge into one file cryptographyServices.xml and owner-security? -->
     <import resource="classpath:/spring/component/cryptographyServices.xml" />

--- a/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
@@ -6,12 +6,6 @@
                "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
     <!-- TODO merge into one file cryptographyServices.xml and owner-security? -->
     <import resource="classpath:/spring/component/cryptographyServices.xml" />
     <import resource="classpath:/spring/component/transmission/owner-security.xml" />

--- a/webofneeds/won-utils/won-utils-crawl/src/main/resources/spring/app/linkeddata-crawler.xml
+++ b/webofneeds/won-utils/won-utils-crawl/src/main/resources/spring/app/linkeddata-crawler.xml
@@ -17,10 +17,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines components to provide an environment for running bots
     -->

--- a/webofneeds/won-utils/won-utils-mail/src/main/resources/mail-sender.xml
+++ b/webofneeds/won-utils/won-utils-mail/src/main/resources/mail-sender.xml
@@ -16,14 +16,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 
     <!-- configuration with gmail smtp server, uses unsafe access and requires


### PR DESCRIPTION
First Step of the property refactoring process:

We moved all context:property-placeholder occurences within the spring-xml-config from the subconfigs to the initializing/starting bean config

e.g. every occurence of a property-placeholder within the imports of the DebugBotApp was moved directly in the debugBotApp.xml, that way we can already see in one file which property files are needed to start a certain bot/webapp etc.