### PR TITLE
Feat clean ontology

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugNeedWithFacetsAction.java
@@ -92,7 +92,7 @@ public class CreateDebugNeedWithFacetsAction extends AbstractCreateNeedAction
         if (needDataset != null) {
 
             DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(needDataset);
-            titleString = needModelWrapper.getTitleFromIsOrAll();
+            titleString = needModelWrapper.getSomeTitleFromIsOrAll("en","de");
             createNeed = needModelWrapper.hasFlag(WON.USED_FOR_TESTING) && !needModelWrapper.hasFlag(WON.NO_HINT_FOR_ME);
         }
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -1,5 +1,6 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -176,7 +177,7 @@ public class MailCommandAction extends BaseEventBotAction {
                 for(WonURI u : needUris) {
                     Dataset needRDF = getEventListenerContext().getLinkedDataSource().getDataForResource(u.getUri());
                     DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(needRDF);
-                    String needTitle = needModelWrapper.getTitleFromIsOrAll().trim();
+                    String needTitle = StringUtils.trim(needModelWrapper.getSomeTitleFromIsOrAll("en","de"));
                     if(titleToClose.equals(needTitle) && needModelWrapper.getNeedState().equals(NeedState.ACTIVE)){
                         return u.getUri();
                     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -1,5 +1,6 @@
 package won.bot.framework.eventbot.action.impl.mail.send;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.*;
 import org.apache.jena.tdb.TDB;
 import org.apache.velocity.Template;
@@ -125,7 +126,7 @@ public class WonMimeMessageGenerator {
         MimeMessage answerMessage = (MimeMessage) msgToRespondTo.reply(false);
         answerMessage.setFrom(new InternetAddress(sentFrom, sentFromName));
         answerMessage.setText("");
-        answerMessage.setSubject(answerMessage.getSubject() + " <-> " + needModelWrapper.getTitleFromIsOrAll());
+        answerMessage.setSubject(answerMessage.getSubject() + " <-> " + StringUtils.trim(needModelWrapper.getSomeTitleFromIsOrAll("en","de")));
 
         //We need to create an instance of our own MimeMessage Implementation in order to have the Unique Message Id set before sending
         WonMimeMessage wonAnswerMessage = new WonMimeMessage(answerMessage);
@@ -154,10 +155,10 @@ public class WonMimeMessageGenerator {
         Dataset remoteNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(remoteNeedUri);
         DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(remoteNeedRDF);
 
-        velocityContext.put("remoteNeedTitle", needModelWrapper.getTitleFromIsOrAll().replaceAll(
+        velocityContext.put("remoteNeedTitle", StringUtils.trim(needModelWrapper.getSomeTitleFromIsOrAll("en","de")).replaceAll(
           "\\n", "\n" + QUOTE_CHAR));
-        velocityContext.put("remoteNeedDescription", needModelWrapper.getDescription(
-                NeedContentPropertyType.ALL).replaceAll("\\n", "\n" + QUOTE_CHAR));
+        velocityContext.put("remoteNeedDescription", StringUtils.trim(needModelWrapper.getSomeDescription(
+                NeedContentPropertyType.ALL,"en","de")).replaceAll("\\n", "\n" + QUOTE_CHAR));
 
         Collection<String> tags = needModelWrapper.getTags(NeedContentPropertyType.ALL);
         velocityContext.put("remoteNeedTags", tags.size() > 0 ? tags : null);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateEchoNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateEchoNeedWithFacetsAction.java
@@ -59,7 +59,7 @@ public class CreateEchoNeedWithFacetsAction extends AbstractCreateNeedAction
       final Dataset needDataset = ((NeedCreatedEventForMatcher)event).getNeedData();
       DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(needDataset);
 
-      String titleString = needModelWrapper.getTitleFromIsOrAll();
+      String titleString = needModelWrapper.getSomeTitleFromIsOrAll("en","de");
       if (titleString != null){
         replyText = titleString;
       } else {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/util/TelegramMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/util/TelegramMessageGenerator.java
@@ -28,8 +28,8 @@ public class TelegramMessageGenerator {
         Dataset remoteNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(remoteNeedUri);
 
         DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(remoteNeedRDF);
-        String title = needModelWrapper.getTitleFromIsOrAll();
-        String description = needModelWrapper.getDescription(NeedContentPropertyType.ALL);
+        String title = needModelWrapper.getSomeTitleFromIsOrAll("en","de");
+        String description = needModelWrapper.getSomeDescription(NeedContentPropertyType.ALL,"en","de");
 
         SendMessage sendMessage = new SendMessage();
         sendMessage.setChatId(chatId);
@@ -49,8 +49,8 @@ public class TelegramMessageGenerator {
         Dataset remoteNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(remoteNeedUri);
 
         DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(remoteNeedRDF);
-        String title = needModelWrapper.getTitleFromIsOrAll();
-        String description = needModelWrapper.getDescription(NeedContentPropertyType.ALL);
+        String title = needModelWrapper.getSomeTitleFromIsOrAll("en","de");
+        String description = needModelWrapper.getSomeDescription(NeedContentPropertyType.ALL, "en","de");
 
         SendMessage sendMessage = new SendMessage();
         sendMessage.setChatId(chatId);
@@ -81,8 +81,8 @@ public class TelegramMessageGenerator {
         Dataset createdNeedRDF = eventListenerContext.getLinkedDataSource().getDataForResource(needURI);
 
         DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(createdNeedRDF);
-        String title = needModelWrapper.getTitleFromIsOrAll();
-        String description = needModelWrapper.getDescription(NeedContentPropertyType.ALL);
+        String title = needModelWrapper.getSomeTitleFromIsOrAll("en","de");
+        String description = needModelWrapper.getSomeDescription(NeedContentPropertyType.ALL, "en","de");
 
         SendMessage sendMessage = new SendMessage();
         sendMessage.setChatId(chatId);

--- a/webofneeds/won-core/doc/web-identity.md
+++ b/webofneeds/won-core/doc/web-identity.md
@@ -39,7 +39,7 @@ Below is an example of part of a Need resource description in TRIG format:
     won:hasBasicNeedType  won:Demand ;
     won:hasContent        [ a  won:NeedContent ;
                                dc:title               "WANTED: external CD burner."^^xsd:string ;
-                               won:hasTextDescription "Mine broke. Need a new one ASAP."^^xsd:string
+                               dc:description "Mine broke. Need a new one ASAP."^^xsd:string
                           ] ;
     won:hasFacet          won:OwnerFacet ;
     won:hasNeedModality   [ a  won:NeedModality ] ;

--- a/webofneeds/won-core/src/main/java/won/protocol/util/DefaultNeedModelWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/DefaultNeedModelWrapper.java
@@ -6,12 +6,12 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
-import won.protocol.exception.IncorrectPropertyCountException;
 import won.protocol.model.Coordinate;
 import won.protocol.model.NeedContentPropertyType;
 import won.protocol.vocabulary.WON;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Extends {@link NeedModelWrapper} to add matchat specific methods to access content fields like title, description, tags, etc.
@@ -44,36 +44,65 @@ public class DefaultNeedModelWrapper extends NeedModelWrapper {
         setContentPropertyStringValue(type, DC.title, title);
     }
 
-    public String getTitleFromIsOrAll() {
-
-        String title = null;
-        try {
-            title = getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title);
-        } catch (IncorrectPropertyCountException e1) {
-            title = getContentPropertyStringValue(NeedContentPropertyType.ALL, DC.title);
-        }
-
-        return title;
+    public Collection<String> getTitlesFromIsOrAll() {
+        return getTitlesFromIsOrAll(null);
     }
 
-    public Collection<String> getTitles(Resource contentNode) { return getContentPropertyStringValues(contentNode, DC.title);}
+    public Collection<String> getTitlesFromIsOrAll(String language) {
 
-    public Collection<String> getTitles(NeedContentPropertyType type) { return getContentPropertyStringValues(type, DC.title);}
+        Collection<String> titles = null;
+        titles = getContentPropertyStringValues(NeedContentPropertyType.IS, DC.title, language);
+        if (titles != null && titles.size() > 0) return titles;
+        titles = getContentPropertyStringValues(NeedContentPropertyType.IS, DC.title, null);
+        if (titles != null && titles.size() > 0) return titles;
+        titles = getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title, language);
+        if (titles != null && titles.size() > 0) return titles;
+        titles = getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title, null);
+        if (titles != null && titles.size() > 0) return titles;
+        return Collections.emptyList();
+    }
+
+    public String getSomeTitleFromIsOrAll(String... preferredLanguages) {
+        String title = null;
+        title = getSomeContentPropertyStringValue(NeedContentPropertyType.IS, DC.title, preferredLanguages);
+        if (title != null) return title;
+        title = getSomeContentPropertyStringValue(NeedContentPropertyType.ALL, DC.title, preferredLanguages);
+        if (title != null) return title;
+        return null;
+    }
+
+    public String getSomeTitle(Resource contentNode, String... preferredLanguages) {
+        String title = null;
+        return getSomeContentPropertyStringValue(contentNode, DC.title, preferredLanguages);
+    }
+
+    public Collection<String> getTitles(Resource contentNode){ return getTitles(contentNode, null);}
+    public Collection<String> getTitles(Resource contentNode, String language) { return getContentPropertyStringValues(contentNode, DC.title, language);}
+
+    public Collection<String> getTitles(NeedContentPropertyType type) { return getTitles(type, null);}
+    public Collection<String> getTitles(NeedContentPropertyType type, String language) { return getContentPropertyStringValues(type, DC.title, language);}
 
     public void setDescription(NeedContentPropertyType type, String description) {
         createContentNodeIfNonExist(type);
         setContentPropertyStringValue(type, DC.description, description);
     }
 
-    public Collection<String> getDescriptions(Resource contentNode) {
-        return getContentPropertyStringValues(contentNode,DC.description);
+    public String getSomeDescription(NeedContentPropertyType type, String... preferredLanguages) {
+        return getSomeContentPropertyStringValue(type, DC.description, preferredLanguages);
     }
 
-    public String getDescription(NeedContentPropertyType type) {
-        return getContentPropertyStringValue(type, DC.description);
+    public String getSomeDescription(Resource contentNode, String... preferredLanguages){
+        return getSomeContentPropertyStringValue(contentNode, DC.description, preferredLanguages);
     }
-    public Collection<String> getDescriptions(NeedContentPropertyType type) {
-        return getContentPropertyStringValues(type, DC.description);
+
+
+    public Collection<String> getDescriptions(Resource contentNode) { return getDescriptions(contentNode, null); }
+    public Collection<String> getDescriptions(Resource contentNode, String language) {
+        return getContentPropertyStringValues(contentNode,DC.description, language);
+    }
+    public Collection<String> getDescriptions(NeedContentPropertyType type) { return getDescriptions(type, null);}
+    public Collection<String> getDescriptions(NeedContentPropertyType type, String language) {
+        return getContentPropertyStringValues(type, DC.description, language);
     }
 
     public void addTag(NeedContentPropertyType type, String tag) {
@@ -82,11 +111,11 @@ public class DefaultNeedModelWrapper extends NeedModelWrapper {
     }
 
     public Collection<String> getTags(Resource contentNode) {
-        return getContentPropertyStringValues(contentNode, WON.HAS_TAG);
+        return getContentPropertyStringValues(contentNode, WON.HAS_TAG, null);
     }
 
     public Collection<String> getTags(NeedContentPropertyType type) {
-        return getContentPropertyStringValues(type, WON.HAS_TAG);
+        return getContentPropertyStringValues(type, WON.HAS_TAG, null);
     }
 
     public Coordinate getLocationCoordinate(Resource contentNode) {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/DefaultNeedModelWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/DefaultNeedModelWrapper.java
@@ -56,34 +56,24 @@ public class DefaultNeedModelWrapper extends NeedModelWrapper {
         return title;
     }
 
-    public String getTitle(Resource contentNode) {
-        return getContentPropertyStringValue(contentNode, DC.title);
-    }
     public Collection<String> getTitles(Resource contentNode) { return getContentPropertyStringValues(contentNode, DC.title);}
 
-    public String getTitle(NeedContentPropertyType type) {
-        return getContentPropertyStringValue(type, DC.title);
-    }
     public Collection<String> getTitles(NeedContentPropertyType type) { return getContentPropertyStringValues(type, DC.title);}
 
     public void setDescription(NeedContentPropertyType type, String description) {
         createContentNodeIfNonExist(type);
-        setContentPropertyStringValue(type, WON.HAS_TEXT_DESCRIPTION, description);
-    }
-
-    public String getDescription(Resource contentNode) {
-        return getContentPropertyStringValue(contentNode, WON.HAS_TEXT_DESCRIPTION);
+        setContentPropertyStringValue(type, DC.description, description);
     }
 
     public Collection<String> getDescriptions(Resource contentNode) {
-        return getContentPropertyStringValues(contentNode, WON.HAS_TEXT_DESCRIPTION);
+        return getContentPropertyStringValues(contentNode,DC.description);
     }
 
     public String getDescription(NeedContentPropertyType type) {
-        return getContentPropertyStringValue(type, WON.HAS_TEXT_DESCRIPTION);
+        return getContentPropertyStringValue(type, DC.description);
     }
     public Collection<String> getDescriptions(NeedContentPropertyType type) {
-        return getContentPropertyStringValues(type, WON.HAS_TEXT_DESCRIPTION);
+        return getContentPropertyStringValues(type, DC.description);
     }
 
     public void addTag(NeedContentPropertyType type, String tag) {

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -79,8 +79,6 @@ public class WON
   public static final Resource GOOD = m.createResource(BASE_URI + "Good");
   public static final Resource BAD = m.createResource(BASE_URI+"Bad");
 
-  public static final Property HAS_TEXT_DESCRIPTION = m.createProperty(BASE_URI, "hasTextDescription");
-  public static final Property HAS_CONTENT_DESCRIPTION = m.createProperty(BASE_URI, "hasContentDescription");
   public static final Property HAS_TAG = m.createProperty(BASE_URI, "hasTag");
   public static final Property HAS_ATTACHED_MEDIA = m.createProperty(BASE_URI, "hasAttachedMedia");
   public static final Property HAS_HEIGHT = m.createProperty(BASE_URI, "hasHeight");

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/sparql/WonQueries.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/sparql/WonQueries.java
@@ -23,7 +23,7 @@ public class WonQueries {
     public static final String SPARQL_ALL_NEEDS = SPARQL_PREFIX + "SELECT * WHERE " +
                                                     "{ ?need won:hasContent ?x; " +
                                                             "won:isInState ?state. " +
-                                                        "?x   won:hasTextDescription ?desc; " +
+                                                        "?x   dc:description ?desc; " +
                                                              "won:hasTag ?tag; " +
                                                              "dc:title ?title. " +
                                                         "?x won:hasContentDescription ?y. " +
@@ -45,7 +45,7 @@ public class WonQueries {
     public static final String SPARQL_NEEDS_FILTERED_BY_URI = SPARQL_PREFIX + "SELECT * WHERE " +
                                                     "{ ?need won:hasContent ?x; " +
                                                             "won:isInState ?state. " +
-                                                        "?x  won:hasTextDescription ?desc; " +
+                                                        "?x  dc:description ?desc; " +
                                                             "won:hasTag ?tag; " +
                                                             "dc:title ?title. " +
                                                         "?x won:hasContentDescription ?y. " +
@@ -132,8 +132,8 @@ public class WonQueries {
                 "}" +
             "}";
 
-    //public static final String SPARQL_MY_NEED = "SELECT * WHERE {?need won:containedInPrivateGraph ?graph. ?need won:hasContent ?x; won:isInState ?state. ?x won:hasTextDescription ?desc; won:hasTag ?tag; dc:title ?title.}";
-    //public static final String SPARQL_NEEDS_FILTERED_BY_UUIDS = "SELECT * WHERE { ?need won:hasContent ?x; won:isInState ?state. ?x won:hasTextDescription ?desc; won:hasTag ?tag; dc:title ?title. filter (?need in (<http://rsa021.researchstudio.at:8080/won/resource/need/5630666034445812000>))}";
+    //public static final String SPARQL_MY_NEED = "SELECT * WHERE {?need won:containedInPrivateGraph ?graph. ?need won:hasContent ?x; won:isInState ?state. ?x dc:description ?desc; won:hasTag ?tag; dc:title ?title.}";
+    //public static final String SPARQL_NEEDS_FILTERED_BY_UUIDS = "SELECT * WHERE { ?need won:hasContent ?x; won:isInState ?state. ?x dc:description ?desc; won:hasTag ?tag; dc:title ?title. filter (?need in (<http://rsa021.researchstudio.at:8080/won/resource/need/5630666034445812000>))}";
 
     //queryString = WonQueries.SPARQL_PREFIX +
 //                    "SELECT ?need ?connection ?need2 WHERE {" +

--- a/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWarpperTest.java
+++ b/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWarpperTest.java
@@ -6,7 +6,9 @@ import org.apache.jena.vocabulary.DC;
 import org.junit.Assert;
 import org.junit.Test;
 import won.protocol.message.Utils;
-import won.protocol.model.*;
+import won.protocol.model.NeedContentPropertyType;
+import won.protocol.model.NeedGraphType;
+import won.protocol.model.NeedState;
 import won.protocol.vocabulary.WON;
 
 import java.io.IOException;
@@ -129,9 +131,9 @@ public class NeedModelWarpperTest {
         Assert.assertEquals(NEED_URI, needModelWrapper.getNeedUri());
 
         // adding content without creating content nodes doesnt work
-        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TEXT_DESCRIPTION, "description");
+        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.IS, DC.description, "description");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TAG, "tag");
-        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TEXT_DESCRIPTION).size(), 0);
+        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description).size(), 0);
         Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG).size(), 0);
 
         // add different content nodes now and check that they are there
@@ -149,16 +151,16 @@ public class NeedModelWarpperTest {
         Assert.assertEquals("https://is_and_seeks_uri", needModelWrapper.getContentNodes(NeedContentPropertyType.IS_AND_SEEKS).iterator().next().getURI());
 
         // add content now and check if it can be queried correctly
-        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TEXT_DESCRIPTION, "description");
-        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.SEEKS, WON.HAS_TEXT_DESCRIPTION, "description1");
-        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.SEEKS, WON.HAS_TEXT_DESCRIPTION, "description2");
+        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.IS, DC.description, "description");
+        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.SEEKS, DC.description, "description1");
+        needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.SEEKS, DC.description, "description2");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TAG, "tag1");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.SEEKS, WON.HAS_TAG, "tag2");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TAG, "tag3");
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TEXT_DESCRIPTION).size());
-        Assert.assertEquals(1, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TEXT_DESCRIPTION).size());
-        Assert.assertEquals("description2", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TEXT_DESCRIPTION));
-        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TEXT_DESCRIPTION).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description).size());
+        Assert.assertEquals(1, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, DC.description).size());
+        Assert.assertEquals("description2", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.description));
+        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.description).size());
         Assert.assertEquals(3, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TAG).size());
         Assert.assertEquals(6, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TAG).size());
         Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG).size());

