### PR TITLE
Refac  default js extension

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -2,30 +2,30 @@
  * Created by ksinger on 19.02.2016.
  */
 
-import  won from '../won-es6';
+import  won from '../won-es6.js';
 import Immutable from 'immutable';
-import { actionTypes, actionCreators } from './actions';
-import { fetchOwnedData } from '../won-message-utils';
+import { actionTypes, actionCreators } from './actions.js';
+import { fetchOwnedData } from '../won-message-utils.js';
 import {
     registerAccount,
     login,
     privateId2Credentials,
     logout,
     parseCredentials,
-} from '../won-utils';
+} from '../won-utils.js';
 import {
     stateGoCurrent,
 
-} from './cstm-router-actions';
+} from './cstm-router-actions.js';
 import {
     resetParams,
     checkAccessToCurrentRoute,
-} from '../configRouting';
+} from '../configRouting.js';
 
 import {
     checkHttpStatus,
     getIn,
-} from '../utils';
+} from '../utils.js';
 
 /**
  * @param privateId

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/action-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/action-utils.js
@@ -2,9 +2,9 @@
  * Created by ksinger on 26.11.2015.
  */
 
-import { reduceAndMapTreeKeys, flattenTree, tree2constants } from '../utils';
+import { reduceAndMapTreeKeys, flattenTree, tree2constants } from '../utils.js';
 
-import won from '../won-es6';
+import won from '../won-es6.js';
 
 export function hierarchy2Creators(actionHierarchy) {
     const actionTypes = tree2constants(actionHierarchy);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -35,7 +35,7 @@
  * in the reducers.
  */
 
-import  won from '../won-es6';
+import  won from '../won-es6.js';
 import Immutable from 'immutable';
 
 // <utils>
@@ -43,16 +43,16 @@ import Immutable from 'immutable';
 import {
     tree2constants,
     entries,
-} from '../utils';
-import { hierarchy2Creators } from './action-utils';
+} from '../utils.js';
+import { hierarchy2Creators } from './action-utils.js';
 import {
     buildCloseNeedMessage,
     buildOpenNeedMessage
-} from '../won-message-utils';
+} from '../won-message-utils.js';
 
 import {
     needCreate,
-} from './create-need-action';
+} from './create-need-action.js';
 
 import {
     stateBack,
@@ -61,7 +61,7 @@ import {
     stateGoDefault,
     stateGoKeepParams,
     stateGoResetParams,
-} from './cstm-router-actions';
+} from './cstm-router-actions.js';
 
 // </utils>
 
@@ -71,16 +71,16 @@ import {
     accountLogin,
     accountLogout,
     accountRegister,
-} from './account-actions';
+} from './account-actions.js';
 
-import * as cnct from './connections-actions';
-import * as messages from './messages-actions';
+import * as cnct from './connections-actions.js';
+import * as messages from './messages-actions.js';
 
 import {
     configInit,
     pageLoadAction
-} from './load-action';
-import { matchesLoad } from './matches-actions';
+} from './load-action.js';
+import { matchesLoad } from './matches-actions.js';
 import { stateGo, stateReload, stateTransitionTo } from 'redux-ui-router';
 
 // </action-creators>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -2,7 +2,7 @@
  * Created by ksinger on 19.02.2016.
  */
 
-import  won from '../won-es6';
+import  won from '../won-es6.js';
 import Immutable from 'immutable';
 import jsonld from 'jsonld'; //import *after* the rdfstore to shadow its custom jsonld
 
@@ -10,7 +10,7 @@ import {
     selectAllByConnectionUri,
     selectOpenConnectionUri,
     selectRemoteEvents,
-} from '../selectors';
+} from '../selectors.js';
 
 import {
     is,
@@ -18,16 +18,16 @@ import {
     msStringToDate,
     getIn,
     jsonld2simpleFormat,
-} from '../utils';
+} from '../utils.js';
 
 import {
    makeParams,
-} from '../configRouting';
+} from '../configRouting.js';
 
 import {
     actionTypes,
     actionCreators,
-} from './actions';
+} from './actions.js';
 
 import {
     buildOpenMessage,
@@ -36,7 +36,7 @@ import {
     buildRateMessage,
     buildConnectMessage,
     getEventsFromMessage,
-} from '../won-message-utils';
+} from '../won-message-utils.js';
 
 export function connectionsChatMessage(chatMessage, connectionUri) {
    return dispatch => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -6,26 +6,26 @@ import Immutable from 'immutable';
 
 import {
     buildCreateMessage,
-} from '../won-message-utils';
+} from '../won-message-utils.js';
 
 import {
     actionCreators,
     actionTypes,
-} from './actions';
+} from './actions.js';
 
 import {
    accountRegister,
-} from './account-actions';
+} from './account-actions.js';
 
 import {
     registerAccount,
     generatePrivateId,
     login,
-} from '../won-utils';
+} from '../won-utils.js';
 
 import {
     delay,
-} from '../utils';
+} from '../utils.js';
 
 export function needCreate(draft, nodeUri) {
     return (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/cstm-router-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/cstm-router-actions.js
@@ -6,12 +6,12 @@ import Immutable from 'immutable';
 
 import {
     getIn,
-} from '../utils';
+} from '../utils.js';
 
 import {
     actionCreators,
     actionTypes
-} from './actions';
+} from './actions.js';
 
 import {
     makeParams,
@@ -19,7 +19,7 @@ import {
     resetParamsImm,
     constantParams,
     addConstParams,
-} from '../configRouting';
+} from '../configRouting.js';
 
 /**
  * Action-Creator that goes back in the browser history

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -2,40 +2,40 @@
  * Created by ksinger on 18.02.2016.
  */
 
-import  won from '../won-es6';
+import  won from '../won-es6.js';
 import Immutable from 'immutable';
