### PR TITLE
Improve message handling

### DIFF
--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
@@ -68,7 +68,12 @@ public class FailResponder extends AbstractCamelProcessor
       } else {
         errormessage = String.format("An error occurred while processing message %s", originalMessage.getMessageURI());
       }
-
+      if (originalMessage.getMessageType() == WonMessageType.HINT_MESSAGE){
+          //we don't want to send a FailureResponse for a hint message as matchers
+          //are not fully compatible messaging agents (needs), so sending this message will fail.
+          logger.debug("suppressing failure response for HINT message", exception);
+          return;
+      }
       logger.info("Caught error while processing WON message {} (type:{}) : {} - sending FailureResponse (more info on log level DEBUG)",
                    new Object[]{originalMessage.getMessageURI(), originalMessage.getMessageType(), errormessage});
       if (exception != null) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
@@ -21,6 +21,7 @@ import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
 import won.protocol.message.WonMessageDirection;
+import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
 
@@ -40,6 +41,12 @@ public class SuccessResponder extends AbstractCamelProcessor
     //only send success message if the original message was sent on behalf of a need (otherwise we have to find out
     // with other means which ownerapplications to send the response to.
     if (originalMessage.getSenderNeedURI() == null) return;
+      if (originalMessage.getMessageType() == WonMessageType.HINT_MESSAGE){
+          //we don't want to send a SuccessResponse for a hint message as matchers
+          //are not fully compatible messaging agents (needs), so sending this message will fail.
+          logger.debug("suppressing success response for HINT message");
+          return;
+      }
     URI newMessageURI = this.wonNodeInformationService.generateEventURI();
     WonMessage responseMessage = WonMessageBuilder.setPropertiesForNodeResponse(originalMessage, true,
       newMessageURI).build();


### PR DESCRIPTION
should fixes #1237 
i was testing about 1 hour on master after increasing to the neweset camel version and the cyclic expections didnt occur anymore.
also dont try to send failure and success respose messages to matchers for hints