--- a/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWarpperTest.java
+++ b/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWarpperTest.java
@@ -67,10 +67,10 @@ public class NeedModelWarpperTest {
         Assert.assertEquals(0, needModelWrapper.getContentNodes(NeedContentPropertyType.IS_AND_SEEKS).size());
         Assert.assertEquals("Offering tennis lessons", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title));
         Assert.assertEquals("tennis students", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.SEEKS, DC.title));
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title).size());
-        Assert.assertEquals(3, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG).size());
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, WON.HAS_TAG).size());
-        Assert.assertEquals(5, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TAG).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title, null).size());
+        Assert.assertEquals(3, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG, null).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, WON.HAS_TAG, null).size());
+        Assert.assertEquals(5, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TAG, null).size());
         Assert.assertEquals("16.358398", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, "won:hasLocation/<s:geo>/<s:longitude>"));
     }
 
@@ -85,8 +85,8 @@ public class NeedModelWarpperTest {
         Assert.assertEquals(2, needModelWrapper.getContentNodes(NeedContentPropertyType.SEEKS).size());
         Assert.assertEquals("title1", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title));
         Assert.assertEquals("title1", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.title));
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title).size());
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title, null).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.title, null).size());
     }
 
     @Test
@@ -133,8 +133,8 @@ public class NeedModelWarpperTest {
         // adding content without creating content nodes doesnt work
         needModelWrapper.setContentPropertyStringValue(NeedContentPropertyType.IS, DC.description, "description");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TAG, "tag");
