### PR TITLE
crawl only new needs and connections in matcher service

### DIFF
--- a/webofneeds/conf/matcher-service/matcher-service.properties
+++ b/webofneeds/conf/matcher-service/matcher-service.properties
@@ -29,7 +29,7 @@ wonNodeController.wonNode.lifeCheckDuration=10000
 crawler.propertyPaths.base=<http://www.w3.org/2000/01/rdf-schema#member>,(<http://purl.org/webofneeds/model#hasConnections>/<http://www.w3.org/2000/01/rdf-schema#member>)/<http://purl.org/webofneeds/model#hasRemoteNeed>
 crawler.propertyPaths.nonBase=<http://purl.org/webofneeds/model#hasConnections>,<http://purl.org/webofneeds/model#hasConnections>/<http://www.w3.org/2000/01/rdf-schema#member>
 
-# time in minutes when crawled resources are considered outdated and are crawled again
+# time in minutes until won nodes are crawled the next time
 crawler.recrawl.interval.minutes=300
 
 # execute the meta data rdf update at least every x milliseconds

--- a/webofneeds/won-core/src/main/java/won/protocol/model/Need.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/Need.java
@@ -44,7 +44,7 @@ public class Need implements VersionedEntity {
 
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "last_update", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
-    private Date lastUpdate = new Date();
+    private Date lastUpdate;
 
     /* The URI of the need */
     @Column(name = "needURI", unique = true)
@@ -134,6 +134,7 @@ public class Need implements VersionedEntity {
     @PrePersist
     protected void onCreate() {
         creationDate = new Date();
+        lastUpdate = creationDate;
         incrementVersion();
     }
 
@@ -143,6 +144,7 @@ public class Need implements VersionedEntity {
 
     public void setCreationDate(Date creationDate) {
         this.creationDate = creationDate;
+        lastUpdate = creationDate;
     }
 
     @XmlTransient

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/DatasetResponseWithStatusCodeAndHeaders.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/DatasetResponseWithStatusCodeAndHeaders.java
@@ -17,8 +17,7 @@
 package won.protocol.rest;
 
 import org.apache.jena.query.Dataset;
-
-import java.util.Map;
+import org.springframework.http.HttpHeaders;
 
 /**
  * Simple structure to hold a dataset and the response headers that were sent along with the dataset.
@@ -27,9 +26,9 @@ public class DatasetResponseWithStatusCodeAndHeaders
 {
   private Dataset dataset;
   private int statusCode;
-  private Map<String, String> responseHeaders;
+  private HttpHeaders responseHeaders;
 
-  public DatasetResponseWithStatusCodeAndHeaders(final Dataset dataset, final int statusCode, final Map<String, String> responseHeaders) {
+  public DatasetResponseWithStatusCodeAndHeaders(final Dataset dataset, final int statusCode, final HttpHeaders responseHeaders) {
     this.dataset = dataset;
     this.statusCode = statusCode;
     this.responseHeaders = responseHeaders;
@@ -43,7 +42,7 @@ public class DatasetResponseWithStatusCodeAndHeaders
     return statusCode;
   }
 
-  public Map<String, String> getResponseHeaders() {
+  public HttpHeaders getResponseHeaders() {
     return responseHeaders;
   }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -30,7 +30,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.text.MessageFormat;
-import java.util.HashMap;
 import java.util.Map;
 
 public abstract class LinkedDataRestClient {
@@ -97,7 +96,7 @@ public abstract class LinkedDataRestClient {
         //it was probably the wrong resourceURI
         Dataset result;
         int statusCode = -1;
-        Map<String, String> responseHeaderMap = null;
+        HttpHeaders responseHeaders = null;
         try {
             HttpHeaders headers = new HttpHeaders();
             for (String key : requestHeaders.keySet()) {
@@ -108,12 +107,7 @@ public abstract class LinkedDataRestClient {
             ResponseEntity<Dataset> response = restTemplate.exchange(resourceURI, HttpMethod.GET, entity, Dataset.class);
             //RestTemplate will automatically follow redirects on HttpGet calls
             statusCode = response.getStatusCode().value();
-            HttpHeaders responseHeaders = response.getHeaders();
-            if (responseHeaders == null) {
-                responseHeaderMap = new HashMap<>();
-            } else {
-                responseHeaderMap = responseHeaders.toSingleValueMap();
-            }
+            responseHeaders = response.getHeaders();
             if (!response.getStatusCode().is2xxSuccessful()) {
                 throw new HttpClientErrorException(response.getStatusCode());
             }
@@ -139,7 +133,7 @@ public abstract class LinkedDataRestClient {
             logger.debug("fetched model with {} statements in default model for resource {}", result.getDefaultModel().size(),
                     resourceURI);
         }
-        return new DatasetResponseWithStatusCodeAndHeaders(result, statusCode, responseHeaderMap);
+        return new DatasetResponseWithStatusCodeAndHeaders(result, statusCode, responseHeaders);
     }
 
 

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -33,110 +33,114 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class LinkedDataRestClient
-{
+public abstract class LinkedDataRestClient {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-
-  /**
-   * Retrieves RDF for the specified resource URI.
-   * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
-   * Paging is not supported.
-   *
-   * @param resourceURI
-   * @return
-   */
-  public Dataset readResourceData(URI resourceURI) {
-    return readResourceDataWithHeaders(resourceURI).getDataset();
-  }
-
-  public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI);
-
-  public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, Map<String, String>
-    requestHeaders);
-
-  /**
-   * Retrieves RDF for the specified resource URI for the entity with provided WebID.
-   * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
-   * Paging is not supported.
-   *
-   * @param resourceURI
-   * @param requesterWebID
-   * @return
-   */
-  public Dataset readResourceData(URI resourceURI, URI requesterWebID){
-    return readResourceDataWithHeaders(resourceURI, requesterWebID).getDataset();
-  }
-
-  public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, URI requesterWebID);
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
 
