### PR TITLE
Enable remember-me in owner webapp

### DIFF
--- a/webofneeds/won-node/src/main/resources/db/migration/V4_1__add_persistent_logins.sql
+++ b/webofneeds/won-node/src/main/resources/db/migration/V4_1__add_persistent_logins.sql
@@ -1,0 +1,7 @@
+BEGIN;
+-- used for spring remember-me functionality
+CREATE TABLE persistent_logins (username varchar(64) not null,
+								series varchar(64) primary key,
+								token varchar(64) not null,
+								last_used timestamp not null);
+COMMIT;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
@@ -269,7 +269,7 @@ public class RestUserController
    */
   @RequestMapping(
     value = "/signin",
-    method = RequestMethod.GET
+    method = RequestMethod.POST
   )
   //TODO: move transactionality annotation into the service layer
   @Transactional(propagation = Propagation.SUPPORTS)

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -77,7 +77,9 @@
 				services-alias="rememberMeServices"
 				remember-me-parameter="remember-me"
 				remember-me-cookie="remember-me"
-				token-validity-seconds="5184000"/>
+				token-validity-seconds="5184000"
+				data-source-ref="dataSource"
+				/>
 
 		<!-- use spring security's default http headers -->
 		<!-- see http://docs.spring.io/spring-security/site/docs/3.2.9.RELEASE/reference/htmlsingle/#headers for

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -9,7 +9,7 @@
 
 	<!-- special config for linked data brige: we want no caching headers added  -->
 	<http use-expressions="true" pattern="/rest/linked-data/**"
-		  entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint" security-context-repository-ref="securityContextRepository">
+		  entry-point-ref="ajaxLoginUrlAuthenticationEntryPoint" security-context-repository-ref="securityContextRepository" >
 		<headers defaults-disabled="true">
 			<content-type-options />
 			<hsts />
@@ -63,6 +63,21 @@
             see: http://spring.io/blog/2014/09/16/preview-spring-security-websocket-support-sessions
         -->
         <custom-filter ref="sessionRepositoryFilter" before="FIRST" />
+
+		<!--
+			this config resets all remember-me cookies on startup because the
+			'key' property is by default set to a newly generated SecureRandom value.
+			Alternatively, we can inject a value through external configuration.
+			A suitable name for that property would be ${owner.webapp.rememberme.key}.
+		-->
+
+		<remember-me
+				user-service-ref="wonUserDetailService"
+				use-secure-cookie="true"
+				services-alias="rememberMeServices"
+				remember-me-parameter="remember-me"
+				remember-me-cookie="remember-me"
+				token-validity-seconds="5184000"/>
 
 		<!-- use spring security's default http headers -->
 		<!-- see http://docs.spring.io/spring-security/site/docs/3.2.9.RELEASE/reference/htmlsingle/#headers for

--- a/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webofneeds/won-owner-webapp/src/main/webapp/WEB-INF/web.xml
@@ -77,9 +77,9 @@
 	    <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
-    <!-- for testing closing websocket connection purposes -->
-    <!--session-config>
-        <session-timeout>1</session-timeout>
-    </session-config-->
+    <!-- session timeout -->
+    <session-config>
+        <session-timeout>86400</session-timeout>
+    </session-config>
 
 </web-app>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
