### PR TITLE
Cause LinkedDataRestClient to fail only on 4xx responses

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -108,7 +108,7 @@ public abstract class LinkedDataRestClient {
             //RestTemplate will automatically follow redirects on HttpGet calls
             statusCode = response.getStatusCode().value();
             responseHeaders = response.getHeaders();
-            if (!response.getStatusCode().is2xxSuccessful()) {
+            if (response.getStatusCode().is4xxClientError()) {
                 throw new HttpClientErrorException(response.getStatusCode());
             }
             result = response.getBody();


### PR DESCRIPTION
Previously, the LDRC failed with an Exception on anything but a 2xx
response, breaking things like caching with the CachingLinkedDataSource

Fixes #1319 