-import { actionTypes, actionCreators } from './actions';
-import { selectOpenPostUri } from '../selectors';
+import { actionTypes, actionCreators } from './actions.js';
+import { selectOpenPostUri } from '../selectors.js';
 
 import {
     accessControl,
     checkAccessToCurrentRoute,
-} from '../configRouting';
+} from '../configRouting.js';
 
 import {
     stateGoCurrent,
-} from './cstm-router-actions';
+} from './cstm-router-actions.js';
 
 import {
     checkLoginStatus,
     privateId2Credentials,
     login,
     logout,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import config from '../config';
+import config from '../config.js';
 
 import {
     checkHttpStatus,
     getParameterByName,
-} from '../utils';
+} from '../utils.js';
 
 import {
     fetchOwnedData,
     fetchDataForNonOwnedNeedOnly,
     emptyDataset,
     wellFormedPayload,
-} from '../won-message-utils';
+} from '../won-message-utils.js';
 
 
 export const pageLoadAction = () => (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/matches-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/matches-actions.js
@@ -2,8 +2,8 @@
  * Created by ksinger on 19.02.2016.
  */
 
-import  won from '../won-es6';
-import { actionCreators, actionTypes } from './actions';
+import  won from '../won-es6.js';
+import { actionCreators, actionTypes } from './actions.js';
 
 export function matchesLoad(data) {
     return (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -3,9 +3,9 @@
  */
 
 
-import  won from '../won-es6';
-import { actionTypes, actionCreators, getConnectionRelatedData } from './actions';
-import { setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils';
+import  won from '../won-es6.js';
+import { actionTypes, actionCreators, getConnectionRelatedData } from './actions.js';
+import { setCommStateFromResponseForLocalNeedMessage } from '../won-message-utils.js';
 
 import Immutable from 'immutable';
 
@@ -13,16 +13,16 @@ import {
     clone,
     jsonld2simpleFormat,
     getIn,
-} from '../utils';
+} from '../utils.js';
 
 import {
     fetchDataForOwnedNeeds
-} from '../won-message-utils';
+} from '../won-message-utils.js';
 
 import {
     makeParams,
     resetParams,
-} from '../configRouting';
+} from '../configRouting.js';
 
 export function successfulCloseNeed(event) {
     return (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -24,8 +24,6 @@ import {
     delay,
 } from './utils.js';
 
-import foobar from './deletme.js'
-
 //---------- Config -----------
 import { configRouting, runAccessControl } from './configRouting.js';
 import configRedux from './configRedux.js';

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -22,36 +22,38 @@ import {
     hyphen2Camel,
     firstToLowerCase,
     delay,
-} from './utils';
+} from './utils.js';
+
+import foobar from './deletme.js'
 
 //---------- Config -----------
-import { configRouting, runAccessControl } from './configRouting';
-import configRedux from './configRedux';
+import { configRouting, runAccessControl } from './configRouting.js';
+import configRedux from './configRedux.js';
 
 //--------- Actions -----------
-import { actionCreators }  from './actions/actions';
+import { actionCreators }  from './actions/actions.js';
 
 //-------- Components ---------
-import topnav from './components/topnav';
-import createNeedComponent from './components/create-need/create-need';
-import overviewIncomingRequestsComponent from './components/overview-incoming-requests/overview-incoming-requests';
-import overviewSentRequestsComponent from './components/overview-sent-requests/overview-sent-requests';
-import postComponent from './components/post/post';
-import landingPageComponent from './components/landingpage/landingpage';
-import overviewPostsComponent from './components/overview-posts/overview-posts';
-import feedComponent from './components/feed/feed';
-import overviewMatchesComponent from './components/overview-matches/overview-matches';
-import aboutComponent from './components/about/about';
-import signupComponent from './components/signup/signup';
+import topnav from './components/topnav.js';
+import createNeedComponent from './components/create-need/create-need.js';
+import overviewIncomingRequestsComponent from './components/overview-incoming-requests/overview-incoming-requests.js';
+import overviewSentRequestsComponent from './components/overview-sent-requests/overview-sent-requests.js';
+import postComponent from './components/post/post.js';
+import landingPageComponent from './components/landingpage/landingpage.js';
+import overviewPostsComponent from './components/overview-posts/overview-posts.js';
+import feedComponent from './components/feed/feed.js';
+import overviewMatchesComponent from './components/overview-matches/overview-matches.js';
+import aboutComponent from './components/about/about.js';
+import signupComponent from './components/signup/signup.js';
 
 
 //settings
-import settingsTitleBarModule from './components/settings-title-bar';
-import avatarSettingsModule from './components/settings/avatar-settings';
-import generalSettingsModule from './components/settings/general-settings';
+import settingsTitleBarModule from './components/settings-title-bar.js';
+import avatarSettingsModule from './components/settings/avatar-settings.js';
+import generalSettingsModule from './components/settings/general-settings.js';
 
 //won import (used so you can access the debugmode variable without reloading the page)
-import won from './service/won';
+import won from './service/won.js';
 window.won = won;
 
 
@@ -59,7 +61,7 @@ window.won = won;
  * approach to asynchronity (Remove it or the thunk-based
  * solution afterwards)
  */
-import { runMessagingAgent } from './messaging-agent';
+import { runMessagingAgent } from './messaging-agent.js';
 
 let app = angular.module('won.owner', [
     /* to enable legacy $stateChange* events in ui-router (see

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
@@ -1,16 +1,16 @@
 ;
 
 import angular from 'angular';
-import topNavModule from '../topnav';
-import overviewTitleBarModule from '../visitor-title-bar';
-import compareToModule from '../../directives/compareTo';
-import accordionModule from '../accordion';
-import flexGridModule from '../flexgrid';
-import config from '../../config';
+import topNavModule from '../topnav.js';
+import overviewTitleBarModule from '../visitor-title-bar.js';
+import compareToModule from '../../directives/compareTo.js';
+import accordionModule from '../accordion.js';
+import flexGridModule from '../flexgrid.js';
+import config from '../../config.js';
 import {
     attach,
-} from '../../utils';
-import { actionCreators }  from '../../actions/actions';
+} from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', /*'$routeParams' /*injections as strings here*/];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -3,17 +3,17 @@
  */
 ;
 import angular from 'angular';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import dropdownModule from './covering-dropdown';
-import loginFormModule from './login-form';
-import loggedInMenuModule from './logged-in-menu';
+import dropdownModule from './covering-dropdown.js';
+import loginFormModule from './login-form.js';
+import loggedInMenuModule from './logged-in-menu.js';
 
-import * as srefUtils from '../sref-utils';
+import * as srefUtils from '../sref-utils.js';
 
 function genLogoutConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
@@ -4,7 +4,7 @@
 
 ;
 
-// import Medium from '../mediumjs-es6';
+// import Medium from '../mediumjs-es6.js';
 import angular from 'angular';
 import 'ng-redux';
 import Immutable from 'immutable';
@@ -14,8 +14,8 @@ import {
     attach,
     delay,
     is,
-} from '../utils';
-import { actionCreators }  from '../actions/actions';
+} from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
@@ -2,23 +2,23 @@
  * Created by ksinger on 10.04.2017.
  */
 
-import won from '../won-es6';
+import won from '../won-es6.js';
 import angular from 'angular';
 import {
     labels,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import { attach } from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     selectOpenConnectionUri,
     selectNeedByConnectionUri,
     selectAllTheirNeeds
-} from '../selectors';
+} from '../selectors.js';
 
-import postHeaderModule from './post-header';
+import postHeaderModule from './post-header.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection.js
@@ -8,19 +8,19 @@ import {
     getIn,
     attach,
     decodeUriComponentProperly,
-} from '../utils';
+} from '../utils.js';
 import {
     labels,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     selectOpenPostUri,
-} from '../selectors';
+} from '../selectors.js';
 
