### PR TITLE
fix for the fail of npm clean  in won-owner-webapp

### DIFF
--- a/webofneeds/won-owner-webapp/pom.xml
+++ b/webofneeds/won-owner-webapp/pom.xml
@@ -417,5 +417,46 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>suppress-npm-clean</id>
+            <activation>
+                <file>
+                    <missing>src/main/webapp/node</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.ekryd.echo-maven-plugin</groupId>
+                        <artifactId>echo-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>frontend-suppress-npm-clean</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>echo</goal>
+                                </goals>
+                                <configuration>
+                                    <message>Note: the profile 'suppress-npm-clean' is active because the local installation of nodejs was not found in 'src/main/webapp/node'. 'npm run clean' will not be executed.</message>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>npm-run-clean</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
 If the won-owner-webapp project is built with 'clean' before the first 'install', the 'clean' goal used to fail. this is becaue node.js is only installed locally with the first run of 'mvn install'. This fix adds a maven profile that deactivates the npm clean command if the local installation of nodejs is not found.

To test this PR, clone this branch into a new folder and try `mvn clean`. Before this PR, this fails, with the PR, it succeeds.