### PR TITLE
use UTF-8 encoding in postJson Http request for Solr matcher

### DIFF
--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/http/HttpService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/http/HttpService.java
@@ -6,55 +6,58 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.Charset;
+
 /**
  * Service to use HTTP to request resources
- *
+ * <p/>
  * User: hfriedrich
  * Date: 04.05.2015
  */
 @Component
 @Scope("prototype")
-public class HttpService
-{
-  private final Logger log = LoggerFactory.getLogger(getClass());
-  private RestTemplate restTemplate;
-  private HttpHeaders jsonHeaders;
+public class HttpService {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private RestTemplate restTemplate;
+    private HttpHeaders jsonHeaders;
 
-  public HttpService() {
+    public HttpService() {
 
-    HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-    init(factory);
-  }
-
-  public HttpService(int readTimeout, int connectionTimeout) {
-
-    HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-    factory.setReadTimeout(readTimeout);
-    factory.setConnectTimeout(connectionTimeout);
-    init(factory);
-  }
-
-  private void init(ClientHttpRequestFactory factory) {
-    restTemplate = new RestTemplate(factory);
-    jsonHeaders = new HttpHeaders();
-    jsonHeaders.add("Content-Type", "application/json");
-    jsonHeaders.add("Accept", "*/*");
-  }
-
-  public void postJsonRequest(String uri, String body) {
-
-    ResponseEntity<String> response = null;
-    log.debug("POST URI: {}", uri);
-    HttpEntity<String> jsonEntity = new HttpEntity(body, jsonHeaders);
-    response = restTemplate.exchange(uri, HttpMethod.POST, jsonEntity, String.class);
-
-    if (response.getStatusCode() != HttpStatus.OK) {
-      log.warn("HTTP POST request returned status code: {}", response.getStatusCode());
-      throw new HttpClientErrorException(response.getStatusCode());
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        init(factory);
     }
-  }
+
+    public HttpService(int readTimeout, int connectionTimeout) {
+
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setReadTimeout(readTimeout);
+        factory.setConnectTimeout(connectionTimeout);
+        init(factory);
+    }
+
+    private void init(ClientHttpRequestFactory factory) {
+        restTemplate = new RestTemplate(factory);
+        restTemplate.getMessageConverters().add(new StringHttpMessageConverter(Charset.forName("UTF-8")));
+        jsonHeaders = new HttpHeaders();
+        jsonHeaders.add("Content-Type", "application/json");
+        jsonHeaders.add("Accept", "*/*");
+    }
+
+    public void postJsonRequest(String uri, String body) {
+
+        ResponseEntity<String> response = null;
+        log.debug("POST URI: {}", uri);
+        HttpEntity<String> jsonEntity = new HttpEntity(body, jsonHeaders);
+        response = restTemplate.exchange(uri, HttpMethod.POST, jsonEntity, String.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            log.warn("HTTP POST request returned status code: {}", response.getStatusCode());
+            throw new HttpClientErrorException(response.getStatusCode());
+        }
+    }
 }


### PR DESCRIPTION
fixes #1189 
=> the json http request to the solr index didnt encode the sent data as UTF-8 => this is fixed now and special character are saved correctly in the index