### PR TITLE
Fix  relative time stamps

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -131,8 +131,7 @@ export function connectionsConnect(connectionUri, textMessage) {
 
         dispatch(actionCreators.messages__send({eventUri: cnctMsg.eventUri, message: cnctMsg.message}));
 
-        const event = await messageGraphToEvent(cnctMsg.eventUri, cnctMsg.message);
-        //const smarterMessage = await won.WonMessageFromMessageLoadedFromStore(event);
+        const optimisticEvent = await won.toWonMessage(cnctMsg.message);
 
         dispatch({
             type: actionTypes.connections.connect,
@@ -140,7 +139,7 @@ export function connectionsConnect(connectionUri, textMessage) {
                 connectionUri,
                 textMessage,
                 eventUri: cnctMsg.eventUri,
-                optimisticEvent: event,
+                optimisticEvent,
                 //optimisticWonMessage: smarterMessage,
             }
         });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -91,9 +91,10 @@ export function connectionsOpen(connectionUri, message) {
         const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
 
         buildOpenMessage(connectionUri, ownNeed.get("uri"), theirNeedUri, ownNeed.get("nodeUri"), theirNeed.get("nodeUri"), theirConnectionUri, message)
-        .then(msgData =>
-            Promise.all([won.wonMessageFromJsonLd(msgData.message), msgData.message]))
-        .then(([optimisticEvent, jsonldMessage]) => {
+        .then(async msgData => {
+            const jsonldMessage = msgData.message;
+            const optimisticEvent = await won.wonMessageFromJsonLd(msgData.message);
+            //const smarterMessage = await won.WonMessageFromMessageLoadedFromStore(optimisticEvent);
             // dispatch(actionCreators.messages__send(messageData));
             dispatch({
                 type: actionTypes.connections.open,
@@ -101,6 +102,7 @@ export function connectionsOpen(connectionUri, message) {
                     eventUri: optimisticEvent.getMessageUri(),
                     message: jsonldMessage,
                     optimisticEvent,
+                    //optimisticWonMessage: smarterMessage,
                 }
             });
 
@@ -130,6 +132,7 @@ export function connectionsConnect(connectionUri, textMessage) {
         dispatch(actionCreators.messages__send({eventUri: cnctMsg.eventUri, message: cnctMsg.message}));
 
         const event = await messageGraphToEvent(cnctMsg.eventUri, cnctMsg.message);
+        //const smarterMessage = await won.WonMessageFromMessageLoadedFromStore(event);
 
         dispatch({
             type: actionTypes.connections.connect,
@@ -138,6 +141,7 @@ export function connectionsConnect(connectionUri, textMessage) {
                 textMessage,
                 eventUri: cnctMsg.eventUri,
                 optimisticEvent: event,
+                //optimisticWonMessage: smarterMessage,
             }
         });
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -254,6 +254,7 @@ function getConnectionData(event) {
 
                 data.receivedEvent = event.getMessageUri();
                 data.updatedConnection = connectionData.uri;
+                data.message = event;
 
                 return data
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -15,6 +15,10 @@ import {
     connect2Redux,
 } from '../won-utils.js'
 
+import {
+    relativeTime,
+} from '../won-label-utils.js'
+
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
@@ -41,6 +45,11 @@ function genComponentConf() {
           <span>Available until 5th May</span>
         </div>
         -->
+        <div class="pc__datetime" ng-show="self.relativeCreationDate">
+          <img class="pc__icon"
+            src="generated/icon-sprite.svg#ico16_indicator_time"/>
+          <span>Posted {{ self.relativeCreationDate }}</span>
+        </div>
         <div class="pc__text"
           ng-show="!!self.need.get('description')">
           <img
@@ -75,8 +84,11 @@ function genComponentConf() {
             attach(this, serviceDependencies, arguments);
             window.pc4dbg = this;
             const selectFromState = (state) => {
+                const lastUpdateTime = state.get('lastUpdateTime');
+                const need = state.getIn(['needs', this.needUri]);
                 return {
-                    need: state.getIn(['needs', this.needUri]),
+                    need,
+                    relativeCreationDate: need && relativeTime(lastUpdateTime, need.get('creationDate')),
                 }
             };
             /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -15,10 +15,6 @@ import {
     connect2Redux,
 } from '../won-utils.js'
 
-import {
-    relativeTime,
-} from '../won-label-utils.js'
-
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
@@ -45,11 +41,6 @@ function genComponentConf() {
           <span>Available until 5th May</span>
         </div>
         -->
-        <div class="pc__datetime" ng-show="self.relativeCreationDate">
-          <img class="pc__icon"
-            src="generated/icon-sprite.svg#ico16_indicator_time"/>
-          <span>Posted {{ self.relativeCreationDate }}</span>
-        </div>
         <div class="pc__text"
           ng-show="!!self.need.get('description')">
           <img
@@ -84,11 +75,8 @@ function genComponentConf() {
             attach(this, serviceDependencies, arguments);
             window.pc4dbg = this;
             const selectFromState = (state) => {
-                const lastUpdateTime = state.get('lastUpdateTime');
-                const need = state.getIn(['needs', this.needUri]);
                 return {
-                    need,
-                    relativeCreationDate: need && relativeTime(lastUpdateTime, need.get('creationDate')),
+                    need: state.getIn(['needs', this.needUri]),
                 }
             };
             /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -5,6 +5,9 @@ import Immutable from 'immutable';
 import squareImageModule from './square-image.js';
 import chatTextFieldModule from './chat-textfield.js';
 import {
+    relativeTime,
+} from '../won-label-utils.js'
+import {
     connect2Redux,
 } from '../won-utils.js';
 import {
@@ -67,7 +70,7 @@ function genComponentConf() {
                         <div
                             ng-hide="message.get('unconfirmed')"
                             class="pm__content__message__content__time">
-                                {{ message.get('date') }}
+                                {{ self.relativeTime(self.lastUpdateTime, message.get('date')) }}
                         </div>
                         <a
                           ng-show="self.debugmode && message.get('outgoingMessage')"
@@ -104,6 +107,7 @@ function genComponentConf() {
     class Controller {
         constructor(/* arguments = dependency injections */) {
             attach(this, serviceDependencies, arguments);
+            this.relativeTime = relativeTime;
             window.pm4dbg = this;
 
             const self = this;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -826,7 +826,7 @@ import won from './won.js';
                 {node: "won:isInState"},
                 {node: "won:hasFlag"},
                 {node: "won:hasFacet"},
-                {node: "dtc:created"},
+                {node: "dct:created"},
                 {
                     node: "won:hasEventContainer",
                     children: [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -915,7 +915,7 @@ import jsonld from 'jsonld';
      * @param message
      * @constructor
      */
-    won.WonMessageFromMessageLoadedFromStore = function (message) {
+    won.WonMessageFromMessageLoadedFromStore = async function (message) {
         //console.log("converting this result from store to WonMessage", message)
 
         let contentResource = message;
@@ -975,7 +975,7 @@ import jsonld from 'jsonld';
 
 
 
-    won.wonMessageFromJsonLd = function(wonMessageAsJsonLD){
+    won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD){
         //console.log("converting this JSON-LD to WonMessage", wonMessageAsJsonLD)
         return jsonld.promises.expand(wonMessageAsJsonLD)
             .then(expandedJsonLd =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -908,6 +908,25 @@ import jsonld from 'jsonld';
         }
     }
 
+
+    /**
+     * This function should take any of the different chat-message-structures flying around in this code-base
+     * and return a WonMessage object.
+     * @param message
+     * @returns {*|Promise.<WonMessage>}
+     */
+    won.toWonMessage = function(message) {
+        if(message.uri && message.type) {
+            return won.WonMessageFromMessageLoadedFromStore(message);
+        } else if (message['@graph']) {
+            return won.wonMessageFromJsonLd(message);
+        } else if (message instanceof WonMessage) {
+            return Promise.resolve(message);
+        } else {
+            throw new Exception('Couldn\'t convert the following to a WonMessage: ', message);
+        }
+    };
+
     /**
      * This is a hack that allows us to wrap a WonMessage object around a message that
      * is retrieved from the local rdf store. This will work for Chat messages


### PR DESCRIPTION
The chat-messages should have relative timestamps (e.g. "just now", "5 minutes ago") again. Timestamps should (also) show again for matches, the post-info-page, etc.

NOTE: merge after #1252 