### PR TITLE
Feat unified js

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
@@ -9,6 +9,7 @@ import angular from 'angular';
 import 'ng-redux';
 import Immutable from 'immutable';
 import 'angular-sanitize';
+import Medium from 'medium.js';
 import {
     dispatchEvent,
     attach,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
@@ -7,6 +7,7 @@
 import angular from 'angular';
 import 'angular-sanitize';
 import Immutable from 'immutable';
+import Medium from 'medium.js';
 import {
     attach,
     delay,

--- a/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/gulpfile.js
@@ -77,11 +77,7 @@ gulp.task('copy-static-res', function(done) {
  */
 gulp.task('copy-static-scripts', function(done) {
     return gulp.src([
-        'node_modules/undo.js/undo.js',
-        'node_modules/rangy/lib/rangy-core.js',
-        'node_modules/medium.js/medium.js',
-        'scripts/jquery.10.2.js',
-        'scripts/jquery.fs.scroller.min.js',
+        //'node_modules/medium.js/medium.js',
     ])
         .pipe(gulp.dest('./generated/scripts/'))
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -21,6 +21,9 @@
     <title>Web Of Needs</title>
     <link rel="stylesheet" href="./generated/won.css" />
     <link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" />
+
+    <link rel="preload" src="./generated/app_jspm.bundle.js"> <!-- atm only chrome, opera -->
+    <link rel="prefetch" src="./generated/app_jspm.bundle.js"> <!-- fallback for other browsers -->
 </head>
 <body>
 <section ui-view></section>

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -21,33 +21,20 @@
     <title>Web Of Needs</title>
     <link rel="stylesheet" href="./generated/won.css" />
     <link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" />
-
-    <!-- <script rel="preload" src="./generated/app_jspm.bundle.js"></script> -->
-    <link rel="preload" src="./generated/app_jspm.bundle.js"> <!-- atm only chrome, opera -->
-    <link rel="prefetch" src="./generated/app_jspm.bundle.js"> <!-- fallback for other browsers -->
 </head>
 <body>
 <section ui-view></section>
-
-<!--
-due to the bundle's size it should reliably finish
-loading after the other scripts it needs as dependencies
-(and will only then be executed, thanks to the `async` property).
--->
-<!--<script async src="./generated/app_jspm.bundle.js"></script>-->
-
-<!-- TODO make sure to only show the svgs once angular has finished rendering -->
-
-<!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
-<img src="./generated/icon-sprite.svg" style="display:none">
 
 <!--
 this line loads the bundled app. comment it out if you want
 jspm to dynamically load and compile the sources at runtime.
 this makes for easier debugging, as you get seperate
 source files in the dev-tools' source explorer.-->
-
 <script src="./generated/app_jspm.bundle.js"></script>
+
+<!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
+<img src="./generated/icon-sprite.svg" style="display:none">
+
 </body>
 </html>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -42,16 +42,6 @@ loading after the other scripts it needs as dependencies
 <img src="./generated/icon-sprite.svg" style="display:none">
 
 <!--
-these static imports are necessary due to problems with bundling
-medium.js, as documented here:
-https://github.com/researchstudio-sat/webofneeds/issues/664
--->
-<!-- each of these has to be copied here manually by the gulp build task -->
-<script src="./generated/scripts/undo.js"></script>
-<script src="./generated/scripts/rangy-core.js"></script>
-<script src="./generated/scripts/medium.js"></script>
-
-<!--
 this line loads the bundled app. comment it out if you want
 jspm to dynamically load and compile the sources at runtime.
 this makes for easier debugging, as you get seperate

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -22,11 +22,19 @@
     <link rel="stylesheet" href="./generated/won.css" />
     <link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" />
 
+    <!-- <script rel="preload" src="./generated/app_jspm.bundle.js"></script> -->
     <link rel="preload" src="./generated/app_jspm.bundle.js"> <!-- atm only chrome, opera -->
     <link rel="prefetch" src="./generated/app_jspm.bundle.js"> <!-- fallback for other browsers -->
 </head>
 <body>
 <section ui-view></section>
+
+<!--
+due to the bundle's size it should reliably finish
+loading after the other scripts it needs as dependencies
+(and will only then be executed, thanks to the `async` property).
+-->
+<!--<script async src="./generated/app_jspm.bundle.js"></script>-->
 
 <!-- TODO make sure to only show the svgs once angular has finished rendering -->
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -43,9 +43,6 @@ https://github.com/researchstudio-sat/webofneeds/issues/664
 <script src="./generated/scripts/rangy-core.js"></script>
 <script src="./generated/scripts/medium.js"></script>
 
-<!--<script src="./generated/scripts/jquery.10.2.js"></script>-->
-<!--<script src="./generated/scripts/jquery.fs.scroller.min.js"></script>-->
-
 <!--
 this line loads the bundled app. comment it out if you want
 jspm to dynamically load and compile the sources at runtime.

--- a/webofneeds/won-owner-webapp/src/main/webapp/jspm_config.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/jspm_config.js
@@ -33,6 +33,7 @@ System.config({
     "immutable": "npm:immutable@3.7.5",
     "jsonld": "npm:jsonld@0.4.12",
     "leaflet": "npm:leaflet@0.7.7",
+    "medium.js": "npm:medium.js@1.0.1",
     "ng-redux": "npm:ng-redux@3.4.1",
     "rdfstore-js": "scripts/rdfstore-js/rdf_store.js",
     "reduce-reducers": "npm:reduce-reducers@0.1.1",
@@ -42,6 +43,7 @@ System.config({
     "redux-ui-router": "npm:redux-ui-router@0.7.2",
     "reselect": "npm:reselect@2.0.2",
     "sockjs": "bower:sockjs@0.3.4",
+    "undo.js": "npm:undo.js@0.2.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.4.1"
     },
@@ -187,6 +189,10 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
+    "npm:medium.js@1.0.1": {
+      "rangy": "npm:rangy@1.3.0",
+      "undo.js": "npm:undo.js@0.2.0"
+    },
     "npm:ng-redux@3.4.1": {
       "invariant": "npm:invariant@2.2.2",
       "lodash.assign": "npm:lodash.assign@3.2.0",
@@ -242,6 +248,9 @@ System.config({
     },
     "npm:string_decoder@0.10.31": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+    },
+    "npm:undo.js@0.2.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -2,9 +2,6 @@
   "name": "won-owner-webapp",
   "version": "0.2.0",
   "dependencies": {
-    "medium.js": "github:jakiestfu/Medium.js",
-    "rangy": "1.3.0",
-    "undo.js": "0.2.0"
   },
   "scripts": {
     "postinstall": "npm rebuild node-sass && jspm registry create bower jspm-bower-endpoint -y && jspm install",
@@ -38,14 +35,17 @@
       "immutable": "npm:immutable@3.7.5",
       "jsonld": "npm:jsonld@0.4.12",
       "leaflet": "npm:leaflet@0.7.7",
+      "medium.js": "npm:medium.js@1.0.1",
       "ng-redux": "npm:ng-redux@x3.4.1",
+      "rangy": "npm:rangy@1.3.0",
       "reduce-reducers": "npm:reduce-reducers@0.1.1",
       "redux": "npm:redux@3.7.2",
       "redux-immutablejs": "npm:redux-immutablejs@0.0.8",
       "redux-thunk": "npm:redux-thunk@1.0.0",
       "redux-ui-router": "npm:redux-ui-router@0.7.2",
       "reselect": "npm:reselect@2.0.2",
-      "sockjs": "bower:sockjs@0.3.4"
+      "sockjs": "bower:sockjs@0.3.4",
+      "undo.js": "npm:undo.js@0.2.0"
     },
     "devDependencies": {
       "babel": "npm:babel-core@5.8.35",


### PR DESCRIPTION
Medium.js is capable of being bundled (without extra config) now! This allows us to load bundle directly after the html finishes loading/parsing.

**before:**

![loading_landingpage_-_good_3g_-_with_gzip](https://user-images.githubusercontent.com/1730492/30169001-61dd35f0-93eb-11e7-9cf7-27773ef40614.PNG)

(see [here](https://github.com/researchstudio-sat/webofneeds/issues/546#issuecomment-327556409) for explanation of the experiment))

**after:**

![loading_landingpage_-_good_3g_-_with_gzip_and_bundled_mediumjs](https://user-images.githubusercontent.com/1730492/30214712-b11234e6-94ad-11e7-8339-807e93ada36a.PNG)

The **1 second spent queuing** for the bundle-download is gone. For some reason the bundle download is faster now but the sign-in request takes a lot longer.
