### PR TITLE
Won't trigger bogus click when feedback-choice shows up.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
@@ -56,7 +56,7 @@ function genComponentConf() {
 
         <div
             class="mfi__match clickable"
-            ng-if="!self.feedbackVisible"
+            ng-show="!self.feedbackVisible"
             ng-click="self.showFeedback()"
             ng-mouseenter="self.showFeedback()">
                 <div class="mfi__match__description">
@@ -75,7 +75,7 @@ function genComponentConf() {
         </div>
         <won-feedback-grid
             connection-uri="self.connectionUri"
-            ng-if="self.feedbackVisible"
+            ng-show="self.feedbackVisible"
             ng-mouseleave="self.hideFeedback()"/>
     `;
 


### PR DESCRIPTION
Go to matches-tab using the dev-tools' mobile-simulation or on your phone -- if you press at the bottom of a tile, the feedback-buttons should show up properly. (Before, the buttons showing up would get clicked instantly)