### PR TITLE
Fix do not match closed needs

### DIFF
--- a/webofneeds/conf/matcher-service/matcher-service.properties
+++ b/webofneeds/conf/matcher-service/matcher-service.properties
@@ -30,7 +30,7 @@ crawler.propertyPaths.base=<http://www.w3.org/2000/01/rdf-schema#member>,(<http:
 crawler.propertyPaths.nonBase=<http://purl.org/webofneeds/model#hasConnections>,<http://purl.org/webofneeds/model#hasConnections>/<http://www.w3.org/2000/01/rdf-schema#member>
 
 # time in minutes until won nodes are crawled the next time
-crawler.recrawl.interval.minutes=300
+crawler.recrawl.interval.minutes=60
 
 # execute the meta data rdf update at least every x milliseconds
 crawler.metaDataUpdate.maxDuration=10000

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/event/NeedEvent.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/event/NeedEvent.java
@@ -32,7 +32,7 @@ public class NeedEvent implements Serializable
 
   public static enum TYPE
   {
-    CREATED, ACTIVATED, DEACTIVATED
+      ACTIVE, INACTIVE
   }
 
   public NeedEvent(String uri, String wonNodeUri, TYPE eventType, long crawlDate, String resource, Lang format) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
@@ -147,7 +147,7 @@ public class MasterCrawlerActor extends UntypedActor
    * @param message
    */
   @Override
