### PR TITLE
Fix lost updates

### DIFF
--- a/webofneeds/conf/owner.properties
+++ b/webofneeds/conf/owner.properties
@@ -27,7 +27,7 @@ uri.owner.protocol.endpoint=${uri.prefix.owner}/protocol
 # otherwise owner cannot connect to won node
 node.default.scheme=https
 node.default.host=localhost
-node.default.http.port=8080
+node.default.http.port=8443
 uri.prefix.node.default=${node.default.scheme}://${node.default.host}:${node.default.http.port}/won
 
 

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveExitingTest.xml
@@ -16,16 +16,33 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml and in matcher-nodeurisource-all.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveFailingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCActiveNotComletingTest.xml
@@ -16,16 +16,33 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCActiveNotComletingTest.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCAdditionalParticipantsTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingExitingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingFailingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCCompletingNotCompletingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicCCTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicCC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveExitingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveFailingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baAtomicPCActiveNotCompletingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/baccTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBACC.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBACC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBACC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBACC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/bapcTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAPC.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAPC.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/botRunner.xml
@@ -16,46 +16,41 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
+
     <!--
        context that combines components to provide an environment for running bots
     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
-
-
     <!--import resource="classpath:/spring/component/linkeddatasource/owner-linkeddatasource.xml" /-->
-    <import resource="classpath:/spring/component/scheduling/scheduling.xml" />
-    <import resource="classpath:/spring/component/ownerCallback/ownerCallback.xml" />
+    <import resource="classpath:/spring/component/scheduling/scheduling.xml"/>
+    <import resource="classpath:/spring/component/ownerCallback/ownerCallback.xml"/>
     <import resource="classpath:/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml"/>
-    <import resource="classpath:/spring/component/botManager/botManager.xml" />
+    <import resource="classpath:/spring/component/botManager/botManager.xml"/>
     <!-- this introduces the email-based subsystem for generating needs to be loaded, which is not desirable for most
      applications. -->
     <!-- import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" /-->
-    <import resource="classpath:/spring/component/nodeurisource/nodeurisource-roundrobin.xml" />
-    <import resource="classpath:/spring/owner-jmsonly.xml" />
+    <import resource="classpath:/spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>
+    <import resource="classpath:/spring/owner-jmsonly.xml"/>
     <!-- monitoring -->
     <!--
     <import resource="classpath:/spring/component/monitoring/bot-monitoring-jmx.xml" />
     <import resource="classpath:/spring/component/monitoring/bot-monitoring.xml" />
     -->
-    <import resource="classpath:/spring/component/monitoring/monitoring-recorder.xml" />
+    <import resource="classpath:/spring/component/monitoring/monitoring-recorder.xml"/>
 
     <!--import resource="classpath:/spring/component/wonNodeInformationService.xml"/-->
 
     <!--import resource="classpath:/spring/matcher-jmsonly.xml"/-->
 
-    <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
+    <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml"/>
     <import resource="classpath:/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml"/>
-    <import resource="classpath:/spring/component/camel/matcher-camel.xml" />
-    <import resource="classpath:/spring/core/matcher-core.xml" />
-    <import resource="classpath:/spring/component/storage/storage.xml" />
+    <import resource="classpath:/spring/component/camel/matcher-camel.xml"/>
+    <import resource="classpath:/spring/core/matcher-core.xml"/>
+    <import resource="classpath:/spring/component/storage/storage.xml"/>
     <import resource="classpath:/spring/component/services/matcher-services.xml"/>
-    <import resource="classpath:/spring/component/linkeddatasource/matcher-linkeddatasource.xml" />
-    <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml" />
-    <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml" />
+    <import resource="classpath:/spring/component/linkeddatasource/matcher-linkeddatasource.xml"/>
+    <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml"/>
+    <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml"/>
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/debugBotApp.xml
@@ -16,16 +16,36 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within DebutBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within DebutBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/DebugBot.xml" />
+    <import resource="classpath:/spring/bot/DebugBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/echoBotApp.xml
@@ -16,16 +16,35 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within EchoBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within EchoBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/EchoBot.xml" />
+    <import resource="classpath:/spring/bot/EchoBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/feedbackTesterApp.xml
@@ -16,18 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
-
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml and needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml and nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
-    <import resource="classpath:/spring/bot/randomSimulatorBot.xml" />
-
-
-
+    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml"/>
+    <import resource="classpath:/spring/bot/randomSimulatorBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/lastSeenNeedsMatcherApp.xml
@@ -16,16 +16,36 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and LastSeenNeedsMatcherBot.xml and botContext.xml within LastSeenNeedsMatcherBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within LastSeenNeedsMatcherBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within LastSeenNeedsMatcherBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml" />
+    <import resource="classpath:/spring/bot/LastSeenNeedsMatcherBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/mail2wonBotApp.xml
@@ -16,16 +16,32 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in Mail2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Mail2WonBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/Mail2WonBot.xml" />
-
-
+    <import resource="classpath:/spring/bot/Mail2WonBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/matcherApp.xml
@@ -16,16 +16,32 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/MatcherBot.xml" />
+    <import resource="classpath:/spring/bot/MatcherBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/needCreatorBotApp.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml and needCreatorBot.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml within needCreatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within needCreatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/needCreatorBot.xml" />
-
-
+    <import resource="classpath:/spring/bot/needCreatorBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/randomSimulatorBotApp.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails-nonstop.xml within randomSimulatorBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within randomSimulatorBot.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/randomSimulatorBot.xml" />
+    <import resource="classpath:/spring/bot/randomSimulatorBot.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-oncePerNode-testBot.xml
@@ -17,20 +17,22 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate-oncepernode.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerOwnerEmulateOncePerNode" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate-oncepernode.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
+
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerOwnerEmulateOncePerNode"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerOncePerNodeBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerOncePerNodeBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-emulateOwner-testBot.xml
@@ -17,20 +17,22 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerOwnerEmulate" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <import resource="classpath:spring/component/needconsumer/needconsumer-owneremulate.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
+
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerOwnerEmulate"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToOwnerBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/readMailsFromFolder-writeToSysout-testBot.xml
@@ -17,20 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <import resource="classpath:spring/component/needconsumer/needconsumer-sysout.xml" />
-    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml" />
-    <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml" />
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer" >
-        <property name="needConsumer" ref="needConsumerSysout" />
-        <property name="needProducer" ref="needProducerFromMails" />
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml -->
+
+    <import resource="classpath:spring/component/needconsumer/needconsumer-sysout.xml"/>
+    <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
+    <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
+
+    <bean id="needProsumer" class="won.bot.framework.component.needprosumer.NeedProsumer">
+        <property name="needConsumer" ref="needConsumerSysout"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
     </bean>
-    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToSysoutBot" />
+    <bean id="commandLineRunner" class="won.bot.app.SimpleMaildirToSysoutBot"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/securityBotTest.xml
@@ -23,15 +23,15 @@
         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
-       context tat combines bot definitions with runner context
+       context that combines bot definitions with runner context
     -->
 
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
                                   ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
-                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml -->
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotBAPC#.xml -->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
-                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAAtomicPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotBAPC.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
                                   ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
     <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
@@ -42,8 +42,4 @@
 
     <!-- the runner -->
     <import resource="classpath:/spring/app/botRunner.xml"/>
-    <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml"/>
-
-
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedConversationTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in mailBaseSimpleReactiveBotConnection2Needs.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaseSimpleReactiveBotConnecting2Needs.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml" />
+    <import resource="classpath:/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simple2NeedGroupingTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotGroupConversation.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotGroupConversation.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleCommentTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotComment.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotComment.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotComment.xml" />
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotComment.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/simpleMatcherTest.xml
@@ -16,16 +16,32 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBasedSimpleReactiveBotMatcher.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBasedSimpleReactiveBotMatcher.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotMatcher.xml" />
-
-
+    <import resource="classpath:/spring/bot/mailBasedSimpleReactiveBotMatcher.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitNoVoteTest.xml
@@ -16,16 +16,32 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context tat combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml --><!-- mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml" />
-
-
+    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/standardTwoPhaseCommitTest.xml
@@ -16,16 +16,34 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in needproducer-mails.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml  and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml" />
+    <import resource="classpath:/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml"/>
 
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/app/telegram2wonBotApp.xml
@@ -16,16 +16,32 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
        context that combines bot definitions with runner context
     -->
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in botRunner.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties"
+                                  ignore-unresolvable="true"/> <!-- was in Telegram2WonBot.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties"
+                                  ignore-unresolvable="true"/> <!-- was in nodeurisource-random.xml within Telegram2WonBot.xml and in ownerCallback.xml and noderurisource-roundrobin.xml and matcherProtocolMatcherServiceHandler.xml within botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties"
+                                  ignore-unresolvable="true"/><!-- was in matcher-camel.xml within botRunner.xml and in in matcher-core.xml within botRunner.xml and in matcher-service.xml withihn botRunner.xml-->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- all within botRunner.xml -->
+
     <!-- the runner -->
-    <import resource="classpath:/spring/app/botRunner.xml" />
+    <import resource="classpath:/spring/app/botRunner.xml"/>
     <!-- the bots to run -->
-    <import resource="classpath:/spring/bot/Telegram2WonBot.xml" />
-
-
+    <import resource="classpath:/spring/bot/Telegram2WonBot.xml"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/DebugBot.xml
@@ -17,31 +17,32 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.DebugBot">
         <!-- optional property, by default one echo need per each need will be created -->
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
-        <property name="matcherUri" value="${matcher.uri}" />
+        <property name="matcherUri" value="${matcher.uri}"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
         <!--property name="ownerService" ref="ownerProtocolNeedServiceClient" /-->
         <property name="matcherProtocolNeedServiceClient" ref="matcherProtocolNeedServiceClient"/>
         <property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
-        
+
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/EchoBot.xml
@@ -17,16 +17,17 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
+
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.EchoBot">
         <!-- optional property, by default one echo need per each need will be created -->
-        <property name="numberOfEchoNeedsPerNeed" value="3" />
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="numberOfEchoNeedsPerNeed" value="3"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
@@ -38,10 +39,10 @@
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/LastSeenNeedsMatcherBot.xml
@@ -16,32 +16,28 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
-    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml" />
+    <import resource="classpath:/spring/component/needproducer/needproducer-mixed.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.LastSeenNeedsMatcherBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--property name="needProducer" ref="needProducerFromMails" /-->
         <!--property name="nodeURISource" ref="nodeUriSourceRandom" /-->
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
-        <property name="matcherUri" value="${matcher.uri}" />
+        <property name="matcherUri" value="${matcher.uri}"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Mail2WonBot.xml
@@ -19,21 +19,16 @@
        xmlns:mail="http://www.springframework.org/schema/integration/mail"
        xmlns:int="http://www.springframework.org/schema/integration"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/integration/mail
         http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
         http://www.springframework.org/schema/util
-        http://www.springframework.org/schema/util/spring-util.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/mail/mailContentExtractor.xml"/>
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-bot.properties" ignore-unresolvable="true"/>
 
     <util:properties id="javaMailProperties">
         <prop key="mail.imap.socketFactory.class">javax.net.ssl.SSLSocketFactory</prop>
@@ -72,8 +67,8 @@
     <bean id="mail2wonBot" class="won.bot.impl.Mail2WonBot">
         <!-- optional property, by default one echo need per each need will be created -->
 
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="taskScheduler" ref="taskScheduler" />
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
         <property name="receiveEmailChannel" ref="receiveEmailChannel"/>
         <property name="sendEmailChannel" ref="sendEmailChannel"/>
         <property name="mailGenerator" ref="mailGenerator"/>
@@ -87,10 +82,10 @@
         <!--<property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>-->
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="60000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="60000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>
@@ -107,6 +102,7 @@
         <property name="velocityEngine" ref="velocityEngine"/>
         <property name="sentFrom" value="${mailbot.email.address}"/>
         <property name="sentFromName" value="${mailbot.email.name}"/>
-        <property name="MAX_CONVERSATION_DEPTH" value="${mailbot.max_conversation_depth}"/> <!-- 0 includes no messages at all, -1 includes all messages -->
+        <property name="MAX_CONVERSATION_DEPTH"
+                  value="${mailbot.max_conversation_depth}"/> <!-- 0 includes no messages at all, -1 includes all messages -->
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/Telegram2WonBot.xml
@@ -16,23 +16,18 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
     <import resource="classpath:spring/component/telegram/telegramContentExtractor.xml"/>
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/telegram-bot.properties" ignore-unresolvable="true"/>
-
     <bean id="telegram2wonBot" class="won.bot.impl.Telegram2WonBot">
         <!-- optional property, by default one echo need per each need will be created -->
 
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="taskScheduler" ref="taskScheduler" />
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
         <property name="token" value="${telegrambot.token}"/>
         <property name="botName" value="${telegrambot.botname}"/>
         <property name="telegramContentExtractor" ref="telegramContentExtractor"/>
