### PR TITLE
Tags can now contain umlauts.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
@@ -93,8 +93,8 @@ function genComponentConf() {
                 .trim();
 
             //ADD TAGS
-            const titleTags = title? title.match(/#(\w+)/gi) : [];
-            const descriptionTags = description? description.match(/#(\w+)/gi) : [];
+            const titleTags = title? title.match(/#(\S+)/gi) : [];
+            const descriptionTags = description? description.match(/#(\S+)/gi) : [];
 
             tags = angular.element.unique(
                 angular.element.merge(


### PR DESCRIPTION
Tags are now only delimited by white-space. Anything else is fair-game, thus enabling the use of the full range of unicode in tags.

Resolves #1039