-  /**
-   * Retrieves RDF for the specified resource URI.
-   * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
-
-   *
-   * @param resourceURI
-   * @return
-   */
-  public Dataset readResourceData(URI resourceURI, URI requesterWebID, Map<String, String>
-    requestHeaders){
-    return readResourceDataWithHeaders(resourceURI, requesterWebID, requestHeaders).getDataset();
-  }
-  public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, URI requesterWebID,
-                                                                                      Map<String,
-    String>
-    requestHeaders);
-
-  protected DatasetResponseWithStatusCodeAndHeaders readResourceData(URI resourceURI, RestTemplate restTemplate, Map<String,
-    String> requestHeaders) {
-    assert resourceURI != null : "resource URI must not be null";
-    logger.debug("fetching linked data resource: {}", resourceURI);
-
-    //If a RestClientException is thrown here complaining that it can't read a Model with MIME media type text/html,
-    //it was probably the wrong resourceURI
-    Dataset result;
-    int statusCode = -1;
-    Map<String, String> responseHeaderMap = null;
-    try {
-      HttpEntity entity = new HttpEntity(requestHeaders);
-      ResponseEntity<Dataset> response = restTemplate.exchange(resourceURI, HttpMethod.GET, entity, Dataset.class);
-      //RestTemplate will automatically follow redirects on HttpGet calls
-      statusCode = response.getStatusCode().value();
-      HttpHeaders responseHeaders = response.getHeaders();
-      if (responseHeaders == null){
-        responseHeaderMap = new HashMap<>();
-      } else {
-        responseHeaderMap = responseHeaders.toSingleValueMap();
-      }
-      if(!response.getStatusCode().is2xxSuccessful()){
-        throw new HttpClientErrorException(response.getStatusCode());
-      }
-      result = response.getBody();
-    } catch (RestClientException e) {
-      if(e instanceof HttpClientErrorException){
-        throw new IllegalArgumentException(
-                MessageFormat.format(
-                        "caught a HttpClientErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}", resourceURI, e.getMessage(), ((HttpClientErrorException) e).getResponseBodyAsString()), e);
-      }
-      if (e instanceof HttpServerErrorException) {
-        throw new IllegalArgumentException(
-                MessageFormat.format(
-                        "caught a HttpServerErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}", resourceURI, e.getMessage(), ((HttpServerErrorException) e).getResponseBodyAsString()), e);
-      }
-      throw new IllegalArgumentException(
-              MessageFormat.format(
-                      "caught a clientHandler exception, " +
-                              "which may indicate that the URI that was accessed isn''t a" +
-                              " linked data URI, please check {0}. Underlying error message is: {1}", resourceURI, e.getMessage()), e);
+    /**
+     * Retrieves RDF for the specified resource URI.
+     * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
+     * Paging is not supported.
+     *
+     * @param resourceURI
+     * @return
+     */
+    public Dataset readResourceData(URI resourceURI) {
+        return readResourceDataWithHeaders(resourceURI).getDataset();
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug("fetched model with {} statements in default model for resource {}",result.getDefaultModel().size(),
-                   resourceURI);
+
+    public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI);
+
+    public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, Map<String, String>
+            requestHeaders);
+
+    /**
+     * Retrieves RDF for the specified resource URI for the entity with provided WebID.
+     * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
+     * Paging is not supported.
+     *
+     * @param resourceURI
+     * @param requesterWebID
+     * @return
+     */
+    public Dataset readResourceData(URI resourceURI, URI requesterWebID) {
+        return readResourceDataWithHeaders(resourceURI, requesterWebID).getDataset();
     }
-    return new DatasetResponseWithStatusCodeAndHeaders(result, statusCode, responseHeaderMap);
-  }
+
+    public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, URI requesterWebID);
+
+
+    /**
+     * Retrieves RDF for the specified resource URI.
+     * Expects that the resource URI will lead to a 303 response, redirecting to the URI where RDF can be downloaded.
+     *
+     * @param resourceURI
+     * @return
+     */
+    public Dataset readResourceData(URI resourceURI, URI requesterWebID, Map<String, String>
+            requestHeaders) {
+        return readResourceDataWithHeaders(resourceURI, requesterWebID, requestHeaders).getDataset();
+    }
+
+    public abstract DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(URI resourceURI, URI requesterWebID,
+                                                                                        Map<String,
+                                                                                                String>
+                                                                                                requestHeaders);
+
+    protected DatasetResponseWithStatusCodeAndHeaders readResourceData(URI resourceURI, RestTemplate restTemplate, Map<String,
+            String> requestHeaders) {
+        assert resourceURI != null : "resource URI must not be null";
+        logger.debug("fetching linked data resource: {}", resourceURI);
+
+        //If a RestClientException is thrown here complaining that it can't read a Model with MIME media type text/html,
+        //it was probably the wrong resourceURI
+        Dataset result;
+        int statusCode = -1;
+        Map<String, String> responseHeaderMap = null;
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            for (String key : requestHeaders.keySet()) {
+                headers.add(key, requestHeaders.get(key));
+            }
+            HttpEntity entity = new HttpEntity(null, headers);
+
+            ResponseEntity<Dataset> response = restTemplate.exchange(resourceURI, HttpMethod.GET, entity, Dataset.class);
+            //RestTemplate will automatically follow redirects on HttpGet calls
+            statusCode = response.getStatusCode().value();
+            HttpHeaders responseHeaders = response.getHeaders();
+            if (responseHeaders == null) {
+                responseHeaderMap = new HashMap<>();
+            } else {
+                responseHeaderMap = responseHeaders.toSingleValueMap();
+            }
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new HttpClientErrorException(response.getStatusCode());
+            }
+            result = response.getBody();
+        } catch (RestClientException e) {
+            if (e instanceof HttpClientErrorException) {
+                throw new IllegalArgumentException(
+                        MessageFormat.format(
+                                "caught a HttpClientErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}", resourceURI, e.getMessage(), ((HttpClientErrorException) e).getResponseBodyAsString()), e);
+            }
+            if (e instanceof HttpServerErrorException) {
+                throw new IllegalArgumentException(
+                        MessageFormat.format(
+                                "caught a HttpServerErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}", resourceURI, e.getMessage(), ((HttpServerErrorException) e).getResponseBodyAsString()), e);
+            }
+            throw new IllegalArgumentException(
+                    MessageFormat.format(
+                            "caught a clientHandler exception, " +
+                                    "which may indicate that the URI that was accessed isn''t a" +
+                                    " linked data URI, please check {0}. Underlying error message is: {1}", resourceURI, e.getMessage()), e);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("fetched model with {} statements in default model for resource {}", result.getDefaultModel().size(),
+                    resourceURI);
+        }
+        return new DatasetResponseWithStatusCodeAndHeaders(result, statusCode, responseHeaderMap);
+    }
 
 
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
@@ -267,7 +267,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
     }
 
     //if we don't get a new etag, see if we have a 304 code - then we can use th old etag
