### PR TITLE
"removes" won-need-map from tile view (makes leaflet too slow)

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
@@ -29,16 +29,16 @@ function genComponentConf() {
                 max-thumbnails="self.maxThumbnails"
                 items="self.images"
                 class="horizontal"
-                ng-show="!self.remoteNeed.get('location') && self.images.length > 0">
+                ng-show="(true || !self.remoteNeed.get('location')) && self.images.length > 0">
             </won-extended-gallery>
             <won-square-image 
                 title="self.remoteNeed.get('title')"
                 uri="self.remoteNeed.get('uri')"
-                ng-show="!self.remoteNeed.get('location') && self.images.length == 0">
+                ng-show="(true || !self.remoteNeed.get('location')) && self.images.length == 0">
             </won-square-image>
             <won-need-map
                 uri="self.remoteNeed.get('uri')"
-                ng-if="self.remoteNeed.get('location') && self.images.length == 0">
+                ng-if="false && self.remoteNeed.get('location') && self.images.length == 0">
             </won-need-map>
         </div>
 


### PR DESCRIPTION
fixes the many requests sent to leaflet by removing the map in the tile view (for now, until we have found a better and more performant solution to include open-street-maps/leaflet)