-import connectionSelectionItemModule from './connection-selection-item';
+import connectionSelectionItemModule from './connection-selection-item.js';
 
 
 const serviceDependencies = ['$ngRedux', '$scope'];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-map.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-map.js
@@ -4,22 +4,22 @@
 import angular from 'angular';
 import inviewModule from 'angular-inview';
 
-import { attach, decodeUriComponentProperly} from '../utils';
-import won from '../won-es6';
+import { attach, decodeUriComponentProperly} from '../utils.js';
+import won from '../won-es6.js';
 import {
     selectOpenPostUri,
     displayingOverview,
     selectAllConnections,
-} from '../selectors';
-import { actionCreators }  from '../actions/actions';
-import L from '../leaflet-bundleable';
+} from '../selectors.js';
+import { actionCreators }  from '../actions/actions.js';
+import L from '../leaflet-bundleable.js';
 import {
     initLeaflet,
-} from '../won-utils';
+} from '../won-utils.js';
 
 import {
     DomCache,
-} from '../cstm-ng-utils';
+} from '../cstm-ng-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -5,27 +5,27 @@
  * Created by ksinger on 12.04.2017.
  */
 
-import won from '../won-es6';
+import won from '../won-es6.js';
 import angular from 'angular';
-import squareImageModule from './square-image';
-import connectionSelectionModule from './connection-selection';
-import postHeaderModule from './post-header';
+import squareImageModule from './square-image.js';
+import connectionSelectionModule from './connection-selection.js';
+import postHeaderModule from './post-header.js';
 
 import {
     labels,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 
 import { attach } from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 
 import {
     selectAllOwnNeeds,
     selectRouterParams,
     selectNeedByConnectionUri,
-} from '../selectors';
+} from '../selectors.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/covering-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/covering-dropdown.js
@@ -5,12 +5,12 @@
 
 import angular from 'angular';
 import Immutable from 'immutable';
-import won from '../won-es6';
-import { actionCreators }  from '../actions/actions';
-import { attach } from '../utils';
+import won from '../won-es6.js';
+import { actionCreators }  from '../actions/actions.js';
+import { attach } from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const serviceDependencies = ['$scope', '$ngRedux'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-need/create-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-need/create-need.js
@@ -5,14 +5,14 @@
 
 import angular from 'angular'
 import 'ng-redux';
-import createPostModule from '../create-post';
+import createPostModule from '../create-post.js';
 
 import {
     attach,
     clone,
-} from '../../utils';
-import { actionCreators }  from '../../actions/actions';
-import won from '../../won-es6';
+} from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
+import won from '../../won-es6.js';
 
 //TODO can't inject $scope with the angular2-router, preventing redux-cleanup
 const serviceDependencies = ['$ngRedux', '$scope'/*'$routeParams' /*injections as strings here*/];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -5,22 +5,22 @@
 
 import angular from 'angular'
 import 'ng-redux';
-import createNeedTitleBarModule from './create-need-title-bar';
-import posttypeSelectModule from './posttype-select';
-import labelledHrModule from './labelled-hr';
-import needTextfieldModule from './need-textfield';
-import imageDropzoneModule from './image-dropzone';
-import locationPickerModule from './location-picker';
+import createNeedTitleBarModule from './create-need-title-bar.js';
+import posttypeSelectModule from './posttype-select.js';
+import labelledHrModule from './labelled-hr.js';
+import needTextfieldModule from './need-textfield.js';
+import imageDropzoneModule from './image-dropzone.js';
+import locationPickerModule from './location-picker.js';
 import {
     attach,
     reverseSearchNominatim,
     nominatim2draftLocation,
-} from '../utils';
-import { actionCreators }  from '../actions/actions';
-import won from '../won-es6';
+} from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
+import won from '../won-es6.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const postTypeTexts = [
     {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
@@ -5,23 +5,23 @@
 
 
 import angular from 'angular';
-import squareImageModule from '../components/square-image';
-import { actionCreators }  from '../actions/actions';
+import squareImageModule from '../components/square-image.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     attach,
-} from '../utils';
+} from '../utils.js';
 import {
     labels,
     relativeTime,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     selectLastUpdateTime,
     selectAllTheirNeeds,
-} from '../selectors';
+} from '../selectors.js';
 
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const serviceDependencies = ['$scope', '$interval', '$ngRedux'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -1,23 +1,23 @@
 import angular from 'angular';
 import Immutable from 'immutable';
-import squareImageModule from '../components/square-image';
-import won from '../won-es6';
-import { actionCreators }  from '../actions/actions';
-import { attach } from '../utils';
+import squareImageModule from '../components/square-image.js';
+import won from '../won-es6.js';
+import { actionCreators }  from '../actions/actions.js';
+import { attach } from '../utils.js';
 import {
     labels,
     relativeTime,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     selectLastUpdateTime,
-} from '../selectors';
+} from '../selectors.js';
 import {
    connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import * as srefUtils from '../sref-utils';
+import * as srefUtils from '../sref-utils.js';
 
-import feedItemLineModule from './feed-item-line';
+import feedItemLineModule from './feed-item-line.js';
 
 const serviceDependencies = ['$scope', '$interval', '$ngRedux', '$state'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
@@ -1,18 +1,18 @@
 import angular from 'angular';
-import overviewTitleBarModule from '../overview-title-bar';
-import feedItemModule from '../feed-item'
-import { actionCreators }  from '../../actions/actions';
-import { attach } from '../../utils';
+import overviewTitleBarModule from '../overview-title-bar.js';
+import feedItemModule from '../feed-item.js'
+import { actionCreators }  from '../../actions/actions.js';
+import { attach } from '../../utils.js';
 
 import {
     resetParams,
-} from '../../configRouting';
+} from '../../configRouting.js';
 
 import {
     selectAllOwnNeeds,
-} from '../../selectors';
+} from '../../selectors.js';
 
