### PR TITLE
fixed deletion of connections to owned needs

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -14,6 +14,10 @@ import toastReducer from './toast-reducer';
 import {
     getIn,
 } from '../utils';
+import {
+    selectNeedByConnectionUri,
+    selectAllConnections
+} from '../selectors';
 
 /*
  * this reducer attaches a 'router' object to our state that keeps the routing state.
@@ -178,10 +182,22 @@ export default reduceReducers( //passes on the state from one reducer to another
 
 window.Immutable4dbg = Immutable;
 
-//TODO: DELETE CONNECTIONS BETWEEN OWNED
 function deleteConnectionsBetweenOwnNeeds(state) {
-    //TODO: REMOVE CONNECTION
-    //remove all connections (['needs', needUri, 'connections', connectionUri, 'remoteNeedUri']) that have a remoteNeedId that is also an ownNeed (['needs', needUri, 'ownNeed'] == true)
+    const connections = selectAllConnections(state);
+
+    let connectionsToDelete = connections.filter(function(conn){
+        return !!state.getIn(["needs", conn.get("remoteNeedUri"), ownNeed]);
+    });
+
+    connectionsToDelete.map(function(conn){
+        const connUri = conn.get("uri");
+        const need = selectNeedByConnectionUri(state, connUri);
+
+        if(need){
+            const needUri = need.get("uri");
+            state = state.deleteIn(["needs", needUri, "connections", connUri]);
+        }
+    });
 
     return state;
 }


### PR DESCRIPTION
deletes present connections if they are connecting two needs that are owned by the user itself (aka do not match with own)