### PR TITLE
Fix visible click indicator

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
@@ -11,7 +11,7 @@
                     there are no recent events for any of your needs. You will
                     find new matches, conversation requests, and messages in one condensed list here.</span>
             </div>
-            <a ng-click="self.router__stateGoResetParams('createNeed')" class="fc__empty__link">
+            <a ng-click="self.router__stateGoResetParams('createNeed')" class="fc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_plus" class="fc__empty__link__icon">
                 <span class="fc__empty__link__caption">Create a Need</span>
             </a>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login.js
@@ -11,7 +11,7 @@ import {
 import { actionCreators }  from '../actions/actions';
 
 function genLoginConf() {
-    let template = `<a class="wl__button" ng-click="self.hideLogin()">
+    let template = `<a class="wl__button clickable" ng-click="self.hideLogin()">
                         <span class="wl__button__caption">Sign in</span>
                         <img src="generated/icon-sprite.svg#ico16_arrow_up_hi" class="wl__button__carret">
                     </a>
@@ -54,7 +54,8 @@ function genLoginConf() {
                     </div>-->
                     <div class="wl__register">
                         No Account yet?
-                        <a ng-click="self.router__stateGoAbs('landingpage', {focusSignup: true})">
+                        <a ng-click="self.router__stateGoAbs('landingpage', {focusSignup: true})"
+                           class="clickable">
                             Sign up
                         </a>
                     </div>`;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches.js
@@ -31,7 +31,7 @@ let template = `
                  You cannot influence the matching process. It might take some time, or maybe there is nothing to
                     be found for you, yet. Check back later or post more needs!</span>
             </div>
-            <a ng-click="self.router__stateGoResetParams('createNeed')" class="omc__empty__link">
+            <a ng-click="self.router__stateGoResetParams('createNeed')" class="omc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_plus" class="omc__empty__link__icon">
                 <span class="omc__empty__link__caption">Create a Need</span>
             </a>
@@ -39,15 +39,18 @@ let template = `
         <div class="omc__header" ng-if="self.hasMatches">
             <div class="title">Matches to your post{{ self.isOverview? 's' : '' }}</div>
             <div class="omc__header__viewtype">
-                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.TILES})">
+                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.TILES})"
+                   class="clickable">
                     <img ng-src="{{self.layout === 'tiles' ? 'generated/icon-sprite.svg#ico-filter_tile_selected' : 'generated/icon-sprite.svg#ico-filter_tile'}}"
                      class="omc__header__viewtype__icon clickable"/>
                 </a>
-                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.GRID})">
+                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.GRID})"
+                   class="clickable">
                     <img ng-src="{{self.layout === 'grid' ? 'generated/icon-sprite.svg#ico-filter_compact_selected' : 'generated/icon-sprite.svg#ico-filter_compact'}}"
                      class="omc__header__viewtype__icon clickable"/>
                 </a>
-                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.LIST})">
+                <a ng-click="self.router__stateGoCurrent({layout: self.LAYOUT.LIST})"
+                   class="clickable">
                     <img ng-src="{{self.layout === 'list' ? 'generated/icon-sprite.svg#ico-filter_list_selected' : 'generated/icon-sprite.svg#ico-filter_list'}}"
                      class="omc__header__viewtype__icon clickable"/>
                 </a>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
@@ -20,7 +20,8 @@ const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
       <div class="or__header">
-        <a ng-click="self.router__stateGoCurrent({connectionUri: null})">
+        <a ng-click="self.router__stateGoCurrent({connectionUri: null})"
+           class="clickable">
           <img class="or__header__icon clickable" src="generated/icon-sprite.svg#ico36_close"/>
         </a>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.html
@@ -11,7 +11,7 @@
                 <span class="opc__empty__description__text">Here you will see all incoming requests for your needs, but
                     currently there are none. Check again later!</span>
             </div>
-            <a ng-click="self.router__stateGoResetParams('createNeed')" class="opc__empty__link">
+            <a ng-click="self.router__stateGoResetParams('createNeed')" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_plus" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Create a Need</span>
             </a>
@@ -24,7 +24,7 @@
         </won-connections-overview>
     </div>
     <won-open-request
-        class="oir__openrequest"
+        class="oir__openrequest"#
         ng-if="self.connection">
     </won-open-request>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.html
@@ -11,7 +11,7 @@
                 <span class="opc__empty__description__text">This is the overview of your postings. It is currently
                     empty. When you create needs, they will be listed here.</span>
             </div>
-            <a ng-click="self.router__stateGoResetParams('createNeed')" class="opc__empty__link">
+            <a ng-click="self.router__stateGoResetParams('createNeed')" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_plus" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Create a Need</span>
             </a>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
@@ -20,27 +20,32 @@ function genComponentConf() {
         <nav ng-cloak ng-show="{{true}}" class="main-tab-bar">
             <div class="mtb__inner">
                 <ul class="mtb__inner__center mtb__tabs">
-                    <li ng-class="{'mtb__tabs__selected' : self.selection == 0}">
+                    <li ng-class="{'mtb__tabs__selected' : self.selection == 0}"
+                        class="clickable">
                         <a ng-click="self.router__stateGoResetParams('feed')"
                             ng-class="{'disabled' : !self.hasPosts}">
                             Feed
                         </a>
                     </li>
-                    <li ng-class="{'mtb__tabs__selected' : self.selection == 1}">
+                    <li ng-class="{'mtb__tabs__selected' : self.selection == 1}"
+                        class="clickable">
                         <a ng-click="self.router__stateGoResetParams('overviewPosts')"
-                            ng-class="{'disabled' : !self.hasPosts}">
+                            ng-class="{'disabled' : !self.hasPosts}"
+                            class="clickable">
                             Posts
                             <span class="mtb__tabs__unread">{{ self.nrOfNeedsWithUnreadEvents }}</span>
                         </a>
                     </li>
-                    <li ng-class="{'mtb__tabs__selected' : self.selection == 2}">
+                    <li ng-class="{'mtb__tabs__selected' : self.selection == 2}"
+                        class="clickable">
                         <a ng-click="self.router__stateGoResetParams('overviewIncomingRequests')"
                             ng-class="{'disabled' : !self.hasRequests}">
                             Incoming Requests
                             <span class="mtb__tabs__unread">{{ self.nrOfUnreadIncomingRequests }}</span>
                         </a>
                     </li>
-                    <li ng-class="{'mtb__tabs__selected' : self.selection == 3}">
+                    <li ng-class="{'mtb__tabs__selected' : self.selection == 3}"
+                        class="clickable">
                         <a ng-click="self.router__stateGoResetParams('overviewMatches')"
                             ng-class="{'disabled' : !self.hasMatches}">
                             Matches

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -71,34 +71,39 @@ function genComponentConf() {
 
                     <div class ="ntb__inner__right__lower">
                         <ul class="ntb__tabs">
-                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === 'Info'}">
-                                <a ng-click="self.router__stateGoAbs('post', {postUri: self.postUri})">
+                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === 'Info'}"
+                                class="clickable">
+                                <a ng-click="self.router__stateGoAbs('post', {postUri: self.postUri})"
+                                    class="clickable">
                                     Post Info
                                 </a>
                             </li>
-                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.Connected}">
-
+                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.Connected}"
+                                class="clickable">
                                 <a ng-click="self.router__stateGoAbs('post', {connectionType: self.WON.Connected, postUri: self.postUri})"
                                     ng-class="{'disabled' : !self.hasConnected || !self.isActive}">
                                     Messages
                                     <span class="ntb__tabs__unread">{{ self.unreadMessagesCount }}</span>
                                 </a>
                             </li>
-                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.Suggested}">
+                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.Suggested}"
+                                class="clickable">
                                 <a ng-click="self.router__stateGoAbs('post', {connectionType: self.WON.Suggested, postUri: self.postUri})"
                                     ng-class="{'disabled' : !self.hasMatches || !self.isActive}">
                                     Matches
                                     <span class="ntb__tabs__unread">{{ self.unreadMatchesCount }}</span>
                                 </a>
                             </li>
-                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.RequestReceived}">
+                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.RequestReceived}"
+                                class="clickable">
                                 <a ng-click="self.router__stateGoAbs('post', {connectionType: self.WON.RequestReceived, postUri: self.postUri})"
                                     ng-class="{'disabled' : !self.hasIncomingRequests || !self.isActive}">
                                     Requests
                                     <span class="ntb__tabs__unread">{{ self.unreadIncomingRequestsCount }}</span>
                                 </a>
                             </li>
-                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.RequestSent}">
+                            <li ng-class="{'ntb__tabs__selected' : self.selectedTab === self.WON.RequestSent}"
+                                class="clickable">
                                 <a ng-click="self.router__stateGoAbs('post', {connectionType: self.WON.RequestSent, postUri: self.postUri})"
                                     ng-class="{'disabled' : !self.hasSentRequests || !self.isActive}">
                                     Sent Requests

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
@@ -14,7 +14,8 @@ const serviceDependencies = ['$scope', '$interval', '$ngRedux'];
 function genComponentConf() {
     let template = `
             <div class="pil__information">
-                <a ng-click="self.router__stateGoAbs('post', {postUri: self.needUri})">
+                <a ng-click="self.router__stateGoAbs('post', {postUri: self.needUri})"
+                    class="clickable">
                     <won-square-image  
                         ng-class="{'inactive' : !self.isActive()}" 
                         src="self.ownNeed.get('titleImgSrc')"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -21,12 +21,13 @@ const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 function genComponentConf() {
     let template = `
         <div class="pm__header">
-            <a ng-click="self.router__stateGoCurrent({connectionUri : null})">
+            <a class="clickable"
+                ng-click="self.router__stateGoCurrent({connectionUri : null})">
                 <img class="pm__header__icon clickable"
                      src="generated/icon-sprite.svg#ico36_close"/>
             </a>
-            <div class="pm__header__title"
-              ng-click="self.router__stateGoAbs('post', { postUri: self.theirNeed.get('uri')})">
+            <div class="pm__header__title clickable"
+                ng-click="self.router__stateGoAbs('post', { postUri: self.theirNeed.get('uri')})">
                 {{ self.theirNeed.get('title') }}
             </div>
         </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -38,7 +38,7 @@
                 <img src="generated/icon-sprite.svg#ico36_message_grey" class="opc__empty__description__icon">
                 <span class="opc__empty__description__text">You will be able to communicate with others once there are accepted connections. Accept a request or send requests and wait until the counterpart accepts it.</span>
             </div>
-            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.RequestReceived})" class="opc__empty__link">
+            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.RequestReceived})" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_incoming" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Accept requests</span>
             </a>
@@ -50,11 +50,11 @@
                 <img src="generated/icon-sprite.svg#ico36_incoming_grey" class="opc__empty__description__icon">
                 <span class="opc__empty__description__text">This view shows you all the incoming request for this specific need. Wait until someone tries to connect with you.</span>
             </div>
-            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Connected})" class="opc__empty__link">
+            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Connected})" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_message" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Go to conversations</span>
             </a>
-            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Suggested})" class="opc__empty__link">
+            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Suggested})" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_match" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Go to matches</span>
             </a>
@@ -66,11 +66,11 @@
                 <img src="generated/icon-sprite.svg#ico36_outgoing_grey" class="opc__empty__description__icon">
                 <span class="opc__empty__description__text">This view shows you all your sent requests for this specific need. Connect with a match to see it here.</span>
             </div>
-            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Connected})" class="opc__empty__link">
+            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Connected})" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_message" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Go to conversations</span>
             </a>
-            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Suggested})" class="opc__empty__link">
+            <a ng-click="self.router__stateGoCurrent({connectionType: self.won.Suggested})" class="opc__empty__link clickable">
                 <img src="generated/icon-sprite.svg#ico36_match" class="opc__empty__link__icon">
                 <span class="opc__empty__link__caption">Go to matches</span>
             </a>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -14,7 +14,8 @@ function genComponentConf() {
     let template = `
       <div class="sr__caption">
         <div class="sr__caption__title">Send Conversation Request</div>
-        <a ng-click="self.router__stateGoCurrent({connectionUri: null})">
+        <a ng-click="self.router__stateGoCurrent({connectionUri: null})"
+            class="clickable">
           <img
             class="sr__caption__icon clickable"
             src="generated/icon-sprite.svg#ico36_close"/>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -34,7 +34,7 @@ function genTopnavConf() {
 
             <div class="topnav__inner">
                 <div class="topnav__inner__left">
-                    <a  ng-click="self.router__stateGoResetParams(self.loggedIn ? 'feed' : 'landingpage')" class="topnav__button">
+                    <a  ng-click="self.router__stateGoResetParams(self.loggedIn ? 'feed' : 'landingpage')" class="topnav__button clickable">
                         <img src="generated/icon-sprite.svg#WON_ico_header" class="topnav__button__icon">
                         <span class="topnav__page-title topnav__button__caption">
                             Web of Needs &ndash; Beta
@@ -42,7 +42,7 @@ function genTopnavConf() {
                     </a>
                 </div>
                 <div class="topnav__inner__center">
-                    <a ng-click="self.router__stateGoResetParams('createNeed')" class="topnav__button">
+                    <a ng-click="self.router__stateGoResetParams('createNeed')" class="topnav__button clickable">
                         <img src="generated/icon-sprite.svg#ico36_plus" class="topnav__button__icon logo">
                         <span class="topnav__button__caption">New Need</span>
                     </a>


### PR DESCRIPTION
css class clickable was added to some elements (mostly in the navbars) that previously used the ui-sref as a action but now use ng-click, long story short the pointer icon was not automatically present anymore, this pr fixes this and gives a visual feedback of links/buttons that can be clicked again