### PR TITLE
fixes styling and key of addDetail Pane

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -98,9 +98,10 @@ function genComponentConf() {
             </div>
 
             <div class="cp__addDetail" ng-if="self.isValid()">
-                <div class="cp__header addDetail clickable" ng-click="self.toggleDetail()">
+                <div class="cp__header addDetail clickable" ng-click="self.toggleDetail()" ng-class="{'closedDetail': !self.showDetail}">
                     <span class="nonHover">Add more detail</span>
-                    <span class="hover">Close more detail</span>
+                    <span class="hover" ng-if="!self.showDetail">Open more detail</span>
+                    <span class="hover" ng-if="self.showDetail">Close more detail</span>
                 </div>
                 <div class="cp__detail__items" ng-if="self.showDetail" >
                     <div class="cp__detail__items__item location" 
@@ -213,7 +214,8 @@ function genComponentConf() {
         mergeTags() {
             let detailTags = Immutable.Set(this.tagsString? this.tagsString.match(/#(\S+)/gi) : []).map(tag => tag.substr(1)).toJS();
 
-            let combinedTags = detailTags.concat(this.tempTags);
+            let combinedTags = this.tempTags? detailTags.concat(this.tempTags) : detailTags;
+
             const immutableTagSet = Immutable.Set(combinedTags);
             return immutableTagSet.toJS();
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
@@ -252,6 +252,10 @@ won-create-post {
         background-image: url('icon-sprite.svg#ico36_close_circle_hi');
         color: black;
       }
+
+      &.closedDetail:hover {
+        background-image: url('icon-sprite.svg#ico36_plus_circle_hi');
+      }
     }
   }
 }


### PR DESCRIPTION
fixes two things:
-the hover label/icon of the addDetail Element is showing the correct Icon and key before it is openend
-the emptytag that was always present is also stripped from the tags view now