-    String etag = responseData.getResponseHeaders().get(HttpHeaders.ETAG);
+    String etag = responseData.getResponseHeaders().getFirst(HttpHeaders.ETAG);
     if (etag == null && responseData.getStatusCode() == HttpStatus.NOT_MODIFIED.value()
       && linkedDataCacheEntry != null){
       etag = linkedDataCacheEntry.getEtag();
@@ -365,7 +365,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
   }
 
   private Date parseExpiresHeader(final URI resource, final DatasetResponseWithStatusCodeAndHeaders responseData) {
-    String expiresHeader = responseData.getResponseHeaders().get(HttpHeaders.EXPIRES);
+    String expiresHeader = responseData.getResponseHeaders().getFirst(HttpHeaders.EXPIRES);
     if (expiresHeader == null) {
         return null;
     }
@@ -396,7 +396,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
 
   private Date parseDateHeader(final URI resource, final DatasetResponseWithStatusCodeAndHeaders
     responseData) {
-    String dateHeader = responseData.getResponseHeaders().get(HttpHeaders.DATE);
+    String dateHeader = responseData.getResponseHeaders().getFirst(HttpHeaders.DATE);
     if (dateHeader == null){
       return null;
     }
@@ -414,7 +414,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
   }
 
   private EnumSet<CacheControlFlag> parseCacheControlHeaderFlags(final URI resource, final DatasetResponseWithStatusCodeAndHeaders responseData) {
-    String cacheControlHeaderValue = responseData.getResponseHeaders().get(HttpHeaders.CACHE_CONTROL);
+    String cacheControlHeaderValue = responseData.getResponseHeaders().getFirst(HttpHeaders.CACHE_CONTROL);
     EnumSet<CacheControlFlag> cacheControlFlags = EnumSet.noneOf(CacheControlFlag.class);
     if (cacheControlHeaderValue == null) return cacheControlFlags;
     String[] values = cacheControlHeaderValue.split(",");
@@ -428,7 +428,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
   }
 
   private Date parseCacheControlMaxAgeValue(final URI resource, final DatasetResponseWithStatusCodeAndHeaders responseData) {
-    String cacheControlHeaderValue = responseData.getResponseHeaders().get(HttpHeaders.CACHE_CONTROL);
+    String cacheControlHeaderValue = responseData.getResponseHeaders().getFirst(HttpHeaders.CACHE_CONTROL);
     if (cacheControlHeaderValue == null) return null;
     Pattern maxagePattern = Pattern.compile("[^\\s,]*max-age\\s*=\\s*(\\d+)[$\\s,]");
     Matcher m = maxagePattern.matcher(cacheControlHeaderValue);
@@ -520,11 +520,11 @@ public static class LinkedDataCacheEntry
     private Date expires = null;
     private byte[] dataset = null;
     private EnumSet<CacheControlFlag> cacheControlFlags = noneOf(CacheControlFlag.class);
-    private Map<String, String> headers;
+    private HttpHeaders headers;
     private int statusCode;
 
 
-    public LinkedDataCacheEntry(final String etag, final Date expires, final byte[] dataset, final EnumSet<CacheControlFlag> cacheControlFlags, final Map<String, String> headers, final int statusCode) {
+    public LinkedDataCacheEntry(final String etag, final Date expires, final byte[] dataset, final EnumSet<CacheControlFlag> cacheControlFlags, final HttpHeaders headers, final int statusCode) {
       this.etag = etag;
       this.expires = expires;
       this.dataset = dataset;

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSource.java
@@ -25,34 +25,35 @@ import java.util.List;
 /**
  * Interface for fetching linked data as a jena Model.
  */
-public interface LinkedDataSource
-{
-  /**
-   * Obtains resource description of the resource identified by the given URI
-   * @param resourceURI
-   * @return resource description as Dataset, or empty Dataset if not a valid URI or not found
-   */
-  public Dataset getDataForResource(URI resourceURI);
+public interface LinkedDataSource {
+    /**
+     * Obtains resource description of the resource identified by the given URI
+     *
+     * @param resourceURI
+     * @return resource description as Dataset, or empty Dataset if not a valid URI or not found
+     */
+    public Dataset getDataForResource(URI resourceURI);
 
-  /**
-   * Obtains resource description of the resource identified by the given URI
-   * for the requester identified by the given WebID. Used in case access
-   * to the resource is restricted by WebAccessControl (WebID-based access control).
-   * @param resourceURI URI of the resource
-   * @param requesterWebID WebID of the entity requesting the resource
-   * @return resource description as Dataset, or empty Dataset if not a valid URI or not found or access not granted
-   */
-  public Dataset getDataForResource(URI resourceURI, URI requesterWebID);
+    /**
+     * Obtains resource description of the resource identified by the given URI
+     * for the requester identified by the given WebID. Used in case access
+     * to the resource is restricted by WebAccessControl (WebID-based access control).
+     *
+     * @param resourceURI    URI of the resource
+     * @param requesterWebID WebID of the entity requesting the resource
+     * @return resource description as Dataset, or empty Dataset if not a valid URI or not found or access not granted
+     */
+    public Dataset getDataForResource(URI resourceURI, URI requesterWebID);
 
-  public Dataset getDataForResource(final URI resourceURI, List<URI> properties,
-    int maxRequest, int maxDepth);
+    public Dataset getDataForResource(final URI resourceURI, List<URI> properties,
+                                      int maxRequest, int maxDepth);
 
-  public Dataset getDataForResource(final URI resourceURI, URI requesterWebID, List<URI> properties,
-                                    int maxRequest, int maxDepth);
+    public Dataset getDataForResource(final URI resourceURI, URI requesterWebID, List<URI> properties,
+                                      int maxRequest, int maxDepth);
 
-  public Dataset getDataForResourceWithPropertyPath(final URI resourceURI, final List<Path> properties, int maxRequest,
-    int maxDepth, final boolean moveAllTriplesInDefaultGraph);
+    public Dataset getDataForResourceWithPropertyPath(final URI resourceURI, final List<Path> properties, int maxRequest,
+                                                      int maxDepth, final boolean moveAllTriplesInDefaultGraph);
 
-  public Dataset getDataForResourceWithPropertyPath(final URI resourceURI, URI requesterWebID, final List<Path>
-    properties, int maxRequest, int maxDepth, final boolean moveAllTriplesInDefaultGraph);
+    public Dataset getDataForResourceWithPropertyPath(final URI resourceURI, URI requesterWebID, final List<Path>
+            properties, int maxRequest, int maxDepth, final boolean moveAllTriplesInDefaultGraph);
 }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
@@ -290,6 +290,8 @@ public class MasterCrawlerActor extends UntypedActor
   private void startCrawling(WonNodeInfo wonNodeInfo) {
 
       // get the last needUri we crawled from the rdf store and continue crawling from that point
+      // this may not be optimal since last crawled need doesn't mean need with newest creation date at some point of time
+      // on the won node, but it is considered a good enough approach for now
       String lastNeedUri = sparqlService.retrieveLastCrawledNeedUri(wonNodeInfo.getWonNodeURI());
       String lastNeedId = getNeedOrConnectionIdFromUri(lastNeedUri);
       if (lastNeedId != null) {
@@ -313,6 +315,8 @@ public class MasterCrawlerActor extends UntypedActor
       }
 
       // get the last connectionUri we crawled from the rdf store and continue crawling from that point
+      // this may not be optimal since last crawled connection doesn't mean newest connection at some point of time
+      // on the won node, but it is considered a good enough approach for now
       String lastConnectionUri = sparqlService.retrieveLastCrawledConnectionUri(wonNodeInfo.getWonNodeURI());
       String lastConnectionId = getNeedOrConnectionIdFromUri(lastConnectionUri);
       if (lastConnectionId != null) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
@@ -33,179 +33,187 @@ import java.util.Set;
 /**
  * Actor requests linked data URI using HTTP and saves it to a triple store using SPARQL UPDATE query.
  * Responds to the sender with extracted URIs from the linked data URI.
- *
+ * <p>
  * This class uses property paths to extract URIs from linked data resources. These property paths are executed
  * relative to base URIs. Therefore there are two types of property paths. Base property path extract URIs that are
  * taken as new base URIs. Non-base property paths extract URIs that keep the current base URI.
- *
+ * <p>
  * User: hfriedrich
  * Date: 07.04.2015
  */
 @Component
 @Scope("prototype")
-public class WorkerCrawlerActor extends UntypedActor
-{
-  private LoggingAdapter log = Logging.getLogger(getContext().system(), this);
+public class WorkerCrawlerActor extends UntypedActor {
+    private LoggingAdapter log = Logging.getLogger(getContext().system(), this);
 
-  @Autowired
-  private LinkedDataSource linkedDataSource;
+    @Autowired
+    private LinkedDataSource linkedDataSource;
 
-  @Autowired
-  private CrawlSparqlService sparqlService;
+    @Autowired
+    private CrawlSparqlService sparqlService;
 
-  @Autowired
-  private CrawlConfig config;
+    @Autowired
+    private CrawlConfig config;
 
-  private ActorRef pubSubMediator;
+    private ActorRef pubSubMediator;
 
-  @Override
-  public void preStart() {
+    @Override
+    public void preStart() {
 
-    // initialize the distributed event bus to send need events to the matchers
-    pubSubMediator = DistributedPubSub.get(getContext().system()).mediator();
-  }
-
-  /**
-   * Receives messages with an URI and processes them by requesting the resource,
-   * saving it to a triple store, extracting URIs from content and answering the sender.
-   *
-   * @param msg if type is {@link CrawlUriMessage} then process it
-   */
-  @Override
-  public void onReceive(Object msg) throws RestClientException {
-
-    if (!(msg instanceof CrawlUriMessage)) {
-      unhandled(msg);
-      return;
+        // initialize the distributed event bus to send need events to the matchers
+        pubSubMediator = DistributedPubSub.get(getContext().system()).mediator();
     }
 
-    CrawlUriMessage uriMsg = (CrawlUriMessage) msg;
-    if (!uriMsg.getStatus().equals(CrawlUriMessage.STATUS.PROCESS) &&
-      !uriMsg.getStatus().equals(CrawlUriMessage.STATUS.SAVE)) {
-      unhandled(msg);
-      return;
-    }
+    /**
+     * Receives messages with an URI and processes them by requesting the resource,
+     * saving it to a triple store, extracting URIs from content and answering the sender.
+     *
+     * @param msg if type is {@link CrawlUriMessage} then process it
+     */
+    @Override
+    public void onReceive(Object msg) throws RestClientException {
 
-    // URI message to process received
-    // start the crawling request
-    Dataset ds = null;
+        if (!(msg instanceof CrawlUriMessage)) {
+            unhandled(msg);
+            return;
+        }
 
-    // check if resource is already downloaded
-    if (uriMsg instanceof ResourceCrawlUriMessage) {
-      ResourceCrawlUriMessage resMsg = ((ResourceCrawlUriMessage) uriMsg);
-      if (resMsg.getSerializedResource() != null && resMsg.getSerializationFormat() != null) {
+        CrawlUriMessage uriMsg = (CrawlUriMessage) msg;
+        if (!uriMsg.getStatus().equals(CrawlUriMessage.STATUS.PROCESS) &&
+                !uriMsg.getStatus().equals(CrawlUriMessage.STATUS.SAVE)) {
+            unhandled(msg);
+            return;
+        }
+
+        // URI message to process received
+        // start the crawling request
+        Dataset ds = null;
+
+        // check if resource is already downloaded
+        if (uriMsg instanceof ResourceCrawlUriMessage) {
+            ResourceCrawlUriMessage resMsg = ((ResourceCrawlUriMessage) uriMsg);
+            if (resMsg.getSerializedResource() != null && resMsg.getSerializationFormat() != null) {
+                try {
+                    // TODO: this should be optimized, why deserialize the resource here when we just want to save it in the RDF
+                    // store? How to insert this serialized resource into the SPARQL endpoint?
+                    ds = SparqlService.deserializeDataset(resMsg.getSerializedResource(), resMsg.getSerializationFormat());
+                } catch (Exception e) {
+                    throw new CrawlWrapperException(e, uriMsg);
+                }
+            }
+        }
+
+        // download resource if not already downloaded
+        if (ds == null) {
+            try {
+                ds = linkedDataSource.getDataForResource(URI.create(uriMsg.getUri()));
+            } catch (RestClientException e) {
+                throw new CrawlWrapperException(e, uriMsg);
+            }
+        }
+        Lock lock = ds == null ? null : ds.getLock();
+        lock.enterCriticalSection(true);
+
+        // Save dataset to triple store
+        sparqlService.updateNamedGraphsOfDataset(ds);
+        String wonNodeUri = extractWonNodeUri(ds, uriMsg.getUri());
+        if (wonNodeUri == null) {
+            wonNodeUri = uriMsg.getWonNodeUri();
+        }
+
+        // do nothing more here if the STATUS of the message was SAVE
+        if (uriMsg.getStatus().equals(CrawlUriMessage.STATUS.SAVE)) {
+            log.debug("processed crawl uri event {} with status 'SAVE'", uriMsg);
+            return;
+        }
+
+        // send extracted non-base URIs back to sender and save meta data about crawling the URI
+        // extract only uris which were crawled at least one recrawl interval ago
+        long crawlDate = System.currentTimeMillis();
+        log.debug("Extract non-base URIs from message {}", uriMsg);
+
+        // we set the date threshold parameter of extractUri() to 0 here.
+        // That means filtering out all URIs that have already been crawled at some point in time.
+        // Therefore we don't get updates of needs from crawling but it reduces crawling activity a lot
+        long threshold = 0;
+        Set<String> extractedURIs = sparqlService.extractURIs(
+                uriMsg.getUri(), uriMsg.getBaseUri(), config.getCrawlNonBasePropertyPaths(), threshold);
+        for (String extractedURI : extractedURIs) {
+            CrawlUriMessage newUriMsg = new CrawlUriMessage(
+                    extractedURI, uriMsg.getBaseUri(), wonNodeUri, CrawlUriMessage.STATUS.PROCESS, crawlDate);
+            getSender().tell(newUriMsg, getSelf());
+        }
+
+        // send extracted base URIs back to sender and save meta data about crawling the URI
+        // extract only uris which were crawled at least one recrawl interval ago
+        log.debug("Extract base URIs from message {}", uriMsg);
+
+        // we set the date threshold parameter of extractUri() to 0 here.
+        // That means filtering out all URIs that have already been crawled at some point in time.
+        // Therefore we don't get updates of needs from crawling but it reduces crawling activity a lot
+        threshold = 0;
+        extractedURIs = sparqlService.extractURIs(
+                uriMsg.getUri(), uriMsg.getBaseUri(), config.getCrawlBasePropertyPaths(), threshold);
+        for (String extractedURI : extractedURIs) {
+            CrawlUriMessage newUriMsg = new CrawlUriMessage(
+                    extractedURI, extractedURI, wonNodeUri, CrawlUriMessage.STATUS.PROCESS, crawlDate);
+            getSender().tell(newUriMsg, getSelf());
+        }
+
+        // signal sender that this URI is processed and save meta data about crawling the URI.
+        // This needs to be done after all extracted URI messages have been sent to guarantee consistency
+        // in case of failure
+        crawlDate = System.currentTimeMillis();
+        CrawlUriMessage uriDoneMsg = new CrawlUriMessage(
+                uriMsg.getUri(), uriMsg.getBaseUri(), wonNodeUri, CrawlUriMessage.STATUS.DONE, crawlDate);
+        log.info("Crawling done for URI {}", uriDoneMsg.getUri());
+        getSender().tell(uriDoneMsg, getSelf());
+
+        // if this URI/dataset was a need then send an event to the distributed event bus
+        NeedModelWrapper needModelWrapper;
         try {
-          // TODO: this should be optimized, why deserialize the resource here when we just want to save it in the RDF
-          // store? How to insert this serialized resource into the SPARQL endpoint?
-          ds = SparqlService.deserializeDataset(resMsg.getSerializedResource(), resMsg.getSerializationFormat());
+
+            // only send active needs right now
+            needModelWrapper = new NeedModelWrapper(ds);
+            if (needModelWrapper.isANeed()) {
+                NeedState state = needModelWrapper.getNeedState();
+                if (state.equals(NeedState.ACTIVE)) {
+
+                    log.debug("Created need event for need uri {}", uriMsg.getUri());
+                    NeedEvent.TYPE type = NeedEvent.TYPE.CREATED;
+                    NeedEvent needEvent = new NeedEvent(uriMsg.getUri(), wonNodeUri, type, crawlDate, ds);
+                    pubSubMediator
+                            .tell(new DistributedPubSubMediator.Publish(needEvent.getClass().getName(), needEvent), getSelf());
+                }
+            }
+
+        } catch (DataIntegrityException e) {
+            log.debug("no valid need model found in dataset for uri {}", uriMsg.getUri());
         } catch (Exception e) {
-          throw new CrawlWrapperException(e, uriMsg);
+            log.debug("caught exception trying to interpret as a need dataset: {}", uriMsg.getUri());
+        } finally {
+            if (lock != null) {
+                lock.leaveCriticalSection();
+            }
         }
-      }
     }
 
-    // download resource if not already downloaded
-    if (ds == null) {
-      try {
-        ds = linkedDataSource.getDataForResource(URI.create(uriMsg.getUri()));
-      } catch (RestClientException e) {
-        throw new CrawlWrapperException(e, uriMsg);
-      }
-    }
-    Lock lock = ds == null ? null : ds.getLock();
-    lock.enterCriticalSection(true);
-
-    // Save dataset to triple store
-    sparqlService.updateNamedGraphsOfDataset(ds);
-    String wonNodeUri = extractWonNodeUri(ds, uriMsg.getUri());
-    if (wonNodeUri == null) {
-      wonNodeUri = uriMsg.getWonNodeUri();
-    }
-
-    // do nothing more here if the STATUS of the message was SAVE
-    if (uriMsg.getStatus().equals(CrawlUriMessage.STATUS.SAVE)) {
-      log.debug("processed crawl uri event {} with status 'SAVE'", uriMsg);
-      return;
-    }
-
-    // send extracted non-base URIs back to sender and save meta data about crawling the URI
-    // extract only uris which were crawled at least one recrawl interval ago
-    long crawlDate = System.currentTimeMillis();
-    log.debug("Extract non-base URIs from message {}", uriMsg);
-    Set<String> extractedURIs = sparqlService.extractURIs(
-      uriMsg.getUri(), uriMsg.getBaseUri(), config.getCrawlNonBasePropertyPaths(),
-      crawlDate - config.getRecrawlIntervalDuration().toMillis());
-    for (String extractedURI : extractedURIs) {
-      CrawlUriMessage newUriMsg = new CrawlUriMessage(
-        extractedURI, uriMsg.getBaseUri(), wonNodeUri, CrawlUriMessage.STATUS.PROCESS, crawlDate);
-      getSender().tell(newUriMsg, getSelf());
-    }
-
-    // send extracted base URIs back to sender and save meta data about crawling the URI
-    // extract only uris which were crawled at least one recrawl interval ago
-    log.debug("Extract base URIs from message {}", uriMsg);
-    extractedURIs = sparqlService.extractURIs(uriMsg.getUri(), uriMsg.getBaseUri(), config.getCrawlBasePropertyPaths(),
-      crawlDate - config.getRecrawlIntervalDuration().toMillis());
-    for (String extractedURI : extractedURIs) {
-      CrawlUriMessage newUriMsg = new CrawlUriMessage(
-        extractedURI, extractedURI, wonNodeUri, CrawlUriMessage.STATUS.PROCESS, crawlDate);
-      getSender().tell(newUriMsg, getSelf());
-    }
-
-    // signal sender that this URI is processed and save meta data about crawling the URI.
-    // This needs to be done after all extracted URI messages have been sent to guarantee consistency
-    // in case of failure
-    crawlDate = System.currentTimeMillis();
-    CrawlUriMessage uriDoneMsg = new CrawlUriMessage(
-      uriMsg.getUri(), uriMsg.getBaseUri(), wonNodeUri, CrawlUriMessage.STATUS.DONE, crawlDate);
-    log.info("Crawling done for URI {}", uriDoneMsg.getUri());
-    getSender().tell(uriDoneMsg, getSelf());
-
-    // if this URI/dataset was a need then send an event to the distributed event bus
-    NeedModelWrapper needModelWrapper;
-    try {
-
-      // only send active needs right now
-      needModelWrapper = new NeedModelWrapper(ds);
-      if (needModelWrapper.isANeed()) {
-        NeedState state = needModelWrapper.getNeedState();
-        if (state.equals(NeedState.ACTIVE)) {
-
-          log.debug("Created need event for need uri {}", uriMsg.getUri());
-          NeedEvent.TYPE type = NeedEvent.TYPE.CREATED;
-          NeedEvent needEvent = new NeedEvent(uriMsg.getUri(), wonNodeUri, type, crawlDate, ds);
-          pubSubMediator
-                  .tell(new DistributedPubSubMediator.Publish(needEvent.getClass().getName(), needEvent), getSelf());
+    /**
+     * Extract won node uri from a won resource
+     *
+     * @param ds  resource as dataset
+     * @param uri uri that represents resource
+     * @return won node uri or null if link to won node is not linked in the resource
+     */
+    private String extractWonNodeUri(Dataset ds, String uri) {
+        try {
+            return RdfUtils.findOnePropertyFromResource(ds, URI.create(uri), WON.HAS_WON_NODE).asResource().getURI();
+        } catch (IncorrectPropertyCountException e) {
+            return null;
         }
-      }
-
-    } catch (DataIntegrityException e) {
-      log.debug("no valid need model found in dataset for uri {}", uriMsg.getUri());
-    } catch (Exception e){
-      log.debug("caught exceptiontrying to interpret as a need dataset: {}", uriMsg.getUri());
-    } finally {
-      if (lock != null){
-        lock.leaveCriticalSection();
-      }
     }
-  }
 
-  /**
-   * Extract won node uri from a won resource
-   *
-   * @param ds resource as dataset
-   * @param uri uri that represents resource
-   * @return won node uri or null if link to won node is not linked in the resource
-   */
-  private String extractWonNodeUri(Dataset ds, String uri) {
-    try {
-      return RdfUtils.findOnePropertyFromResource(ds, URI.create(uri), WON.HAS_WON_NODE).asResource().getURI();
-    } catch (IncorrectPropertyCountException e) {
-      return null;
+    public void setSparqlService(final CrawlSparqlService sparqlService) {
+        this.sparqlService = sparqlService;
     }
-  }
-
-  public void setSparqlService(final CrawlSparqlService sparqlService) {
-    this.sparqlService = sparqlService;
-  }
 }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -162,7 +162,7 @@ public class CrawlSparqlService extends SparqlService {
                     "SELECT ?obj WHERE {\n" +
                     " <" + baseUri + "> " + prop + " ?obj.\n" +
                     " OPTIONAL {?obj won:crawlDate ?crawlDate. }\n" +
-                    " FILTER ((?crawlDate < \" + crawlDateThreshold + \" ) || !BOUND(?crawlDate)) }\n";
+                    " FILTER ((?crawlDate < " + crawlDateThreshold + " ) || !BOUND(?crawlDate)) }\n";
 
             log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
             log.debug("Execute query: {}", queryString);

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -20,213 +20,263 @@ import java.util.Set;
 
 /**
  * Sparql service extended with methods for crawling
- *
+ * <p>
  * User: hfriedrich
  * Date: 04.05.2015
  */
 @Component
-public class CrawlSparqlService extends SparqlService
-{
-  public static final String METADATA_GRAPH = WON.BASE_URI + "crawlMetadata";
-  public static final String CRAWL_DATE_PREDICATE = WON.BASE_URI + "crawlDate";
-  public static final String CRAWL_STATUS_PREDICATE = WON.BASE_URI + "crawlStatus";
-  public static final String CRAWL_BASE_URI_PREDICATE = WON.BASE_URI + "crawlBaseUri";
-  public static final String CRAWL_WON_NODE_URI_PREDICATE = WON.BASE_URI + "wonNodeUri";
+public class CrawlSparqlService extends SparqlService {
+    public static final String METADATA_GRAPH = WON.BASE_URI + "crawlMetadata";
+    public static final String CRAWL_DATE_PREDICATE = WON.BASE_URI + "crawlDate";
+    public static final String CRAWL_STATUS_PREDICATE = WON.BASE_URI + "crawlStatus";
+    public static final String CRAWL_BASE_URI_PREDICATE = WON.BASE_URI + "crawlBaseUri";
+    public static final String CRAWL_WON_NODE_URI_PREDICATE = WON.BASE_URI + "wonNodeUri";
 
-  @Autowired
-  public CrawlSparqlService(@Value("${uri.sparql.endpoint}") final String sparqlEndpoint) {
-    super(sparqlEndpoint);
-  }
-
-  /**
-   * Update the message meta data about the crawling process using a separate graph.
-   * For each crawled URI save the date, the current status and the baseUri.
-   * This enables to construct the message again (e.g. for executing (unfinished)
-   * crawling again later)
-   *
-   * @param msg message that describe crawling meta data to update
-   */
-  public void updateCrawlingMetadata(CrawlUriMessage msg) {
-
-    // delete the old entry
-    String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
-      "DELETE WHERE { GRAPH won:crawlMetadata { <" + msg.getUri() + "> ?y ?z}}\n;";
-
-    // insert new entry
-    queryString += "\nINSERT DATA { GRAPH won:crawlMetadata {\n" +
-      "<" + msg.getUri() + "> won:crawlDate " + msg.getCrawlDate() + ".\n" +
-      "<" + msg.getUri() + "> won:crawlStatus '" + msg.getStatus() + "'.\n" +
-      "<" + msg.getUri() + "> won:crawlBaseUri <" + msg.getBaseUri() + ">.\n";
-    if (msg.getWonNodeUri() != null) {
-      queryString += "<" + msg.getUri() + "> won:wonNodeUri <" + msg.getWonNodeUri() + ">.\n";
-    }
-    queryString += "}}\n";
-
-    // execute query
-    executeUpdateQuery(queryString);
-  }
-
-  /**
-   * Bulk update of several meta data messages about the crawling process using a separate graph.
-   * For each crawled URI save the date, the current status and the baseUri using only a
-   * single Sparql update query.
-   * This enables to construct the message again (e.g. for executing (unfinished)
-   * crawling again later).
-   *
-   * @param msgs multiple messages that describe crawling meta data to update
-   */
-  public void bulkUpdateCrawlingMetadata(Collection<CrawlUriMessage> msgs) {
-
-    // delete the old entries
-    StringBuilder builder = new StringBuilder();
-    builder.append("prefix won: <http://purl.org/webofneeds/model#>\n");
-    for (CrawlUriMessage msg : msgs) {
-      builder.append("\nDELETE WHERE { GRAPH won:crawlMetadata { <");
-      builder.append(msg.getUri()).append("> ?p ?o }};");
+    @Autowired
+    public CrawlSparqlService(@Value("${uri.sparql.endpoint}") final String sparqlEndpoint) {
+        super(sparqlEndpoint);
     }
 
-    // insert the new entries
-    builder.append("\n\nINSERT DATA { GRAPH won:crawlMetadata {\n");
-    for (CrawlUriMessage msg : msgs) {
-      builder.append("<").append(msg.getUri()).append("> won:crawlDate ").append(msg.getCrawlDate()).append(".\n");
-      builder.append("<").append(msg.getUri()).append("> won:crawlStatus '").append(msg.getStatus()).append("'.\n");
-      builder.append("<").append(msg.getUri()).append("> won:crawlBaseUri <").append(msg.getBaseUri()).append(">.\n");
-      if (msg.getWonNodeUri() != null) {
-        builder.append("<").append(msg.getUri()).append("> won:wonNodeUri <").append(msg.getWonNodeUri()).append(">.\n");
-      }
-    }
-    builder.append("}};\n");
+    /**
+     * Update the message meta data about the crawling process using a separate graph.
+     * For each crawled URI save the date, the current status and the baseUri.
+     * This enables to construct the message again (e.g. for executing (unfinished)
+     * crawling again later)
+     *
+     * @param msg message that describe crawling meta data to update
+     */
+    public void updateCrawlingMetadata(CrawlUriMessage msg) {
 
-    // execute the bulk query
-    executeUpdateQuery(builder.toString());
-  }
+        // delete the old entry
+        String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
+                "DELETE WHERE { GRAPH won:crawlMetadata { <" + msg.getUri() + "> ?y ?z}}\n;";
 
-  /**
-   * Gets all messages saved in the db of a certain status (e.g. FAILED) and puts
-   * them in the STATUS PROCESS to be able to execute the crawling again.
-   *
-   * @param status
-   * @return
-   */
-  public Set<CrawlUriMessage> retrieveMessagesForCrawling(CrawlUriMessage.STATUS status) {
+        // insert new entry
+        queryString += "\nINSERT DATA { GRAPH won:crawlMetadata {\n" +
+                "<" + msg.getUri() + "> won:crawlDate " + msg.getCrawlDate() + ".\n" +
+                "<" + msg.getUri() + "> won:crawlStatus '" + msg.getStatus() + "'.\n" +
+                "<" + msg.getUri() + "> won:crawlBaseUri <" + msg.getBaseUri() + ">.\n";
+        if (msg.getWonNodeUri() != null) {
+            queryString += "<" + msg.getUri() + "> won:wonNodeUri <" + msg.getWonNodeUri() + ">.\n";
+        }
+        queryString += "}}\n";
 
-    Set<CrawlUriMessage> msgs = new LinkedHashSet<>();
-    String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
-      "SELECT ?uri ?base ?wonNode WHERE { GRAPH won:crawlMetadata {\n" +
-      " ?uri ?p '" + status + "'.\n" +
-      " ?uri won:crawlBaseUri ?base.\n" +
-      " OPTIONAL { ?uri won:wonNodeUri ?wonNode }\n}}\n";
-    log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-    log.debug("Execute query: {}", queryString);
-    Query query = QueryFactory.create(queryString);
-    QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
-    ResultSet results = qexec.execSelect();
-
-    while (results.hasNext()) {
-
-      QuerySolution qs = results.nextSolution();
-      String uri = qs.get("uri").asResource().getURI();
-      String baseUri = qs.get("base").asResource().getURI();
-      CrawlUriMessage msg = null;
-      if (qs.get("wonNode") != null) {
-        String wonNode = qs.get("wonNode").asResource().getURI();
-        msg = new CrawlUriMessage(uri, baseUri, wonNode, CrawlUriMessage.STATUS.PROCESS, System.currentTimeMillis());
-      } else {
-        msg = new CrawlUriMessage(uri, baseUri, CrawlUriMessage.STATUS.PROCESS, System.currentTimeMillis());
-      }
-
-      log.debug("Created message: {}", msg);
-      msgs.add(msg);
-    }
-    qexec.close();
-    return msgs;
-  }
-
-  /**
-   * Extract linked URIs of resource URI that have not been crawled since a certain date (crawlDateThreshold). Use
-   * specified property paths to construct the query.
-   *
-   * @param uri current processed resource URI
-   * @param properties property paths used to query the sparql endpoint
-   * @param crawlDateThreshold extract only uris that have a crawlDate < crawlDateThreshold
-   * @return set of extracted URIs from the resource URI
-   */
-  public Set<String> extractURIs(String uri, String baseUri, Iterable<String> properties, long crawlDateThreshold) {
-    Set<String> extractedURIs = new HashSet<String>();
-    for (String prop : properties) {
-      if (prop.trim().length()==0) {
-        continue;
-        //ignore empty strings
-      }
-      // select URIs specified by property paths that have not already been crawled
-      String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
-        "SELECT ?obj WHERE {\n" +
-        " <" + baseUri +"> " + prop + " ?obj.\n" +
-        " OPTIONAL {?obj won:crawlDate ?crawlDate. FILTER ( ?crawlDate < " + crawlDateThreshold + " )}\n}\n";
-
-      log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-      log.debug("Execute query: {}", queryString);
-      Query query = QueryFactory.create(queryString);
-      QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
-      ResultSet results = qexec.execSelect();
-
-      while (results.hasNext()) {
-        QuerySolution qs = results.nextSolution();
-        String extractedUri = qs.get("obj").asResource().getURI();
-        log.debug("Extracted URI: {}", extractedUri);
-        extractedURIs.add(extractedUri);
-      }
-      qexec.close();
+        // execute query
+        executeUpdateQuery(queryString);
     }
 
-    return extractedURIs;
-  }
+    /**
+     * Bulk update of several meta data messages about the crawling process using a separate graph.
+     * For each crawled URI save the date, the current status and the baseUri using only a
+     * single Sparql update query.
+     * This enables to construct the message again (e.g. for executing (unfinished)
+     * crawling again later).
+     *
+     * @param msgs multiple messages that describe crawling meta data to update
+     */
+    public void bulkUpdateCrawlingMetadata(Collection<CrawlUriMessage> msgs) {
 
-  public BulkNeedEvent retrieveActiveNeedEvents(long fromDate, long toDate, int offset, int limit, boolean
-    sortAscending) {
+        // delete the old entries
+        StringBuilder builder = new StringBuilder();
+        builder.append("prefix won: <http://purl.org/webofneeds/model#>\n");
+        for (CrawlUriMessage msg : msgs) {
+            builder.append("\nDELETE WHERE { GRAPH won:crawlMetadata { <");
+            builder.append(msg.getUri()).append("> ?p ?o }};");
+        }
 
-    // query template to retrieve all alctive cralwed/saved needs in a certain date range
-    String orderClause = sortAscending ? "ORDER BY ?date\n" : "ORDER BY DESC(?date)\n";
-    log.debug("bulk load need data from sparql endpoint in date range: [{},{}]", fromDate, toDate);
-    String queryTemplate = "prefix won: <http://purl.org/webofneeds/model#> \n" +
-      "SELECT ?needUri ?wonNodeUri ?date WHERE {  \n" +
-      "  ?needUri a won:Need. \n" +
-      "  ?needUri won:crawlDate ?date.  \n" +
-      "  ?needUri won:isInState won:Active. \n" +
-      "  ?needUri won:hasWonNode ?wonNodeUri. \n" +
-      "  {?needUri won:crawlStatus 'SAVE'.} UNION {?needUri won:crawlStatus 'DONE'.}\n" +
-      "  FILTER (?date >= %d && ?date < %d ) \n" +
-      "} " + orderClause +
-      " OFFSET %d\n" +
-      " LIMIT %d";
+        // insert the new entries
+        builder.append("\n\nINSERT DATA { GRAPH won:crawlMetadata {\n");
+        for (CrawlUriMessage msg : msgs) {
+            builder.append("<").append(msg.getUri()).append("> won:crawlDate ").append(msg.getCrawlDate()).append(".\n");
+            builder.append("<").append(msg.getUri()).append("> won:crawlStatus '").append(msg.getStatus()).append("'.\n");
+            builder.append("<").append(msg.getUri()).append("> won:crawlBaseUri <").append(msg.getBaseUri()).append(">.\n");
+            if (msg.getWonNodeUri() != null) {
+                builder.append("<").append(msg.getUri()).append("> won:wonNodeUri <").append(msg.getWonNodeUri()).append(">.\n");
+            }
+        }
+        builder.append("}};\n");
 
-    String queryString = String.format(queryTemplate, fromDate, toDate, offset, limit);
-
-    log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-    log.debug("Execute query: {}", queryString);
-    Query query = QueryFactory.create(queryString);
-    QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
-    ResultSet results = qexec.execSelect();
-
-    // load all the needs into one bulk need event
-    BulkNeedEvent bulkNeedEvent = new BulkNeedEvent();
-    while (results.hasNext()) {
-
-      QuerySolution qs = results.nextSolution();
-      String needUri = qs.get("needUri").asResource().getURI();
-      String wonNodeUri = qs.get("wonNodeUri").asResource().getURI();
-      long crawlDate = qs.getLiteral("date").getLong();
-
-      Dataset ds = retrieveNeedDataset(needUri);
-      StringWriter sw = new StringWriter();
-      RDFDataMgr.write(sw, ds, RDFFormat.TRIG.getLang());
-      NeedEvent needEvent = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.CREATED,
-                                          crawlDate, sw.toString(), RDFFormat.TRIG.getLang());
-      bulkNeedEvent.addNeedEvent(needEvent);
+        // execute the bulk query
+        executeUpdateQuery(builder.toString());
     }
-    qexec.close();
-    log.debug("number of need events created: " + bulkNeedEvent.getNeedEvents().size());
-    return bulkNeedEvent;
-  }
+
+    /**
+     * Gets all messages saved in the db of a certain status (e.g. FAILED) and puts
+     * them in the STATUS PROCESS to be able to execute the crawling again.
+     *
+     * @param status
+     * @return
+     */
+    public Set<CrawlUriMessage> retrieveMessagesForCrawling(CrawlUriMessage.STATUS status) {
+
+        Set<CrawlUriMessage> msgs = new LinkedHashSet<>();
+        String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
+                "SELECT ?uri ?base ?wonNode WHERE { GRAPH won:crawlMetadata {\n" +
+                " ?uri ?p '" + status + "'.\n" +
+                " ?uri won:crawlBaseUri ?base.\n" +
+                " OPTIONAL { ?uri won:wonNodeUri ?wonNode }\n}}\n";
+        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        log.debug("Execute query: {}", queryString);
+        Query query = QueryFactory.create(queryString);
+        QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
+        ResultSet results = qexec.execSelect();
+
+        while (results.hasNext()) {
+
+            QuerySolution qs = results.nextSolution();
+            String uri = qs.get("uri").asResource().getURI();
+            String baseUri = qs.get("base").asResource().getURI();
+            CrawlUriMessage msg = null;
+            if (qs.get("wonNode") != null) {
+                String wonNode = qs.get("wonNode").asResource().getURI();
+                msg = new CrawlUriMessage(uri, baseUri, wonNode, CrawlUriMessage.STATUS.PROCESS, System.currentTimeMillis());
+            } else {
+                msg = new CrawlUriMessage(uri, baseUri, CrawlUriMessage.STATUS.PROCESS, System.currentTimeMillis());
+            }
+
+            log.debug("Created message: {}", msg);
+            msgs.add(msg);
+        }
+        qexec.close();
+        return msgs;
+    }
+
+    /**
+     * Extract linked URIs of resource URI that have not been crawled since a certain date (crawlDateThreshold). Use
+     * specified property paths to construct the query.
+     *
+     * @param uri                current processed resource URI
+     * @param properties         property paths used to query the sparql endpoint
+     * @param crawlDateThreshold extract only uris that have a crawlDate < crawlDateThreshold
+     * @return set of extracted URIs from the resource URI
+     */
+    public Set<String> extractURIs(String uri, String baseUri, Iterable<String> properties, long crawlDateThreshold) {
+        Set<String> extractedURIs = new HashSet<String>();
+        for (String prop : properties) {
+            if (prop.trim().length() == 0) {
+                continue;
+                //ignore empty strings
+            }
+            // select URIs specified by property paths that have not already been crawled
+            String queryString = "prefix won: <http://purl.org/webofneeds/model#>\n" +
+                    "SELECT ?obj WHERE {\n" +
+                    " <" + baseUri + "> " + prop + " ?obj.\n" +
+                    " OPTIONAL {?obj won:crawlDate ?crawlDate. }\n" +
+                    " FILTER ((?crawlDate < \" + crawlDateThreshold + \" ) || !BOUND(?crawlDate)) }\n";
+
+            log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+            log.debug("Execute query: {}", queryString);
+            Query query = QueryFactory.create(queryString);
+            QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
+            ResultSet results = qexec.execSelect();
+
+            while (results.hasNext()) {
+                QuerySolution qs = results.nextSolution();
+                String extractedUri = qs.get("obj").asResource().getURI();
+                log.debug("Extracted URI: {}", extractedUri);
+                extractedURIs.add(extractedUri);
+            }
+            qexec.close();
+        }
+
+        return extractedURIs;
+    }
+
+    /**
+     * retrieve the last crawled needUri from a certain won node
+     * @param wonNodeUri won node to retrieve the last crawled uri for
+     * @return returns the last crawled needUri or null if none exists
+     */
+    public String retrieveLastCrawledNeedUri(String wonNodeUri) {
+
+        String query = "prefix won: <http://purl.org/webofneeds/model#>\n" +
+                "SELECT ?needUri WHERE {\n" +
+                " ?needUri a won:Need.\n" +
+                " ?needUri won:hasWonNode <" + wonNodeUri + ">. \n" +
+                " ?needUri won:crawlDate ?date. \n" +
+                "} ORDER BY DESC(?date) LIMIT 1\n";
+
+        QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
+        ResultSet results = qexec.execSelect();
+        String needUri = null;
+        if (results.hasNext()) {
+            QuerySolution qs = results.nextSolution();
+            needUri = qs.get("needUri").asResource().getURI();
+        }
+        qexec.close();
+        return needUri;
+    }
+
+    /**
+     * retrieve the last crawled connectionUri from a certain won node
+     * @param wonNodeUri won node to retrieve the last crawled uri for
+     * @return returns the last crawled connectionUri or null if none exists
+     */
+    public String retrieveLastCrawledConnectionUri(String wonNodeUri) {
+
+        String query = "prefix won: <http://purl.org/webofneeds/model#>\n" +
+                "SELECT ?connectionUri WHERE {\n" +
+                " ?connectionUri a won:Connection.\n" +
+                " ?connectionUri won:hasWonNode <" + wonNodeUri + ">. \n" +
+                " ?connectionUri won:crawlDate ?date. \n" +
+                "} ORDER BY DESC(?date) LIMIT 1\n";
+
+        QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
+        ResultSet results = qexec.execSelect();
+        String connectionUri = null;
+        if (results.hasNext()) {
+            QuerySolution qs = results.nextSolution();
+            connectionUri = qs.get("connectionUri").asResource().getURI();
+        }
+        qexec.close();
+        return connectionUri;
+    }
+
+    public BulkNeedEvent retrieveActiveNeedEvents(long fromDate, long toDate, int offset, int limit, boolean
+            sortAscending) {
+
+        // query template to retrieve all alctive cralwed/saved needs in a certain date range
+        String orderClause = sortAscending ? "ORDER BY ?date\n" : "ORDER BY DESC(?date)\n";
+        log.debug("bulk load need data from sparql endpoint in date range: [{},{}]", fromDate, toDate);
+        String queryTemplate = "prefix won: <http://purl.org/webofneeds/model#> \n" +
+                "SELECT ?needUri ?wonNodeUri ?date WHERE {  \n" +
+                "  ?needUri a won:Need. \n" +
+                "  ?needUri won:crawlDate ?date.  \n" +
+                "  ?needUri won:isInState won:Active. \n" +
+                "  ?needUri won:hasWonNode ?wonNodeUri. \n" +
+                "  {?needUri won:crawlStatus 'SAVE'.} UNION {?needUri won:crawlStatus 'DONE'.}\n" +
+                "  FILTER (?date >= %d && ?date < %d ) \n" +
+                "} " + orderClause +
+                " OFFSET %d\n" +
+                " LIMIT %d";
+
+        String queryString = String.format(queryTemplate, fromDate, toDate, offset, limit);
+
+        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        log.debug("Execute query: {}", queryString);
+        Query query = QueryFactory.create(queryString);
+        QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, query);
+        ResultSet results = qexec.execSelect();
+
+        // load all the needs into one bulk need event
+        BulkNeedEvent bulkNeedEvent = new BulkNeedEvent();
+        while (results.hasNext()) {
+
+            QuerySolution qs = results.nextSolution();
+            String needUri = qs.get("needUri").asResource().getURI();
+            String wonNodeUri = qs.get("wonNodeUri").asResource().getURI();
+            long crawlDate = qs.getLiteral("date").getLong();
+
+            Dataset ds = retrieveNeedDataset(needUri);
+            StringWriter sw = new StringWriter();
+            RDFDataMgr.write(sw, ds, RDFFormat.TRIG.getLang());
+            NeedEvent needEvent = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.CREATED,
+                    crawlDate, sw.toString(), RDFFormat.TRIG.getLang());
+            bulkNeedEvent.addNeedEvent(needEvent);
+        }
+        qexec.close();
+        log.debug("number of need events created: " + bulkNeedEvent.getNeedEvents().size());
+        return bulkNeedEvent;
+    }
 
 }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -73,10 +73,10 @@ public class NeedInformationServiceImpl implements NeedInformationService
     }
     Slice<URI> slice = null;
     if (needState == null) {
-      slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
+      slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "lastUpdate"));
     } else {
       slice = needRepository.getAllNeedURIs(needState, new PageRequest(pageNum, pageSize, Sort.Direction.DESC,
-                                                                       "creationDate"));
+                                                                       "lastUpdate"));
     }
     return slice;
   }
@@ -93,10 +93,10 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     if (needState == null) {
       slice = needRepository.getNeedURIsBefore(referenceDate, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "creationDate"));
+        .Direction.DESC, "lastUpdate"));
     } else {
       slice = needRepository.getNeedURIsBefore(referenceDate, needState, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "creationDate"));
+        .Direction.DESC, "lastUpdate"));
     }
     return slice;
   }
@@ -113,10 +113,10 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     if (needState == null) {
       slice = needRepository.getNeedURIsAfter(referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                             "creationDate"));
+                                                                             "lastUpdate"));
     } else {
       slice = needRepository.getNeedURIsAfter(referenceDate, needState, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                                        "creationDate"));
+                                                                                        "lastUpdate"));
     }
     return slice;
   }


### PR DESCRIPTION
fixes #1001 
fixes #1268 
* crawl needs and connections only once
* query new needs and connections by using http query parameter "resumeafter" for needs and connections of a won node
* handle paging if won node sends previous "link" in http response with uri to further data
* sort needs in won node by modification date instead of creation date

Note:

for my testing i added an http paging header in my requests:

won/protocol/rest/LinkedDataRestClientHttps.java:131

````
@Override
  public DatasetResponseWithStatusCodeAndHeaders readResourceDataWithHeaders(final URI resourceURI) {
    Map<String, String> requestHeaders = new HashMap<String, String>();
    requestHeaders.put(HttpHeaders.ACCEPT, this.acceptHeaderValue);

    // added
    requestHeaders.put("Prefer", "return=representation; max-member-count=10");

    return super.readResourceData(resourceURI, restTemplateWithDefaultWebId, requestHeaders);
  }
````