@@ -47,10 +42,10 @@
         <!--<property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>-->
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="6002000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="6002000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommit.xml
@@ -17,25 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.StandardTwoPhaseCommitNoVoteBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaisedSimpleReactiveBotStandardTwoPhaseCommitNoVote.xml
@@ -17,25 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBaseSimpleReactiveBotConnecting2Needs.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-roundrobin.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.ConversationBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRoundRobin" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRoundRobin"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCC.xml
@@ -17,25 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveExiting.xml
@@ -17,25 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveFailing.xml
@@ -17,28 +17,28 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
 </beans>
 
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCActiveNotCompleting.xml
@@ -17,27 +17,27 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCActiveNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCAdditionalParticipants.xml
@@ -17,25 +17,25 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCAdditionalParticipants">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingExiting.xml
@@ -17,27 +17,27 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingFailing.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicCCCompletingNotCompleting.xml
@@ -14,30 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicCCCompletingNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPC.xml
@@ -14,30 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveExiting.xml
@@ -14,30 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveExitingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveFailing.xml
@@ -14,30 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveFailingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAAtomicPCActiveNotCompleting.xml
@@ -14,30 +14,28 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAAtomicPCActiveNotCompletingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-    <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
-    <property name="trigger">
-        <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-            <constructor-arg name="period" value="200" />
-            <constructor-arg name="timeUnit" value="MILLISECONDS" />
-            <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-            <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
-        </bean>
-    </property>
-</bean>
-        </beans>
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
+        <property name="trigger">
+            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
+            </bean>
+        </property>
+    </bean>
+</beans>
 

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBACC.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BACCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotBAPC.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.BAPCBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotComment.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.CommentBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotGroupConversation.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.GroupingBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="200" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="200"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/mailBasedSimpleReactiveBotMatcher.xml
@@ -14,33 +14,31 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="mailBasedSimpleReactiveBot" class="won.bot.impl.MatcherProtocolTestBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <property name="matcherNodeURISource" ref="matcherNodeURISource"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="matcherProtocolNeedServiceClient" ref="matcherProtocolNeedServiceClient"/>
         <property name="matcherProtocolMatcherService" ref="matcherProtocolMatcherServiceJMSBased"/>
         <property name="registrationMatcherRetryInterval" value="5000"/>
 
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="2000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="2000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/needCreatorBot.xml
@@ -16,15 +16,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties"
-                                  ignore-unresolvable="true"/>
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!--<import resource="classpath:spring/component/needproducer/needproducer-mails.xml"/>-->
     <!--<import resource="classpath:spring/component/needproducer/needproducer-trig.xml"/>-->
@@ -33,20 +26,20 @@
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="needCreatorBot" class="won.bot.impl.NeedCreatorBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
         <!--<property name="needProducer" ref="needProducerFromMails" />-->
         <!--<property name="needProducer" ref="needProducerFromTrig" />-->
-        <property name="needProducer" ref="needProducerMixed" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="needProducer" ref="needProducerMixed"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="${needCreatorBot.period}" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="true" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="${needCreatorBot.period}"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="true"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/bot/randomSimulatorBot.xml
@@ -14,28 +14,26 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <import resource="classpath:spring/component/needproducer/needproducer-mails-nonstop.xml"/>
     <import resource="classpath:spring/component/nodeurisource/nodeurisource-random.xml"/>
     <import resource="classpath:spring/component/botContext/botContext.xml"/>
 
     <bean id="randomSimulatorBot" class="won.bot.impl.RandomSimulatorBot">
-        <property name="taskScheduler" ref="taskScheduler" />
-        <property name="botContext" ref="${botContext.impl}" />
-        <property name="needProducer" ref="needProducerFromMails" />
-        <property name="nodeURISource" ref="nodeUriSourceRandom" />
+        <property name="taskScheduler" ref="taskScheduler"/>
+        <property name="botContext" ref="${botContext.impl}"/>
+        <property name="needProducer" ref="needProducerFromMails"/>
+        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
         <!-- expects a bean named "ownerProtocolNeedServiceClient" in the context -->
-        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased" />
+        <property name="wonMessageSender" ref="ownerProtocolNeedServiceClientJMSBased"/>
         <property name="trigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="1000" />
-                <constructor-arg name="timeUnit" value="MILLISECONDS" />
-                <property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="false" />  <!-- fixed delay after completion -->
+                <constructor-arg name="period" value="1000"/>
+                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
+                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
+                <property name="fixedRate" value="false"/>  <!-- fixed delay after completion -->
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/botContext/botContext.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/botContext/botContext.xml
@@ -17,11 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/data/mongo
-        http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- MongoDB config -->
     <bean id="mongoClientUri" class="com.mongodb.MongoClientURI">
@@ -36,9 +32,9 @@
 
     <!-- use this mongo converter to be able to save keys with dots -->
     <bean id="mongoConverter" class="org.springframework.data.mongodb.core.convert.MappingMongoConverter">
-        <constructor-arg index="0" ref="mongoDbFactory" />
+        <constructor-arg index="0" ref="mongoDbFactory"/>
         <constructor-arg index="1">
-            <bean class="org.springframework.data.mongodb.core.mapping.MongoMappingContext" />
+            <bean class="org.springframework.data.mongodb.core.mapping.MongoMappingContext"/>
         </constructor-arg>
 
         <!-- replace dots by '^^^' -->

--- a/webofneeds/won-bot/src/main/resources/spring/component/botManager/botManager.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/botManager/botManager.xml
@@ -17,16 +17,15 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="botManager" class="won.bot.framework.manager.impl.SpringAwareBotManagerImpl" >
+    <bean id="botManager" class="won.bot.framework.manager.impl.SpringAwareBotManagerImpl">
         <property name="checkWorkDoneTrigger">
             <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="10" />
-                <constructor-arg name="timeUnit" value="SECONDS" />
-                <property name="fixedRate" value="true" />
-                <property name="initialDelay" value="10" />
+                <constructor-arg name="period" value="10"/>
+                <constructor-arg name="timeUnit" value="SECONDS"/>
+                <property name="fixedRate" value="true"/>
+                <property name="initialDelay" value="10"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/mail/mailContentExtractor.xml
@@ -16,44 +16,43 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="mailExtractor" class="won.bot.framework.eventbot.action.impl.mail.receive.MailContentExtractor">
         <property name="demandTypePattern">
             <bean id="demandTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[WANT\].*" />
+                <constructor-arg value="(?si)^\[WANT\].*"/>
             </bean>
         </property>
         <property name="supplyTypePattern">
             <bean id="supplyTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[OFFER\].*" />
+                <constructor-arg value="(?si)^\[OFFER\].*"/>
             </bean>
         </property>
         <property name="doTogetherTypePattern">
             <bean id="doTogetherTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[TOGETHER\].*" />
+                <constructor-arg value="(?si)^\[TOGETHER\].*"/>
             </bean>
         </property>
         <property name="critiqueTypePattern">
             <bean id="critiqueTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[CRITIQUE\].*" />
+                <constructor-arg value="(?si)^\[CRITIQUE\].*"/>
             </bean>
         </property>
         <property name="tagExtractionPattern">
             <bean id="tagExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="[#]+[\w]+\b" />
+                <constructor-arg value="[#]+[\w]+\b"/>
             </bean>
         </property>
         <property name="textMessageExtractionPattern">
             <bean id="textMessageExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?s).+?(?=\b[^\n]*\n>)" />
+                <constructor-arg value="(?s).+?(?=\b[^\n]*\n>)"/>
             </bean>
         </property>
         <property name="descriptionExtractionPattern">
             <bean id="descriptionExtractionPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?s).*" />
+                <constructor-arg value="(?s).*"/>
             </bean>
         </property>
         <property name="titleExtractionPattern">
@@ -65,37 +64,37 @@
         </property>
         <property name="usedForTestingPattern">
             <bean id="usedForTestingPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[DEBUG\].*?" />
+                <constructor-arg value=".*?\[DEBUG\].*?"/>
             </bean>
         </property>
         <property name="cmdTakenPattern">
             <bean id="cmdTakenPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[TAKEN\].*?" />
+                <constructor-arg value=".*?\[TAKEN\].*?"/>
             </bean>
         </property>
         <property name="doNotMatchPattern">
             <bean id="doNotMatchPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value=".*?\[NO_MATCH\].*?" />
+                <constructor-arg value=".*?\[NO_MATCH\].*?"/>
             </bean>
         </property>
         <property name="cmdClosePattern">
             <bean id="cmdClosePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^close.*" />
+                <constructor-arg value="(?si)^close.*"/>
             </bean>
         </property>
         <property name="cmdConnectPattern">
             <bean id="cmdConnectPattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^connect.*" />
+                <constructor-arg value="(?si)^connect.*"/>
             </bean>
         </property>
         <property name="cmdSubscribePattern">
             <bean id="cmdSubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^subscribe.*" />
+                <constructor-arg value="(?si)^subscribe.*"/>
             </bean>
         </property>
         <property name="cmdUnsubscribePattern">
             <bean id="cmdUnsubscribePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^unsubscribe.*" />
+                <constructor-arg value="(?si)^unsubscribe.*"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/matcherProtocolMatcherServiceHandler/matcherProtocolMatcherServiceHandler.xml
@@ -15,23 +15,13 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
     <!-- expects a botManager and a taskScheduler bean -->
-    <bean id="matcherProtocolMatcherServiceHandler" class="won.bot.integration.BotMatcherProtocolMatcherServiceCallback" >
-        <property name="botManager" ref="botManager" />
-        <property name="taskScheduler" ref="taskScheduler" />
+    <bean id="matcherProtocolMatcherServiceHandler"
+          class="won.bot.integration.BotMatcherProtocolMatcherServiceCallback">
+        <property name="botManager" ref="botManager"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring-jmx.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring-jmx.xml
@@ -17,17 +17,9 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd
-        http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean" >
+    <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean">
         <property name="callbacks">
             <list>
                 <bean class="org.javasimon.jmx.JmxRegisterCallback">

--- a/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/monitoring/bot-monitoring.xml
@@ -17,15 +17,12 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+
+
         http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+        http://www.springframework.org/schema/aop/spring-aop-4.1.xsd">
 
     <bean id="monitoringInterceptor" class="org.javasimon.spring.MonitoringInterceptor"/>
 

--- a/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-nop.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-nop.xml
@@ -15,14 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needConsumerNop" class="won.bot.framework.component.needconsumer.impl.NopNeedConsumer" />
+    <bean id="needConsumerNop" class="won.bot.framework.component.needconsumer.impl.NopNeedConsumer"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-sysout.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needconsumer/needconsumer-sysout.xml
@@ -15,14 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="needConsumerSysout" class="won.bot.framework.component.needconsumer.impl.SysoutNeedConsumer" />
+    <bean id="needConsumerSysout" class="won.bot.framework.component.needconsumer.impl.SysoutNeedConsumer"/>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails-nonstop.xml
@@ -15,73 +15,65 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    
-
-    <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromMails"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
-                <bean id="supplyNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl" />
+                <bean id="supplyNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.supply}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.supply}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="demandNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl" />
+                <bean id="demandNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.demand}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.demand}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="doTogetherNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl" />
+                <bean id="doTogetherNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.doTogether}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.doTogether}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="critiqueNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl" />
+                <bean id="critiqueNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.critique}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="true" />
+                            <property name="directory" value="${mail.directory.critique}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="true"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
@@ -91,4 +83,4 @@
         </property>
     </bean>
 
-        </beans>
+</beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mails.xml
@@ -15,73 +15,65 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    
-
-    <bean id="needProducerFromMails" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
+    <bean id="needProducerFromMails"
+          class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <property name="needFactories">
             <set>
-                <bean id="supplyNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl" />
+                <bean id="supplyNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-supply.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.supply}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.supply}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="demandNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl" />
+                <bean id="demandNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-demand.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.demand}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.demand}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="doTogetherNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl" />
+                <bean id="doTogetherNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-doTogether.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.doTogether}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.doTogether}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
                 </bean>
-                <bean id="critiqueNeedProducer" class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer" >
-                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl" />
+                <bean id="critiqueNeedProducer"
+                      class="won.bot.framework.component.needproducer.impl.TemplateBasedNeedProducer">
+                    <property name="template" value="classpath:/default-templates/default-template-critique.ttl"/>
                     <property name="wrappedProducer">
                         <bean class="won.bot.framework.component.needproducer.impl.DirectoryBasedNeedProducer">
-                            <property name="directory" value="${mail.directory.critique}" />
-                            <property name="filenameFilterRegex" value=".*eml" />
-                            <property name="repeat" value="false" />
+                            <property name="directory" value="${mail.directory.critique}"/>
+                            <property name="filenameFilterRegex" value=".*eml"/>
+                            <property name="repeat" value="false"/>
                             <property name="fileBasedNeedProducer">
-                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer" />
+                                <bean class="won.bot.framework.component.needproducer.impl.MailFileNeedProducer"/>
                             </property>
                         </bean>
                     </property>
@@ -91,4 +83,4 @@
         </property>
     </bean>
 
-        </beans>
+</beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-mixed.xml
@@ -15,22 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/>
-
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="needProducerMixed" class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">
         <qualifier value="default"/>

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-trig.xml
@@ -15,21 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/>
-
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="needProducerFromTrig"
           class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/needproducer/needproducer-turtle.xml
@@ -15,21 +15,8 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!-- 
-          Load properties but ignore unresolvable properties so that 
-          they are searched in other property configuerers defined in the context 
-     -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/>
-
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="needProducerFromTurtle"
           class="won.bot.framework.component.needproducer.impl.RoundRobinCompositeNeedProducer">

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-random.xml
@@ -15,22 +15,10 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
-
-    <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource" >
-        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
+    <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource">
+        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/nodeurisource/nodeurisource-roundrobin.xml
@@ -15,23 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
-
-    <bean id="nodeUriSourceRoundRobin" class="won.bot.framework.component.nodeurisource.impl.RoundRobinMultiNodeUriSource" >
-        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />
-        <qualifier value="default" />
+    <bean id="nodeUriSourceRoundRobin"
+          class="won.bot.framework.component.nodeurisource.impl.RoundRobinMultiNodeUriSource">
+        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}"/>
+        <qualifier value="default"/>
     </bean>
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/ownerCallback/ownerCallback.xml
@@ -15,24 +15,13 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
     <!-- expects a botManager and a taskScheduler bean -->
