### PR TITLE
Refac remove closedconnectionsfromfeed

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
@@ -62,7 +62,7 @@ function genComponentConf() {
             const self = this;
             const selectFromState = (state) => {
                 const lastUpdated = selectLastUpdateTime(state);
-                const connection = state.getIn(["needs", this.needUri, "connections", this.connectionUri]).filter(con => con.get("state") === won.WON.Closed );
+                const connection = state.getIn(["needs", this.needUri, "connections", this.connectionUri]);
                 const remoteNeedUri = connection && connection.get('remoteNeedUri');
                 const remoteNeed = remoteNeedUri && selectAllTheirNeeds(state).get(remoteNeedUri);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item-line.js
@@ -62,7 +62,7 @@ function genComponentConf() {
             const self = this;
             const selectFromState = (state) => {
                 const lastUpdated = selectLastUpdateTime(state);
-                const connection = state.getIn(["needs", this.needUri, "connections", this.connectionUri]);
+                const connection = state.getIn(["needs", this.needUri, "connections", this.connectionUri]).filter(con => con.get("state") === won.WON.Closed );
                 const remoteNeedUri = connection && connection.get('remoteNeedUri');
                 const remoteNeed = remoteNeedUri && selectAllTheirNeeds(state).get(remoteNeedUri);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -128,7 +128,7 @@ function genComponentConf() {
                 const lastUpdated = selectLastUpdateTime(state);
 
                 const ownNeed = state.getIn(["needs", self.needUri]);
-                const connections = ownNeed && ownNeed.get("connections");
+                const connections = ownNeed && ownNeed.get("connections").filter(con => con.get("state") === won.WON.Closed );
 
                 const unreadMatchesCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.Suggested).size;
                 const unreadRequestsCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.RequestReceived).size;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -128,15 +128,16 @@ function genComponentConf() {
                 const lastUpdated = selectLastUpdateTime(state);
 
                 const ownNeed = state.getIn(["needs", self.needUri]);
-                const connections = ownNeed && ownNeed.get("connections").filter(conn => conn.get("state") !== won.WON.Closed );
+                const connections = ownNeed && ownNeed.get("connections");
+                const connectionsWithoutClosed = connections && connections.filter(conn => conn.get("state") !== won.WON.Closed);
 
-                const unreadMatchesCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.Suggested).size;
-                const unreadRequestsCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.RequestReceived).size;
+                const unreadMatchesCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.Suggested).size;
+                const unreadRequestsCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.RequestReceived).size;
 
                 return {
                     ownNeed,
-                    connectionsArray: connections && connections.toArray(),
-                    connectionsSize: connections && connections.size,
+                    connectionsArray: connectionsWithoutClosed && connectionsWithoutClosed.toArray(),
+                    connectionsSize: connectionsWithoutClosed && connectionsWithoutClosed.size,
                     WON: won.WON,
                     createdOn: ownNeed && relativeTime(lastUpdated, ownNeed.get('creationDate')),
                     unreadMatchesCount,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -128,7 +128,7 @@ function genComponentConf() {
                 const lastUpdated = selectLastUpdateTime(state);
 
                 const ownNeed = state.getIn(["needs", self.needUri]);
-                const connections = ownNeed && ownNeed.get("connections").filter(con => con.get("state") === won.WON.Closed );
+                const connections = ownNeed && ownNeed.get("connections").filter(conn => conn.get("state") !== won.WON.Closed );
 
                 const unreadMatchesCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.Suggested).size;
                 const unreadRequestsCount = connections && connections.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.RequestReceived).size;


### PR DESCRIPTION
Removes the (visibility of) closed connections from the feed -> we do not need to show these in the feed