-        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description).size(), 0);
-        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG).size(), 0);
+        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description, null).size(), 0);
+        Assert.assertEquals(needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG, null).size(), 0);
 
         // add different content nodes now and check that they are there
         needModelWrapper.createContentNode(NeedContentPropertyType.IS, "https://is_uri");
@@ -157,14 +157,14 @@ public class NeedModelWarpperTest {
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS, WON.HAS_TAG, "tag1");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.SEEKS, WON.HAS_TAG, "tag2");
         needModelWrapper.addContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TAG, "tag3");
-        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description).size());
-        Assert.assertEquals(1, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, DC.description).size());
+        Assert.assertEquals(2, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.description, null).size());
+        Assert.assertEquals(1, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, DC.description, null).size());
         Assert.assertEquals("description2", needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.description));
-        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.description).size());
-        Assert.assertEquals(3, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TAG).size());
-        Assert.assertEquals(6, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TAG).size());
-        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG).size());
-        Assert.assertEquals(5, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, WON.HAS_TAG).size());
+        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, DC.description, null).size());
+        Assert.assertEquals(3, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS_AND_SEEKS, WON.HAS_TAG, null).size());
+        Assert.assertEquals(6, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.ALL, WON.HAS_TAG, null).size());
+        Assert.assertEquals(4, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, WON.HAS_TAG, null).size());
+        Assert.assertEquals(5, needModelWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, WON.HAS_TAG, null).size());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class NeedModelWarpperTest {
         String isSeeksTitle = needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.title);
         Assert.assertEquals("title1", isSeeksTitle);
         Assert.assertEquals(isSeeksTitle, normalizedWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title));