-import * as srefUtils from '../../sref-utils';
+import * as srefUtils from '../../sref-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$state'/*'$routeParams' /*injections as strings here*/];
 class FeedController {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feedback-grid.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feedback-grid.js
@@ -2,11 +2,11 @@
 
 import angular from 'angular';
 import 'ng-redux';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/flexgrid.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/flexgrid.js
@@ -1,7 +1,7 @@
 ;
 
 import angular from 'angular';
-import labelledHrModule from 'app/components/labelled-hr';
+import labelledHrModule from './labelled-hr.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/image-dropzone.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/image-dropzone.js
@@ -5,8 +5,8 @@
 
 import angular from 'angular';
 import 'angular-sanitize';
-import enterModule from '../directives/enter';
-import { dispatchEvent, attach, readAsDataURL } from '../utils';
+import enterModule from '../directives/enter.js';
+import { dispatchEvent, attach, readAsDataURL } from '../utils.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/landingpage/landingpage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/landingpage/landingpage.js
@@ -1,14 +1,14 @@
 ;
 
 import angular from 'angular';
-import topNavModule from '../topnav';
-import createPostModule from '../create-post';
+import topNavModule from '../topnav.js';
+import createPostModule from '../create-post.js';
 import {
     attach,
-} from '../../utils';
-import { actionCreators }  from '../../actions/actions';
+} from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
 
-import * as srefUtils from '../../sref-utils';
+import * as srefUtils from '../../sref-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$state' /*'$routeParams' /*injections as strings here*/];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/location-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/location-picker.js
@@ -4,22 +4,22 @@
 
 import angular from 'angular';
 import Immutable from 'immutable'; // also exports itself as (window).L
-import L from '../leaflet-bundleable';
+import L from '../leaflet-bundleable.js';
 import {
     attach,
     searchNominatim,
     reverseSearchNominatim,
     nominatim2draftLocation,
 } from '../utils.js';
-import { actionCreators }  from '../actions/actions';
+import { actionCreators }  from '../actions/actions.js';
 import {
     doneTypingBufferNg,
     DomCache,
-} from '../cstm-ng-utils'
+} from '../cstm-ng-utils.js'
 
 import {
     initLeaflet,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const serviceDependencies = ['$scope', '$element', '$sce'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
@@ -3,13 +3,13 @@
  */
 ;
 import angular from 'angular';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import * as srefUtils from '../sref-utils';
+import * as srefUtils from '../sref-utils.js';
 
 function genComponentConf() {
 let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
@@ -7,13 +7,13 @@ import {
     attach,
     delay,
     dispatchEvent,
-} from '../utils';
-import { actionCreators }  from '../actions/actions';
+} from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import * as srefUtils from '../sref-utils';
+import * as srefUtils from '../sref-utils.js';
 
 function genLoginConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
@@ -1,25 +1,25 @@
 ;
 
 import angular from 'angular';
-import squareImageModule from './square-image';
-import needMapModule from './need-map';
-import extendedGalleryModule from './extended-gallery';
-import feedbackGridModule from './feedback-grid';
-import postHeaderModule from './post-header';
-import postContentModule from './post-content';
+import squareImageModule from './square-image.js';
+import needMapModule from './need-map.js';
+import extendedGalleryModule from './extended-gallery.js';
+import feedbackGridModule from './feedback-grid.js';
+import postHeaderModule from './post-header.js';
+import postContentModule from './post-content.js';
 
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     labels,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 import {
     selectNeedByConnectionUri
-} from '../selectors';
+} from '../selectors.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$interval'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-grid-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-grid-item.js
@@ -1,19 +1,19 @@
 ;
 
 import angular from 'angular';
-import squareImageModule from './square-image';
-import feedbackGridModule from './feedback-grid';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
-import { labels, } from '../won-label-utils';
+import squareImageModule from './square-image.js';
+import feedbackGridModule from './feedback-grid.js';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
+import { labels, } from '../won-label-utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 import {
     selectNeedByConnectionUri,
-} from '../selectors';
-import postHeaderModule from './post-header';
-import postContentModule from './post-content';
+} from '../selectors.js';
+import postHeaderModule from './post-header.js';
+import postContentModule from './post-content.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$interval'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches.js
@@ -1,32 +1,32 @@
 ;
 
 import Immutable from 'immutable';
-import won from '../won-es6';
+import won from '../won-es6.js';
 import angular from 'angular';
-import overviewTitleBarModule from './overview-title-bar';
-import matchesFlowItemModule from './matches-flow-item';
-import matchesGridItemModule from './matches-grid-item';
-import connectionsMapModule from './connections-map';
-import sendRequestModule from './send-request';
-import connectionsOverviewModule from './connections-overview';
-import connectionSelectionModule from './connection-selection';
+import overviewTitleBarModule from './overview-title-bar.js';
+import matchesFlowItemModule from './matches-flow-item.js';
+import matchesGridItemModule from './matches-grid-item.js';
+import connectionsMapModule from './connections-map.js';
+import sendRequestModule from './send-request.js';
+import connectionsOverviewModule from './connections-overview.js';
+import connectionSelectionModule from './connection-selection.js';
 
 import {
     attach,
     decodeUriComponentProperly,
     getIn,
-} from '../utils';
+} from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { labels } from '../won-label-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { labels } from '../won-label-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     selectOpenPostUri,
     displayingOverview,
     selectAllConnections,
     selectNeedByConnectionUri,
