### PR TITLE
Fix build problem with qpid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ webofneeds/conf.*
 /webofneeds/data.local
 webofneeds/state.config.properties
 webofneeds/won.log
+certs
 
 #local package caches
 bower_components/

--- a/webofneeds/pom.xml
+++ b/webofneeds/pom.xml
@@ -94,11 +94,6 @@
                 <artifactId>activemq-broker</artifactId>
                 <version>${activemq.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.qpid</groupId>
-                <artifactId>qpid-client</artifactId>
-                <version>${qpid.version}</version>
-            </dependency>
             <!-- xbean is required for ActiveMQ broker configuration in the spring xml file -->
             <dependency>
                 <groupId>org.apache.xbean</groupId>
@@ -118,6 +113,10 @@
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.qpid</groupId>
+                        <artifactId>proton-jms</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Qpid version we depend upon is (temporarily?) not available.
Found out we actually don't need it.