### PR TITLE
Enabled gzip-compression in tomcat's server.xml.

### DIFF
--- a/webofneeds/won-docker/image/owner/ssl/server.xml
+++ b/webofneeds/won-docker/image/owner/ssl/server.xml
@@ -67,6 +67,8 @@
          Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" protocol="HTTP/1.1"
+               compression="on"
+               compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript"
                connectionTimeout="20000"
                redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->
@@ -87,6 +89,8 @@
                clientAuth="false" sslProtocol="TLS" />
     -->
 	<Connector
+    compression="on"
+    compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript"
     clientAuth="wanted" port="8443" minSpareThreads="5" maxSpareThreads="75"
     enableLookups="true" disableUploadTimeout="true"
     acceptCount="100" maxThreads="200"

--- a/webofneeds/won-docker/image/owner/ssl/server.xml
+++ b/webofneeds/won-docker/image/owner/ssl/server.xml
@@ -68,7 +68,7 @@
     -->
     <Connector port="8080" protocol="HTTP/1.1"
                compression="on"
-               compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript"
+               compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/x-font-ttf"
                connectionTimeout="20000"
                redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->
@@ -90,7 +90,7 @@
     -->
 	<Connector
     compression="on"
-    compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript"
+    compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/x-font-ttf"
     clientAuth="wanted" port="8443" minSpareThreads="5" maxSpareThreads="75"
     enableLookups="true" disableUploadTimeout="true"
     acceptCount="100" maxThreads="200"


### PR DESCRIPTION
On [integration-testing](https://satvm05.researchstudio.at/owner/#!/landingpage) you can see that in the response-header of e.g. app_jspm.bundle.js the content-encoding is "gzip". You should also be able to notice the speed with which the bundle load in comparison to [matchat](https://www.matchat.org/owner/#/landingpage) (if necessary, set throttling to "fast 3g" to have an even more pronounced contrast)

Make sure to also enable it in you local setup: <https://github.com/researchstudio-sat/webofneeds/issues/1198#issuecomment-327824502>