-} from '../selectors';
+} from '../selectors.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-map.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-map.js
@@ -4,18 +4,18 @@
 import angular from 'angular';
 import inviewModule from 'angular-inview';
 
-import { attach } from '../utils';
-import won from '../won-es6';
-import { actionCreators }  from '../actions/actions';
-import L from '../leaflet-bundleable';
+import { attach } from '../utils.js';
+import won from '../won-es6.js';
+import { actionCreators }  from '../actions/actions.js';
+import L from '../leaflet-bundleable.js';
 import {
     initLeaflet,
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 import {
     DomCache,
-} from '../cstm-ng-utils';
+} from '../cstm-ng-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-textfield.js
@@ -11,7 +11,7 @@ import {
     attach,
     delay,
     dispatchEvent,
-} from '../utils';
+} from '../utils.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/open-request.js
@@ -3,21 +3,21 @@
 import angular from 'angular';
 import {
     labels,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     attach,
 } from '../utils.js'
 import {
     connect2Redux,
-} from '../won-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     selectOpenConnectionUri,
     selectNeedByConnectionUri,
-} from '../selectors';
+} from '../selectors.js';
 
-import postContentModule from './post-content';
-import postHeaderModule from './post-header';
+import postContentModule from './post-content.js';
+import postHeaderModule from './post-header.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
@@ -1,21 +1,21 @@
 ;
 
 import angular from 'angular';
-import overviewTitleBarModule from '../overview-title-bar';
-import openRequestModule from '../open-request';
-import connectionsOverviewModule from '../connections-overview';
+import overviewTitleBarModule from '../overview-title-bar.js';
+import openRequestModule from '../open-request.js';
+import connectionsOverviewModule from '../connections-overview.js';
 import {
     attach,
     getIn,
-} from '../../utils';
-import { actionCreators }  from '../../actions/actions';
+} from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
 import {
     selectNeedByConnectionUri,
     selectAllConnections
-} from '../../selectors';
+} from '../../selectors.js';
 import {
     resetParams,
-} from '../../configRouting';
+} from '../../configRouting.js';
 
 
 const serviceDependencies = ['$ngRedux', '$scope'];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-matches/overview-matches.js
@@ -2,12 +2,12 @@
 
 import angular from 'angular';
 
-import overviewTitleBarModule from '../overview-title-bar';
-import matchesModule from  '../matches';
-import topnavModule from '../topnav';
+import overviewTitleBarModule from '../overview-title-bar.js';
+import matchesModule from  '../matches.js';
+import topnavModule from '../topnav.js';
 
-import { attach } from '../../utils';
-import { actionCreators }  from '../../actions/actions';
+import { attach } from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 class OverviewMatchesController {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-posts/overview-posts.js
@@ -1,20 +1,20 @@
 ;
 import Immutable from 'immutable';
 import angular from 'angular';
-import overviewTitleBarModule from '../overview-title-bar';
-import postItemLineModule from '../post-item-line';
-import { actionCreators }  from '../../actions/actions';
+import overviewTitleBarModule from '../overview-title-bar.js';
+import postItemLineModule from '../post-item-line.js';
+import { actionCreators }  from '../../actions/actions.js';
 import {
     attach,
 } from '../../utils.js';
 import {
     selectAllOwnNeeds,
-} from '../../selectors';
+} from '../../selectors.js';
 
 import {
     resetParams,
-} from '../../configRouting';
-import won from '../../won-es6';
+} from '../../configRouting.js';
+import won from '../../won-es6.js';
 
 const ZERO_UNSEEN = Object.freeze({
     matches: 0,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-sent-requests/overview-sent-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-sent-requests/overview-sent-requests.js
@@ -4,15 +4,15 @@
 ;
 
 import angular from 'angular';
-import overviewTitleBarModule from '../overview-title-bar';
-import openRequestModule from '../open-request';
+import overviewTitleBarModule from '../overview-title-bar.js';
+import openRequestModule from '../open-request.js';
 import {
     attach,
     getIn,
-} from '../../utils';
-import { actionCreators }  from '../../actions/actions';
+} from '../../utils.js';
+import { actionCreators }  from '../../actions/actions.js';
 
-import connectionsOverviewModule from  '../connections-overview';
+import connectionsOverviewModule from  '../connections-overview.js';
 
 
 const serviceDependencies = ['$ngRedux', '$scope'];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
@@ -4,17 +4,17 @@
 ;
 
 import angular from 'angular';
-import { attach } from '../utils';
+import { attach } from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     selectAllOwnNeeds,
     selectAllConnections,
     selectAllMessages,
-} from '../selectors';
-import won from '../won-es6';
+} from '../selectors.js';
+import won from '../won-es6.js';
 
 
 const serviceDependencies = ['$ngRedux', '$scope'];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -1,22 +1,22 @@
 ;
 
 import angular from 'angular';
-import squareImageModule from '../components/square-image';
+import squareImageModule from '../components/square-image.js';
 import {
     attach,
     decodeUriComponentProperly,
     getIn,
-} from '../utils';
+} from '../utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import won from '../won-es6';
-import { labels } from '../won-label-utils';
+} from '../won-utils.js';
+import won from '../won-es6.js';
+import { labels } from '../won-label-utils.js';
 import {
     selectOpenPostUri,
     selectAllMessagesByNeedUri,
-} from '../selectors';
-import { actionCreators }  from '../actions/actions';
+} from '../selectors.js';
+import { actionCreators }  from '../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -6,14 +6,14 @@
 
 import angular from 'angular';
 import 'ng-redux';
-import extendedGalleryModule from '../components/extended-gallery';
-import { actionCreators }  from '../actions/actions';
+import extendedGalleryModule from '../components/extended-gallery.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     attach,
 } from '../utils.js'
 import {
     connect2Redux,
-} from '../won-utils'
+} from '../won-utils.js'
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -4,21 +4,21 @@
  */
 import angular from 'angular';
 import 'ng-redux';
