### PR TITLE
fixed typos in nginx config

### DIFF
--- a/webofneeds/won-docker/image/nginx/nginx-master.conf
+++ b/webofneeds/won-docker/image/nginx/nginx-master.conf
@@ -79,7 +79,7 @@ http {
 
             # Set origin to the real instance, otherwise a of Spring security check will fail
             # Same value as defined in proxy_pass
-            proxy_set_header Origin "https://satvm05.researchstudio.at:8082/owner";
+            proxy_set_header Origin "https://satvm02.researchstudio.at:8082/owner";
 
             # add for web socket compatibility
             proxy_http_version 1.1;

--- a/webofneeds/won-docker/image/nginx/nginx.conf
+++ b/webofneeds/won-docker/image/nginx/nginx.conf
@@ -143,7 +143,7 @@ http {
 
             # Set origin to the real instance, otherwise a of Spring security check will fail
             # Same value as defined in proxy_pass
-            proxy_set_header Origin "https://satvm05.researchstudio.at:8889/won";
+            proxy_set_header Origin "https://satvm01.researchstudio.at:8443/won";
 
             # Set Host header so the wonnode can operate on the original uri for access control checks
             proxy_set_header   Host $host;


### PR DESCRIPTION
In both the master and the live config, the directive setting the Origin header was copied from integration-test and not changed.