-    <bean id="botOwnerProtocolAdapter" class="won.bot.integration.BotOwnerCallback" >
-        <property name="botManager" ref="botManager" />
-        <property name="taskScheduler" ref="taskScheduler" />
+    <bean id="botOwnerProtocolAdapter" class="won.bot.integration.BotOwnerCallback">
+        <property name="botManager" ref="botManager"/>
+        <property name="taskScheduler" ref="taskScheduler"/>
     </bean>
 
     <!-- provides the bean expected by the dynamic camel route configuration in won-owner -->

--- a/webofneeds/won-bot/src/main/resources/spring/component/scheduling/scheduling.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/scheduling/scheduling.xml
@@ -15,17 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >
-    <property name="poolSize" value="15" />
-</bean>
+    <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler"
+          destroy-method="destroy">
+        <property name="poolSize" value="15"/>
+    </bean>
 
 </beans>

--- a/webofneeds/won-bot/src/main/resources/spring/component/telegram/telegramContentExtractor.xml
+++ b/webofneeds/won-bot/src/main/resources/spring/component/telegram/telegramContentExtractor.xml
@@ -16,29 +16,29 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <bean id="telegramContentExtractor" class="won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor">
+    <bean id="telegramContentExtractor"
+          class="won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor">
         <property name="demandTypePattern">
             <bean id="demandTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[WANT\].*" />
+                <constructor-arg value="(?si)^\[WANT\].*"/>
             </bean>
         </property>
         <property name="supplyTypePattern">
             <bean id="supplyTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[OFFER\].*" />
+                <constructor-arg value="(?si)^\[OFFER\].*"/>
             </bean>
         </property>
         <property name="doTogetherTypePattern">
             <bean id="doTogetherTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[TOGETHER\].*" />
+                <constructor-arg value="(?si)^\[TOGETHER\].*"/>
             </bean>
         </property>
         <property name="critiqueTypePattern">
             <bean id="critiqueTypePattern" class="java.util.regex.Pattern" factory-method="compile">
-                <constructor-arg value="(?si)^\[CRITIQUE\].*" />
+                <constructor-arg value="(?si)^\[CRITIQUE\].*"/>
             </bean>
         </property>
     </bean>

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveExitingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveExitingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveExitingTest.xml"})
 
 public class BAAtomicCCActiveExitingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveFailingBotTest.java
@@ -39,7 +39,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveFailingTest.xml"})
 
 public class BAAtomicCCActiveFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCActiveNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCActiveNotComletingTest.xml"})
 
 public class BAAtomicCCActiveNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCAdditionalParticipantsBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCAdditionalParticipantsBotTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCAdditionalParticipantsTest.xml"})
 
 public class BAAtomicCCAdditionalParticipantsBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCBotTest.java
@@ -40,7 +40,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCTest.xml"})
 
 public class BAAtomicCCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingFailingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCCompletingFailingTest.xml"})
 
 public class BAAtomicCCCompletingFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicCCCompletingNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicCCCompletingNotCompletingTest.xml"})
 
 public class BAAtomicCCCompletingNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveExitingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveExitingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveExitingTest.xml"})
 
 public class BAAtomicPCActiveExitingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveFailingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveFailingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveFailingTest.xml"})
 
 public class BAAtomicPCActiveFailingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveNotCompletingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCActiveNotCompletingBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCActiveNotCompletingTest.xml"})
 
 public class BAAtomicPCActiveNotCompletingBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAAtomicPCBotTest.java
@@ -41,7 +41,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baAtomicPCTest.xml"})
 
 public class BAAtomicPCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BACCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BACCBotTest.java
@@ -44,7 +44,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/baccTest.xml"})
 
 public class BACCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAPCBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/BAPCBotTest.java