-import squareImageModule from './square-image';
-import { actionCreators }  from '../actions/actions';
+import squareImageModule from './square-image.js';
+import { actionCreators }  from '../actions/actions.js';
 import {
     labels,
     relativeTime
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     attach,
 } from '../utils.js'
 import {
     connect2Redux,
-} from '../won-utils'
+} from '../won-utils.js'
 import {
     selectLastUpdateTime,
-} from '../selectors';
+} from '../selectors.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -6,21 +6,21 @@
 ;
 
 import angular from 'angular';
-import needMapModule from './need-map';
+import needMapModule from './need-map.js';
 
-import { attach, } from '../utils';
-import won from '../won-es6';
+import { attach, } from '../utils.js';
+import won from '../won-es6.js';
 import {
     relativeTime,
-} from '../won-label-utils';
+} from '../won-label-utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 import {
     selectOpenPostUri,
     selectLastUpdateTime,
-} from '../selectors';
-import { actionCreators }  from '../actions/actions';
+} from '../selectors.js';
+import { actionCreators }  from '../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
@@ -1,17 +1,17 @@
 ;
 
 import angular from 'angular';
-import squareImageModule from '../components/square-image';
-import won from '../won-es6';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
-import { labels, relativeTime, } from '../won-label-utils';
+import squareImageModule from '../components/square-image.js';
+import won from '../won-es6.js';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
+import { labels, relativeTime, } from '../won-label-utils.js';
 import {
     selectAllOwnNeeds,
-} from '../selectors';
+} from '../selectors.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 const serviceDependencies = ['$scope', '$interval', '$ngRedux'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -2,22 +2,22 @@
 
 import angular from 'angular';
 import Immutable from 'immutable';
-import squareImageModule from './square-image';
-import chatTextFieldModule from './chat-textfield';
+import squareImageModule from './square-image.js';
+import chatTextFieldModule from './chat-textfield.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 import {
     attach,
     delay,
 } from '../utils.js'
 import {
     actionCreators
-}  from '../actions/actions';
+}  from '../actions/actions.js';
 import {
     selectOpenConnectionUri,
     selectNeedByConnectionUri,
-} from '../selectors';
+} from '../selectors.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -4,29 +4,29 @@
 ;
 
 import angular from 'angular';
-import ownerTitleBarModule from '../owner-title-bar';
-//import galleryModule from '../gallery';
-import postMessagesModule from '../post-messages';
+import ownerTitleBarModule from '../owner-title-bar.js';
+//import galleryModule from '../gallery.js';
+import postMessagesModule from '../post-messages.js';
 import {
     attach,
     mapToMatches,
     decodeUriComponentProperly,
     getIn,
-} from '../../utils';
-import won from '../../won-es6';
-import { actionCreators }  from '../../actions/actions';
-import openRequestModule from '../open-request';
-import connectionSelectionModule from '../connection-selection';
-import postInfoModule from '../post-info';
-import matchesModule from '../matches';
+} from '../../utils.js';
+import won from '../../won-es6.js';
+import { actionCreators }  from '../../actions/actions.js';
+import openRequestModule from '../open-request.js';
+import connectionSelectionModule from '../connection-selection.js';
+import postInfoModule from '../post-info.js';
+import matchesModule from '../matches.js';
 import {
     selectOpenPostUri,
     selectOpenConnectionUri,
-} from '../../selectors';
+} from '../../selectors.js';
 
 import {
    makeParams,
-} from '../../configRouting';
+} from '../../configRouting.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 class Controller {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/posttype-select.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/posttype-select.js
@@ -5,8 +5,8 @@
 ;
 
 import angular from 'angular';
-import { dispatchEvent, attach } from '../utils';
-import enterModule from '../directives/enter';
+import { dispatchEvent, attach } from '../utils.js';
+import enterModule from '../directives/enter.js';
 
 function genComponentConf() {
     /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -2,17 +2,17 @@
 
 import angular from 'angular';
 import 'ng-redux';
-import postContentModule from './post-content';
-import postHeaderModule from './post-header';
-import { selectNeedByConnectionUri } from '../selectors';
+import postContentModule from './post-content.js';
+import postHeaderModule from './post-header.js';
+import { selectNeedByConnectionUri } from '../selectors.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 import {
     attach,
     getIn,
-} from '../utils';
-import { actionCreators }  from '../actions/actions';
+} from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings-title-bar.js
@@ -7,11 +7,11 @@ import angular from 'angular';
 import {
     attach,
     getIn,
-} from '../utils';
-import { actionCreators } from '../actions/actions';
+} from '../utils.js';
+import { actionCreators } from '../actions/actions.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/avatar-settings.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/avatar-settings.js
@@ -1,7 +1,7 @@
 ;
 
 import angular from 'angular';
-import avatarImageSelectorModule from '../settings/avatarimage-selector';
+import avatarImageSelectorModule from '../settings/avatarimage-selector.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/general-settings.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/general-settings.js
@@ -1,9 +1,9 @@
 ;
 
 import angular from 'angular';
-import accountSettingsModule from '../settings/account-settings';
-import addressSettingsModule from '../settings/address-settings';
-import notificationSettingsModule from '../settings/notification-settings';
+import accountSettingsModule from '../settings/account-settings.js';
+import addressSettingsModule from '../settings/address-settings.js';
+import notificationSettingsModule from '../settings/notification-settings.js';
 
 function genComponentConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -6,16 +6,16 @@
 import angular from 'angular';
 import {
     attach,
-} from '../../utils';
+} from '../../utils.js';
 import {
     actionCreators
-}  from '../../actions/actions';
+}  from '../../actions/actions.js';
 
-import signupTitleBarModule from '../signup-title-bar';
+import signupTitleBarModule from '../signup-title-bar.js';
 
-import topNavModule from '../topnav';
+import topNavModule from '../topnav.js';
 
-import * as srefUtils from '../../sref-utils';
+import * as srefUtils from '../../sref-utils.js';
 
 const serviceDependencies = ['$ngRedux', '$scope', '$state', /*'$routeParams' /*injections as strings here*/];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -2,20 +2,20 @@
  * Created by ksinger on 20.08.2015.
  */
 ;
-import won from '../won-es6';
+import won from '../won-es6.js';
 import angular from 'angular';
