### PR TITLE
Fix view remote after connect #1057

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -78,7 +78,11 @@ function genComponentConf() {
                 <p ng-show="self.debugmode">
                     <a class="debuglink" target="_blank" href="{{self.post.get('@id')}}">[DATA]</a>
                 </p>
-                <div class="post-info__mapmount" id="post-info__mapmount" in-view="$inview && self.mapInView($inviewInfo)"></div>
+                <div class="post-info__mapmount"
+                     id="post-info__mapmount"
+                     in-view="$inview && self.mapInView($inviewInfo)"
+                     ng-show="self.location">
+                 </div>
             </div>
         </div>
     `;
@@ -105,7 +109,7 @@ function genComponentConf() {
                 (location, previousLocationValue) => {
                     console.log('in location watch: ', location, previousLocationValue);
                     if(location && !this._mapHasBeenAutoCentered) {
-                        this.updateMap(location)
+                        this.updateMap(location);
                         this._mapHasBeenAutoCentered = true;
                     }
                 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -40,7 +40,8 @@ function genComponentConf() {
                     <img class="pm__header__icon clickable"
                          src="generated/icon-sprite.svg#ico36_close"/>
                 </a>
-                <div class="pm__header__title">
+                <div class="pm__header__title"
+                  ui-sref="post({ postUri: self.theirNeed.get('@id'), connectionUri: null, connectionType: null})">
                     {{ self.theirNeedContent.get('dc:title') }}
                 </div>
                 <!--div class="pm__header__options">
@@ -70,6 +71,7 @@ function genComponentConf() {
                         title="self.theirNeedContent.get('dc:title')"
                         src="self.theirNeedContent.get('TODOtitleImgSrc')"
                         uri="self.theirNeed.get('@id')"
+                        ui-sref="post({postUri: self.theirNeed.get('@id'), connectionUri: null, connectionType: null})"
                         ng-show="message.get('hasSenderNeed') != self.ownNeed.get('@id')">
                     </won-square-image>
                     <div class="pm__content__message__content">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -34,23 +34,14 @@ const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 
 function genComponentConf() {
     let template = `
-        <div>
-            <div class="pm__header">
-                <a ui-sref="{connectionUri : null}">
-                    <img class="pm__header__icon clickable"
-                         src="generated/icon-sprite.svg#ico36_close"/>
-                </a>
-                <div class="pm__header__title"
-                  ui-sref="post({ postUri: self.theirNeed.get('@id'), connectionUri: null, connectionType: null})">
-                    {{ self.theirNeedContent.get('dc:title') }}
-                </div>
-                <!--div class="pm__header__options">
-                    Options
-                </div>
-                <img
-                    class="pm__header__options__icon clickable"
-                    src="generated/icon-sprite.svg#ico_settings"
-                    ng-click="self.openConversationOption()"/-->
+        <div class="pm__header">
+            <a ui-sref="{connectionUri : null}">
+                <img class="pm__header__icon clickable"
+                     src="generated/icon-sprite.svg#ico36_close"/>
+            </a>
+            <div class="pm__header__title"
+              ui-sref="post({ postUri: self.theirNeed.get('@id'), connectionUri: null, connectionType: null})">
+                {{ self.theirNeedContent.get('dc:title') }}
             </div>
         </div>
         <div class="pm__content">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -28,12 +28,10 @@ function genComponentConf() {
                         src="self.theirPostContent.get('titleImgSrc')"
                         uri="self.theirPost.get('@id')">
                     </won-square-image>
-                    <div class="vtb__inner__left__titles">
-                        <h1 class="vtb__title">{{self.theirPostContent.get('dc:title')}}</h1>
-                        <div class="vtb__inner__left__titles__type">
-                            {{self.labels.type[self.theirPostType] }}
-                        </div>
-                    </div>
+                    <hgroup>
+                        <h1 class="vtb__title">{{ self.theirPostContent.get('dc:title') }}</h1>
+                        <div class="vtb__titles__type">{{self.labels.type[self.theirPostType]}}</div>
+                    </hgroup>
                 </div>
                 <div class="vtb__inner__right" ng-show="self.hasConnectionWithOwnPost">
                     <button class="won-button--filled red">Quit Contact</button>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -397,7 +397,7 @@ import jsonld from 'jsonld'; //import *after* the rdfstore to shadow its custom 
     var cacheItemMarkUnresolvable = function cacheItemMarkUnresolvable(uri, reason){
         //console.log("linkeddata-service-won.js: mark unres:      " + uri);
         privateData.cacheStatus[uri] = {timestamp: new Date().getTime(), state: CACHE_ITEM_STATE.UNRESOLVABLE};
-        console.error("Couldn't resolve " + uri + ". reason: " + JSON.stringify(reason));
+        console.error("Couldn't resolve " + uri + ". reason: ", reason);
     }
 
     var cacheItemMarkFetching = function cacheItemMarkFetching(uri){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -208,6 +208,7 @@ export function connectionLastUpdatedAt(state, connection) {
  *          the entire owner-application to the is-seeks need-structure.
  */
 export function seeksOrIs(need) {
+    if(!need) return undefined;
     const seeks = need.get('won:seeks');
     const is = need.get('won:is');
 
@@ -253,6 +254,7 @@ window.seeksOrIs4dbg = seeksOrIs;
  *          to the is-seeks need-structure.
  */
 export function inferLegacyNeedType(need) {
+    if(!need) return undefined;
     const seeks = need.get('won:seeks');
     const is = need.get('won:is');
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-tab-bar.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-tab-bar.scss
@@ -4,7 +4,7 @@
 @import 'sizing-utils';
 @import 'square-image';
 
-@mixin need-tab-bar($prefix, $tabBarWidth) {
+@mixin need-tab-bar($prefix) {
   @include title-bar($prefix);
 
   .#{$prefix}__titles__type {
@@ -31,6 +31,8 @@
       align-items: center;
       justify-content: flex-start;
 
+      margin: 1rem 0;
+
       @media (max-width: $responsivenessBreakPoint){
         @include square-image($postIconSize, 0, 0, 0, 0);
       }
@@ -42,8 +44,6 @@
     > .#{$prefix}__inner__right {
       //TODO dynamically adapt to number of children(?) or at least pull into a config-variable
       // or make won-tabs a parametrized mixin?
-      //flex-basis: $tabBarWidth;
-      //max-width: $tabBarWidth;
       flex-grow: 1;
       margin-top: 1rem;
 
@@ -92,5 +92,5 @@
 }
 
 .need-tab-bar {
-  @include need-tab-bar('ntb', 35rem);
+  @include need-tab-bar('ntb');
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -49,6 +49,7 @@
       font-size: $normalFontSize;
       text-align: left;
       width: 100%;
+      padding: 0.5rem 0;
 
       &__title{
         flex-grow:2;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -53,6 +53,8 @@
       &__title{
         flex-grow:2;
         padding-top:0.5em;
+
+        cursor: pointer;
       }
       &__icon {
         flex-grow:1;
@@ -93,7 +95,7 @@
 
     .pm__content {
       padding: 1rem;
-      margin: 1rem 0;
+      margin-bottom: 1rem;
       background: white;
       border: $thinGrayBorder;
       overflow: auto;
@@ -103,6 +105,10 @@
         margin: 0.5rem 0;
         @include square-image($postIconSize, 0, 0.5rem, 0, 0);
         display: flex;
+
+        won-square-image {
+          cursor: pointer; /* the image links to their post info */
+        }
 
         &.left{
           justify-content: flex-start;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_visitor-title-bar.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_visitor-title-bar.scss
@@ -6,5 +6,5 @@
 @import 'need-tab-bar';
 
 .visitor-title-bar {
-  @include need-tab-bar('vtb', 13rem);
+  @include need-tab-bar('vtb');
 }


### PR DESCRIPTION
"Avatars" and title in the chat are now clickable and lead to the post-info page for the other person's need.

Resolves #1057 (mostly anyway -- for further details see "post info as first 'message'" in #1057 and #1081)