### PR TITLE
Increase message timeout

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -89,7 +89,7 @@ export async function ensureLoggedIn(dispatch, getState) {
 
     // wait for the server to process the login and the reconnect to
     // go through, before proceeding to need-creation.
-    await delay(500);
+    await delay(3000);
 }
 
 let _loginInProcessFor;


### PR DESCRIPTION
In case of an 'anonymous' posting, a new account is created with a
made-up '@matchat.org' email address. The process of creating that
account is currently waited for using a timeout (see #1351). This commit
increases the timeout from 500ms to 3s, hoping to catch most of the
cases.