-  public void onReceive(final Object message) {
+  public void onReceive(final Object message) throws InterruptedException {
 
     if (message.equals(RECRAWL_TICK)) {
       askWonNodeInfoForCrawling();
@@ -239,7 +239,7 @@ public class MasterCrawlerActor extends UntypedActor
    *
    * @param event
    */
-  private void processWonNodeEvent(WonNodeEvent event) {
+  private void processWonNodeEvent(WonNodeEvent event) throws InterruptedException {
 
     if (event.getStatus().equals(WonNodeEvent.STATUS.CONNECTED_TO_WON_NODE)) {
 
@@ -247,6 +247,9 @@ public class MasterCrawlerActor extends UntypedActor
       log.debug("added new won node to set of crawling won nodes: {}", event.getWonNodeUri());
       skipWonNodeUris.remove(event.getWonNodeUri());
       crawlWonNodeUris.add(event.getWonNodeUri());
+
+      // sleep 30 seconds before start crawling to give the matcher time to connect to each other
+      Thread.sleep(30000);
       startCrawling(event.getWonNodeInfo());
 
     } else if (event.getStatus().equals(WonNodeEvent.STATUS.SKIP_WON_NODE)) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
@@ -186,15 +186,12 @@ public class WorkerCrawlerActor extends UntypedActor {
             needModelWrapper = new NeedModelWrapper(ds);
             if (needModelWrapper.isANeed()) {
                 NeedState state = needModelWrapper.getNeedState();
-                if (state.equals(NeedState.ACTIVE)) {
 
-                    log.debug("Created need event for need uri {}", uriMsg.getUri());
-                    long crawlDate = System.currentTimeMillis();
-                    NeedEvent.TYPE type = NeedEvent.TYPE.CREATED;
-                    NeedEvent needEvent = new NeedEvent(uriMsg.getUri(), wonNodeUri, type, crawlDate, ds);
-                    pubSubMediator
-                            .tell(new DistributedPubSubMediator.Publish(needEvent.getClass().getName(), needEvent), getSelf());
-                }
+                NeedEvent.TYPE type = state.equals(NeedState.ACTIVE) ? NeedEvent.TYPE.ACTIVE : NeedEvent.TYPE.INACTIVE;
+                log.debug("Created need event for need uri {}", uriMsg.getUri());
+                long crawlDate = System.currentTimeMillis();
+                NeedEvent needEvent = new NeedEvent(uriMsg.getUri(), wonNodeUri, type, crawlDate, ds);
+                pubSubMediator.tell(new DistributedPubSubMediator.Publish(needEvent.getClass().getName(), needEvent), getSelf());
             }
 
         } catch (DataIntegrityException e) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -371,7 +371,7 @@ public class CrawlSparqlService extends SparqlService {
             Dataset ds = retrieveNeedDataset(needUri);
             StringWriter sw = new StringWriter();
             RDFDataMgr.write(sw, ds, RDFFormat.TRIG.getLang());
-            NeedEvent needEvent = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.CREATED,
+            NeedEvent needEvent = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.ACTIVE,
                     crawlDate, sw.toString(), RDFFormat.TRIG.getLang());
             bulkNeedEvent.addNeedEvent(needEvent);
         }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -278,6 +278,7 @@ public class CrawlSparqlService extends SparqlService {
                 " ?needUri a won:Need.\n" +
                 " ?needUri won:hasWonNode ?wonNodeUri. \n" +
                 " ?needUri dcterms:modified ?modificationDate. \n" +
+                " ?needUri dcterms:crawlStatus 'DONE'. \n" +
                 "} ORDER BY DESC(?modificationDate) LIMIT 1\n";
 
         ParameterizedSparqlString pps = new ParameterizedSparqlString();

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/actor/NeedConsumerProtocolActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/actor/NeedConsumerProtocolActor.java
@@ -79,15 +79,15 @@ public class NeedConsumerProtocolActor extends UntypedConsumerActor
           long crawlDate = System.currentTimeMillis();
 
           if (methodName.equals(MSG_HEADER_METHODNAME_NEEDCREATED)) {
-            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.CREATED, crawlDate,
+            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.ACTIVE, crawlDate,
                                   camelMsg.body().toString(), Lang.TRIG);
             pubSubMediator.tell(new DistributedPubSubMediator.Publish(event.getClass().getName(), event), getSelf());
           } else if (methodName.equals(MSG_HEADER_METHODNAME_NEEDACTIVATED)) {
-            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.ACTIVATED, crawlDate,
+            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.ACTIVE, crawlDate,
                                   camelMsg.body().toString(), Lang.TRIG);
             pubSubMediator.tell(new DistributedPubSubMediator.Publish(event.getClass().getName(), event), getSelf());
           } else if (methodName.equals(MSG_HEADER_METHODNAME_NEEDDEACTIVATED)) {
-            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.DEACTIVATED, crawlDate,
+            event = new NeedEvent(needUri, wonNodeUri, NeedEvent.TYPE.INACTIVE, crawlDate,
                                   camelMsg.body().toString(), Lang.TRIG);
             pubSubMediator.tell(new DistributedPubSubMediator.Publish(event.getClass().getName(), event), getSelf());
           } else {

--- a/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/SolrTest.java
+++ b/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/SolrTest.java
@@ -58,6 +58,6 @@ public class SolrTest {
         }
 
         String needUri = WonRdfUtils.NeedUtils.getNeedURI(dataset).toString();
-        return new NeedEvent(needUri, "no_uri", NeedEvent.TYPE.CREATED, System.currentTimeMillis(), dataset);
+        return new NeedEvent(needUri, "no_uri", NeedEvent.TYPE.ACTIVE, System.currentTimeMillis(), dataset);
     }
 }


### PR DESCRIPTION
closed needs should now (after crawling which takes place every 60 min) not be matched anymore.
you can test this the following way:

* create a need A with Account 1
* create another need B on Account 2 to see that the matching works
* close the need A 
* restart the matching service (to trigger the recrawling) => wait for ~ a minute so that all recrawling has happended
* create another need C on Account 2 which is not matched anymore with need A cause need A was closed 

The need state can also be checked in these servers:
matching service: http://satvm05.researchstudio.at:9999/bigdata
solr matcher: http://satvm05.researchstudio.at:8983/solr/won/browse?q=<needid>
