### PR TITLE
Avoid text-clashes in title-bar

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -4,6 +4,7 @@
 ;
 import angular from 'angular';
 import { attach } from '../utils.js';
+import { ellipsizeString } from '../utils.js';
 import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
@@ -63,6 +64,7 @@ function genLogoutConf() {
 
             this.email = "";
             this.password = "";
+            this.maxEmailLength = 16;
 
             const logout = (state) => ({
                 loggedIn: state.getIn(['user','loggedIn']),
@@ -73,12 +75,7 @@ function genLogoutConf() {
         }
 
         getEmail() {
-            if(this.email.length > 16) {
-                var mail = this.email;
-                return mail.substring (0, 8) + "..." + mail.substring(mail.length-5,mail.length);
-            } else {
-                return this.email;
-            }
+            return ellipsizeString(this.email, this.maxEmailLength);
         }
     }
     Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -22,7 +22,7 @@ function genLogoutConf() {
 
 
                 <span class="topnav__button__caption hide-in-responsive">
-                    {{self.loggedIn? self.email : "Sign In"}}
+                    {{self.loggedIn? self.getEmail() : "Sign In"}}
                 </span>
                 <img
                     src="generated/icon-sprite.svg#ico16_arrow_down"
@@ -70,6 +70,15 @@ function genLogoutConf() {
             });
 
             connect2Redux(logout, actionCreators, [], this);
+        }
+
+        getEmail() {
+            if(this.email.length > 16) {
+                var mail = this.email;
+                return mail.substring (0, 8) + "..." + mail.substring(mail.length-5,mail.length);
+            } else {
+                return this.email;
+            }
         }
     }
     Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -998,3 +998,19 @@ export function getParameters(url) {
 
     return params;
 }
+
+/**
+ * Ellipsize a too long String
+ * used in account-menu.js to ellipsize the email in the topnav
+ * @param string
+ * @param size
+ * @returns {*}
+ */
+export function ellipsizeString (string, size) {
+
+    if(string.length > size) {
+        return string.substring (0, 8) + "…" + string.substring(string.length-5,string.length);
+    } else {
+        return string;
+    }
+}


### PR DESCRIPTION
Issue #1222
If the username is longer than 16 characters the middle part is hidden and replaced with "...". Now there are no clashes with the name anymore.