@@ -44,7 +44,7 @@ import static junit.framework.TestCase.assertTrue;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/bapcTest.xml"})
 
 public class BAPCBotTest
 {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
@@ -56,7 +56,7 @@ import static junit.framework.TestCase.assertTrue;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simpleCommentTest.xml"})
 public class CommentBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simple2NeedConversationTest.xml"})
 public class ConversationBotTest
 {
 

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simple2NeedGroupingTest.xml"})
 public class GroupingBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/simpleMatcherTest.xml"})
 public class MatcherBotTest
 {
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/securityBotTest.xml"})
 public class SecurityBotTests
 {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitBotTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  * Date: 14.5.14.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/standardTwoPhaseCommitTest.xml"})
 public class StandardTwoPhaseCommitBotTest {
   private static final int RUN_ONCE = 1;
   private static final long ACT_LOOP_TIMEOUT_MILLIS = 100;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitNoVoteBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/StandardTwoPhaseCommitNoVoteBotTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/app/botRunner.xml"})
+@ContextConfiguration(locations = {"classpath:/spring/app/standardTwoPhaseCommitNoVoteTest.xml"})
 
 public class StandardTwoPhaseCommitNoVoteBotTest
 {

--- a/webofneeds/won-bot/src/test/resources/botContext.xml
+++ b/webofneeds/won-bot/src/test/resources/botContext.xml
@@ -19,14 +19,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mongo="http://www.springframework.org/schema/data/mongo"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/data/mongo
         http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/bot.properties" ignore-unresolvable="true"/>
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- MongoDB config -->
     <mongo:mongo id="mongo" host="localhost" port="27017"/>

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/KeyStoreService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/KeyStoreService.java
@@ -164,17 +164,16 @@ public class KeyStoreService
    * @param certificateChain
    * @param certificate
    * @param replace
-   * @throws IOException
    */
   private synchronized void putEntry(String alias, PrivateKey key, Certificate[] certificateChain, Certificate
-    certificate, boolean replace) throws IOException {
+    certificate, boolean replace){
 
     try {
       if (!replace && store.containsAlias(alias)) {
-        throw new IOException("Could not add new entry - key store already contains entry for " + alias);
+        return;
       }
     } catch (Exception e) {
-      throw new IOException("Could not add into the key store entry for " + alias, e);
+      throw new RuntimeException("Error checking if key with alias '"+ alias +"' is in the keystore", e);
     }
 
     try {
@@ -183,11 +182,11 @@ public class KeyStoreService
       } else if (alias != null && certificate != null) {
         store.setCertificateEntry(alias, certificate);
       } else {
-        throw new IOException("Could not add entry for " + alias + " to the key store");
+        throw new RuntimeException("Could not add entry for " + alias + " to the key store");
       }
       saveStoreToFile();
     } catch (Exception e) {
-      throw new IOException("Could not add entry for " + alias + " to the key store", e);
+      throw new RuntimeException("Could not add entry for " + alias + " to the key store", e);
     }
 
   }

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/camel/FacetExtractingCamelProcessor.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/camel/FacetExtractingCamelProcessor.java
@@ -19,6 +19,9 @@ package won.protocol.message.processor.camel;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.exception.MissingMessagePropertyException;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
@@ -37,6 +40,7 @@ public class FacetExtractingCamelProcessor implements Processor{
   ConnectionRepository connectionRepository;
 
   @Override
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.READ_COMMITTED)
   public void process(Exchange exchange) throws Exception {
     URI facetType = null;
     //first, try to extract the facet from the message

--- a/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionContainer.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionContainer.java
@@ -17,6 +17,7 @@
 package won.protocol.model;
 
 import won.protocol.model.parentaware.ParentAware;
+import won.protocol.model.parentaware.VersionedEntity;
 
 import javax.persistence.*;
 import java.util.Collection;
@@ -24,7 +25,7 @@ import java.util.Date;
 
 @Entity
 @Table(name="connection_container")
-public class ConnectionContainer implements ParentAware<Need>
+public class ConnectionContainer implements ParentAware<Need>, VersionedEntity
 {
   @Id
   @Column( name = "id" )
@@ -33,21 +34,32 @@ public class ConnectionContainer implements ParentAware<Need>
   @OneToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private Collection<Connection> connections;
 
-  @Version
   @Column(name="version", columnDefinition = "integer DEFAULT 0", nullable = false)
   private int version = 0;
 
-  @Version
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name="last_update", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
   private Date lastUpdate = new Date();
 
-  @OneToOne (fetch = FetchType.LAZY)
+  @OneToOne (fetch = FetchType.LAZY, optional = false)
   @MapsId
   private Need need;
 
   public Collection<Connection> getConnections() {
     return connections;
+  }
+
+  @Override
+  @PrePersist
+  @PreUpdate
+  public void incrementVersion() {
+    this.version++;
+    this.lastUpdate = new Date();
+  }
+
+  @Override
+  public Date getLastUpdate() {
+    return lastUpdate;
   }
 
   public int getVersion() {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionEventContainer.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionEventContainer.java
@@ -25,7 +25,7 @@ import java.net.URI;
 @DiscriminatorValue("Connection")
 public class ConnectionEventContainer extends EventContainer implements ParentAware<Connection>
 {
-  @OneToOne(fetch = FetchType.LAZY)
+  @OneToOne(fetch = FetchType.LAZY, mappedBy = "eventContainer", optional = false)
   private Connection connection;
 
   public ConnectionEventContainer() {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/EventContainer.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/EventContainer.java
@@ -16,6 +16,8 @@
 
 package won.protocol.model;
 
+import won.protocol.model.parentaware.VersionedEntity;
+
 import javax.persistence.*;
 import java.net.URI;
 import java.util.ArrayList;
@@ -26,7 +28,7 @@ import java.util.Date;
 @Inheritance
 @DiscriminatorColumn(name="parent_type")
 @Table(name="event_container")
-public abstract class EventContainer
+public abstract class EventContainer implements VersionedEntity
 {
   @Id
   @GeneratedValue
@@ -40,11 +42,9 @@ public abstract class EventContainer
   @OneToMany(fetch = FetchType.LAZY)
   private Collection<MessageEventPlaceholder> events = new ArrayList<>(1);
 
-  @Version
   @Column(name="version", columnDefinition = "integer DEFAULT 0", nullable = false)
   private int version = 0;
 
-  @Version
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name="last_update", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
   private Date lastUpdate = new Date();
@@ -54,6 +54,19 @@ public abstract class EventContainer
 
   public EventContainer(final URI parentUri) {
     this.parentUri = parentUri;
+  }
+
+  @Override
+  @PrePersist
+  @PreUpdate
+  public void incrementVersion() {
+    this.version++;
+    this.lastUpdate = new Date();
+  }
+
+  @Override
+  public Date getLastUpdate() {
+    return lastUpdate;
   }
 
   public Long getId() {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/Need.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/Need.java
@@ -18,6 +18,7 @@ package won.protocol.model;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
+import won.protocol.model.parentaware.VersionedEntity;
 
 import javax.persistence.*;
 import javax.xml.bind.annotation.XmlTransient;
@@ -31,175 +32,177 @@ import java.util.List;
 @Entity
 @Table(name = "need")
 //@Inheritance(strategy=InheritanceType.JOINED)
-public class Need
-{
-  @Id
-  @GeneratedValue
-  @Column( name = "id" )
-  private Long id;
+public class Need implements VersionedEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private Long id;
 
-  @Version
-  @Column(name="version", columnDefinition = "integer DEFAULT 0", nullable = false)
-  private int version = 0;
+    @Column(name = "version", columnDefinition = "integer DEFAULT 0", nullable = false)
+    private int version = 0;
 
-  @Version
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name="last_update", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
-  private Date lastUpdate = new Date();
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_update", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private Date lastUpdate = new Date();
 
-  /* The URI of the need */
-  @Column( name = "needURI", unique = true)
-  @Convert( converter = URIConverter.class)
-  protected URI needURI;
+    /* The URI of the need */
+    @Column(name = "needURI", unique = true)
+    @Convert(converter = URIConverter.class)
+    protected URI needURI;
 
-  /* The state of the need */
-  @Column( name = "state")
-  @Enumerated ( EnumType.STRING )
-  private NeedState state;
+    /* The state of the need */
+    @Column(name = "state")
+    @Enumerated(EnumType.STRING)
+    private NeedState state;
 
-  /* The owner protocol endpoint URI where the owner of the need can be reached */
-  @Column( name = "ownerURI" )
-  @Convert( converter = URIConverter.class)
-  private URI ownerURI;
+    /* The owner protocol endpoint URI where the owner of the need can be reached */
+    @Column(name = "ownerURI")
+    @Convert(converter = URIConverter.class)
+    private URI ownerURI;
 
-  /* The need protocol endpoint URI where the won node of the need can be reached */
-  @Column(name="wonNodeURI")
-  @Convert( converter = URIConverter.class)
-  private URI wonNodeURI;
+    /* The need protocol endpoint URI where the won node of the need can be reached */
+    @Column(name = "wonNodeURI")
+    @Convert(converter = URIConverter.class)
+    private URI wonNodeURI;
 
-  /* The creation date of the need */
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column( name = "creationDate", nullable = false)
-  private Date creationDate;
+    /* The creation date of the need */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "creationDate", nullable = false)
+    private Date creationDate;
 
-  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private DatasetHolder datatsetHolder;
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private DatasetHolder datatsetHolder;
 
-  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private List<DatasetHolder> attachmentDatasetHolders;
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<DatasetHolder> attachmentDatasetHolders;
 
-  //EAGERly loaded because accessed outside hibernate session in
-  // OwnerProtocolCamelConfiguratorImpl TODO: change this!
-   @ManyToMany(targetEntity = OwnerApplication.class,fetch = FetchType.EAGER)
-   @JoinTable(name="NEED_OWNERAPP",
-           joinColumns = @JoinColumn(name="need_id"),
-           inverseJoinColumns = @JoinColumn(name = "owner_application_id"))
-   private List<OwnerApplication> authorizedApplications;
+    //EAGERly loaded because accessed outside hibernate session in
+    // OwnerProtocolCamelConfiguratorImpl TODO: change this!
+    @ManyToMany(targetEntity = OwnerApplication.class, fetch = FetchType.EAGER)
+    @JoinTable(name = "NEED_OWNERAPP",
+            joinColumns = @JoinColumn(name = "need_id"),
+            inverseJoinColumns = @JoinColumn(name = "owner_application_id"))
+    private List<OwnerApplication> authorizedApplications;
 
-  @OneToOne(fetch = FetchType.LAZY, mappedBy = "need", cascade = CascadeType.ALL, orphanRemoval = true)
-  private NeedEventContainer eventContainer;
+    @JoinColumn(name = "event_container_id")
+    @OneToOne(fetch = FetchType.LAZY, optional = false, cascade = CascadeType.ALL, orphanRemoval = true)
+    private NeedEventContainer eventContainer;
 
-  @OneToOne(fetch = FetchType.LAZY, mappedBy = "need", cascade = CascadeType.ALL, orphanRemoval = true)
-  private ConnectionContainer connectionContainer;
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "need", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ConnectionContainer connectionContainer;
 
 
-  public NeedEventContainer getEventContainer() {
-    return eventContainer;
-  }
+    public NeedEventContainer getEventContainer() {
+        return eventContainer;
+    }
 
-  protected void setVersion(final int version) {
-    this.version = version;
-  }
-
-  public void setEventContainer(final NeedEventContainer eventContainer) {
-    this.eventContainer = eventContainer;
-  }
-
-  public void setConnectionContainer(final ConnectionContainer connectionContainer) {
-    this.connectionContainer = connectionContainer;
-  }
-
-  public int getVersion() {
-    return version;
-  }
-
-  public ConnectionContainer getConnectionContainer() {
-    return connectionContainer;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    creationDate = new Date();
-  }
-
-  public Date getCreationDate() {
-      return creationDate;
-  }
-
-  public void setCreationDate(Date creationDate) {
-      this.creationDate = creationDate;
-  }
-
-  @XmlTransient
-  public Long getId() {
-      return id;
-  }
-
-  public void setId(Long id) {
-     this.id = id;
-  }
-
-  public URI getNeedURI()
-  {
-    return needURI;
-  }
-
-  public void setNeedURI(final URI URI)
-  {
-     this.needURI = URI;
-  }
-
-  public NeedState getState()
-  {
-    return state;
-  }
-
-  public void setState(final NeedState state)
-  {
-    this.state = state;
-  }
-
-  public URI getOwnerURI()
-  {
-    return ownerURI;
-  }
-
-  public void setOwnerURI(final URI ownerURI)
-  {
-    this.ownerURI = ownerURI;
-  }
-
-  public DatasetHolder getDatatsetHolder() {
-    return datatsetHolder;
-  }
-
-  public void setDatatsetHolder(final DatasetHolder datatsetHolder) {
-    this.datatsetHolder = datatsetHolder;
-  }
-
-  public List<DatasetHolder> getAttachmentDatasetHolders() {
-    return attachmentDatasetHolders;
-  }
-
-  public void setAttachmentDatasetHolders(final List<DatasetHolder> attachmentDatasetHolders) {
-    this.attachmentDatasetHolders = attachmentDatasetHolders;
-  }
-
-  @Override
-  public String toString()
-  {
-    return "Need{" +
-        "id=" + id +
-        ", needURI=" + needURI +
-        ", state=" + state +
-        ", ownerURI=" + ownerURI +
-        ", creationDate=" + creationDate +
-        '}';
-  }
+    @PreUpdate
+    public void incrementVersion() {
+        this.version++;
+        this.lastUpdate = new Date();
+    }
 
     @Override
-    public boolean equals(final Object o)
-    {
+    public Date getLastUpdate() {
+        return lastUpdate;
+    }
+
+    protected void setVersion(final int version) {
+        this.version = version;
+    }
+
+    public void setEventContainer(final NeedEventContainer eventContainer) {
+        this.eventContainer = eventContainer;
+    }
+
+    public void setConnectionContainer(final ConnectionContainer connectionContainer) {
+        this.connectionContainer = connectionContainer;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public ConnectionContainer getConnectionContainer() {
+        return connectionContainer;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        creationDate = new Date();
+        incrementVersion();
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    @XmlTransient
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public URI getNeedURI() {
+        return needURI;
+    }
+
+    public void setNeedURI(final URI URI) {
+        this.needURI = URI;
+    }
+
+    public NeedState getState() {
+        return state;
+    }
+
+    public void setState(final NeedState state) {
+        this.state = state;
+    }
+
+    public URI getOwnerURI() {
+        return ownerURI;
+    }
+
+    public void setOwnerURI(final URI ownerURI) {
+        this.ownerURI = ownerURI;
+    }
+
+    public DatasetHolder getDatatsetHolder() {
+        return datatsetHolder;
+    }
+
+    public void setDatatsetHolder(final DatasetHolder datatsetHolder) {
+        this.datatsetHolder = datatsetHolder;
+    }
+
+    public List<DatasetHolder> getAttachmentDatasetHolders() {
+        return attachmentDatasetHolders;
+    }
+
+    public void setAttachmentDatasetHolders(final List<DatasetHolder> attachmentDatasetHolders) {
+        this.attachmentDatasetHolders = attachmentDatasetHolders;
+    }
+
+    @Override
+    public String toString() {
+        return "Need{" +
+                "id=" + id +
+                ", needURI=" + needURI +
+                ", state=" + state +
+                ", ownerURI=" + ownerURI +
+                ", creationDate=" + creationDate +
+                '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof Need)) return false;
 
@@ -223,12 +226,12 @@ public class Need
     }
 
     public static void main(String args[]) {
-       Configuration config =
-               new Configuration();
-       config.addAnnotatedClass(Need.class);
-       config.configure();
-       new SchemaExport(config).create(true, true);
-   }
+        Configuration config =
+                new Configuration();
+        config.addAnnotatedClass(Need.class);
+        config.configure();
+        new SchemaExport(config).create(true, true);
+    }
 
 
     public List<OwnerApplication> getAuthorizedApplications() {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/NeedEventContainer.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/NeedEventContainer.java
@@ -25,7 +25,7 @@ import java.net.URI;
 @DiscriminatorValue("Need")
 public class NeedEventContainer extends EventContainer implements ParentAware<Need>
 {
-  @OneToOne(fetch = FetchType.LAZY)
+  @OneToOne(fetch = FetchType.LAZY, mappedBy = "eventContainer", optional = false)
   private Need need;
 
   public NeedEventContainer() {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/VersionedEntity.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/VersionedEntity.java
@@ -16,10 +16,13 @@
 
 package won.protocol.model.parentaware;
 
+import java.util.Date;
+
 /**
- * Interface for entities that offer access to their parent entity.
+ * Created by fkleedorfer on 28.03.2017.
  */
-public interface ParentAware<T extends VersionedEntity>
-{
-  public T getParent();
+public interface VersionedEntity {
+    public int getVersion();
+    public void incrementVersion();
+    public Date getLastUpdate();
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionEventContainerRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionEventContainerRepository.java
@@ -16,8 +16,12 @@
 
 package won.protocol.repository;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import won.protocol.model.ConnectionEventContainer;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 
 /**
@@ -26,4 +30,9 @@ import java.net.URI;
 public interface ConnectionEventContainerRepository extends WonRepository<ConnectionEventContainer>
 {
   public ConnectionEventContainer findOneByParentUri(URI parentUri);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select c from ConnectionEventContainer c where c.parentUri = :parentUri")
+  public ConnectionEventContainer findOneByParentUriForUpdate(@Param("parentUri") URI parentUri);
+
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -16,16 +16,16 @@
 
 package won.protocol.repository;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import won.protocol.message.WonMessageType;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionState;
-import won.protocol.model.MessageEventPlaceholder;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
@@ -43,9 +43,15 @@ public interface ConnectionRepository extends WonRepository<Connection>
 
   Connection findOneByConnectionURI(URI URI);
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select con from Connection con where connectionURI = :uri")
+  Connection findOneByConnectionURIForUpdate(@Param("uri") URI uri);
+
   Connection findOneByConnectionURIAndVersionNot(URI URI, long version);
 
-  Connection findOneByNeedURIAndRemoteNeedURIAndTypeURI(URI needURI, URI remoteNeedURI, URI typeUri);
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select con from Connection con where needURI = :needUri and remoteNeedURI = :remoteNeedUri and typeURI = :typeUri")
+  Connection findOneByNeedURIAndRemoteNeedURIAndTypeURIForUpdate(@Param("needUri") URI needURI, @Param("remoteNeedUri") URI remoteNeedURI, @Param("typeUri") URI typeUri);
 
   List<Connection> findByNeedURI(URI URI);
 
@@ -72,8 +78,9 @@ public interface ConnectionRepository extends WonRepository<Connection>
   @Query("select connectionURI from Connection where needURI = ?1 and state != ?2")
   List<URI> getConnectionURIsByNeedURIAndNotInState(URI needURI, ConnectionState connectionState);
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select c from Connection c where c.needURI = ?1 and c.state != ?2")
-  List<Connection> getConnectionsByNeedURIAndNotInState(URI needURI, ConnectionState connectionState);
+  List<Connection> getConnectionsByNeedURIAndNotInStateForUpdate(URI needURI, ConnectionState connectionState);
 
 
 

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/DatasetHolderRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/DatasetHolderRepository.java
@@ -16,9 +16,13 @@
 
 package won.protocol.repository;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import won.protocol.model.DatasetHolder;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 
 /**
@@ -29,4 +33,8 @@ public interface DatasetHolderRepository extends CrudRepository<DatasetHolder, U
   public DatasetHolder findOneByUriAndVersionNot(URI uri, Integer version);
 
   public DatasetHolder findOneByUri(URI uri);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select d from DatasetHolder d where d.uri = :uri")
+  public DatasetHolder findOneByUriForUpdate(@Param("uri") URI uri);
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/MessageEventRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/MessageEventRepository.java
@@ -2,162 +2,172 @@ package won.protocol.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import won.protocol.message.WonMessageType;
 import won.protocol.model.MessageEventPlaceholder;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
 
 public interface MessageEventRepository extends WonRepository<MessageEventPlaceholder> {
 
-  MessageEventPlaceholder findOneByMessageURI(URI URI);
+    MessageEventPlaceholder findOneByMessageURI(URI URI);
 
-  List<MessageEventPlaceholder> findByParentURI(URI URI);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select msg from MessageEventPlaceholder msg where msg.messageURI = :uri")
+    MessageEventPlaceholder findOneByMessageURIforUpdate(@Param("uri") URI uri);
 
-  List<URI> getMessageURIsByParentURI(URI parentURI);
+    List<MessageEventPlaceholder> findByParentURI(URI URI);
 
-  List<MessageEventPlaceholder> findByParentURIAndMessageType(URI parentURI, WonMessageType messageType);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.messageType = :messageType")
+    List<MessageEventPlaceholder> findByParentURIAndMessageTypeForUpdate(
+            @Param("parent") URI parentURI,
+            @Param("messageType") WonMessageType messageType);
 
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and " +
-    "referencedByOtherMessage = false")
-  List<MessageEventPlaceholder> findByParentURIAndNotReferencedByOtherMessage(
-    @Param("parent") URI parentURI);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and " +
+            "referencedByOtherMessage = false")
+    List<MessageEventPlaceholder> findByParentURIAndNotReferencedByOtherMessageForUpdate(
+            @Param("parent") URI parentURI);
 
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent")
-  Slice<URI> getMessageURIsByParentURI(@Param("parent") URI parentURI, Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent")
+    Slice<MessageEventPlaceholder> findByParentURI(@Param("parent") URI parentURI, Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent")
-  Slice<MessageEventPlaceholder> findByParentURI(@Param("parent") URI parentURI, Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent")
+    Slice<MessageEventPlaceholder> findByParentURIFetchDatasetEagerly(@Param("parent") URI parentURI, Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent")
-  Slice<MessageEventPlaceholder> findByParentURIFetchDatasetEagerly(@Param("parent") URI parentURI, Pageable pageable);
+    @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.messageType = :messageType")
+    Slice<URI> getMessageURIsByParentURI(
+            @Param("parent") URI parentURI,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.messageType = :messageType")
-  Slice<URI> getMessageURIsByParentURI(
-    @Param("parent") URI parentURI,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndType(
+            @Param("parent") URI parentURI,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndType(
-    @Param("parent") URI parentURI,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate")
+    Slice<URI> getMessageURIsByParentURIBefore(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
 
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate")
-  Slice<URI> getMessageURIsByParentURIBefore(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate")
+    Slice<MessageEventPlaceholder> findByParentURIBefore(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate")
-  Slice<MessageEventPlaceholder> findByParentURIBefore(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < :referenceDate")
+    Slice<MessageEventPlaceholder> findByParentURIBeforeFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < :referenceDate")
-  Slice<MessageEventPlaceholder> findByParentURIBeforeFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < (select msg2.creationDate from MessageEventPlaceholder msg2 where msg2.messageURI = :referenceMessageUri )")
-  Slice<MessageEventPlaceholder> findByParentURIBeforeFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceMessageUri") URI referenceMessageUri,
-    Pageable pageable);
-
-
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
-  Slice<URI> getMessageURIsByParentURIBefore(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeBefore(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeBeforeFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.messageType = :messageType and msg.creationDate < (select msg2.creationDate from MessageEventPlaceholder msg2 where msg2.messageURI = :referenceMessageUri )")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeBeforeFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceMessageUri") URI referenceMessageURI,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
-
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate")
-  Slice<URI> getMessageURIsByParentURIAfter(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > " +
-    ":referenceDate")
-  Slice<MessageEventPlaceholder> findByParentURIAfter(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate > " +
-    ":referenceDate")
-  Slice<MessageEventPlaceholder> findByParentURIAfterFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
-  Slice<URI> getMessageURIsByParentURIAfter(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < (select msg2.creationDate from MessageEventPlaceholder msg2 where msg2.messageURI = :referenceMessageUri )")
+    Slice<MessageEventPlaceholder> findByParentURIBeforeFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceMessageUri") URI referenceMessageUri,
+            Pageable pageable);
 
 
-  @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeAfter(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
+    Slice<URI> getMessageURIsByParentURIBefore(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
-  Slice<MessageEventPlaceholder> findByParentURIAndTypeAfterFetchDatasetEagerly(
-    @Param("parent") URI parentURI,
-    @Param("referenceDate") Date referenceDate,
-    @Param("messageType") WonMessageType messageType,
-    Pageable pageable);
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeBefore(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
+
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate < :referenceDate and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeBeforeFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
+
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.messageType = :messageType and msg.creationDate < (select msg2.creationDate from MessageEventPlaceholder msg2 where msg2.messageURI = :referenceMessageUri )")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeBeforeFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceMessageUri") URI referenceMessageURI,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
+
+    @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate")
+    Slice<URI> getMessageURIsByParentURIAfter(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
+
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > " +
+            ":referenceDate")
+    Slice<MessageEventPlaceholder> findByParentURIAfter(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
+
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate > " +
+            ":referenceDate")
+    Slice<MessageEventPlaceholder> findByParentURIAfterFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            Pageable pageable);
+
+    @Query("select messageURI from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
+    Slice<URI> getMessageURIsByParentURIAfter(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
 
-  MessageEventPlaceholder findOneByCorrespondingRemoteMessageURI(URI uri);
+    @Query("select msg from MessageEventPlaceholder msg left join fetch msg.datasetHolder where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeAfter(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select max(msg.creationDate) from MessageEventPlaceholder msg where msg.creationDate <= :referenceDate and " +
-    "parentURI = :parent")
-  Date findMaxActivityDateOfParentAtTime(@Param("parent") URI parentURI, @Param("referenceDate") Date referenceDate);
+    @Query("select msg from MessageEventPlaceholder msg where msg.parentURI = :parent and msg.creationDate > :referenceDate and msg.messageType = :messageType")
+    Slice<MessageEventPlaceholder> findByParentURIAndTypeAfterFetchDatasetEagerly(
+            @Param("parent") URI parentURI,
+            @Param("referenceDate") Date referenceDate,
+            @Param("messageType") WonMessageType messageType,
+            Pageable pageable);
 
-  @Query("select max(msg.creationDate) from MessageEventPlaceholder msg where msg.creationDate <= :referenceDate and " +
-    "parentURI = :parent and msg.messageType = :messageType")
-  Date findMaxActivityDateOfParentAtTime(@Param("parent") URI parentURI, @Param("messageType") WonMessageType
-    messageType, @Param("referenceDate") Date referenceDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select msg from MessageEventPlaceholder msg where msg.correspondingRemoteMessageURI = :uri")
+    MessageEventPlaceholder findOneByCorrespondingRemoteMessageURIForUpdate(@Param("uri") URI uri);
+
+
+
+    @Query("select max(msg.creationDate) from MessageEventPlaceholder msg where msg.creationDate <= :referenceDate and " +
+            "parentURI = :parent")
+    Date findMaxActivityDateOfParentAtTime(@Param("parent") URI parentURI, @Param("referenceDate") Date referenceDate);
+
+    @Query("select max(msg.creationDate) from MessageEventPlaceholder msg where msg.creationDate <= :referenceDate and " +
+            "parentURI = :parent and msg.messageType = :messageType")
+    Date findMaxActivityDateOfParentAtTime(@Param("parent") URI parentURI, @Param("messageType") WonMessageType
+            messageType, @Param("referenceDate") Date referenceDate);
 
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/NeedEventContainerRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/NeedEventContainerRepository.java
@@ -16,8 +16,12 @@
 
 package won.protocol.repository;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import won.protocol.model.NeedEventContainer;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 
 /**
@@ -26,4 +30,9 @@ import java.net.URI;
 public interface NeedEventContainerRepository extends WonRepository<NeedEventContainer>
 {
   public NeedEventContainer findOneByParentUri(URI parentUri);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select c from NeedEventContainer c where c.parentUri = :parentUri")
+  public NeedEventContainer findOneByParentUriForUpdate(@Param("parentUri") URI parentUri);
+
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/rdfstorage/impl/JpaRepositoryBasedRdfStorageServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/rdfstorage/impl/JpaRepositoryBasedRdfStorageServiceImpl.java
@@ -20,6 +20,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.protocol.model.DataWithEtag;
@@ -39,7 +40,7 @@ public class JpaRepositoryBasedRdfStorageServiceImpl implements RDFStorageServic
   private DatasetHolderRepository datasetHolderRepository;
 
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   @Override
   public void storeModel(final URI resourceURI, final Model model) {
     Dataset dataset = DatasetFactory.createMem();
@@ -48,7 +49,7 @@ public class JpaRepositoryBasedRdfStorageServiceImpl implements RDFStorageServic
     storeDataset(resourceURI, dataset);
   }
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   @Override
   public void storeDataset(final URI resourceURI, final Dataset dataset) {
     DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(resourceURI);
@@ -60,14 +61,14 @@ public class JpaRepositoryBasedRdfStorageServiceImpl implements RDFStorageServic
     datasetHolderRepository.save(datasetHolder);
   }
 
-  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true, isolation = Isolation.READ_COMMITTED)
   @Override
   public Model loadModel(final URI resourceURI) {
     DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(resourceURI);
     return datasetHolder == null ? null : datasetHolder.getDataset().getDefaultModel();
   }
 
-  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true, isolation = Isolation.READ_COMMITTED)
   @Override
   public DataWithEtag<Model> loadModel(final URI resourceURI, String etag) {
     Integer version = Integer.valueOf(etag);
@@ -80,14 +81,14 @@ public class JpaRepositoryBasedRdfStorageServiceImpl implements RDFStorageServic
   }
 
 
-  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+  @Transactional(propagation = Propagation.SUPPORTS, readOnly = true, isolation = Isolation.READ_COMMITTED)
   @Override
   public Dataset loadDataset(final URI resourceURI) {
     DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(resourceURI);
     return datasetHolder == null ? null : datasetHolder.getDataset();
   }
 
-  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.READ_COMMITTED)
   @Override
   public DataWithEtag<Dataset> loadDataset(final URI resourceURI, String etag) {
     Integer version = etag == null ? -1 : Integer.valueOf(etag);
@@ -99,7 +100,7 @@ public class JpaRepositoryBasedRdfStorageServiceImpl implements RDFStorageServic
     return dataWithEtag;
   }
 
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.REPEATABLE_READ)
   @Override
   public boolean removeContent(final URI resourceURI) {
     try{

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -26,7 +26,6 @@ import won.protocol.model.*;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 
 /**
  * Service for obtaining information about needs and connections in the system in RDF.
@@ -216,28 +215,7 @@ public interface NeedInformationService {
      */
     public Model readConnectionContent(URI connectionURI) throws NoSuchConnectionException;
 
-  /**
-   * Retrieves list of event uris of the specified connection.
-   *
-   * @param connectionUri
-   * @return a collection of all event URIs.
-   */
-    public List<URI> listConnectionEventURIs(URI connectionUri);
 
-
-  /**
-   * Retrieves list of event uris of the specified connection that have a given message type and that are on the
-   * given page, taking into account number of uris per page preference.
-   *
-   * @param connectionUri
-   * @param page
-   * @param preferredPageSize preferred number of members per page, null => use default
-   * @param messageType null => all types
-   * @return a collection of all event URIs.
-   */
-  @Deprecated
-    public Slice<URI> listConnectionEventURIs(
-      URI connectionUri, int page, Integer preferredPageSize, WonMessageType messageType);
 
   public Slice<MessageEventPlaceholder> listConnectionEvents(
     URI connectionUri, int page, Integer preferredPageSize, WonMessageType messageType);

--- a/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
+++ b/webofneeds/won-core/src/main/resources/spring/component/monitoring/monitoring-recorder.xml
@@ -18,10 +18,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/task
-        http://www.springframework.org/schema/task/spring-task-3.1.xsd">
+        http://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
     <!-- expects a bean 'taskScheduler', a spring task scheduler -->
     <task:scheduled-tasks scheduler="taskScheduler">

--- a/webofneeds/won-core/src/main/resources/spring/component/wonNodeInformationService.xml
+++ b/webofneeds/won-core/src/main/resources/spring/component/wonNodeInformationService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <bean id="wonNodeInformationService" class="won.protocol.service.impl.WonNodeInformationServiceImpl">
         <property name="defaultWonNodeUri" value="${uri.node.default}" />

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/webid/WonDefaultAccessControlRules.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/webid/WonDefaultAccessControlRules.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import won.protocol.model.MessageEventPlaceholder;
 import won.protocol.repository.MessageEventRepository;
@@ -29,7 +30,7 @@ public class WonDefaultAccessControlRules implements AccessControlRules
   public WonDefaultAccessControlRules() {
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public boolean isAccessPermitted(String resourceURI, List<String> requesterWebIDs) {
     //TODO retrieve from an acl source for a resource instead of this temporary approach
     //specific for the message event resources

--- a/webofneeds/won-cryptography/src/main/resources/spring/component/cryptographyServices.xml
+++ b/webofneeds/won-cryptography/src/main/resources/spring/component/cryptographyServices.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="java.security.Security.addProvider"/>

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/ehcache/spring-node-ehcache.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/ehcache/spring-node-ehcache.xml
@@ -15,8 +15,7 @@
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/matcher-service/transmission/matcher-security.xml
@@ -15,18 +15,9 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher-service.properties"
-                                  ignore-unresolvable="true"/>
-
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher-service.properties" ignore-unresolvable="true"/>
 
     <bean id="keyStoreService" class="won.cryptography.service.KeyStoreService" init-method="init">
         <constructor-arg type="java.lang.String" value="${keystore.location}" />

--- a/webofneeds/won-matcher-service/src/main/resources/spring/component/scheduling/matcher-service-scheduling.xml
+++ b/webofneeds/won-matcher-service/src/main/resources/spring/component/scheduling/matcher-service-scheduling.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >
     <property name="poolSize" value="15" />

--- a/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
+++ b/webofneeds/won-matcher-solr/src/test/resources/spring/component/solrMatcherEvaluation.xml
@@ -15,10 +15,10 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/mail-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/need-dir-bot.properties" ignore-unresolvable="true"/> <!-- was in needproducer-mixed.xml -->
 
     <import resource="classpath:spring/component/needproducer/needproducer-mixed.xml"/>
 

--- a/webofneeds/won-matcher/src/main/resources/matcherApplicationContext.xml
+++ b/webofneeds/won-matcher/src/main/resources/matcherApplicationContext.xml
@@ -5,10 +5,10 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--
          Load properties but ignore unresolvable properties so that

--- a/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/app/simpleMatcherCLI.xml
@@ -16,8 +16,14 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation=
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
+
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/><!-- was in matcher-jmsonly.xml and matcher-core.xml and in matcher-camel.xml within matcher-jmsonly.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/><!-- was in storage.xml -->
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/><!-- was in matcher-nodeurisource-all.xml within matcher-jmsonly.xml -->
 
     <!--
        context that combines bot definitions with runner context
@@ -32,7 +38,4 @@
     <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
     <import resource="classpath:/spring/component/storage/storage.xml" />
     <import resource="classpath:/spring/component/wonNodeInformationService.xml" />
-
-
-
 </beans>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/CLI/matcher-cli.xml
@@ -15,19 +15,11 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
     <bean id="matcherCLICommandLineRunner" class="won.matcher.cli.MatcherCLI"/>
 </beans>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/MatcherProtocolMatcherService/matcherProtocolMatcherService-jms.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <bean id="matcherProtocolMatcherServiceJMSBased"
           class="won.matcher.protocol.impl.MatcherProtocolMatcherServiceImplJMSBased">
         <property name="matcherProtocolCommunicationService" ref="matcherProtocolCommunicationService"/>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/camel/matcher-camel.xml
@@ -7,14 +7,12 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <camel:camelContext id="wonMatcherCamel">
         <camel:packageScan>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/ehcache/spring-matcher-ehcache.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/ehcache/spring-matcher-ehcache.xml
@@ -14,14 +14,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-matcher/src/main/resources/spring/component/linkeddatasource/matcher-linkeddatasource.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/linkeddatasource/matcher-linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-matcher/src/main/resources/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- expects a bean matcherMessagingService -->
     <bean id="matcherProtocolNeedServiceClientJMSBased"

--- a/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/nodeurisource/matcher-nodeurisource-all.xml
@@ -15,20 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node-uri-source.properties" ignore-unresolvable="true"/>
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="matcherNodeURISource" class="won.matcher.component.MatcherNodeURISourceImpl" >
         <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}" />

--- a/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/services/matcher-services.xml
@@ -15,20 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!--bean id="matcherProtocolCommunicationService"
     class="won.matcher.protocol.impl.MatcherProtocolCommunicationServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/storage/storage.xml
@@ -21,19 +21,11 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 ">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <context:annotation-config />
 
     <!-- Defines where to search for annotated components -->

--- a/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/component/transmission/matcher-security.xml
@@ -15,20 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!--bean id="matcherProtocolCommunicationService"
     class="won.matcher.protocol.impl.MatcherProtocolCommunicationServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/core/matcher-core.xml
@@ -15,20 +15,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
 
     <!-- protocol-level services -->
     <bean id="matcherMessagingService" class="won.protocol.jms.MessagingServiceImpl">

--- a/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
+++ b/webofneeds/won-matcher/src/main/resources/spring/matcher-jmsonly.xml
@@ -19,14 +19,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/matcher.properties" ignore-unresolvable="true"/>
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <import resource="classpath:/spring/component/transmission/matcher-security.xml" />
     <import resource="classpath:/spring/component/matcherProtocolNeedServiceClient/matcherProtocolNeedServiceClient-jms.xml" />
@@ -39,8 +33,4 @@
     <import resource="classpath:/spring/component/ehcache/spring-matcher-ehcache.xml" />
     <import resource="classpath:/spring/component/nodeurisource/matcher-nodeurisource-all.xml" />
     <import resource="classpath:/spring/component/wonNodeInformationService.xml" />
-
-
-
-
 </beans>

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -2,12 +2,35 @@
 
 <beans xmlns:sec="http://www.springframework.org/schema/security"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:context="http://www.springframework.org/schema/context"
              xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
+                                 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
+    <!--context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/-->
+    <!--
+        Problem:
+        1. The embedded activemq broker creates a child spring context
+        2. Properties are not seen in child contexts because they are realized as bean factory post processors,
+            which do not post-process child contexts
+        3. We do not want to re-define the property file in the child context (for ease of configuration)
+        Solution:
+        1. we first define a bean template (abstract=true) for the PPC
+        2. we can define a concrete one in this context and in the child context because the
+            template is visible in the child context
+    -->
+    <bean id="abstractPropertyPlaceholderConfigurer" abstract="true" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="location" value="file:${WON_CONFIG_DIR}/node.properties" />
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+    </bean>
+    <!-- here's the concrete bean for the PPC. The same is done in the activemq.xml file -->
+    <bean id="propertyPlaceholderConfigurer" parent="abstractPropertyPlaceholderConfigurer" />
 
-    <!-- all the beans necessary for node's functioning -->
+    <!-- was in node.xml --><!-- was in message-processors.xml within node.xml--><!-- was in activemq.xml within node-camel.xml within node.xml-->
+    <!-- was in node-camel.xml within node.xml --><!-- was in jdbc-storage.xml within node.xml -->
+    <!-- was in jpabased-rdf-storage.xml within node.xml --><!-- was in node-security.xml within node.xml-->
+    <!-- was in node-core.xml within node.xml--><!-- all the beans necessary for node's functioning -->
     <import resource="classpath:/spring/node.xml"/>
 
     <!--

--- a/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
+++ b/webofneeds/won-node-webapp/src/main/webapp/WEB-INF/linkedDataPageServlet-servlet.xml
@@ -21,9 +21,9 @@
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.1.xsd
        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractFromOwnerCamelProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractFromOwnerCamelProcessor.java
@@ -17,7 +17,6 @@
 package won.node.camel.processor;
 
 import org.apache.camel.Exchange;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Base class for processors handling messages coming from a remote node.
@@ -30,7 +29,6 @@ public abstract class AbstractFromOwnerCamelProcessor extends AbstractCamelProce
    * @param exchange
    * @throws Exception
    */
-  @Transactional
   public void onSuccessResponse(Exchange exchange) throws Exception {
     logger.debug("received success response");
   };
@@ -40,7 +38,6 @@ public abstract class AbstractFromOwnerCamelProcessor extends AbstractCamelProce
    * @param exchange
    * @throws Exception
    */
-  @Transactional
   public void onFailureResponse(Exchange exchange) throws Exception {
     logger.debug("processing failure response");
   };

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/CloseFromNodeOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/CloseFromNodeOwnerFacetImpl.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.facet.ownerFacet;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -22,7 +23,7 @@ public class CloseFromNodeOwnerFacetImpl extends AbstractCamelProcessor
 {
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) {
     logger.debug("default facet implementation, not doing anything");
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/ConnectFromNodeOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/ConnectFromNodeOwnerFacetImpl.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.facet.ownerFacet;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -21,7 +22,7 @@ import won.protocol.vocabulary.WONMSG;
 public class ConnectFromNodeOwnerFacetImpl extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) {
     logger.debug("default facet implementation, not doing anything");
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/OpenFromNodeOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/OpenFromNodeOwnerFacetImpl.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.facet.ownerFacet;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -21,7 +22,7 @@ import won.protocol.vocabulary.WONMSG;
 public class OpenFromNodeOwnerFacetImpl extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) {
     logger.debug("default facet implementation, not doing anything");
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/OpenFromOwnerOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/OpenFromOwnerOwnerFacetImpl.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.facet.ownerFacet;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractFromOwnerCamelProcessor;
@@ -21,7 +22,7 @@ import won.protocol.vocabulary.WONMSG;
 public class OpenFromOwnerOwnerFacetImpl extends AbstractFromOwnerCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) {
     logger.debug("default facet implementation, not doing anything");
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/SendMessageFromNodeOwnerFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/ownerFacet/SendMessageFromNodeOwnerFacetImpl.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.facet.ownerFacet;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -21,7 +22,7 @@ import won.protocol.vocabulary.WONMSG;
 public class SendMessageFromNodeOwnerFacetImpl extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) {
     logger.debug("default facet implementation, not doing anything");
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -27,7 +28,7 @@ import java.net.URI;
 public class ActivateNeedMessageProcessor extends AbstractCamelProcessor
 {
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateNeedMessageReactionProcessor.java
@@ -19,6 +19,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -41,7 +42,7 @@ public class ActivateNeedMessageReactionProcessor extends AbstractCamelProcessor
 {
 
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromNodeProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -26,7 +27,7 @@ import java.net.URI;
 public class CloseMessageFromNodeProcessor extends AbstractCamelProcessor
 {
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromNodeProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -28,7 +29,7 @@ public class ConnectMessageFromNodeProcessor extends AbstractCamelProcessor
 {
 
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
@@ -44,10 +45,10 @@ public class ConnectMessageFromNodeProcessor extends AbstractCamelProcessor
 
     Connection con = null;
     if (connectionURI != null) {
-      con = connectionRepository.findOneByConnectionURI(connectionURI);
+      con = connectionRepository.findOneByConnectionURIForUpdate(connectionURI);
       if (con == null) throw new NoSuchConnectionException(connectionURI);
     } else {
-      con = connectionRepository.findOneByNeedURIAndRemoteNeedURIAndTypeURI(needUri, remoteNeedUri, facetURI);
+      con = connectionRepository.findOneByNeedURIAndRemoteNeedURIAndTypeURIForUpdate(needUri, remoteNeedUri, facetURI);
     }
     if (con == null){
       //create Connection in Database

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromOwnerProcessor.java
@@ -3,6 +3,8 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractFromOwnerCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -27,7 +29,7 @@ import java.net.URI;
 @FixedMessageProcessor(direction= WONMSG.TYPE_FROM_OWNER_STRING,messageType = WONMSG.TYPE_CONNECT_STRING)
 public class ConnectMessageFromOwnerProcessor extends AbstractFromOwnerCamelProcessor
 {
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
@@ -37,10 +39,10 @@ public class ConnectMessageFromOwnerProcessor extends AbstractFromOwnerCamelProc
     URI connectionURI = wonMessage.getSenderURI(); //if the uri is known already, we can load the connection!
     Connection con = null;
     if (connectionURI != null) {
-      con = connectionRepository.findOneByConnectionURI(connectionURI);
+      con = connectionRepository.findOneByConnectionURIForUpdate(connectionURI);
       if (con == null) throw new NoSuchConnectionException(connectionURI);
     } else {
-      con = connectionRepository.findOneByNeedURIAndRemoteNeedURIAndTypeURI(senderNeedURI, receiverNeedURI, facetURI);
+      con = connectionRepository.findOneByNeedURIAndRemoteNeedURIAndTypeURIForUpdate(senderNeedURI, receiverNeedURI, facetURI);
     }
     if (con == null){
       //create Connection in Database
@@ -76,20 +78,20 @@ public class ConnectMessageFromOwnerProcessor extends AbstractFromOwnerCamelProc
   }
 
   @Override
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void onSuccessResponse(final Exchange exchange) throws Exception {
     WonMessage responseMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
-    MessageEventPlaceholder mep = this.messageEventRepository.findOneByCorrespondingRemoteMessageURI(
+    MessageEventPlaceholder mep = this.messageEventRepository.findOneByCorrespondingRemoteMessageURIForUpdate(
       responseMessage
         .getIsResponseToMessageURI());
     //update the connection database: set the remote connection URI just obtained from the response
-    Connection con = this.connectionRepository.findOneByConnectionURI(mep.getSenderURI());
+    Connection con = this.connectionRepository.findOneByConnectionURIForUpdate(mep.getSenderURI());
     con.setRemoteConnectionURI(responseMessage.getSenderURI());
     this.connectionRepository.save(con);
   }
 
   @Override
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void onFailureResponse(final Exchange exchange) throws Exception {
     //TODO: define what to do if the connect fails remotely option: create a system message of type CLOSE,
     // and forward it only to the owner. Add an explanation (a reference to the failure response and some

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageReactionProcessor.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -46,7 +47,7 @@ public class CreateNeedMessageReactionProcessor extends AbstractCamelProcessor
 
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateNeedMessageProcessor.java
@@ -4,6 +4,7 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -28,7 +29,7 @@ public class DeactivateNeedMessageProcessor extends AbstractCamelProcessor
 {
   Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     WonMessage wonMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     URI receiverNeedURI = wonMessage.getReceiverNeedURI();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromSystemToNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromSystemToNodeProcessor.java
@@ -18,6 +18,7 @@ package won.node.camel.processor.fixed;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -37,7 +38,7 @@ import won.protocol.vocabulary.WONMSG;
 public class FailureResponseFromSystemToNodeProcessor extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(Exchange exchange) throws Exception {
     WonMessage wonMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     //prepare the message to pass to the remote node

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
@@ -20,6 +20,8 @@ import org.apache.jena.rdf.model.*;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractFromOwnerCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -41,11 +43,11 @@ import java.net.URI;
 public class HintFeedbackMessageFromOwnerProcessor extends AbstractFromOwnerCamelProcessor
 {
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
-    Connection con = connectionRepository.findOneByConnectionURI(wonMessage.getSenderURI());
+    Connection con = connectionRepository.findOneByConnectionURIForUpdate(wonMessage.getSenderURI());
     logger.debug("HINT_FEEDBACK received from the owner side for connection {}", wonMessage.getSenderURI());
     processFeedbackMessage(con, wonMessage);
   }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintMessageProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -30,7 +31,7 @@ public class HintMessageProcessor extends AbstractCamelProcessor
 {
 
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -26,7 +27,7 @@ import java.net.URI;
 public class OpenMessageFromNodeProcessor extends AbstractCamelProcessor
 {
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
@@ -42,7 +43,7 @@ public class OpenMessageFromNodeProcessor extends AbstractCamelProcessor
                                          wonMessage.getSenderURI(), facet,
                                          ConnectionState.REQUEST_RECEIVED, ConnectionEventType.PARTNER_OPEN);
     } else {
-      con = connectionRepository.findOneByConnectionURI(connectionURIFromWonMessage);
+      con = connectionRepository.findOneByConnectionURIForUpdate(connectionURIFromWonMessage);
     }
     assert con != null;
     assert con.getRemoteNeedURI() != null;

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
@@ -3,6 +3,8 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractFromOwnerCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -24,11 +26,11 @@ import java.net.URI;
 public class OpenMessageFromOwnerProcessor extends AbstractFromOwnerCamelProcessor
 {
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
-    Connection con = connectionRepository.findOneByConnectionURI(wonMessage.getSenderURI());
+    Connection con = connectionRepository.findOneByConnectionURIForUpdate(wonMessage.getSenderURI());
 
     //prepare the message to pass to the remote node
     final WonMessage newWonMessage = createMessageToSendToRemoteNode(wonMessage, con);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
@@ -3,6 +3,7 @@ package won.node.camel.processor.fixed;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -26,7 +27,7 @@ import java.net.URI;
 public class SendMessageFromNodeProcessor extends AbstractCamelProcessor
 {
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
@@ -34,7 +35,7 @@ public class SendMessageFromNodeProcessor extends AbstractCamelProcessor
     if (connectionUri == null){
       throw new MissingMessagePropertyException(URI.create(WONMSG.RECEIVER_PROPERTY.toString()));
     }
-    Connection con = connectionRepository.findOneByConnectionURI(connectionUri);
+    Connection con = connectionRepository.findOneByConnectionURIForUpdate(connectionUri);
     if (con.getState() != ConnectionState.CONNECTED) {
       throw new IllegalMessageForConnectionStateException(connectionUri, "CONNECTION_MESSAGE", con.getState());
     }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SuccessResponseFromSystemToNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SuccessResponseFromSystemToNodeProcessor.java
@@ -18,6 +18,7 @@ package won.node.camel.processor.fixed;
 
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -37,7 +38,7 @@ import won.protocol.vocabulary.WONMSG;
 public class SuccessResponseFromSystemToNodeProcessor extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(Exchange exchange) throws Exception {
     WonMessage wonMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     //prepare the message to pass to the remote node

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
@@ -20,6 +20,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.camel.Exchange;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -41,7 +42,7 @@ import java.net.URI;
 public class FailResponder extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     Exception exception = null;
     WonMessage originalMessage = null;

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
@@ -2,6 +2,7 @@ package won.node.camel.processor.general;
 
 import org.apache.jena.query.Dataset;
 import org.apache.camel.Exchange;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -19,7 +20,7 @@ import java.net.URI;
 public class ResponseResenderProcessor extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     WonMessage originalMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.ORIGINAL_MESSAGE_HEADER);
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
@@ -17,6 +17,7 @@
 package won.node.camel.processor.general;
 
 import org.apache.camel.Exchange;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -35,7 +36,7 @@ import java.net.URI;
 public class SuccessResponder extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     WonMessage originalMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     if (originalMessage == null) throw new WonMessageProcessingException("did not find the original message in the " +

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToNodeSender.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToNodeSender.java
@@ -17,6 +17,7 @@
 package won.node.camel.processor.general;
 
 import org.apache.camel.Exchange;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -30,7 +31,7 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 public class ToNodeSender extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     WonMessage message = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     sendMessageToNode(message);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToOwnerSender.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToOwnerSender.java
@@ -17,6 +17,7 @@
 package won.node.camel.processor.general;
 
 import org.apache.camel.Exchange;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -30,7 +31,7 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 public class ToOwnerSender extends AbstractCamelProcessor
 {
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.REPEATABLE_READ)
   public void process(final Exchange exchange) throws Exception {
     WonMessage message = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
     sendMessageToOwner(message, message.getReceiverNeedURI(), (String) exchange.getIn().getHeader(WonCamelConstants.OWNER_APPLICATION_ID));

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
@@ -22,6 +22,7 @@ import org.apache.jena.sparql.util.IsoMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.protocol.message.WonMessage;
@@ -63,7 +64,7 @@ public class UriAlreadyUsedCheckingWonMessageProcessor implements WonMessageProc
   protected NeedRepository needRepository;
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public WonMessage process(final WonMessage message) throws UriAlreadyInUseException {
     checkEventURI(message);
     checkNeedURI(message);

--- a/webofneeds/won-node/src/main/java/won/node/facet/businessactivity/statemanager/JpaBasedBAStateManager.java
+++ b/webofneeds/won-node/src/main/java/won/node/facet/businessactivity/statemanager/JpaBasedBAStateManager.java
@@ -1,6 +1,7 @@
 package won.node.facet.businessactivity.statemanager;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.node.facet.impl.WON_TX;
@@ -22,7 +23,7 @@ public class JpaBasedBAStateManager implements BAStateManager
 
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
   public URI getStateForNeedUri(final URI coordinatorURI, final URI participantURI, final URI facetURI) {
     List<BAState> states = stateRepository.findByCoordinatorURIAndParticipantURIAndFacetTypeURI(coordinatorURI, participantURI, facetURI);
     Iterator<BAState> stateIterator = states.iterator();
@@ -34,7 +35,7 @@ public class JpaBasedBAStateManager implements BAStateManager
   }
 
   @Override
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.REPEATABLE_READ)
   public void setStateForNeedUri(final URI stateUri, final URI statePhaseURI, final URI coordinatorURI, final URI participantURI, final URI facetURI) {
     BAState state = null;
     List<BAState> states = stateRepository.findByCoordinatorURIAndParticipantURIAndFacetTypeURI(coordinatorURI, participantURI, facetURI);
@@ -56,13 +57,13 @@ public class JpaBasedBAStateManager implements BAStateManager
   }
 
   @Override
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.REPEATABLE_READ)
   public void setStateForNeedUri(final URI stateUri, final URI coordinatorURI, final URI participantURI, final URI facetURI) {
     setStateForNeedUri(stateUri, URI.create(WON_TX.PHASE_NONE.getURI()), coordinatorURI, participantURI, facetURI);
   }
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
   public URI getStatePhaseForNeedUri(final URI coordinatorURI, final URI participantURI, final URI facetURI) {
     List<BAState> states = stateRepository.findByCoordinatorURIAndParticipantURIAndFacetTypeURI(coordinatorURI, participantURI, facetURI);
     Iterator<BAState> stateIterator = states.iterator();

--- a/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolNeedServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolNeedServiceImpl.java
@@ -20,6 +20,7 @@ import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import won.protocol.matcher.MatcherProtocolNeedService;
@@ -40,7 +41,7 @@ public class MatcherProtocolNeedServiceImpl implements MatcherProtocolNeedServic
   private MatcherFacingNeedCommunicationService matcherFacingNeedCommunicationService;
 
   @Override
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.REPEATABLE_READ)
   public void hint(final URI needURI, final URI otherNeed,
                    final double score, final URI originator,
                    Model content, WonMessage wonMessage) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/DataAccessServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/DataAccessServiceImpl.java
@@ -181,7 +181,7 @@ public class DataAccessServiceImpl implements won.node.service.DataAccessService
     Dataset dataset = null;
     if (datasetHolder == null) {
       //if no dataset is found, we create one.
-      dataset = DatasetFactory.createMem();
+      dataset = DatasetFactory.create();
       datasetHolder = new DatasetHolder(connection.getConnectionURI(), dataset);
       connection.setDatasetHolder(datasetHolder);
     } else {
@@ -196,10 +196,11 @@ public class DataAccessServiceImpl implements won.node.service.DataAccessService
     mainRes.addProperty(WON.HAS_FEEDBACK_EVENT, feedback);
     ModelExtract extract = new ModelExtract(new StatementTripleBoundary(TripleBoundary.stopNowhere));
     model.add(extract.extract(feedback, feedback.getModel()));
-    logger.debug("done adding feedback for resource {}, storing...", connection);
+    dataset.setDefaultModel(model);
+    datasetHolder.setDataset(dataset);
     datasetHolderRepository.save(datasetHolder);
     connectionRepository.save(connection);
-    logger.debug("stored feedback");
+    logger.debug("done adding feedback for resource {}", connection);
     return true;
   }
 

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import won.cryptography.rdfsign.WonKeysReaderWriter;
 import won.cryptography.service.CryptographyService;
@@ -129,25 +130,25 @@ public class LinkedDataServiceImpl implements LinkedDataService
     return ret;
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listNeedURIs(final int pageNum)
   {
     return listNeedURIs(pageNum, null, null);
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsBefore(final URI need)
   {
     return listNeedURIsBefore(need, null, null);
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsAfter(final URI need)
   {
     return listNeedURIsAfter(need, null, null);
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listNeedURIs(final int pageNum, final Integer preferedSize,
                                                                     NeedState needState) {
     Slice<URI> slice = needInformationService.listNeedURIs(pageNum, preferedSize, needState);
@@ -155,7 +156,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsBefore(
     final URI need, final Integer preferedSize, NeedState needState) {
 
@@ -164,7 +165,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(
     final URI need, final Integer preferedSize, NeedState needState) {
 
@@ -173,7 +174,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset getNeedDataset(final URI needUri) throws NoSuchNeedException {
   Need need = needInformationService.readNeed(needUri);
 
@@ -210,7 +211,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset getNeedDataset(final URI needUri, boolean deep, Integer deepLayerSize
                                 ) throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException {
     Dataset dataset = getNeedDataset(needUri);
@@ -229,7 +230,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
     return dataset;
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset getNodeDataset()
     {
       Model model = ModelFactory.createDefaultModel();
@@ -293,7 +294,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
    * @return
    */
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final
   boolean
     includeLatestEvent, final String etag)
@@ -358,7 +359,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException {
     List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs());
     NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
@@ -371,7 +372,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page, final Integer
     preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
     Slice<URI> slice = needInformationService.listConnectionURIs(page, preferredSize, timeSpot);
@@ -384,7 +385,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(
     URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
     Slice<URI> slice = needInformationService.listConnectionURIsBefore(beforeConnURI, preferredSize, timeSpot);
@@ -396,7 +397,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(
     URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
     Slice<URI> slice = needInformationService.listConnectionURIsAfter(afterConnURI, preferredSize, timeSpot);
@@ -409,7 +410,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public Dataset listConnectionURIs(final URI needURI, boolean deep, boolean addMetadata)
     throws NoSuchNeedException, NoSuchConnectionException {
     List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs(needURI));
@@ -426,7 +427,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(
     final int page, final URI needURI, final Integer preferredSize, final WonMessageType messageType, final Date
     timeSpot, boolean deep, boolean addMetadata)
@@ -444,7 +445,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(final URI needURI, URI
     beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
                                                                                      boolean addMetadata)
@@ -463,7 +464,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(final URI needURI, URI
     resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
                                                                                     boolean addMetadata)
@@ -511,7 +512,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset listConnectionEventURIs(final URI connectionUri) throws
     NoSuchConnectionException
   {
@@ -519,7 +520,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public Dataset listConnectionEventURIs(final URI connectionUri, boolean deep) throws
     NoSuchConnectionException
   {
@@ -548,7 +549,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(final URI connectionUri, final int
     pageNum, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
@@ -563,7 +564,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsAfter(
     final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
@@ -578,7 +579,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsBefore(
     final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
     NoSuchConnectionException
@@ -591,7 +592,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
     return containerPage;
   }
 
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   private Dataset setDefaults(Dataset dataset) {
     if (dataset == null) return null;
     DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
@@ -600,7 +601,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public DataWithEtag<Dataset> getDatasetForUri(URI datasetUri, String etag) {
     Integer version = etag == null ? -1: Integer.valueOf(etag);
     DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(datasetUri);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -35,7 +35,6 @@ import won.protocol.util.DataAccessUtils;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 
 /**
  * User: fkleedorfer
@@ -291,29 +290,6 @@ public class NeedInformationServiceImpl implements NeedInformationService
     return null;
   }
 
-
-  @Override
-  public List<URI> listConnectionEventURIs(URI connectionUri) {
-    return messageEventRepository.getMessageURIsByParentURI(connectionUri);
-  }
-
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionEventURIs(
-    URI connectionUri, int page, Integer preferedPageSize, WonMessageType messageType)
-  {
-    int pageSize = getPageSize(preferedPageSize);
-    int pageNum = page - 1;
-    Slice<URI> slice = null;
-    if (messageType == null) {
-      slice = messageEventRepository.getMessageURIsByParentURI(
-        connectionUri, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
-    } else {
-      slice = messageEventRepository.getMessageURIsByParentURI(
-        connectionUri, messageType, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
-    }
-    return slice;
-  }
 
   @Override
   public Slice<MessageEventPlaceholder> listConnectionEvents(

--- a/webofneeds/won-node/src/main/resources/db/migration/V3__entity_versioning.sql
+++ b/webofneeds/won-node/src/main/resources/db/migration/V3__entity_versioning.sql
@@ -1,0 +1,4 @@
+ALTER TABLE event_container DROP COLUMN connection_id;
+ALTER TABLE connection ADD COLUMN event_container_id BIGINT NOT NULL;
+ALTER TABLE event_container DROP COLUMN need_id;
+ALTER TABLE need ADD COLUMN event_container_id BIGINT NOT NULL;

--- a/webofneeds/won-node/src/main/resources/db/migration/V3__entity_versioning.sql
+++ b/webofneeds/won-node/src/main/resources/db/migration/V3__entity_versioning.sql
@@ -1,4 +1,7 @@
-ALTER TABLE event_container DROP COLUMN connection_id;
 ALTER TABLE connection ADD COLUMN event_container_id BIGINT NOT NULL;
-ALTER TABLE event_container DROP COLUMN need_id;
+UPDATE connection set event_container_id = (SELECT id FROM event_container WHERE connection_id = connection.id);
+ALTER TABLE event_container DROP COLUMN connection_id;
+
 ALTER TABLE need ADD COLUMN event_container_id BIGINT NOT NULL;
+UPDATE need set event_container_id = (SELECT id FROM event_container WHERE need_id = need.id);
+ALTER TABLE event_container DROP COLUMN need_id;

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -21,23 +21,20 @@
         xmlns:spring="http://www.springframework.org/schema/beans"
         xmlns:context="http://www.springframework.org/schema/context"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
   http://www.springframework.org/schema/context
-  http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configuerers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
-
+  http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
+
+    <!-- This bean extends the the abstract PPC bean in the parent context -->
+    <spring:bean id="propertyPlaceholderConfigurer" parent="abstractPropertyPlaceholderConfigurer" />
+
     <broker xmlns="http://activemq.apache.org/schema/core" brokerName="wonBroker" persistent="false" >
+
+
 
         <!--
             For better performances use VM cursor and small memory limit.

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/message-processors.xml
@@ -15,19 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--import resource="classpath:/spring/component/wonNodeInformationService.xml" /-->
     <!--import resource="classpath:/spring/component/linkeddatasource/linkeddatasource.xml"/-->
     <!--import resource="classpath:/spring/component/ehcache/spring-node-ehcache.xml"/-->

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
@@ -4,18 +4,12 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
 
     <!-- Camel configuration -->
     <!--camel:camelContext id="wonNodeCamel" trace="false"  we comment this out for testing if using the 'trace'

--- a/webofneeds/won-node/src/main/resources/spring/component/ehcache/spring-node-ehcache.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/ehcache/spring-node-ehcache.xml
@@ -15,8 +15,7 @@
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-node/src/main/resources/spring/component/linkeddatasource/linkeddatasource.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/linkeddatasource/linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolMatcherServiceClient/matcherProtocolMatcherServiceClient-jms.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolMatcherServiceClient/matcherProtocolMatcherServiceClient-jms.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
 

--- a/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolNeedService/matcherProtocolNeedService-jms.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/matcherProtocolNeedService/matcherProtocolNeedService-jms.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
     <bean id="matcherProtocolNeedJMSService" class="won.node.protocol.impl.MatcherProtocolNeedServiceImplJMSBased">

--- a/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring-jmx.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring-jmx.xml
@@ -17,8 +17,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="simonManager" class="org.javasimon.spring.ManagerFactoryBean" >
         <property name="callbacks">

--- a/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/monitoring/node-monitoring.xml
@@ -18,12 +18,11 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
         http://www.springframework.org/schema/aop
-        http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+        http://www.springframework.org/schema/aop/spring-aop-4.1.xsd">
 
     <bean id="monitoringInterceptor" class="org.javasimon.spring.MonitoringInterceptor"/>
 

--- a/webofneeds/won-node/src/main/resources/spring/component/scheduling/node-scheduling.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/scheduling/node-scheduling.xml
@@ -18,8 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <!-- required for monitoring stats recorder -->
     <bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler" destroy-method="destroy" >

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -22,19 +22,12 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
-
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
     <!-- Defines where to search for annotated components -->
     <context:component-scan base-package="won.node.protocol.impl" />

--- a/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -19,19 +19,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
 
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--- RDF Storage -->
     <bean id="rdfStorageRef" class="won.protocol.repository.rdfstorage.impl.JpaRepositoryBasedRdfStorageServiceImpl" />
-
-    
 </beans>

--- a/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/transmission/node-security.xml
@@ -14,19 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- private keys and their certificates for node,
              possibly certificates of other parties-->

--- a/webofneeds/won-node/src/main/resources/spring/component/wonNodeInformationService-node.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/wonNodeInformationService-node.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <bean id="wonNodeInformationService" class="won.protocol.service.impl.WonNodeInformationServiceImpl">
         <property name="defaultWonNodeUri" value="${uri.node.default}" />

--- a/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
+++ b/webofneeds/won-node/src/main/resources/spring/core/node-core.xml
@@ -15,21 +15,9 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!--import resource="classpath:/spring/component/security/key-services.xml" /-->
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert strings into jena models -->

--- a/webofneeds/won-node/src/main/resources/spring/node.xml
+++ b/webofneeds/won-node/src/main/resources/spring/node.xml
@@ -3,15 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in th e context
-    -->
-
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <!--context:component-scan base-package="won.*" /-->
     <import resource="classpath:/spring/component/camel/message-processors.xml"/>
     <import resource="classpath:/spring/component/cryptographyServices.xml" />

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailException;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.*;
@@ -126,7 +127,7 @@ public class WonWebSocketHandler
       headers.setLocation(need.getNeedURI());
       return new ResponseEntity<NeedPojo>(createdNeedPojo, headers, HttpStatus.CREATED);     */
   @Override
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.READ_COMMITTED)
   public void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException
   {
     logger.debug("OA Server - WebSocket message received: {}", message.getPayload());
@@ -201,7 +202,7 @@ public class WonWebSocketHandler
   }
 
   @Override
-  @Transactional(propagation = Propagation.SUPPORTS)
+  @Transactional(propagation = Propagation.SUPPORTS, isolation = Isolation.READ_COMMITTED)
   public WonMessage process(final WonMessage wonMessage) {
 
     String wonMessageJsonLdString = WonMessageEncoder.encodeAsJsonLd(wonMessage);

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-context.xml
@@ -18,9 +18,16 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
+    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+    <!-- was in owner-jmsonly.xml --><!-- was in owner-camel.xml within owner-jmsonly.xml-->
+    <!-- was in owner-security.xml within owner-jmsonly.xml--><!-- was in owner-core.xml within owner-jmsonly.xml-->
+    <!-- was in jpabased-rdf-storage.xml within owner-jmsonly.xml--><!-- within jdbc-storage.xml within owner-jmsonly.xml-->
+    <!-- was in owner-mailer.xml -->
 
     <!-- owner functioning -->
     <import resource="classpath:/spring/owner-jmsonly.xml"/>

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-mailer.xml
@@ -16,20 +16,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- configuration with gmail smtp server, uses unsafe access and requires
     that https://www.google.com/settings/security/lesssecureapps is turned on.

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-message.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-message.xml
@@ -19,7 +19,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="ownerApplicationService" class="won.owner.service.impl.OwnerApplicationService"/>
 

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -3,7 +3,7 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns:beans="http://www.springframework.org/schema/beans" xmlns:benas="http://www.springframework.org/schema/beans"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 								 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -21,11 +21,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:websocket="http://www.springframework.org/schema/websocket"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd
+http://www.springframework.org/schema/context/spring-context-4.1.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.1.xsd
 http://www.springframework.org/schema/websocket
-http://www.springframework.org/schema/websocket/spring-websocket-4.0.xsd">
+http://www.springframework.org/schema/websocket/spring-websocket-4.1.xsd">
 
     <!--import resource="classpath:/spring/owner-jmsonly.xml"/>
     <import resource="classpath:/spring/owner-context.xml"/>

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCommunicationServiceImpl.java
@@ -101,7 +101,7 @@ public class OwnerProtocolCommunicationServiceImpl implements OwnerProtocolCommu
       configureCamelEndpoint(wonNodeURI, ownerApplicationId);
       configureRemoteEndpointsForOwnerApplication(ownerApplicationId, getProtocolCamelConfigurator().getEndpoint
         (wonNodeURI), messagingService);
-      logger.debug("connected with WoN node: : " + wonNodeURI);
+      logger.debug("connected with WoN node: " + wonNodeURI);
     } else {
       logger.info("we're not yet registered. Registering with WoN node:" + wonNodeURI);
       String nodeGeneratedOwnerApplicationId = registrationClient.register(wonNodeURI.toString());

--- a/webofneeds/won-owner/src/main/resources/db/migration/V3__entity_versioning.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V3__entity_versioning.sql
@@ -1,0 +1,4 @@
+ALTER TABLE event_container DROP COLUMN connection_id;
+ALTER TABLE connection ADD COLUMN event_container_id BIGINT NOT NULL;
+ALTER TABLE event_container DROP COLUMN need_id;
+ALTER TABLE need ADD COLUMN event_container_id BIGINT NOT NULL;

--- a/webofneeds/won-owner/src/main/resources/db/migration/V3__entity_versioning.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V3__entity_versioning.sql
@@ -1,4 +1,7 @@
-ALTER TABLE event_container DROP COLUMN connection_id;
 ALTER TABLE connection ADD COLUMN event_container_id BIGINT NOT NULL;
-ALTER TABLE event_container DROP COLUMN need_id;
+UPDATE connection set event_container_id = (SELECT id FROM event_container WHERE connection_id = connection.id);
+ALTER TABLE event_container DROP COLUMN connection_id;
+
 ALTER TABLE need ADD COLUMN event_container_id BIGINT NOT NULL;
+UPDATE need set event_container_id = (SELECT id FROM event_container WHERE need_id = need.id);
+ALTER TABLE event_container DROP COLUMN need_id;

--- a/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/camel/owner-camel.xml
@@ -7,18 +7,12 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.1.xsd
                 http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
 
     <!-- messaging beans -->
     <camel:camelContext id="wonOwnerCamel">

--- a/webofneeds/won-owner/src/main/resources/spring/component/ehcache/spring-owner-ehcache.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ehcache/spring-owner-ehcache.xml
@@ -13,14 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" >
         <property name="cacheManager" ref="ehcache"/>

--- a/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- REST stuff -->
     <!-- required so our linked data client can convert http responses into jena models -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/ownerProtocolCommunicationService.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/ownerProtocolCommunicationService.xml
@@ -15,14 +15,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 
     <bean id="messagingService" class="won.protocol.jms.MessagingServiceImpl">

--- a/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/wonNodeRegistrationEventPublisher.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/ownerProtocolCommunicationService/wonNodeRegistrationEventPublisher.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spring="http://camel.apache.org/schema/spring"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:task="http://www.springframework.org/schema/task"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
 
     <bean id="wonNodeRegistrationEventPublisher" class="won.owner.messaging.WonNodeRegistrationEventPublisher" />
     <task:scheduled-tasks>

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/filebased-rdf-storage.xml
@@ -21,17 +21,12 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/inmemory-rdf-storage.xml
@@ -21,17 +21,12 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
 
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/node.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jdbc-storage.xml
@@ -22,20 +22,12 @@
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
     <context:annotation-config />
 
     <!-- Defines where to search for annotated components -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/storage/jpabased-rdf-storage.xml
@@ -21,17 +21,11 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:jpa="http://www.springframework.org/schema/data/jpa"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
                 http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
                 http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository-1.8.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
     <context:annotation-config />
 
     <!--- RDF Storage -->

--- a/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/transmission/owner-security.xml
@@ -15,22 +15,12 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!-- REST stuff
 
     <context:component-scan base-package="won.protocol.rest">
         <context:include-filter type="regex" expression="won.protocol.rest.*"/>
     </context:component-scan>-->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
     <bean id="clientKeyStoreService" class="won.cryptography.service.KeyStoreService" init-method="init">
         <constructor-arg type="java.lang.String" value="${keystore.location}" />
         <constructor-arg type="java.lang.String" value="${keystore.password}" />

--- a/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/core/owner-core.xml
@@ -15,21 +15,7 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
-
-
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <bean id="uriService" class="won.owner.service.impl.URIService">
         <property name="ownerProtocolOwnerServiceEndpointURI" value="${uri.owner.protocol.endpoint}" />
         <property name="defaultOwnerProtocolNeedServiceEndpointURI" value="${uri.need.protocol.endpoint.default}" />

--- a/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/owner-jmsonly.xml
@@ -3,14 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation=
-               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-
-    <!--
-         Load properties but ignore unresolvable properties so that
-         they are searched in other property configurers defined in the context
-    -->
-    <context:property-placeholder location="file:${WON_CONFIG_DIR}/owner.properties" ignore-unresolvable="true"/>
+               "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <!-- TODO merge into one file cryptographyServices.xml and owner-security? -->
     <import resource="classpath:/spring/component/cryptographyServices.xml" />

--- a/webofneeds/won-utils/won-utils-crawl/src/main/resources/spring/app/linkeddata-crawler.xml
+++ b/webofneeds/won-utils/won-utils-crawl/src/main/resources/spring/app/linkeddata-crawler.xml
@@ -17,10 +17,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.1.xsd">
     <!--
        context that combines components to provide an environment for running bots
     -->

--- a/webofneeds/won-utils/won-utils-mail/src/main/resources/mail-sender.xml
+++ b/webofneeds/won-utils/won-utils-mail/src/main/resources/mail-sender.xml
@@ -16,14 +16,7 @@
   ~    limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"        xmlns:context="http://www.springframework.org/schema/context"        xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-4.1.xsd         http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 
     <!-- configuration with gmail smtp server, uses unsafe access and requires


### PR DESCRIPTION
Discovered and fixed a lost update issue in won-node

fix comprises:
* saving feedback did not work, now it does
* saving the responses for messages failed - now it works. This query should only find Responses:
```
select count(*), messagetype, version from message_event where responsemessageuri is  null group by messagetype, version order by messagetype, version
``` 
* saving the 'referencedByOtherMessage' flag sometimes failed, causing messages to be referenced multiple times. This query should now show an ok picture: the last messages can be unreferenced.
```
select messageuri, responsemessageuri, messagetype, version, referencedbyothermessage, parentURI, creationdate from message_event order by parentURI, creationdate
```

