### PR TITLE
Feat  login multidispatch

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -144,10 +144,24 @@ export function accountLogin(credentials, options) {
                 return stateGoCurrent({privateId: credentials.privateId})(dispatch, getState);
             }
         })
-
         .then(() =>
             login(credentials)
         )
+        .then(() =>
+            dispatch({
+                type: actionTypes.login,
+                payload: Immutable.fromJS({email: email, loggedIn: true})
+            })
+        )
+        .then(() => {
+            if(!options_.doRedirects) {
+                return;
+            } else if (options_.redirectToFeed) {
+                return dispatch(actionCreators.router__stateGoResetParams("feed"))
+            } else {
+                return checkAccessToCurrentRoute(dispatch, getState);
+            }
+        })
         .then(response =>
             options_.fetchData ? fetchOwnedData(email) : Immutable.Map() // only need to fetch data for non-new accounts
         )
@@ -164,15 +178,6 @@ export function accountLogin(credentials, options) {
          */
             dispatch(actionCreators.reconnect())
         )
-        .then(() => {
-            if(!options_.doRedirects) {
-                return;
-            } else if (options_.redirectToFeed) {
-                return dispatch(actionCreators.router__stateGoResetParams("feed"))
-            } else {
-                return checkAccessToCurrentRoute(dispatch, getState);
-            }
-        })
         .catch(error => {
             console.error("accountLogin ErrorObject", error);
             return Promise.resolve()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -168,7 +168,7 @@ export function accountLogin(credentials, options) {
         .then(allThatData =>
             dispatch({
                 type: actionTypes.login,
-                payload: allThatData.merge({email: email, loggedIn: true})
+                payload: allThatData.merge({email: email, loggedIn: true, loginFinished: true})
             })
         )
         .then(() =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -80,7 +80,12 @@ function loadingWhileSignedIn(dispatch, getState, username) {
 
 
     loginSuccess(username, true, dispatch, getState);
-    fetchOwnedData(username, dispatchInitialPageLoad(dispatch));
+    fetchOwnedData(username, dispatchInitialPageLoad(dispatch))
+    .then(() => dispatch({
+            type: actionTypes.initialPageLoad,
+            payload: Immutable.fromJS({initialLoadFinished: true})
+        })
+    );
 }
 
 function loadingWithAnonymousAccount(dispatch, getState, privateId) {
@@ -99,7 +104,7 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
     ).then(allThatData => {
         return dispatch({
             type: actionTypes.initialPageLoad,
-            payload: allThatData
+            payload: allThatData.merge({initialLoadFinished: true})
         });
     }).catch(e => {
         console.error('failed to sign-in with privateId ', privateId, ' because of: ', e);
@@ -138,7 +143,7 @@ function loadingWhileSignedOut(dispatch, getState) {
     return dataPromise.then(publicData =>
         dispatch({
             type: actionTypes.initialPageLoad,
-            payload: publicData
+            payload: publicData.merge({initialLoadFinished: true})
         })
     ).then(() =>
         checkAccessToCurrentRoute(dispatch, getState)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
@@ -3,9 +3,22 @@
     <won-overview-title-bar selection="self.selection"></won-overview-title-bar>
 </header>
 <main class="feedcontent">
-    <div class="fc__inner" ng-class="{'empty' : self.ownNeedUris.length == 0}">
-        <div class="fc__empty" ng-if="self.ownNeedUris.length == 0">
+    
+    <div class="fc__loading" ng-show="self.showSpinner">
+        <img src="images/spinner/on_white.gif"
+             alt="Loading&hellip;"
+             class="hspinner"/>
+        <span class="fc__loading__text">Loading your posts&hellip;</span>
+    </div>
+
+    <div class="fc__inner"
+         ng-show="!self.showSpinner"
+         ng-class="{'empty' : self.ownNeedUris.length == 0}"
+    >
+        <div class="fc__empty" ng-if="self.showPlaceholder">
+        <!--<div class="fc__empty">-->
             <div class="fc__empty__description">
+
                 <img src="generated/icon-sprite.svg#ico-filter_list_grey"
                      class="fc__empty__description__icon">
                 <span class="fc__empty__description__text">
@@ -20,11 +33,11 @@
                 <span class="fc__empty__link__caption">Create a Need</span>
             </a>
         </div>
-        <h1 class="title" ng-if="self.ownNeedUris.length > 0">Recent activities</h1>
 
+        <h1 class="title" ng-if="self.showFeed">Recent activities</h1>
         <won-feed-item ng-repeat="uri in self.ownNeedUris"
                        need-uri="uri"
-                       ng-show="uri">
+                       ng-show="self.showFeed">
         </won-feed-item>
     </div>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.html
@@ -3,20 +3,18 @@
     <won-overview-title-bar selection="self.selection"></won-overview-title-bar>
 </header>
 <main class="feedcontent">
-    
-    <div class="fc__loading" ng-show="self.showSpinner">
-        <img src="images/spinner/on_white.gif"
-             alt="Loading&hellip;"
-             class="hspinner"/>
-        <span class="fc__loading__text">Loading your posts&hellip;</span>
-    </div>
+    <div class="fc__inner" ng-class="{'empty' : self.ownNeedUris.length == 0}">
 
-    <div class="fc__inner"
-         ng-show="!self.showSpinner"
-         ng-class="{'empty' : self.ownNeedUris.length == 0}"
-    >
+
+        <div class="fc__loading" ng-show="self.showSpinner">
+            <img src="images/spinner/on_white.gif"
+                 alt="Loading&hellip;"
+                 class="hspinner"/>
+            <span class="fc__loading__text">Loading your posts&hellip;</span>
+        </div>
+
+
         <div class="fc__empty" ng-if="self.showPlaceholder">
-        <!--<div class="fc__empty">-->
             <div class="fc__empty__description">
 
                 <img src="generated/icon-sprite.svg#ico-filter_list_grey"
@@ -34,10 +32,13 @@
             </a>
         </div>
 
+
         <h1 class="title" ng-if="self.showFeed">Recent activities</h1>
         <won-feed-item ng-repeat="uri in self.ownNeedUris"
                        need-uri="uri"
                        ng-show="self.showFeed">
         </won-feed-item>
+
+
     </div>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
@@ -2,7 +2,10 @@ import angular from 'angular';
 import overviewTitleBarModule from '../overview-title-bar.js';
 import feedItemModule from '../feed-item.js'
 import { actionCreators }  from '../../actions/actions.js';
-import { attach } from '../../utils.js';
+import {
+    attach,
+    getIn,
+} from '../../utils.js';
 
 import {
     resetParams,
@@ -27,8 +30,20 @@ class FeedController {
         const selectFromState = (state) => {
             const ownActiveNeeds = selectAllOwnNeeds(state).filter(need => need.get("state") === won.WON.ActiveCompacted);
 
+            const initialLoadInProgress = !getIn(state, ['initialLoadFinished']);
+            const loginInProgress = !!getIn(state, ['loginInProcessFor']);
+            const ownNeedUris = ownActiveNeeds &&
+                ownActiveNeeds.map(
+                        need => need.get('uri')
+                ).toArray();
+            const hasOwnNeeds = ownNeedUris && ownNeedUris.length > 0;
+            const showSpinner = loginInProgress || initialLoadInProgress;
+
             return {
-                ownNeedUris: ownActiveNeeds && ownActiveNeeds.map(need => need.get('uri')).toArray(),
+                showSpinner,
+                showPlaceholder: !showSpinner && !hasOwnNeeds,
+                showFeed: !showSpinner && hasOwnNeeds,
+                ownNeedUris,
             }
         };
         const disconnect = this.$ngRedux.connect(selectFromState,actionCreators)(this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed/feed.js
@@ -42,7 +42,7 @@ class FeedController {
             return {
                 showSpinner,
                 showPlaceholder: !showSpinner && !hasOwnNeeds,
-                showFeed: !showSpinner && hasOwnNeeds,
+                showFeed: hasOwnNeeds,
                 ownNeedUris,
             }
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -178,7 +178,7 @@ function storeConnectionsData(state, connectionsToStore, newConnections) {
     newConnections = newConnections ? newConnections : Immutable.Set();
 
     if(connectionsToStore && connectionsToStore.size > 0) {
-        connectionsToStore.map(function(connection){
+        connectionsToStore.forEach(connection => {
             state = addConnectionFull(state, connection, newConnections);
         });
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -49,6 +49,12 @@ const reducers = {
                 return getIn(action, ['payload', 'email']);
 
             case actionTypes.login:
+                if(getIn(action, ['payload', 'loginFinished'])) {
+                    return undefined;
+                } else {
+                    return loginInProcessFor;
+                }
+
             case actionTypes.loginFailed:
                 return undefined;
 
@@ -72,7 +78,10 @@ const reducers = {
 
 
     initialLoadFinished: (state = false, action = {}) =>
-        state || action.type === actionTypes.initialPageLoad,
+        state || (
+            action.type === actionTypes.initialPageLoad &&
+            getIn(action, ['payload', 'initialLoadFinished'])
+        ),
 
     loginVisible: (visible = false, action = {}) => {
         switch (action.type) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_feed.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_feed.scss
@@ -8,6 +8,22 @@
 
   @include empty-description('fc');
 
+  .fc__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2rem;
+
+    .fc__loading__text {
+      color: $won-line-gray;
+    }
+
+    .hspinner {
+      opacity: 0.5;
+      margin-right: 0.5rem;
+    }
+  }
+
   .title {
     font-weight: 300;
     text-align: center;


### PR DESCRIPTION
With this, needs are dispatched as soon as they are returned from the server (instead of waiting for all own needs to load, then waiting for all connections to load, etc, i.e. "aligning" them). This should make a improve the time to the first meaningful render for accounts with a lot of needs and/or connections.