### PR TITLE
Suppress hints for Reply needs

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -249,6 +249,7 @@ function generateResponseNeedTo(theirNeed) {
         type: reNeedType,
         tags: cloneAsMutable(get(theirNeed, 'tags')),
         location: cloneAsMutable(get(theirNeed, 'location')),
+        noHints: true,
     };
 
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -108,7 +108,7 @@ import won from './won.js';
             putIntoBoth ||
             args.type === won.WON.BasicNeedTypeDemandCompacted;
 
-        const hasFlag = [];
+        let hasFlag = [];
 
         if(!!won.debugmode) {
             hasFlag.push("won:UsedForTesting");
@@ -118,6 +118,20 @@ import won from './won.js';
             hasFlag.push("won:WhatsAround");
             hasFlag.push("won:NoHintForCounterpart");
         }
+
+        if(!!args.noHints){
+            hasFlag.push("won:NoHintForMe");
+            hasFlag.push("won:NoHintForCounterpart");
+        }
+
+        //remove possible duplicates in hasFlag
+        const result = [];
+        hasFlag.forEach(function(item) {
+            if(result.indexOf(item) < 0) {
+                result.push(item);
+            }
+        });
+        hasFlag = result;
 
         var graph = [
             {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -268,6 +268,7 @@ export function buildCreateMessage(needData, wonNodeUri) {
         attachmentUris: attachmentUris, //optional, should be same as in `attachments` below
         location: getIn(needData, ['location']),
         whatsAround: needData.whatsAround,
+        noHints: needData.noHints,
     });
     const msgUri = wonNodeUri + '/event/' + getRandomPosInt(); //mandatory
     const msgJson = won.buildMessageRdf(contentRdf, {


### PR DESCRIPTION
* Changed the reply need creation process by adding a noHints flag to the intermediate need structure.
* Adapted won.buildNeedRdf to pick up that new flag

How to test:
1. create a need A
2. with another account, create a What's Around B need such that it will be matched with A
3. connect from B to A
4. with yet another account, create another What's Around need C such that it will be matched with A
5. observe that you do not get a hint to B
6. do the same on a system before this PR, and C will get a hint to B

