### PR TITLE
Suppress tracking request for each hint

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
@@ -119,7 +119,7 @@ export const piwikMiddleware = store => next => action => {
             'messages.openMessageReceived',
             'connections.connect',
             'messages.connectMessageReceived',
-            'messages.hintMessageReceived',
+#            'messages.hintMessageReceived', 
             'connections.close',
         ],
         Needs: [


### PR DESCRIPTION
It's wasteful to send a tracking request for each hint. We suppress that now, we may do something more complicated once we see that we really need it, like waiting for all hints and then sending one tracking request.