-//import loginComponent from './login';
-//import logoutComponent from './logout';
-import dropdownModule from './covering-dropdown';
-import accountMenuModule from './account-menu';
-import { attach } from '../utils';
-import { actionCreators }  from '../actions/actions';
-import config from '../config';
+//import loginComponent from './login.js';
+//import logoutComponent from './logout.js';
+import dropdownModule from './covering-dropdown.js';
+import accountMenuModule from './account-menu.js';
+import { attach } from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
+import config from '../config.js';
 import {
     connect2Redux,
-} from '../won-utils';
+} from '../won-utils.js';
 
-import * as srefUtils from '../sref-utils';
+import * as srefUtils from '../sref-utils.js';
 
 function genTopnavConf() {
     let template = `

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -4,13 +4,13 @@
 ;
 
 import angular from 'angular';
-import { attach, } from '../utils';
-import { labels } from '../won-label-utils';
+import { attach, } from '../utils.js';
+import { labels } from '../won-label-utils.js';
 import {
     connect2Redux,
-} from '../won-utils';
-import { selectOpenPostUri } from '../selectors';
-import { actionCreators }  from '../actions/actions';
+} from '../won-utils.js';
+import { selectOpenPostUri } from '../selectors.js';
+import { actionCreators }  from '../actions/actions.js';
 
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/config.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/config.js
@@ -4,7 +4,7 @@
 
 import {
     deepFreeze,
-} from './utils';
+} from './utils.js';
 
 export default deepFreeze({
     adminEmail: 'office.sat@researchstudio.at',

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
@@ -2,10 +2,10 @@
  * Created by ksinger on 08.10.2015.
  */
 
-import reducer from './reducers/reducers';
+import reducer from './reducers/reducers.js';
 import thunk from 'redux-thunk';
 
-import { piwikMiddleware } from './piwik';
+import { piwikMiddleware } from './piwik.js';
 
 export default function configRedux($ngReduxProvider) {
     $ngReduxProvider.createStoreWith(reducer, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -2,28 +2,28 @@
  * Created by ksinger on 08.10.2015.
  */
 
-import won from './won-es6';
+import won from './won-es6.js';
 import Immutable from 'immutable';
-import { actionTypes, actionCreators } from './actions/actions';
+import { actionTypes, actionCreators } from './actions/actions.js';
 import {
     accountLogin,
     accountLogout,
-} from './actions/account-actions';
+} from './actions/account-actions.js';
 
 import {
     checkLoginStatus,
     privateId2Credentials,
-} from './won-utils';
+} from './won-utils.js';
 
 import {
     selectAllNeeds,
-} from './selectors';
+} from './selectors.js';
 
 import {
     decodeUriComponentProperly,
     checkHttpStatus,
     getIn,
-} from './utils';
+} from './utils.js';
 
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -17,24 +17,24 @@
 * messages to the server via the service.
  */
 
-import won from './won-es6';
+import won from './won-es6.js';
 import {
     attach,
     delay,
     watchImmutableRdxState,
     checkHttpStatus,
     is,
-} from './utils';
+} from './utils.js';
 
 import {
     makeParams,
-} from './configRouting';
+} from './configRouting.js';
 
-import { actionTypes, actionCreators } from './actions/actions';
-//import './message-service'; //TODO still uses es5
-import { getEventsFromMessage,setCommStateFromResponseForLocalNeedMessage } from './won-message-utils';
+import { actionTypes, actionCreators } from './actions/actions.js';
+//import './message-service.js'; //TODO still uses es5
+import { getEventsFromMessage,setCommStateFromResponseForLocalNeedMessage } from './won-message-utils.js';
 import SockJS from 'sockjs';
-import * as messages from './actions/messages-actions';
+import * as messages from './actions/messages-actions.js';
 
 export function runMessagingAgent(redux) {
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
@@ -4,7 +4,7 @@
 
 import {
    getIn,
-} from './utils';
+} from './utils.js';
 
 
 // ------- INIT  --------------------

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/event-reducer.js
@@ -1,16 +1,16 @@
 /**
  * Created by syim on 11.12.2015.
  */
-import { actionTypes } from '../actions/actions';
+import { actionTypes } from '../actions/actions.js';
 import {
     repeatVar,
     getIn,
     contains,
-} from '../utils';
+} from '../utils.js';
 import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
-import { combineReducersStable } from '../redux-utils';
-import won from '../won-es6';
+import { combineReducersStable } from '../redux-utils.js';
+import won from '../won-es6.js';
 
 const initialState = Immutable.fromJS({
     events: {},

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -2,12 +2,12 @@
  * Created by ksinger on 26.11.2015.
  */
 
-import { actionTypes } from '../actions/actions';
-import { repeatVar } from '../utils';
+import { actionTypes } from '../actions/actions.js';
+import { repeatVar } from '../utils.js';
 import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
-import { combineReducersStable } from '../redux-utils';
-import { buildCreateMessage } from '../won-message-utils';
+import { combineReducersStable } from '../redux-utils.js';
+import { buildCreateMessage } from '../won-message-utils.js';
 
 /* TODO this fragment is part of an attempt to sketch a different
  * approach to asynchronity (Remove it or the thunk-based

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -1,11 +1,11 @@
 /**
  * Created by syim on 11.12.2015.
  */
-import { actionTypes } from '../actions/actions';
+import { actionTypes } from '../actions/actions.js';
 import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
-import won from '../won-es6';
-import { msStringToDate } from '../utils';
+import won from '../won-es6.js';
+import { msStringToDate } from '../utils.js';
 
 const initialState = Immutable.fromJS({
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -2,18 +2,18 @@
  * Created by ksinger on 24.09.2015.
  */
 
-import { actionTypes } from '../actions/actions';
+import { actionTypes } from '../actions/actions.js';
 import Immutable from 'immutable';
-import { combineReducersStable } from '../redux-utils';
-import { messagesReducer } from './message-reducers';
+import { combineReducersStable } from '../redux-utils.js';
+import { messagesReducer } from './message-reducers.js';
 import reduceReducers from 'reduce-reducers';
-import needReducer from './need-reducer';
-import eventReducer from './event-reducer';
-import userReducer from './user-reducer';
-import toastReducer from './toast-reducer';
+import needReducer from './need-reducer.js';
+import eventReducer from './event-reducer.js';
+import userReducer from './user-reducer.js';
+import toastReducer from './toast-reducer.js';
 import {
     getIn,
-} from '../utils';
+} from '../utils.js';
 
 /*
  * this reducer attaches a 'router' object to our state that keeps the routing state.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -1,12 +1,12 @@
-import { actionTypes } from '../actions/actions';
+import { actionTypes } from '../actions/actions.js';
 import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
-import won from '../won-es6';
+import won from '../won-es6.js';
 import {
     getIn,
     generateIdString,
-} from '../utils';
-import config from '../config';
+} from '../utils.js';
+import config from '../config.js';
 
 const initialState = Immutable.fromJS({
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
@@ -1,13 +1,13 @@
 /**
  * Created by ksinger on 10.05.2016.
  */
-import { actionTypes } from '../actions/actions';
-import { repeatVar } from '../utils';
+import { actionTypes } from '../actions/actions.js';
+import { repeatVar } from '../utils.js';
 import Immutable from 'immutable';
 import { createReducer } from 'redux-immutablejs'
-import { combineReducersStable } from '../redux-utils';
-import { buildCreateMessage } from '../won-message-utils';
-import won from '../won-es6';
+import { combineReducersStable } from '../redux-utils.js';
+import { buildCreateMessage } from '../won-message-utils.js';
+import won from '../won-es6.js';
 
 const initialState = Immutable.fromJS({loggedIn: false});
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -4,12 +4,12 @@
 
 import { createSelector } from 'reselect';
 import Immutable from 'immutable';
-import won from './won-es6';
+import won from './won-es6.js';
 import {
     decodeUriComponentProperly,
     is,
     getIn,
-} from './utils';
+} from './utils.js';
 
 export const selectEvents = state => state.getIn(['events', 'events']);
 export const selectLastUpdateTime = state => state.get('lastUpdateTime');

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/draft-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/draft-builder.js
@@ -5,7 +5,7 @@
 
 //TODO switch to requirejs for dependency mngmt (so this lib isn't angular-bound)
 //TODO replace calls to `won` object to `require('util')`
-import won from './won';
+import won from './won.js';
 
 (function(){ // <need-builder-js> scope
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -26,11 +26,11 @@ import {
     contains,
     camel2Hyphen,
     somePromises,
-} from '../utils';
+} from '../utils.js';
 
 import rdfstore from 'rdfstore-js';
 import jld from 'jsonld';
-import won from './won';
+import won from './won.js';
 (function(){
 
     /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
@@ -4,7 +4,7 @@
 
 //TODO switch to requirejs for dependency mngmt (so this lib isn't angular-bound)
 //TODO replace calls to `won` object to `require('util')`
-import won from './won';
+import won from './won.js';
 (function(){ // <message-builder-js> scope
 
     /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -5,7 +5,7 @@
  */
 //TODO switch to requirejs for dependency mngmt (so this lib isn't angular-bound)
 //TODO replace calls to `won` object to `require('util')`
-import won from './won';
+import won from './won.js';
 
 (function(){ // <need-builder-js> scope
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sref-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sref-utils.js
@@ -5,7 +5,7 @@
 import {
     getParameterByName,
     getParameters,
-} from './utils';
+} from './utils.js';
 
 import {
     makeParams,
@@ -13,7 +13,7 @@ import {
     resetParamsImm,
     constantParams,
     addConstParams,
-} from './configRouting';
+} from './configRouting.js';
 
 /**
  * e.g. `absSRef('post', {postUri: 'http://...'})` + pre-existing private Id =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -46,19 +46,6 @@ export function dispatchEvent(elem, eventName, eventData) {
     //console.log('dispatching');
 }
 
-export function readAsDataURL(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = function() {
-            resolve(reader.result);
-        };
-        reader.onerror = function() {
-            reject(f);
-        };
-        reader.readAsDataURL(file);
-    });
-};
-
 /*
  * Freezes an object recursively.
  *

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-es6.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-es6.js
@@ -8,10 +8,10 @@
  * default export`ing the won-object)
  */
 
