### PR TITLE
Fix the lost postings bug, without using timeouts

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -86,10 +86,6 @@ export async function ensureLoggedIn(dispatch, getState) {
         console.error(`Creating temporary account (${privateId}) has failed due to `, err);
         dispatch(actionCreators.registerFailed({privateId}));
     }
-
-    // wait for the server to process the login and the reconnect to
-    // go through, before proceeding to need-creation.
-    await delay(3000);
 }
 
 let _loginInProcessFor;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -167,9 +167,6 @@ async function connectAdHoc(theirNeedUri, textMessage, dispatch, getState) {
 
     console.log('STARTED PUBLISHING AD HOC DRAFT: ', adHocDraft);
 
-    //TODO wait for success-response instead
-    await delay(1000); // to give the server enough time to handle need creation.
-
     // TODO handle failure to post need (the needUri won't be valid)
 
     const cnctMsg = await buildAdHocConnectMessage(needUri, theirNeedUri, nodeUri, theirNeed.get("nodeUri"), textMessage);


### PR DESCRIPTION
In the open() handler of the websocket, after registering the redux
watches, the first enqueued message is sent, causing a chain reaction
that sends all enqueued messages.
All related timeouts are removed, making the app faster.

Fixes #1351