@@ -17,7 +17,7 @@ import * as srefUtils from '../sref-utils.js';
 
 function genLoginConf() {
     let template = `
-        <form ng-submit="::self.login({email: self.email, password: self.password}, {redirectToFeed: false})"
+        <form ng-submit="::self.login({email: self.email, password: self.password, rememberMe: self.rememberMe}, {redirectToFeed: false})"
             id="loginForm"
             class="loginForm"
         >
@@ -47,6 +47,10 @@ function genLoginConf() {
                 <!--ng-click="::self.login(self.email, self.password)">-->
                     Sign in
             </button>
+            <input
+                id="remember-me"
+                ng-model="self.rememberMe"
+                type="checkbox"/> remember me
         </form>
         <div class="wl__register">
             No Account yet?
@@ -66,6 +70,7 @@ function genLoginConf() {
 
             this.email = "";
             this.password = "";
+            this.rememberMe = false;
 
             const login = (state) => ({
                 loginVisible: state.get('loginVisible'),
@@ -81,7 +86,8 @@ function genLoginConf() {
             if(event.keyCode == 13) {
                 this.login({
                     email: this.email,
-                    password: this.password
+                    password: this.password,
+                    rememberMe: this.rememberMe,
                 }, {
                     redirectToFeed: false
                 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.html
@@ -36,6 +36,11 @@
                            ng-model="self.passwordAgain" required type="password" compare-to="self.password"
                            ng-keyup="self.formKeyup($event)"/>
 
+                    <input
+                            id="remember-me"
+                            ng-model="self.rememberMe"
+                            type="checkbox"/> remember me
+
                     <span class="tg__errormsg"
                           ng-show="registerForm.password_repeat.$error.compareTo">
                         Password is not equal
@@ -43,7 +48,7 @@
                 </div>
                 <button id="signup" class="won-button--filled red"
                         ng-disabled="registerForm.$invalid"
-                        ng-click="::self.register({email: self.email, password: self.password})">
+                        ng-click="::self.register({email: self.email, password: self.password, rememberMe: self.rememberMe})">
                     That’s all we need. Let’s go!
                 </button>
             </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -23,6 +23,7 @@ class SignupController {
 
     constructor(/* arguments <- serviceDependencies */) {
         attach(this, serviceDependencies, arguments);
+        this.rememberMe=false;
         Object.assign(this, srefUtils); // bind srefUtils to scope
         const self = this;
 
@@ -40,7 +41,7 @@ class SignupController {
             event.keyCode == 13 &&
             this.passwordAgain === this.password
         ) {
-            this.register({email: this.email, password: this.password})
+            this.register({email: this.email, password: this.password, rememberMe:this.rememberMe})
         }
     }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -176,14 +176,16 @@ export function registerAccount(credentials) {
  */
 export function login(credentials) {
     const {email, password, rememberMe} = parseCredentials(credentials);
-    const loginUrl = '/owner/rest/users/signin?username=' + encodeURIComponent(email) + '&password=' + encodeURIComponent(password) + (rememberMe ? '&remember-me=true':'');
+    const loginUrl = '/owner/rest/users/signin'
+    const params = 'username=' + encodeURIComponent(email) + '&password=' + encodeURIComponent(password) + (rememberMe ? '&remember-me=true':'');
 
     return fetch(loginUrl, {
-        method: 'get',
+        method: 'post',
         headers: {
             'Accept': 'application/json',
-            'Content-Type': 'application/json'
+            "Content-Type": "application/x-www-form-urlencoded",
         },
+        body: params,
         credentials: 'include',
     })
     .then(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -175,15 +175,16 @@ export function registerAccount(credentials) {
  * @returns {*}
  */
 export function login(credentials) {
-    const {email, password} = parseCredentials(credentials);
-    return fetch('/owner/rest/users/signin', {
-        method: 'post',
+    const {email, password, rememberMe} = parseCredentials(credentials);
+    const loginUrl = '/owner/rest/users/signin?username=' + email + '&password=' + password + (rememberMe ? '&remember-me=true':'');
+
+    return fetch(loginUrl, {
+        method: 'get',
         headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         },
         credentials: 'include',
-        body: JSON.stringify({username: email, password: password})
     })
     .then(
         checkHttpStatus

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -176,7 +176,7 @@ export function registerAccount(credentials) {
  */
 export function login(credentials) {
     const {email, password, rememberMe} = parseCredentials(credentials);
-    const loginUrl = '/owner/rest/users/signin?username=' + email + '&password=' + password + (rememberMe ? '&remember-me=true':'');
+    const loginUrl = '/owner/rest/users/signin?username=' + encodeURIComponent(email) + '&password=' + encodeURIComponent(password) + (rememberMe ? '&remember-me=true':'');
 
     return fetch(loginUrl, {
         method: 'get',

--- a/webofneeds/won-owner/src/main/resources/db/migration/V4_1__add_persistent_logins.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V4_1__add_persistent_logins.sql
@@ -1,0 +1,7 @@
+BEGIN;
+-- used for spring remember-me functionality
+CREATE TABLE persistent_logins (username varchar(64) not null,
+								series varchar(64) primary key,
+								token varchar(64) not null,
+								last_used timestamp not null);
+COMMIT;


### PR DESCRIPTION
* changes signin request from post to get so we can easily pass parameters that can be
picked up by the RememberMeServices

* configures RememberMeServices in owner-security.xml

* changes login method in won-utils.js

* changes the session timeout to 1 day

How to test:
1. log in with an account
2. note there is a 'remember me' checkbox in the login popover
3. do not check that box
4. when logged in, close the window (and all other windows, so the session is closed)
5. open a new browser window
6. open the owner webapp
7. notice that you are not logged in.
8. log in again, now checking 'remember-me'
9. when logged in, close all browser windows
10. open a new browser window and open the owner webapp
11. check that you are now logged in

Note: the remember-me function survives an owner-webapp server restart 