### PR TITLE
Fix  matches hr

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/matches-flow-item.js
@@ -8,7 +8,11 @@ import feedbackGridModule from './feedback-grid.js';
 import postHeaderModule from './post-header.js';
 import postContentModule from './post-content.js';
 
-import { attach } from '../utils.js';
+import {
+    attach,
+    get,
+    getIn,
+} from '../utils.js';
 import { actionCreators }  from '../actions/actions.js';
 import {
     labels,
@@ -48,9 +52,10 @@ function genComponentConf() {
               need-uri="self.remoteNeed.get('uri')"
               hide-image="true">
             </won-post-header>
-            <hr/>
+            <hr ng-show="self.hasOptionalFields"/>
             <won-post-content
-              need-uri="self.remoteNeed.get('uri')">
+              need-uri="self.remoteNeed.get('uri')"
+              ng-show="self.hasOptionalFields">
             </won-post-content>
         </div>
 
@@ -92,9 +97,12 @@ function genComponentConf() {
                 const connectionData = ownNeed && state.getIn(["needs", ownNeed.get("uri"), "connections", self.connectionUri]);
                 const remoteNeed = connectionData && state.getIn(["needs", connectionData.get("remoteNeedUri")]);
 
+                const hasOptionalFields = !!(get(remoteNeed, 'location') || get(remoteNeed, 'description'));
+
                 return {
                     ownNeed,
                     remoteNeed,
+                    hasOptionalFields,
                 };
             };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -736,7 +736,9 @@ export function cloneAsMutable(obj) {
  * @param property
  */
 export function get(obj, property) {
-    if(obj.get) {
+    if(!obj) {
+        return undefined;
+    } else if(obj.get) {
         return obj.get(property);
     } else {
         return obj[property];


### PR DESCRIPTION
Matches-tiles shouldn't have an `<hr>` anymore if there's no description or address on the remote need.