### PR TITLE
message count in owner title bar only shows messages of connected con…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -14,7 +14,7 @@ import won from '../won-es6.js';
 import { labels } from '../won-label-utils.js';
 import {
     selectOpenPostUri,
-    selectAllMessagesByNeedUri,
+    selectAllMessagesByNeedUriAndConnected,
 } from '../selectors.js';
 import { actionCreators }  from '../actions/actions.js';
 
@@ -145,7 +145,7 @@ function genComponentConf() {
                 const incomingRequests = connections && connections.filter(conn => conn.get("state") === won.WON.RequestReceived);
                 const matches = connections && connections.filter(conn => conn.get("state") === won.WON.Suggested);
                 const connected = connections && connections.filter(conn => conn.get("state") === won.WON.Connected);
-                const messages = selectAllMessagesByNeedUri(state, postUri);
+                const messages = selectAllMessagesByNeedUriAndConnected(state, postUri);
 
                 const unreadMatchesCount = matches && matches.filter(conn => conn.get("newConnection")).size;
                 const unreadSentRequestsCount = sentRequests && sentRequests.filter(conn => conn.get("newConnection")).size;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -43,7 +43,7 @@ function genComponentConf() {
         <input
           type="text"
           ng-model="self.message"
-          placeholder="Reply Message (optional)"/>
+          placeholder="Request Message (optional)"/>
         <div class="flexbuttons">
           <button
             class="won-button--filled black"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -81,6 +81,20 @@ export function selectAllMessagesByNeedUri(state, needUri) {
     return messages;
 }
 
+export function selectAllMessagesByNeedUriAndConnected(state, needUri) {
+    const connections = state.getIn(["needs", needUri, "connections"]);
+    const connectionsWithoutClosed = connections && connections.filter(conn => conn.get("state") === won.WON.Connected);
+    let messages = Immutable.Map();
+
+    if(connectionsWithoutClosed){
+        connectionsWithoutClosed.map(function(conn){
+            messages = messages.merge(conn.get("messages"));
+        });
+    }
+
+    return messages;
+}
+
 export const selectOpenConnectionUri = createSelector(
     selectRouterParams,
     (routerParams) => {


### PR DESCRIPTION
…nections now

Fixes that the messagecount in the title-bar is only considering connected connections now (before it took all the messages present in the state which resulted in a faulty number when the connection was closed)