### PR TITLE
Using textContent instead of innerHTML to get title.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
@@ -87,7 +87,7 @@ function genComponentConf() {
             //titleParagraphDom.innerHTML = titleParagraphDom.innerHTML.replace(/^&nbsp;/, '');
             // ^ can't do this, as it causes the cursor to jump
 
-            const title = titleParagraphDom.innerHTML
+            const title = titleParagraphNg.text()
                 // sometimes mediumjs doesn't remove the placeholder nbsp properly.
                 .replace(/^&nbsp;/, '')
                 .trim();


### PR DESCRIPTION
Test: go to create-need in FF, enter title like "asdf #asdf" and don't line-break. before this fix, the tag would contain a "\<br\>". Alternatively you can just create a need with a title and check how it turns out in any post-specific view where the title shows up.


Resolves #1080, #1052