### PR TITLE
Constant paging

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -87,28 +87,28 @@ public interface ConnectionRepository extends WonRepository<Connection>
   /**
    * Obtains connectionURIs grouped by the connectionURI itself and with message properties attached. The paging
    * request therefore can use criteria based on aggregated messages properties of the connection,
-   * such as max(msg.creationDate). For example:
-   * <code>new PageRequest(0, 1, Sort.Direction.DESC, "max(msg.creationDate)"))</code>
+   * such as min(msg.creationDate). For example:
+   * <code>new PageRequest(0, 1, Sort.Direction.DESC, "min(msg.creationDate)"))</code>
    * @param pageable
    * @return
    */
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) " +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(Pageable pageable);
+  Slice<URI> getConnectionURIByActivityDate(Pageable pageable);
 
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(
+  Slice<URI> getConnectionURIByActivityDate(
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByLatestActivity(
+  Slice<URI> getConnectionURIsBeforeByActivityDate(
     @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
@@ -117,7 +117,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByLatestActivity(
+  Slice<URI> getConnectionURIsAfterByActivityDate(
     @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
@@ -127,8 +127,8 @@ public interface ConnectionRepository extends WonRepository<Connection>
   /**
    * Obtains connectionURIs of the provided Need grouped by the connectionURI itself and with message properties
    * attached. The paging request therefore can use criteria based on aggregated messages properties of the connection,
-   * such as max(msg.creationDate). For example:
-   * <code>new PageRequest(0, 1, Sort.Direction.DESC, "max(msg.creationDate)"))</code>
+   * such as min(msg.creationDate). For example:
+   * <code>new PageRequest(0, 1, Sort.Direction.DESC, "min(msg.creationDate)"))</code>
    * @param needURI
    * @param pageable
    * @return
@@ -137,13 +137,13 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "where (msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI) " +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(@Param("need") URI needURI, Pageable pageable);
+  Slice<URI> getConnectionURIByActivityDate(@Param("need") URI needURI, Pageable pageable);
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate)) " +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(
+  Slice<URI> getConnectionURIByActivityDate(
     @Param("need") URI needURI,
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
@@ -152,7 +152,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate)" +
     "   and (msg.messageType = :messageType)) " +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(
+  Slice<URI> getConnectionURIByActivityDate(
     @Param("need") URI needURI,
     @Param("messageType") WonMessageType messageType,
     @Param("referenceDate") Date referenceDate, Pageable pageable);
@@ -162,7 +162,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
     "   and (msg.messageType = :messageType)) " +
     "group by msg.parentURI")
-  Slice<URI> getConnectionURIByLatestActivity(
+  Slice<URI> getConnectionURIByActivityDate(
     @Param("need") URI needURI,
     @Param("messageType") WonMessageType messageType, Pageable pageable);
 
@@ -172,7 +172,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByLatestActivity(
+  Slice<URI> getConnectionURIsBeforeByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
@@ -182,7 +182,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
     "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
     "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByLatestActivity(
+  Slice<URI> getConnectionURIsBeforeByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("messageType") WonMessageType messageType,
@@ -195,7 +195,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByLatestActivity(
+  Slice<URI> getConnectionURIsAfterByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
@@ -205,7 +205,7 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
     "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
     "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByLatestActivity(
+  Slice<URI> getConnectionURIsAfterByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("messageType") WonMessageType messageType,

--- a/webofneeds/won-node-webapp/doc/linked-data-paging.md
+++ b/webofneeds/won-node-webapp/doc/linked-data-paging.md
@@ -98,8 +98,7 @@ This parameter is supported only for connections container.
 If no page related query parameter is provided, but client signals that it supports paging (by using the above Prefer
 header in hist requests), the node returns the 1st page of the paged resource based on the sorting logic outlined below.
 Therefore, for needs container, the latest created needs are returned. For events container, the latest created 
-events are returned. For connections container, the connections with latest events activity are returned.
-
+events are returned. For connections container, the connections are ordered by their first occured event creation date (latest created connections first).
 
 
 ## Sorting of members for paging

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -73,10 +73,14 @@ public class NeedInformationServiceImpl implements NeedInformationService
     }
     Slice<URI> slice = null;
     if (needState == null) {
-      slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "lastUpdate"));
+
+        // use 'creationDate' to keep a constant need order over requests
+      slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
     } else {
+
+        // use 'creationDate' to keep a constant need order over requests
       slice = needRepository.getAllNeedURIs(needState, new PageRequest(pageNum, pageSize, Sort.Direction.DESC,
-                                                                       "lastUpdate"));
+                                                                       "creationDate"));
     }
     return slice;
   }
@@ -92,11 +96,15 @@ public class NeedInformationServiceImpl implements NeedInformationService
     }
     Slice<URI> slice = null;
     if (needState == null) {
+
+        // use 'creationDate' to keep a constant need order over requests
       slice = needRepository.getNeedURIsBefore(referenceDate, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "lastUpdate"));
+        .Direction.DESC, "creationDate"));
     } else {
+
+        // use 'creationDate' to keep a constant need order over requests
       slice = needRepository.getNeedURIsBefore(referenceDate, needState, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "lastUpdate"));
+        .Direction.DESC, "creationDate"));
     }
     return slice;
   }
@@ -112,11 +120,15 @@ public class NeedInformationServiceImpl implements NeedInformationService
     }
     Slice<URI> slice = null;
     if (needState == null) {
+
+        // use 'creationDate' to keep a constant need order over requests
       slice = needRepository.getNeedURIsAfter(referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                             "lastUpdate"));
+                                                                             "creationDate"));
     } else {
+
+        // use 'creationDate' to keep a constant need order over requests
       slice = needRepository.getNeedURIsAfter(referenceDate, needState, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                                        "lastUpdate"));
+                                                                                        "creationDate"));
     }
     return slice;
   }
@@ -136,12 +148,16 @@ public class NeedInformationServiceImpl implements NeedInformationService
     int pageNum = page - 1;
     Slice<URI> slice;
     if (timeSpot == null) {
-      slice = connectionRepository.getConnectionURIByLatestActivity(
-        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIByActivityDate(
+        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
     } else {
-      slice = connectionRepository.getConnectionURIByLatestActivity(
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIByActivityDate(
         timeSpot,
-        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
     }
     return slice;
   }
@@ -154,8 +170,10 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
     int pageSize = getPageSize(preferredPageSize);
     Slice<URI> slice = null;
-    slice = connectionRepository.getConnectionURIsBeforeByLatestActivity(
-      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+
+      // use 'min(msg.creationDate)' to keep a constant connection order over requests
+    slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
+      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
     return slice;
   }
 
@@ -167,8 +185,10 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
     int pageSize = getPageSize(preferredPageSize);
     Slice<URI> slice = null;
-    slice = connectionRepository.getConnectionURIsAfterByLatestActivity(
-      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "max(msg.creationDate)"));
+
+      // use 'min(msg.creationDate)' to keep a constant connection order over requests
+    slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
     return slice;
   }
 
@@ -186,18 +206,20 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     int pageSize = getPageSize(preferedPageSize);
     int pageNum = page - 1;
-    PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "max(msg.creationDate)");
+
+      // use 'min(msg.creationDate)' to keep a constant connection order over requests
+    PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)");
     if (messageType == null) {
       if (timeSpot == null) {
-        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, pageRequest);
+        slice = connectionRepository.getConnectionURIByActivityDate(needURI, pageRequest);
       } else {
-        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, timeSpot, pageRequest);
+        slice = connectionRepository.getConnectionURIByActivityDate(needURI, timeSpot, pageRequest);
       }
     } else {
       if (timeSpot == null) {
-        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, messageType, pageRequest);
+        slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, pageRequest);
       } else {
-        slice = connectionRepository.getConnectionURIByLatestActivity(needURI, messageType, timeSpot, pageRequest);
+        slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, timeSpot, pageRequest);
       }
     }
     return slice;
@@ -213,13 +235,17 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     if (messageType == null) {
       resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-      slice = connectionRepository.getConnectionURIsBeforeByLatestActivity(
-        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
+        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
     } else {
       resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-      slice = connectionRepository.getConnectionURIsBeforeByLatestActivity(
+      
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
         needURI, resume, messageType, timeSpot, new PageRequest(
-          0, pageSize, Sort.Direction.DESC, "max(msg.creationDate)"));
+          0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
     }
     return slice;
   }
@@ -234,13 +260,17 @@ public class NeedInformationServiceImpl implements NeedInformationService
     Slice<URI> slice = null;
     if (messageType == null) {
       resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-      slice = connectionRepository.getConnectionURIsAfterByLatestActivity(
-        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "max(msg.creationDate)"));
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
     } else {
       resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-      slice = connectionRepository.getConnectionURIsAfterByLatestActivity(
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+      slice = connectionRepository.getConnectionURIsAfterByActivityDate(
         needURI, resume, messageType, timeSpot, new PageRequest(
-          0, pageSize, Sort.Direction.ASC, "max(msg.creationDate)"));
+          0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
     }
     return slice;
   }


### PR DESCRIPTION
we have to change the ordering criteria of needs and connections in order for it to be unchanging between requests: 
* for need order criteria we use creationDate (again) instead of modifiedDate
* for connection order criteria we use the creation date of the first event (corresponds to creation date in needs since we dont have a creation date for connections right now) instead of the last event creation date per connection (corresponds modification date in needs)