-import won from './service/won';
-import './service/need-builder';
-import './service/message-builder';
-import './service/linkeddata-service-won';
+import won from './service/won.js';
+import './service/need-builder.js';
+import './service/message-builder.js';
+import './service/linkeddata-service-won.js';
 export default won;
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -1,6 +1,6 @@
 ;
-import won from './won-es6';
-import {deepFreeze} from './utils';
+import won from './won-es6.js';
+import {deepFreeze} from './utils.js';
 
 export const labels = deepFreeze({
     type: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -3,7 +3,7 @@
  */
 
 
-import won from './won-es6';
+import won from './won-es6.js';
 import Immutable from 'immutable';
 import {
     getRandomPosInt,
@@ -15,11 +15,11 @@ import {
     entries,
     is,
     getIn,
-} from './utils';
+} from './utils.js';
 
 import {
     actionTypes,
-} from './actions/actions';
+} from './actions/actions.js';
 
 import jsonld from 'jsonld';
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -3,13 +3,13 @@
  */
 
 import Immutable from 'immutable';
-import L from './leaflet-bundleable';
+import L from './leaflet-bundleable.js';
 import {
     arrEq,
     checkHttpStatus,
     generateIdString,
     getIn,
-} from './utils';
+} from './utils.js';
 
 export function initLeaflet(mapMount) {
     if(!L) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/jspm_config.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/jspm_config.js
@@ -1,5 +1,4 @@
 System.config({
-  defaultJSExtensions: true,
   transpiler: "babel",
   babelOptions: {
     "optional": [


### PR DESCRIPTION
I'd already changed all the import statements in the the refac__treeshaking(-with-bower) branch, as the new version of jspm seems to not support the `defaultJSExtension`-flag anymore. Even though the rest of that branch shouldn't be merged (as we're already using treeshaking...sparingly, and bundles are bigger there), I think we should keep the changes to the immport statements as it:

* will be necessary anyway should we ever update to a newer (gulp-)jspm
* will be necessary for a potential typescript-transition (as soon as the support in jspm is where we want it to be), as it allows both script-file-types to coexist.
* allows us to debug/diagnose treeshaking, by using a (seperately installed) version of jspm-0.17-beta, as prints diagnostics during `jspm build`

This PR also removes a duplicate export in utils.js.