### PR TITLE
Rescal big tensor data

### DIFF
--- a/webofneeds/won-matcher-rescal/src/main/java/won/matcher/rescal/service/HintReader.java
+++ b/webofneeds/won-matcher-rescal/src/main/java/won/matcher/rescal/service/HintReader.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Used to read a hint matrix mtx file and create (bulk) hint event objects from it.
@@ -40,10 +41,7 @@ public class HintReader {
         String line = null;
         int i = 0;
         while ((line = br.readLine()) != null) {
-            if (line.startsWith(TensorMatchingData.NEED_PREFIX)) {
-                String originalHeaderEntry = line.substring(TensorMatchingData.NEED_PREFIX.length());
-                needHeaders.add(i, originalHeaderEntry);
-            }
+            needHeaders.add(i, line);
             i++;
         }
         br.close();
@@ -99,7 +97,10 @@ public class HintReader {
 
             String needUri1 = needUris.get(i);
             String needUri2 = needUris.get(j);
-            if (needUri1 != null && needUri2 != null) {
+
+            List<String> matchingDataNeeds = matchingData.getNeeds();
+
+            if (needUri1 != null && needUri2 != null && matchingDataNeeds.contains(needUri1) && matchingDataNeeds.contains(needUri2)) {
 
                 // wonNodeUri must have been set as attribute before to be able to read it here
                 String fromWonNodeUri = matchingData.getFirstAttributeOfNeed(needUri1, "wonNodeUri");
@@ -107,6 +108,8 @@ public class HintReader {
                 HintEvent hint = new HintEvent(fromWonNodeUri, needUri1, toWonNodeUri,
                         needUri2, config.getPublicMatcherUri(), value);
                 hints.addHintEvent(hint);
+            } else {
+                throw new IllegalStateException("MatchingData does not contain needs with URI " + needUri1 + " or " + needUri2);
             }
         }
 

--- a/webofneeds/won-matcher-rescal/src/main/python/rescal-matcher.py
+++ b/webofneeds/won-matcher-rescal/src/main/python/rescal-matcher.py
@@ -13,7 +13,7 @@ _log = logging.getLogger()
 
 
 from tools.tensor_utils import read_input_tensor, SparseTensor, execute_extrescal, \
-    predict_rescal_hints_by_threshold, create_hint_mask_matrix
+    predict_rescal_hints_by_threshold, test_create_hint_mask_matrix, test_predict_rescal_hints_by_threshold
 
 
 # ==========================================================================
@@ -41,6 +41,7 @@ if __name__ == '__main__':
 
     # load the tensor
     header_file = "headers.txt"
+    need_indices_file = "needIndices.txt"
 
     slice_files = []
     for file in os.listdir(args.inputfolder):
@@ -48,18 +49,19 @@ if __name__ == '__main__':
             slice_files.append(file)
 
     header_input = args.inputfolder + "/" + header_file
+    need_indices_input = args.inputfolder + "/" + need_indices_file
     data_input = []
     for slice in slice_files:
         data_input.append(args.inputfolder + "/" + slice)
-    input_tensor = read_input_tensor(header_input, data_input, True)
+    input_tensor = read_input_tensor(header_input, need_indices_input, data_input, True)
 
     # execute rescal
     A,R = execute_extrescal(input_tensor, args.rank)
 
     # predict new hints
     _log.info("predict hints with threshold: %f" % args.threshold)
-    mask_matrix = create_hint_mask_matrix(input_tensor)
-    connection_prediction = predict_rescal_hints_by_threshold(A, R, args.threshold, mask_matrix)
+    connection_prediction = predict_rescal_hints_by_threshold(A, R, args.threshold, input_tensor)
+
     _log.info("number of hints created: %d" % len(connection_prediction.nonzero()[0]))
 
     # write the hint output matrix

--- a/webofneeds/won-matcher-utils/src/main/java/won/matcher/utils/tensor/TensorMatchingData.java
+++ b/webofneeds/won-matcher-utils/src/main/java/won/matcher/utils/tensor/TensorMatchingData.java
@@ -24,10 +24,8 @@ public class TensorMatchingData {
     private static final Logger logger = LoggerFactory.getLogger(TensorMatchingData.class);
 
     private static final int MAX_DIMENSION = 1000000;
-
-    public static final String NEED_PREFIX = "Need: ";
-    public static final String ATTRIBUTE_PREFIX = "Attr: ";
     public static final String HEADERS_FILE = "headers.txt";
+    public static final String NEED_INDICES_FILE = "needIndices.txt";
 
     public static final String CONNECTION_SLICE_NAME = "connection";
 
@@ -246,7 +244,7 @@ public class TensorMatchingData {
     }
 
     public ArrayList<String> getNeedHeaders() {
-        return needs;
+        return (ArrayList<String>) needs.clone();
     }
 
     public List<String> getNeeds() {
@@ -347,8 +345,18 @@ public class TensorMatchingData {
         OutputStreamWriter os = new OutputStreamWriter(fos, "UTF-8");
 
         for (int i = 0; i < nextIndex; i++) {
-            String entity = (needs.get(i) != null) ? NEED_PREFIX + needs.get(i) : ATTRIBUTE_PREFIX + attributes.get(i);
+            String entity = (needs.get(i) != null) ? needs.get(i) : attributes.get(i);
             os.append(entity + "\n");
+        }
+        os.close();
+
+        // write the need indices file
+        fos = new FileOutputStream(new File(folder + "/" + NEED_INDICES_FILE));
+        os = new OutputStreamWriter(fos, "UTF-8");
+        for (int i = 0; i < nextIndex; i++) {
+            if (needs.get(i) != null) {
+                os.append(i + "\n");
+            }
         }
         os.close();
 


### PR DESCRIPTION
improve the rescal matchers scalability and performance by not computing whole mask and prediction matrices anymore. also use a needIndices file to identify the needs (in contrast to attributes) in the header file. 