-        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title).contains(isSeeksTitle));
+        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title, null).contains(isSeeksTitle));
     }
 
     @Test
@@ -211,7 +211,7 @@ public class NeedModelWarpperTest {
         String isSeeksTitle = needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.title);
         Assert.assertEquals("title1", isSeeksTitle);
         Assert.assertEquals(isSeeksTitle, normalizedWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title));
-        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title).contains(isSeeksTitle));
+        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title, null).contains(isSeeksTitle));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class NeedModelWarpperTest {
         String isSeeksTitle = needModelWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS_AND_SEEKS, DC.title);
         Assert.assertEquals("title1", isSeeksTitle);
         Assert.assertEquals(isSeeksTitle, normalizedWrapper.getContentPropertyStringValue(NeedContentPropertyType.IS, DC.title));
-        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title).contains(isSeeksTitle));
+        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title, null).contains(isSeeksTitle));
     }
 
     @Test
@@ -242,8 +242,8 @@ public class NeedModelWarpperTest {
         Assert.assertEquals(needModelWrapper.getContentNodes(NeedContentPropertyType.IS),
                 needModelWrapper.getContentNodes(NeedContentPropertyType.IS_AND_SEEKS));
         Assert.assertEquals(normalizedWrapper.getContentNodes(NeedContentPropertyType.IS_AND_SEEKS).size(), 0);
-        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title).contains("title3"));
-        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.title).contains("title3"));
+        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.SEEKS, DC.title, null).contains("title3"));
+        Assert.assertTrue(normalizedWrapper.getContentPropertyStringValues(NeedContentPropertyType.IS, DC.title, null).contains("title3"));
     }
 
     @Test

