### PR TITLE
Made app-bundle self-executing.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
@@ -25,7 +25,11 @@ gulp.task('watch', ['sass', 'iconsprite', 'bundlejs', 'copy-static-res'], functi
 gulp.task('bundlejs', function(){
     return gulp.src('app/app_jspm.js')
         .pipe(sourcemaps.init())
-        .pipe(gulp_jspm())
+        //.pipe(gulp_jspm())
+        .pipe(gulp_jspm({
+            selfExecutingBundle: true,
+            //minify: true,
+        }))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('./generated/'));
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
@@ -82,9 +82,6 @@ gulp.task('copy-static-scripts', function(done) {
         'node_modules/medium.js/medium.js',
         'scripts/jquery.10.2.js',
         'scripts/jquery.fs.scroller.min.js',
-        'jspm_packages/system.js',
-        'jspm_packages/system-polyfills.js',
-        'jspm_config.js',
     ])
         .pipe(gulp.dest('./generated/scripts/'))
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -43,10 +43,6 @@ https://github.com/researchstudio-sat/webofneeds/issues/664
 <script src="./generated/scripts/jquery.10.2.js"></script>
 <script src="./generated/scripts/jquery.fs.scroller.min.js"></script>
 
-<script src="./generated/scripts/system.js"></script>
-<script src="./generated/scripts/system-polyfills.js"></script>
-<script src="./generated/scripts/jspm_config.js"></script>
-
 <!--
 this line loads the bundled app. comment it out if you want
 jspm to dynamically load and compile the sources at runtime.
@@ -54,11 +50,6 @@ this makes for easier debugging, as you get seperate
 source files in the dev-tools' source explorer. -->
 
 <script src="./generated/app_jspm.bundle.js"></script>
-
-<script>
-    System.import('./app/app_jspm')
-            .catch(console.error.bind(console));
-</script>
 </body>
 </html>
 


### PR DESCRIPTION
Doesn't need systemjs as an external dependency
any more.

This *might* fix the white-screen-of-death-issue #1109 (i can't test locally as the issue only occurs on matchat)