--- a/webofneeds/won-core/src/test/resources/docs/test_intervals.ttl
+++ b/webofneeds/won-core/src/test/resources/docs/test_intervals.ttl
@@ -12,7 +12,7 @@
         won:hasBasicNeedType         won:Demand ;
         won:hasContent               [ a                       won:NeedContent ;
                                        dc:title                "Test ranges"^^xsd:string ;
-                                       won:hasTextDescription  "I'm just testing ranges here."^^xsd:string
+                                       dc:description  "I'm just testing ranges here."^^xsd:string
                                      ] ;
         won:hasNeedModality          [ a                          won:NeedModality ;
                                        won:hasPriceSpecification  [ a                       won:PriceSpecification ;

--- a/webofneeds/won-core/src/test/resources/needmodel/need1.trig
+++ b/webofneeds/won-core/src/test/resources/needmodel/need1.trig
@@ -21,7 +21,7 @@
             won:is        [ a                       won:NeedContent ;
                             dc:title                "Offering tennis lessons";
                             won:hasTag              "tennis" , "lesson", "offer" ;
-                            won:hasTextDescription  "tennis lessons for kids and adults of all levels";
+                            dc:description  "tennis lessons for kids and adults of all levels";
                             won:hasLocation  [ a                   <s:Place> ;
                                                 won:hasBoundingBox  [ won:hasNorthWestCorner  [ a              <s:GeoCoordinates> ;
                                                                                                 <s:latitude>   "48.213814" ;
@@ -42,7 +42,7 @@
             won:seeks     [ a                       won:NeedContent ;
                             dc:title                "tennis students";
                             won:hasTag              "tennis" , "lesson" ;
-                            won:hasTextDescription  "people learning tennis"
+                            dc:description  "people learning tennis"
                                                           ] ;
             won:hasFacet          won:OwnerFacet ;
             won:hasFlag           won:UsedForTesting ;

--- a/webofneeds/won-core/src/test/resources/validation/invalid/create_msg_invalid.trig
+++ b/webofneeds/won-core/src/test/resources/validation/invalid/create_msg_invalid.trig
@@ -109,7 +109,7 @@ event:2100661890849016800error
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "fish" ;
-                                    won:hasTextDescription     "fish"
+                                    dc:description     "fish"
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             <http://www.w3.org/ns/auth/cert#key>

--- a/webofneeds/won-core/src/test/resources/validation/invalid/env_chain_invalid.trig
+++ b/webofneeds/won-core/src/test/resources/validation/invalid/env_chain_invalid.trig
@@ -118,7 +118,7 @@
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "fish" ;
-                                    won:hasTextDescription     "fish"
+                                    dc:description     "fish"
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             <http://www.w3.org/ns/auth/cert#key>

--- a/webofneeds/won-core/src/test/resources/validation/valid/create_msg.trig
+++ b/webofneeds/won-core/src/test/resources/validation/valid/create_msg.trig
@@ -23,7 +23,7 @@
             won:hasBasicNeedType  won:Supply ;
             won:hasContent        [ a                       won:NeedContent ;
                                     dc:title                "[FCNYC] OFFER:   Trifle Dessert Bowl (UES/90th Street)"^^xsd:string ;
-                                    won:hasTextDescription  "8\" diameter, bowl is 5\" deep, whole bowl stands 9\" tall\r\n\r\n\r\nLooks like This:\r\n\r\n\r\nhttp://www.pier1.com/Large-Trifle-Bowl/2292937,default,pd.html?utm_source=Google&utm_medium=PLA&utm_campaign=google_pla&utm_content=2292937&s_cid=pla0000001&kpid=2292937\r\n\r\nPick up after noon on Sunday\r\n"^^xsd:string
+                                    dc:description  "8\" diameter, bowl is 5\" deep, whole bowl stands 9\" tall\r\n\r\n\r\nLooks like This:\r\n\r\n\r\nhttp://www.pier1.com/Large-Trifle-Bowl/2292937,default,pd.html?utm_source=Google&utm_medium=PLA&utm_campaign=google_pla&utm_content=2292937&s_cid=pla0000001&kpid=2292937\r\n\r\nPick up after noon on Sunday\r\n"^^xsd:string
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             won:hasNeedModality   [ a  won:NeedModality ] ;

--- a/webofneeds/won-cryptography/src/test/resources/test_intervals.ttl
+++ b/webofneeds/won-cryptography/src/test/resources/test_intervals.ttl
@@ -12,7 +12,7 @@
         won:hasBasicNeedType         won:Demand ;
         won:hasContent               [ a                       won:NeedContent ;
                                        dc:title                "Test ranges"^^xsd:string ;
-                                       won:hasTextDescription  "I'm just testing ranges here."^^xsd:string
+                                       dc:description  "I'm just testing ranges here."^^xsd:string
                                      ] ;
         won:hasNeedModality          [ a                          won:NeedModality ;
                                        won:hasPriceSpecification  [ a                       won:PriceSpecification ;

--- a/webofneeds/won-cryptography/src/test/resources/won-signed-messages/create-need-msg.trig
+++ b/webofneeds/won-cryptography/src/test/resources/won-signed-messages/create-need-msg.trig
@@ -32,7 +32,7 @@
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "aaa" ;
-                                    won:hasTextDescription     "a"
+                                    dc:description     "a"
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             cert:key [ cert:PublicKey

--- a/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-core-nosig.trig
+++ b/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-core-nosig.trig
@@ -31,7 +31,7 @@
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "aaa" ;
-                                    won:hasTextDescription     "a"
+                                    dc:description     "a"
                                   ] ;
             won:hasFacet          won:OwnerFacet .
 }

--- a/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-node-msg-nosig.trig
+++ b/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-node-msg-nosig.trig
@@ -32,7 +32,7 @@
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "aaa" ;
-                                    won:hasTextDescription     "a"
+                                    dc:description     "a"
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             cert:key [ cert:PublicKey

--- a/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-owner-msg-nosig.trig
+++ b/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-owner-msg-nosig.trig
@@ -32,7 +32,7 @@
                                                                                                ]
                                                                ] ;
                                     won:hasTag                 "aaa" ;
-                                    won:hasTextDescription     "a"
+                                    dc:description     "a"
                                   ] ;
             won:hasFacet          won:OwnerFacet ;
             cert:key [ cert:PublicKey

--- a/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-with-nl-nosig.trig
+++ b/webofneeds/won-cryptography/src/test/resources/won-signed-messages/need-with-nl-nosig.trig
@@ -33,7 +33,7 @@
                                     won:hasTag                 """a
                                     a
                                     a""" ;
-                                    won:hasTextDescription     "hi  i havae a briken wahing machine   come take it away.\r\n \r\n \r\ns d"
+                                    dc:description     "hi  i havae a briken wahing machine   come take it away.\r\n \r\n \r\ns d"
                                   ] ;
             won:hasFacet          won:OwnerFacet .
 }

--- a/webofneeds/won-docker/image/solr/core/won/conf/schema.xml
+++ b/webofneeds/won-docker/image/solr/core/won/conf/schema.xml
@@ -474,11 +474,11 @@
     <field name="_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_seeks.http___purl.org_dc_elements_1.1_title"
            type="text_en_syn_stem" termVectors="true" multiValued="true" indexed="true" stored="true"/>
 
-    <field name="_graph.http___purl.org_webofneeds_model_is.http___purl.org_webofneeds_model_hasTextDescription"
+    <field name="_graph.http___purl.org_webofneeds_model_is.http___purl.org_dc_elements_1.1_description"
            type="text_en_syn_stem" termVectors="true" multiValued="true" indexed="true" stored="true"/>
-    <field name="_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_hasTextDescription"
+    <field name="_graph.http___purl.org_webofneeds_model_seeks.is.http___purl.org_dc_elements_1.1_description"
            type="text_en_syn_stem" termVectors="true" multiValued="true" indexed="true" stored="true"/>
-    <field name="_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_hasTextDescription"
+    <field name="_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_seeks.is.http___purl.org_dc_elements_1.1_description"
            type="text_en_syn_stem" termVectors="true" multiValued="true" indexed="true" stored="true"/>
 
     <!-- Do not use stemming or synonyms for multivalued tags field -->

--- a/webofneeds/won-matcher-rescal/src/main/resources/queries/attribute/is_description.rq
+++ b/webofneeds/won-matcher-rescal/src/main/resources/queries/attribute/is_description.rq
@@ -8,7 +8,7 @@ SELECT DISTINCT ?slice ?need ?value WHERE {
     ?need won:crawlStatus ?crawlStatus.
     ?need won:crawlDate ?date.
     ?need won:isInState won:Active.
-    ?need won:is/won:hasTextDescription ?value.
+    ?need won:is/dc:description ?value.
     OPTIONAL {?needUri won:hasFlag ?flag}.
     FILTER (!bound(?flag) || (?flag != won:DoNotMatch && ?flag != won:UsedForTesting))
     FILTER (?date >= ?from && ?date < ?to)  # bind variables ?from and ?to here

--- a/webofneeds/won-matcher-rescal/src/main/resources/queries/attribute/seeks_description.rq
+++ b/webofneeds/won-matcher-rescal/src/main/resources/queries/attribute/seeks_description.rq
@@ -8,7 +8,7 @@ SELECT DISTINCT ?slice ?need ?value WHERE {
     ?need won:crawlStatus ?crawlStatus.
     ?need won:crawlDate ?date.
     ?need won:isInState won:Active.
-    ?need won:seeks/won:hasTextDescription ?value.
+    ?need won:seeks/dc:description ?value.
     OPTIONAL {?needUri won:hasFlag ?flag}.
     FILTER (!bound(?flag) || (?flag != won:DoNotMatch && ?flag != won:UsedForTesting))
     FILTER (?date >= ?from && ?date < ?to)  # bind variables ?from and ?to here

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicNeedQueryFactory.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicNeedQueryFactory.java
@@ -34,7 +34,7 @@ public class BasicNeedQueryFactory extends NeedDatasetQueryFactory {
     {
         descriptionFieldMap = new HashMap<>();
         descriptionFieldMap.put(NeedContentPropertyType.IS,
-                "_graph.http___purl.org_webofneeds_model_is.is.http___purl.org_dc_elements_1.1_description");
+                "_graph.http___purl.org_webofneeds_model_is.http___purl.org_dc_elements_1.1_description");
         descriptionFieldMap.put(NeedContentPropertyType.SEEKS,
                 "_graph.http___purl.org_webofneeds_model_seeks.is.http___purl.org_dc_elements_1.1_description");
         descriptionFieldMap.put(NeedContentPropertyType.SEEKS_SEEKS,

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicNeedQueryFactory.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicNeedQueryFactory.java
@@ -34,11 +34,11 @@ public class BasicNeedQueryFactory extends NeedDatasetQueryFactory {
     {
         descriptionFieldMap = new HashMap<>();
         descriptionFieldMap.put(NeedContentPropertyType.IS,
-                "_graph.http___purl.org_webofneeds_model_is.http___purl.org_webofneeds_model_hasTextDescription");
+                "_graph.http___purl.org_webofneeds_model_is.is.http___purl.org_dc_elements_1.1_description");
         descriptionFieldMap.put(NeedContentPropertyType.SEEKS,
-                "_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_hasTextDescription");
+                "_graph.http___purl.org_webofneeds_model_seeks.is.http___purl.org_dc_elements_1.1_description");
         descriptionFieldMap.put(NeedContentPropertyType.SEEKS_SEEKS,
-                "_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_hasTextDescription");
+                "_graph.http___purl.org_webofneeds_model_seeks.http___purl.org_webofneeds_model_seeks.is.http___purl.org_dc_elements_1.1_description");
     }
 
     public static final Map<NeedContentPropertyType, String> tagFieldMap;

--- a/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
+++ b/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
@@ -84,7 +84,7 @@ public class SolrMatcherEvaluation
 
     try {
       DefaultNeedModelWrapper needModelWrapper = new DefaultNeedModelWrapper(need);
-      title = needModelWrapper.getTitle(NeedContentPropertyType.ALL);
+      title = needModelWrapper.getTitles(NeedContentPropertyType.ALL).iterator().next();
       title = title.replaceAll("[^A-Za-z0-9 ]", "_");
       title = title.replaceAll("NOT", "_");
       title = title.replaceAll("AND", "_");

--- a/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
+++ b/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
@@ -89,7 +89,7 @@ public class SolrMatcherEvaluation
       title = title.replaceAll("NOT", "_");
       title = title.replaceAll("AND", "_");
       title = title.replaceAll("OR", "_");
-      description = needModelWrapper.getDescription(NeedContentPropertyType.ALL);
+      description = needModelWrapper.getSomeDescription(NeedContentPropertyType.ALL);
     } catch (IncorrectPropertyCountException e) {
 
       // do nothing

--- a/webofneeds/won-matcher-solr/src/test/resources/needmodel/need1.trig
+++ b/webofneeds/won-matcher-solr/src/test/resources/needmodel/need1.trig
@@ -21,7 +21,7 @@
             won:is        [ a                       won:NeedContent ;
                             dc:title                "Offering tennis lessons";
                             won:hasTag              "tennis" , "lesson", "offer" ;
-                            won:hasTextDescription  "tennis lessons for kids and adults of all levels";
+                            dc:description  "tennis lessons for kids and adults of all levels";
                             won:hasLocation  [ a                   <s:Place> ;
                                                 won:hasBoundingBox  [ won:hasNorthWestCorner  [ a              <s:GeoCoordinates> ;
                                                                                                 <s:latitude>   "48.213814" ;
@@ -42,7 +42,7 @@
             won:seeks     [ a                       won:NeedContent ;
                             dc:title                "tennis students";
                             won:hasTag              "tennis" , "lesson" ;
-                            won:hasTextDescription  "people learning tennis";
+                            dc:description  "people learning tennis";
                             won:hasLocation  [ a                   <s:Place> ;
                                                                     <s:geo>             [ a              <s:GeoCoordinates> ;
                                                                                           <s:latitude>   "49.2" ;

--- a/webofneeds/won-ontology-validator/src/main/resources/won_ontology_example_1.rdf
+++ b/webofneeds/won-ontology-validator/src/main/resources/won_ontology_example_1.rdf
@@ -586,7 +586,7 @@
         <rdf:type rdf:resource="&won;NeedContent"/>
         <terms:title rdf:datatype="&rdfs;Literal">Couch</terms:title>
         <terms:title rdf:datatype="&xsd;string">Couch</terms:title>
-        <won:hasTextDescription rdf:datatype="&xsd;string">rote Couch mit integrierter Mäusefalle</won:hasTextDescription>
+        <terms:description rdf:datatype="&xsd;string">rote Couch mit integrierter Mäusefalle</terms:description>
         <won:hasDepth rdf:resource="&wonex;CouchDepth"/>
         <won:hasHeight rdf:resource="&wonex;CouchHeight"/>
         <won:hasWeight rdf:resource="&wonex;CouchWeight"/>

--- a/webofneeds/won-ontology-validator/src/test/java/won/ontology/validator/Validator.java
+++ b/webofneeds/won-ontology-validator/src/test/java/won/ontology/validator/Validator.java
@@ -196,7 +196,7 @@ public class Validator
         "SELECT ?need ?text ?description WHERE {" +
         "?need rdf:type won:Need. " +
         "?need won:hasContent ?content." +
-        "?content won:hasTextDescription ?text." +
+        "?content dc:description ?text." +
         "?content won:hasContentDescription ?description." +
         "}";
     Query query = QueryFactory.create(queryString);

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -71,11 +71,11 @@ public class WonOwnerMailSender {
     String ownerAppLink = uriService.getOwnerProtocolOwnerURI().toString();
     Dataset needDataset =  linkedDataSource.getDataForResource(URI.create(remoteNeed));
     DefaultNeedModelWrapper remoteNeedWrapper = new DefaultNeedModelWrapper(needDataset);
-    String remoteNeedTitle = remoteNeedWrapper.getTitleFromIsOrAll();
+    String remoteNeedTitle = remoteNeedWrapper.getSomeTitleFromIsOrAll("en","de");
 
     Dataset localNeedDataset =  linkedDataSource.getDataForResource(URI.create(localNeed));
     DefaultNeedModelWrapper localNeedWrapper = new DefaultNeedModelWrapper(localNeedDataset);
-    String localNeedTitle = localNeedWrapper.getTitleFromIsOrAll();
+    String localNeedTitle = localNeedWrapper.getSomeTitleFromIsOrAll("en","de");
     String linkLocalNeed = ownerAppLink + OWNER_LOCAL_NEED_LINK + localNeed;
     String linkRemoteNeed = uriService.getOwnerProtocolOwnerURI() + OWNER_REMOTE_NEED_LINK + remoteNeed;
     String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK,localNeed, localConnection, ConnectionState.CONNECTED.getURI().toString());

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -43,12 +43,12 @@ function genComponentConf() {
         </div>
         -->
         <div class="pc__text"
-          ng-show="!!self.needContent.get('won:hasTextDescription')">
+          ng-show="!!self.needContent.get('dc:description')">
           <img
             class="pc__icon"
             src="generated/icon-sprite.svg#ico16_indicator_description"/>
           <span>
-            {{ self.needContent.get('won:hasTextDescription') }}
+            {{ self.needContent.get('dc:description') }}
           </span>
         </div>
         <div class="pc__text"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -47,12 +47,12 @@ function genComponentConf() {
                 </p>
 
                 <h2 class="post-info__heading"
-                    ng-show="self.postContent.get('won:hasTextDescription')">
+                    ng-show="self.postContent.get('dc:description')">
                     Description
                 </h2>
                 <p class="post-info__details"
-                    ng-show="self.postContent.get('won:hasTextDescription')">
-                    {{ self.postContent.get('won:hasTextDescription')}}
+                    ng-show="self.postContent.get('dc:description')">
+                    {{ self.postContent.get('dc:description')}}
                 </p>
 
                 <h2 class="post-info__heading"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -122,7 +122,7 @@
             {
                 '@id': '_:needContent',
                 'dc:title': args.title,
-                'won:hasTextDescription': args.description,
+                'dc:description': args.description,
                 'won:hasTag': args.tags,
                 'won:hasAttachment': (hasAttachmentUrls(args) ? attachmentUrisTyped : undefined),
                 'won:hasLocation': (!hasLocation(args)? undefined : {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -156,8 +156,6 @@
     won.WON.hasStartTimeCompacted = won.WON.prefix + ":hasStartTime";
     won.WON.hasTag = won.WON.baseUri + "hasTag";
     won.WON.hasTagCompacted = won.WON.prefix + ":hasTag";
-    won.WON.hasTextDescription = won.WON.baseUri + "hasTextDescription";
-    won.WON.hasTextDescriptionCompacted = won.WON.prefix + ":hasTextDescription";
 
     won.WON.hasMatchScore = won.WON.baseUri + "hasMatchScore";
     won.WON.hasMatchScoreCompacted = won.WON.prefix + ":hasMatchScore";

--- a/webofneeds/won-vocab/src/main/resources/ontology/example/resource_shape_example_2_match.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/example/resource_shape_example_2_match.ttl
@@ -11,7 +11,7 @@ ex:Need2
 	won:hasContent ex:Need2_Content2 ;
 	won:hasMatchingConstraint ex:Need2_Constraint2.
 	
-ex:Need2_Content2 won:hasTextDescription "Zu verschenken, 1 Jacke, hellgrün ist Gr. 22 (Gr. 44 - Kurzgröße) und hat goldene Knöpfe."^^xsd:string
+ex:Need2_Content2 dc:description "Zu verschenken, 1 Jacke, hellgrün ist Gr. 22 (Gr. 44 - Kurzgröße) und hat goldene Knöpfe."^^xsd:string
 
 ex:Need2_Constraint2 
 	a oslc:ResourceShape ;

--- a/webofneeds/won-vocab/src/main/resources/ontology/example/resource_shape_example_2_need.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/example/resource_shape_example_2_need.ttl
@@ -11,7 +11,7 @@ ex:Need1
 	won:hasContent ex:Need1_Content1 ;
 	won:hasMatchingConstraint ex:Need1_Constraint1.
 	
-ex:Need1_Content1 won:hasTextDescription "Ich suche nach einer Mitfahrgelegenheit Wien - Salzburg für 2 Personen. Wär toll wenn sich jemand finden würde. (irgendwann zwischen Fr-So) Bitte, bitte wenn jemand diese Strecke fährt, bei mir melden :-) Dankeschön.. LG"^^xsd:string
+ex:Need1_Content1 dc:description "Ich suche nach einer Mitfahrgelegenheit Wien - Salzburg für 2 Personen. Wär toll wenn sich jemand finden würde. (irgendwann zwischen Fr-So) Bitte, bitte wenn jemand diese Strecke fährt, bei mir melden :-) Dankeschön.. LG"^^xsd:string
 
 ex:Need1_Constraint1 
 	a oslc:ResourceShape ;

--- a/webofneeds/won-vocab/src/main/resources/ontology/example/won_ontology_0.1_fs.svg
+++ b/webofneeds/won-vocab/src/main/resources/ontology/example/won_ontology_0.1_fs.svg
@@ -305,7 +305,7 @@ won:hasOwner</text>
 won:NeedContent</text>
 <rect fill="#000000" height="1" stroke="#000000" stroke-width="1" width="270" x="254" y="694"/>
 <text font-family="Dialog" font-size="12" x="258" y="709">
-won:hasTextDescription : xsd:string</text>
+dc:description : xsd:string</text>
 <text font-family="Dialog" font-size="12" x="258" y="726">
 won:hasContentDescription : owl:Thing</text>
 <text font-family="Dialog" font-size="12" x="258" y="743">

--- a/webofneeds/won-vocab/src/main/resources/ontology/example/won_ontology_example_1.rdf
+++ b/webofneeds/won-vocab/src/main/resources/ontology/example/won_ontology_example_1.rdf
@@ -586,7 +586,7 @@
         <rdf:type rdf:resource="&won;NeedContent"/>
         <terms:title rdf:datatype="&rdfs;Literal">Couch</terms:title>
         <terms:title rdf:datatype="&xsd;string">Couch</terms:title>
-        <won:hasTextDescription rdf:datatype="&xsd;string">rote Couch mit integrierter Mäusefalle</won:hasTextDescription>
+        <terms:description rdf:datatype="&xsd;string">rote Couch mit integrierter Mäusefalle</terms:description>
         <won:hasDepth rdf:resource="&wonex;CouchDepth"/>
         <won:hasHeight rdf:resource="&wonex;CouchHeight"/>
         <won:hasWeight rdf:resource="&wonex;CouchWeight"/>

--- a/webofneeds/won-vocab/src/main/resources/ontology/won_ontology_v1.0.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won_ontology_v1.0.ttl
@@ -167,12 +167,6 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:range xsd:string .
 
 
-###  http://purl.org/webofneeds/model#hasTextDescription
-:hasTextDescription rdf:type owl:ObjectProperty ,
-                             owl:FunctionalProperty ;
-                    rdfs:range xsd:string .
-
-
 ###  http://purl.org/webofneeds/model#hasTimeSpecification
 :hasTimeSpecification rdf:type owl:ObjectProperty ;
                       rdfs:range :TimeSpecification ;
@@ -284,11 +278,6 @@ seeked to fulfill the need in contrast to the part that is available.""" ;
 
 ###  http://purl.org/webofneeds/model#hasTag
 :hasTag rdf:type owl:DatatypeProperty .
-
-
-###  http://purl.org/webofneeds/model#hasTextDescription
-:hasTextDescription rdf:type owl:DatatypeProperty ,
-                             owl:FunctionalProperty .
 
 
 ###  http://purl.org/webofneeds/model#hasTimeStamp


### PR DESCRIPTION
migrated `won:hasTextDescription` to `dc:description`

also removed the getTitle() and getDescription() methods from the NeedModelWrapper because we cannot be sure that there is only one title or description (e.g. because they are provided in different languages).