### PR TITLE
Refactor owner webapp

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
@@ -28,6 +28,7 @@ import won.protocol.exception.WonMessageBuilderException;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
 import won.protocol.model.FacetType;
+import won.protocol.model.NeedGraphType;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.NeedModelWrapper;
 import won.protocol.util.RdfUtils;
@@ -108,7 +109,7 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
         return WonMessageBuilder.setMessagePropertiesForCreate(
             wonNodeInformationService.generateEventURI(wonNodeURI),
             needURI,
-            wonNodeURI).addContent(needModel, null).build();
+            wonNodeURI).addContent(needModelWrapper.copyNeedModel(NeedGraphType.NEED), null).build();
     }
 
     public void setUsedForTesting(final boolean usedForTesting) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
@@ -16,7 +16,10 @@
 
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
+import java.net.URI;
+
 import org.apache.jena.query.Dataset;
+
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
@@ -32,8 +35,7 @@ import won.protocol.model.ConnectionState;
 import won.protocol.model.FacetType;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
-
-import java.net.URI;
+import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
 /**
  * User: fkleedorfer
@@ -59,10 +61,14 @@ public class OpenConnectionAction extends BaseEventBotAction
       return;
     } else if (event instanceof OpenFromOtherNeedEvent){
       ConnectionSpecificEvent connectEvent = (ConnectionSpecificEvent) event;
-      if (((OpenFromOtherNeedEvent) event).getCon().getState() == ConnectionState.REQUEST_RECEIVED) {
+       
+      URI connectionState = WonLinkedDataUtils.getConnectionStateforConnectionURI(connectEvent.getConnectionURI(), getEventListenerContext().getLinkedDataSource());
+      if (ConnectionState.REQUEST_RECEIVED.getURI().equals(connectionState)) {
         logger.debug("auto-replying to open(REQUEST_RECEIVED) with open for connection {}",
           connectEvent.getConnectionURI());
         getEventListenerContext().getWonMessageSender().sendWonMessage(createOpenWonMessage(connectEvent.getConnectionURI()));
+      } else {
+          // else do not respond - we assume the connection is now established.    	  
       }
       return;
     } else if (event instanceof HintFromMatcherEvent) {

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
@@ -157,7 +157,7 @@ public class DebugBot extends EventBot {
         bus.subscribe(OpenFromOtherNeedEvent.class,
                 new ActionOnEventListener(ctx,
                         new MultipleActions(ctx,
-                                new RespondToMessageAction(ctx, "Hi there!"),
+                        		new OpenConnectionAction(ctx, welcomeMessage),
                                 new PublishSetChattinessEventAction(ctx, true))));
 
         //if the bot receives a text message - try to map the command of the text message to a DebugEvent

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
@@ -37,6 +37,13 @@ public class WonLinkedDataUtils
 {
   private static final Logger logger = LoggerFactory.getLogger(WonLinkedDataUtils.class);
 
+  public static URI getConnectionStateforConnectionURI(URI connectionURI, LinkedDataSource linkedDataSource) {
+	    assert linkedDataSource != null : "linkedDataSource must not be null";
+	    Dataset dataset = getDatalForResource(connectionURI, linkedDataSource);
+	    Path propertyPath = PathParser.parse("<" + WON.HAS_CONNECTION_STATE+ ">", PrefixMapping.Standard);
+	    return RdfUtils.getURIPropertyForPropertyPath(dataset, connectionURI, propertyPath);
+	}
+  
   public static URI getRemoteConnectionURIforConnectionURI(URI connectionURI, LinkedDataSource linkedDataSource) {
     assert linkedDataSource != null : "linkedDataSource must not be null";
     Dataset dataset = getDatalForResource(connectionURI, linkedDataSource);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeProcessor.java
@@ -59,15 +59,13 @@ public class OpenMessageFromNodeProcessor extends AbstractCamelProcessor
     if (con == null) throw new IllegalStateException("connection must not be null");
     if (con.getRemoteNeedURI() == null) throw new IllegalStateException("remote need uri must not be null");
     if (!con.getRemoteNeedURI().equals(wonMessage.getSenderNeedURI())) throw new IllegalStateException("the remote need uri of the connection must be equal to the sender need uri of the message");
-    if (con.getRemoteConnectionURI() == null) throw  new IllegalStateException("the remote connection uri must not be null");
     if (wonMessage.getSenderURI() == null) throw new IllegalStateException("the sender uri must not be null");
-    if (!con.getRemoteConnectionURI().equals(wonMessage.getSenderURI())) throw new IllegalStateException("the sender uri of the message must be equal to the remote connection uri");
-
     //it is possible that we didn't store the reference to the remote conneciton yet. Now we can do it.
     if (con.getRemoteConnectionURI() == null) {
       // Set it from the message (it's the sender of the message)
       con.setRemoteConnectionURI(wonMessage.getSenderURI());
     }
+    if (!con.getRemoteConnectionURI().equals(wonMessage.getSenderURI())) throw new IllegalStateException("the sender uri of the message must be equal to the remote connection uri");
     con.setState(con.getState().transit(ConnectionEventType.PARTNER_OPEN));
     connectionRepository.save(con);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -55,6 +55,11 @@ import {
 } from './create-need-action.js';
 
 import {
+    needsConnect,
+} from './needs-actions.js';
+
+
+import {
     stateBack,
     stateGoAbs,
     stateGoCurrent,
@@ -95,7 +100,6 @@ const actionHierarchy = {
     connections:{
         fetch: cnct.connectionsFetch,
         open: cnct.connectionsOpen,
-        connect: cnct.connectionsConnect,
         connectAdHoc: cnct.connectionsConnectAdHoc,
         close: cnct.connectionsClose,
         closeRemote: cnct.connectionsCloseRemote,
@@ -113,7 +117,8 @@ const actionHierarchy = {
         reopen: needsOpen,
         close: needsClose,
         closedBySystem:needsClosedBySystem,
-        failed: INJ_DEFAULT
+        failed: INJ_DEFAULT,
+        connect: needsConnect,
     },
     router: {
         stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed
@@ -185,6 +190,24 @@ const actionHierarchy = {
         hintMessageReceived: messages.hintMessageReceived,
         openMessageReceived: messages.openMessageReceived,
 
+        // register a fully prepared action object to be dispatched
+        // after a specific message (identified by URI)  has been processed
+        // (when the respective success message is processed)
+        dispatchActionOn: {
+        	// registers the action (in action.actionToDispatch)
+        	registerSuccessOwn: INJ_DEFAULT,
+        	registerFailureOwn: INJ_DEFAULT,
+        	registerSuccessRemote: INJ_DEFAULT,
+        	registerFailureRemote: INJ_DEFAULT,
+        	// the action creator dispatches the registered actions
+        	successOwn: messages.dispatchActionOnSuccessOwn,
+        	successRemote: messages.dispatchActionOnSuccessRemote,
+        	// failure actions clear the list of registered success actions
+        	// and vice versa
+        	failureOwn: messages.dispatchActionOnSuccessOwn,
+        	failureRemote: messages.dispatchActionOnSuccessOwn,
+        },
+        
         waitingForAnswer: INJ_DEFAULT,
     },
     hideLogin: INJ_DEFAULT,
@@ -308,7 +331,6 @@ export function needsOpen(needUri) {
             getState().getIn(['config', 'defaultNodeUri'])
         )
             .then((data)=> {
-                console.log(data);
                 dispatch(actionCreators.messages__send({
                     eventUri: data.eventUri,
                     message: data.message
@@ -353,7 +375,6 @@ export function needsClose(needUri) {
             getState().getIn(['config', 'defaultNodeUri'])
         )
         .then((data)=> {
-            console.log(data);
             dispatch(actionCreators.messages__send({
                 eventUri: data.eventUri,
                 message: data.message

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -126,6 +126,8 @@ async function connectAdHoc(theirNeedUri, textMessage, dispatch, getState) {
     const { message, eventUri, needUri } = buildCreateMessage(adHocDraft, nodeUri);
     const cnctMsg = buildConnectMessage(needUri, theirNeedUri, nodeUri, theirNeed.get("nodeUri"), textMessage);
     
+    const optimisticEvent = await won.wonMessageFromJsonLd(cnctMsg.message);
+    
     // connect action to be dispatched when the 
     // ad hoc need has been created: 
     const connectAction = {
@@ -133,6 +135,7 @@ async function connectAdHoc(theirNeedUri, textMessage, dispatch, getState) {
 		payload: {
             eventUri: cnctMsg.eventUri,
             message: cnctMsg.message,
+            optimisticEvent: optimisticEvent,
         }
     }
     

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -64,7 +64,7 @@ export function needCreate(draft, nodeUri) {
                 const { message, eventUri, needUri } = buildCreateMessage(draft, nodeUri);
                 return dispatch({
                     type: actionTypes.needs.create,
-                    payload: {eventUri, message, needUri}
+                    payload: {eventUri, message, needUri, need: draft}
                 })
 
             });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -32,7 +32,7 @@ export function needCreate(draft, nodeUri) {
 
         const currentState = getIn(state, ['router', 'currentState', 'name']);
         const prevState = getIn(state, ['router', 'prevState', 'name']);
-        const prevParams = getIn(state, ['router', 'prevParams']);
+        let prevParams = getIn(state, ['router', 'prevParams']);
 
         if(!state.getIn(['user', 'loggedIn']) && prevParams.privateId){
             /*
@@ -40,7 +40,7 @@ export function needCreate(draft, nodeUri) {
              * there be a previous privateId, we don't want to change
              * back to that later.
              */
-            delete prevParams.privateId;
+        	 prevParams = prevParams.remove("privateId")
         }
 
         return ensureLoggedIn(dispatch, getState)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -327,3 +327,93 @@ export function hintMessageReceived(event) {
         }
     }
 }
+
+/**
+ * Dispatches actions registered for the "successOwn" event for the specified message uri.
+ * The corresponding reducer clears any registered actions for the "failureOwn" event
+ */
+export function dispatchActionOnSuccessOwn(event) {
+    return (dispatch, getState) => {
+		const toDispatchList = getState().getIn(['messages','dispatchOnSuccessOwn', event.getIsResponseTo()]);
+		if (toDispatchList){
+			toDispatchList.forEach( d => {
+				dispatch(d)
+			})
+		}
+		//the reducer will delete the toDispatchList for successOwn and failureOwn
+		dispatch({
+			type: actionTypes.messages.dispatchActionOn.successOwn,
+			payload: {
+				eventUri:  event.getIsResponseTo(),
+			}
+		})
+    }
+}
+
+/**
+ * Dispatches actions registered for the "failureOwn" event for the specified message uri.
+ * The corresponding reducer clears any registered actions for the "successOwn" event
+ */
+export function dispatchActionOnFailureOwn(event) {
+    return (dispatch, getState) => {
+		const toDispatchList = getState().getIn(['messages','dispatchOnFailureOwn', event.getIsResponseTo()]);
+		if (toDispatchList){
+			toDispatchList.forEach( d => {
+				dispatch(d)
+			})
+		}
+		//the reducer will delete the toDispatchList for successOwn and failureOwn
+		dispatch({
+			type: actionTypes.messages.dispatchActionOn.failureOwn,
+			payload: {
+				eventUri:  event.getIsResponseTo(),
+			}
+		})
+    }
+}
+
+/**
+ * Dispatches actions registered for the "successRemote" event for the specified message uri.
+ * The corresponding reducer clears any registered actions for the "failureRemote" event
+ */
+export function dispatchActionOnSuccessRemote(event) {
+    return (dispatch, getState) => {
+		const toDispatchList = getState().getIn(['messages','dispatchOnSuccessRemote', event.getIsRemoteResponseTo()]);
+		if (toDispatchList){
+			toDispatchList.forEach( d => {
+				dispatch(d)
+			})
+		}
+		//the reducer will delete the toDispatchList for successOwn and failureOwn
+		dispatch({
+			type: actionTypes.messages.dispatchActionOn.successRemote,
+			payload: {
+				eventUri:  event.getIsRemoteResponseTo(),
+			}
+		})
+    }
+}
+
+/**
+ * Dispatches actions registered for the "failureRemote" event for the specified message uri.
+ * The corresponding reducer clears any registered actions for the "successRemote" event
+ */
+export function dispatchActionOnFailureRemote(event) {
+    return (dispatch, getState) => {
+		const toDispatchList = getState().getIn(['messages','dispatchOnFailureRemote', event.getIsRemoteResponseTo()]);
+		if (toDispatchList){
+			toDispatchList.forEach( d => {
+				dispatch(d)
+			})
+		}
+		//the reducer will delete the toDispatchList for successOwn and failureOwn
+		dispatch({
+			type: actionTypes.messages.dispatchActionOn.failureRemote,
+			payload: {
+				eventUri:  event.getIsRemoteResponseTo(),
+			}
+		})
+    }
+}
+
+

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -25,10 +25,8 @@ import {
 
 export function successfulCloseNeed(event) {
     return (dispatch, getState) => {
-        console.log("got response for DEACTIVATE: " + event.getMessageType());
         //TODO maybe refactor these response message handling
         if (getState().getIn(['messages', 'waitingForAnswer', event.getIsRemoteResponseTo()])) {
-            console.log("messages waitingForAnswer", event.getMessageUri());
             //dispatch(actionCreators.connections__denied(event));
         }
     }
@@ -90,20 +88,17 @@ export function failedCloseNeed(event) {
 export function successfulCloseConnection(event) {
     return (dispatch, getState) => {
         const state = getState();
-        console.log("got response for CLOSE: " + event.getMessageType());
         let eventUri = null;
         let receiverUri = null;
         let isRemoteResponse = false;
         //TODO maybe refactor these response message handling
         if (state.getIn(['messages', 'waitingForAnswer', event.getIsResponseTo()])) {
-            console.log("messages waitingForAnswer", event.getMessageUri());
             eventUri = event.getIsResponseTo();
             dispatch({
                 type: actionTypes.messages.close.success,
                 payload: event
             });
         } else if (state.getIn(['messages', 'waitingForAnswer', event.getIsRemoteResponseTo()])) {
-            console.log("messages waitingForAnswer", event.getMessageUri());
             eventUri = event.getIsRemoteResponseTo();
             dispatch({
                 type: actionTypes.messages.close.success,
@@ -141,7 +136,6 @@ export function successfulOpen(event){
 export function successfulCreate(event) {
     return (dispatch) => {
         //const state = getState();
-        console.log("got response for CREATE: " + event.getMessageType());
         //TODO: if negative, use alternative need URI and send again
         //fetch need data and store in local RDF store
         //get URI of newly created need from message
@@ -151,7 +145,6 @@ export function successfulCreate(event) {
 
         won.getNeed(needURI)
             .then((need) => {
-                console.log("Dispatching action " + won.EVENT.NEED_CREATED);
                 dispatch(actionCreators.needs__createSuccessful({
                     publishEventUri: event.getIsResponseTo(),
                     needUri: event.getSenderNeed(),
@@ -322,7 +315,6 @@ export function hintMessageReceived(event) {
                     //    linkedDataService.ensureLoaded(eventData.matchCounterpartURI);
                     //}
 
-                    console.log("handling hint message");
                 });
         }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -1,0 +1,64 @@
+/**
+ * Created by ksinger on 19.02.2016.
+ */
+
+import  won from '../won-es6.js';
+import Immutable from 'immutable';
+
+import {
+    is,
+    urisToLookupMap,
+    msStringToDate,
+    getIn,
+    get,
+    jsonld2simpleFormat,
+    cloneAsMutable,
+    delay,
+} from '../utils.js';
+
+
+import {
+    actionTypes,
+    actionCreators,
+} from './actions.js';
+
+import {
+    buildConnectMessage,
+} from '../won-message-utils.js';
+
+
+export function needsConnect(event) {
+    return async (dispatch, getState) => {
+    	const ownNeedUri = event.needUri;
+    	const theirNeedUri = event.remoteNeedUri;
+    	const textMessage = event.textMessage;
+    	
+    	
+        const state = getState();
+        console.log("executing CONNECT NEEDS action");
+        const ownNeed = getState().getIn(["needs", ownNeedUri]);
+        const theirNeed = getState().getIn(["needs", theirNeedUri]);
+        let theirNodeUri = null;
+        if (theirNeed){
+        	theirNodeUri = theirNeed.get("nodeUri");
+        } else {
+        	theirNodeUri = await won.getNode(theirNeedUri).hasWonNode;
+        } 
+        const cnctMsg = await buildConnectMessage(ownNeed.get("uri"), theirNeedUri, ownNeed.get("nodeUri"), theirNeed.get("nodeUri"), textMessage);
+
+        dispatch(actionCreators.messages__send({eventUri: cnctMsg.eventUri, message: cnctMsg.message}));
+
+        const optimisticEvent = await won.toWonMessage(cnctMsg.message);
+
+        dispatch({
+            type: actionTypes.needs.connect,
+            payload: {
+                eventUri: cnctMsg.eventUri,
+                optimisticEvent,
+            }
+        });
+    }
+}
+
+
+

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-map.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-map.js
@@ -108,7 +108,6 @@ function genComponentConf() {
         }
 
         updateMap(postLocation, connections, needs) {
-            console.log("Call an update on the map for location: ", postLocation, "connections: ", connections, "needs: ", needs);
             this.markers.forEach(marker => this.map.removeLayer(marker)); //Remove all existing markers
             this.markers = []; //RESET MARKERS
 
@@ -117,16 +116,12 @@ function genComponentConf() {
             }
 
             if(connections && connections.size > 0){
-                console.log("Setting markers for connections");
                 connections.map(function(conn){
-                    console.log("Looking Up remoteNeed with Uri: ",conn.get("remoteNeedUri")," with data ", needs && needs.get(conn.get("remoteNeedUri")));
                     let need = needs && needs.get(conn.get("remoteNeedUri"));
                     let connLocation = needs && needs.getIn([conn.get("remoteNeedUri"), "location"]);
                     if(need && need.get("location")) {
-                        console.log("setting marker for connectionLocation: ",connLocation.toJS());
                         this.markers.push(this.createUniqueMarker(need, conn));
                     }else{
-                        console.log("no marker set because connection Need does not have a location");
                     }
                 }, this);
             }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -289,9 +289,9 @@ function genComponentConf() {
                                         whatsAround: true
                                     };
 
-                                    this.existingWhatsAroundNeeds.map(
-                                        need => this.needs__close(need.get("uri"))
-                                    );
+                                    this.existingWhatsAroundNeeds
+                                    	.filter( need => need.get("state") == "won:Active" )
+                                    	.map(need => this.needs__close(need.get("uri")) );
 
                                     console.log("Creating Whats around with data: ", whatsAround);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -172,11 +172,9 @@ function genComponentConf() {
         }
 
         selectType(typeIdx) {
-            console.log('selected type ', postTypeTexts[typeIdx].type);
             this.draft.type = postTypeTexts[typeIdx].type;
         }
         unselectType() {
-            console.log('unselected type ');
             this.draft.type = undefined;
         }
         titlePicZoneNg() {
@@ -245,13 +243,11 @@ function genComponentConf() {
         }
 
         removeDetail(detailIndex) {
-            console.log("details before removal of idx: ", detailIndex, ":", this.details);
             var tempDetails = [];
             for(var i=0; i < this.details.length; i++){
                 if(i!=detailIndex) tempDetails.push(this.details[i]);
             }
             this.details = tempDetails;
-            console.log("details after removal of idx: ", detailIndex, ":", this.details);
         }
 
         isDetailPresent(detail) {
@@ -261,12 +257,10 @@ function genComponentConf() {
         createWhatsAround(){
             if (!this.pendingPublishing) {
                 this.pendingPublishing = true;
-                console.log("Create Whats Around");
 
                 if ("geolocation" in navigator) {
                     navigator.geolocation.getCurrentPosition(
                         currentLocation => {
-                            console.log(currentLocation);
                             const lat = currentLocation.coords.latitude;
                             const lng = currentLocation.coords.longitude;
                             const zoom = 13; // TODO use `currentLocation.coords.accuracy` to control coarseness of query / zoom-level
@@ -293,7 +287,6 @@ function genComponentConf() {
                                     	.filter( need => need.get("state") == "won:Active" )
                                     	.map(need => this.needs__close(need.get("uri")) );
 
-                                    console.log("Creating Whats around with data: ", whatsAround);
 
                                     this.needs__create(
                                         whatsAround,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/location-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/location-picker.js
@@ -119,7 +119,6 @@ function genComponentConf() {
             this.placeMarkers([]);
         }
         selectedLocation(location) {
-            console.log("selectedLocation: ", location);
             this.resetSearchResults(); // picked one, can hide the rest if they were there
 
             let draft = {location};
@@ -133,13 +132,11 @@ function genComponentConf() {
         }
         doneTyping() {
             const text = this.textfield().value;
-            console.log('starting type-ahead search for: ' + text);
 
             if(!text) {
                 this.$scope.$apply(() => { this.resetSearchResults(); });
             } else {
                 searchNominatim(text).then( searchResults => {
-                    console.log('location search results: ', searchResults);
                     const parsedResults = scrubSearchResults(searchResults, text);
                     this.$scope.$apply(() => {
                         this.searchResults = parsedResults;
@@ -155,7 +152,6 @@ function genComponentConf() {
                 navigator.geolocation.getCurrentPosition(
                     currentLocation => {
 
-                        console.log(currentLocation);
                         const lat = currentLocation.coords.latitude;
                         const lng = currentLocation.coords.longitude;
                         const zoom = 13; // TODO use `currentLocation.coords.accuracy` to control coarseness of query / zoom-level
@@ -167,7 +163,6 @@ function genComponentConf() {
                         reverseSearchNominatim(lat, lng, zoom)
                             .then(searchResult => {
                                 const location = nominatim2draftLocation(searchResult);
-                                console.log('current location: ', location);
                                 this.$scope.$apply(() => { this.currentLocation = location });
                             });
                     },
@@ -262,13 +257,11 @@ function onMapClick(e, ctrl) {
     // This code was moved out of the controller
     // here to avoid confusion resulting from
     // this binding.
-    console.log('clicked map ', e);
     reverseSearchNominatim(
         e.latlng.lat,
         e.latlng.lng,
         ctrl.map.getZoom()// - 1
     ).then(searchResult => {
-        console.log('nearest address: ', searchResult);
         const location = nominatim2draftLocation(searchResult);
 
         //use coords of original click though (to allow more detailed control)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -102,7 +102,11 @@ function genComponentConf() {
 
                 this.router__stateGoCurrent({connectionUri: null, sendAdHocRequest: null});
             }else{
-                this.connections__open(this.connectionUri, message);
+                this.needs__connect(
+                		this.ownNeed.get("uri"), 
+                		this.connectionUri,
+                		this.ownNeed.getIn(['connections',this.connectionUri]).get("remoteNeedUri"), 
+                		message);
                 this.router__stateGoCurrent({connectionUri: null})
             }
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -105,7 +105,7 @@ function genComponentConf() {
 
                 this.router__stateGoCurrent({connectionUri: null, sendAdHocRequest: null});
             }else{
-                this.connections__connect(this.connectionUri, message);
+                this.connections__open(this.connectionUri, message);
                 this.router__stateGoCurrent({connectionUri: null})
             }
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -92,11 +92,8 @@ function genComponentConf() {
         sendRequest(message) {
             if(this.sendAdHocRequest || (this.ownNeed && this.ownNeed.get("isWhatsAround"))){
                 if(this.ownNeed && this.ownNeed.get("isWhatsAround")){
-                    console.log("sending request from whatsaround need, close original connection");
                     //Close the connection if there was a present connection for a whatsaround need
                     this.connections__close(this.connectionUri);
-                }else{
-                    console.log("sending adhoc request");
                 }
 
                 if(this.postUriToConnectTo){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
@@ -20,12 +20,12 @@ const loggingMiddleware = store => next => action => {
 
     if(window.won && window.won.debugmode) {
         const state = store.getState();
-        console.debug('action:  ', action.type,
-            action.payload && action.payload.toJS ? action.payload.toJS() : action.payload
-        );
-        console.debug('changing state from ',
-            state && state.toJS ?
-                state.toJS() : state);
+        //console.debug('action:  ', action.type,
+        //    action.payload && action.payload.toJS ? action.payload.toJS() : action.payload
+        //);
+        //console.debug('changing state from ',
+        //    state && state.toJS ?
+        //        state.toJS() : state);
     }
 
     const result = next(action);
@@ -33,9 +33,9 @@ const loggingMiddleware = store => next => action => {
     if(window.won && window.won.debugmode) {
         const updatedState = store.getState();
 
-        console.debug('changed state to ',
-            updatedState && updatedState.toJS ?
-                updatedState.toJS() : updatedState);
+        //console.debug('changed state to ',
+        //    updatedState && updatedState.toJS ?
+        //        updatedState.toJS() : updatedState);
     }
 
     return result;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRedux.js
@@ -20,22 +20,25 @@ const loggingMiddleware = store => next => action => {
 
     if(window.won && window.won.debugmode) {
         const state = store.getState();
-        //console.debug('action:  ', action.type,
-        //    action.payload && action.payload.toJS ? action.payload.toJS() : action.payload
-        //);
-        //console.debug('changing state from ',
-        //    state && state.toJS ?
-        //        state.toJS() : state);
+        /*
+        console.debug('action:  ', action.type,
+            action.payload && action.payload.toJS ? action.payload.toJS() : action.payload
+        );
+        console.debug('changing state from ',
+            state && state.toJS ?
+                state.toJS() : state);
+         */
     }
 
     const result = next(action);
 
     if(window.won && window.won.debugmode) {
         const updatedState = store.getState();
-
-        //console.debug('changed state to ',
-        //    updatedState && updatedState.toJS ?
-        //        updatedState.toJS() : updatedState);
+        /*
+        console.debug('changed state to ',
+            updatedState && updatedState.toJS ?
+                updatedState.toJS() : updatedState);
+         */
     }
 
     return result;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -65,7 +65,6 @@ export const constantParams = [
 export const configRouting = [ '$urlRouterProvider', '$stateProvider', ($urlRouterProvider, $stateProvider) => {
     //$urlRouterProvider.otherwise('/landingpage');
     $urlRouterProvider.otherwise(($injector, $location) => {
-        console.log('otherwise ', $injector, $location)
 
         //let updatedRoute =  $location.replace()
         //    .path('/landingpage') // change route to landingpage
@@ -185,7 +184,6 @@ function back(hasPreviousState, $ngRedux) {
 
 export const runAccessControl = [ '$transitions', '$rootScope', '$ngRedux', '$urlRouter',
     ($transitions, $rootScope, $ngRedux, $urlRouter) => {
-        console.log('transitions: ', $transitions);
         //TODO use access-control provided by $transitions.onStart()
         $rootScope.$on('$stateChangeStart',
             (event, toState, toParams, fromState, fromParams, options) =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -38,9 +38,6 @@ import * as messages from './actions/messages-actions.js';
 
 export function runMessagingAgent(redux) {
 
-    console.log('Starting messaging agent.');
-
-
     /**
      * The messageProcessingArray encapsulates all currently implemented message handlers with their respective redux dispatch
      * events, to process another message you add another anonymous function that checks on the necessary message properties/values

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -271,6 +271,10 @@ export function runMessagingAgent(redux) {
     ]
 
     function onMessage(receivedMsg) {
+    	//reset the heartbeat counter when we receive a message.
+    	missedHeartbeats = 0;
+    	 
+    	 
         const data = JSON.parse(receivedMsg.data);
 
         won.wonMessageFromJsonLd(data).then(message => {
@@ -333,7 +337,6 @@ export function runMessagingAgent(redux) {
     };
 
     function onHeartbeat(e) {
-        console.debug('messaging-agent.js: received heartbeat',e);
         missedHeartbeats = 0; // reset the deadman count
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/piwik.js
@@ -78,7 +78,6 @@ export const piwikQueue = _paq;
  */
 let _currentUrl = window.location.href;
 window.addEventListener('hashchange', function() {
-    console.log('piwik.js -- onhashchange');
     //logUrlChange('' + window.location.hash.substr(1));
     logUrlChange();
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -22,6 +22,7 @@ export function messagesReducer(messages = initialState, action = {}) {
         case actionTypes.logout:
             return initialState;
 
+        case actionTypes.needs.connect:            
         case actionTypes.needs.create:
             return messages.setIn(
                 ['enqueued', action.payload.eventUri],
@@ -65,6 +66,31 @@ export function messagesReducer(messages = initialState, action = {}) {
                 .set('lostConnection', false)
                 .set('reconnecting', false);
 
+        case actionTypes.messages.dispatchActionOn.registerSuccessOwn: 
+        	console.log("registering for SuccessOwn");
+        	const path = ['dispatchOnSuccessOwn', action.payload.eventUri];
+        	const toDispatchList = messages.getIn(path);
+        	if (!toDispatchList){
+        		return messages.setIn(path, [action.payload.actionToDispatch]);
+        	} 
+        	return messages.updateIn(path, list => list.push(action.payload.actionToDispatch));
+
+        case actionTypes.messages.dispatchActionOn.failureOwn:
+        case actionTypes.messages.dispatchActionOn.successOwn:
+        	console.log("cleaning up after successOwn");
+        	//all the dispatching was done by the action creator. remove the queued actions now:
+            return messages.removeIn(['dispatchOnSuccessOwn', action.payload.eventUri])
+            			   .removeIn(['dispatchOnFailureOwn', action.payload.eventUri]);	
+
+        case actionTypes.messages.dispatchActionOn.failureRemote:
+        case actionTypes.messages.dispatchActionOn.successRemote:
+        	console.log("cleaning up after successOwn");
+        	//all the dispatching was done by the action creator. remove the queued actions now:
+            return messages.removeIn(['dispatchOnSuccessRemote', action.payload.eventUri])
+            			   .removeIn(['dispatchOnFailureRemote', action.payload.eventUri]);     
+            
+            
+            
         default:
             return messages;
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -77,14 +77,12 @@ export function messagesReducer(messages = initialState, action = {}) {
 
         case actionTypes.messages.dispatchActionOn.failureOwn:
         case actionTypes.messages.dispatchActionOn.successOwn:
-        	console.log("cleaning up after successOwn");
         	//all the dispatching was done by the action creator. remove the queued actions now:
             return messages.removeIn(['dispatchOnSuccessOwn', action.payload.eventUri])
             			   .removeIn(['dispatchOnFailureOwn', action.payload.eventUri]);	
 
         case actionTypes.messages.dispatchActionOn.failureRemote:
         case actionTypes.messages.dispatchActionOn.successRemote:
-        	console.log("cleaning up after successOwn");
         	//all the dispatching was done by the action creator. remove the queued actions now:
             return messages.removeIn(['dispatchOnSuccessRemote', action.payload.eventUri])
             			   .removeIn(['dispatchOnFailureRemote', action.payload.eventUri]);     

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -67,7 +67,6 @@ export function messagesReducer(messages = initialState, action = {}) {
                 .set('reconnecting', false);
 
         case actionTypes.messages.dispatchActionOn.registerSuccessOwn: 
-        	console.log("registering for SuccessOwn");
         	const path = ['dispatchOnSuccessOwn', action.payload.eventUri];
         	const toDispatchList = messages.getIn(path);
         	if (!toDispatchList){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -68,7 +68,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         case actionTypes.needs.close:
             return changeNeedState(allNeedsInState, action.payload.ownNeedUri, won.WON.InactiveCompacted);
 
-        //case actionTypes.needs.create: //TODO optimistic need adding
+        case actionTypes.needs.create: // optimistic need adding
+        	return addNeedInCreation(allNeedsInState, action.payload.need, action.payload.needUri)
         case actionTypes.needs.createSuccessful:
             return addNeed(allNeedsInState, action.payload.need, true);
 
@@ -85,7 +86,12 @@ export default function(allNeedsInState = initialState, action = {}) {
             var remoteNeed = action.payload.remoteNeed;
 
             var stateWithOwnNeed = ownNeedFromState ? allNeedsInState : addNeed(allNeedsInState, ownNeed, true);
-            var stateWithBothNeeds = addNeed(stateWithOwnNeed, remoteNeed, false); // guarantee that remoteNeed is in state
+            var stateWithBothNeeds = addNeed(stateWithOwnNeed, remoteNeed, false); // guarantee
+																					// that
+																					// remoteNeed
+																					// is
+																					// in
+																					// state
             var stateWithBothNeedsAndConnection = addConnectionFull(stateWithBothNeeds, action.payload.connection, true);
 
             let stateWithEverything = stateWithBothNeedsAndConnection;
@@ -97,7 +103,7 @@ export default function(allNeedsInState = initialState, action = {}) {
         case actionTypes.messages.hintMessageReceived:
             return storeConnectionAndRelatedData(allNeedsInState, action.payload, true);
 
-        //NEW CONNECTIONS STATE UPDATES
+        // NEW CONNECTIONS STATE UPDATES
         case actionTypes.connections.close:
             return changeConnectionState(allNeedsInState, action.payload.connectionUri, won.WON.Closed);
 
@@ -110,7 +116,11 @@ export default function(allNeedsInState = initialState, action = {}) {
             var ownNeedUri = optimisticEvent.hasSenderNeed;
             var theirNeedUri = optimisticEvent.hasReceiverNeed;
             var eventUri = optimisticEvent.uri;
-            var tmpConnectionUri = 'connectionFrom:' + eventUri; // need to wait for success-response to set that
+            var tmpConnectionUri = 'connectionFrom:' + eventUri; // need to
+																	// wait for
+																	// success-response
+																	// to set
+																	// that
             var optimisticConnection = Immutable.fromJS({
                 uri: tmpConnectionUri,
                 usingTemporaryUri: true,
@@ -128,7 +138,8 @@ export default function(allNeedsInState = initialState, action = {}) {
                     }
                 }
             });
-            // as eventUris shouldn't clash with connectionUris, we can store it like this and already display it
+            // as eventUris shouldn't clash with connectionUris, we can store it
+			// like this and already display it
             return allNeedsInState.setIn([ownNeedUri, 'connections', tmpConnectionUri], optimisticConnection);
 
 
@@ -145,7 +156,8 @@ export default function(allNeedsInState = initialState, action = {}) {
 
         case actionTypes.messages.open.successRemote:
         case actionTypes.messages.connect.successRemote:
-            // use the remote success message to obtain the remote connection uri (which we may not have known)
+            // use the remote success message to obtain the remote connection
+			// uri (which we may not have known)
             var wonMessage = action.payload;
             var connectionUri =  wonMessage.getReceiver();
             var needUri =  wonMessage.getReceiverNeed();
@@ -159,13 +171,16 @@ export default function(allNeedsInState = initialState, action = {}) {
             }
 
         case actionTypes.messages.connect.successOwn:
-            //TODO SRP; split in isSuccessOfAdHocConnect, addAddHoc(?) and changeConnectionState
+            // TODO SRP; split in isSuccessOfAdHocConnect, addAddHoc(?) and
+			// changeConnectionState
             var wonMessage = action.payload;
             var connectionUri = wonMessage.getReceiver();
             var needForTmpCnct = selectNeedByConnectionUri(allNeedsInState, connectionUri);
             var unsortedAdHocConnection = needForTmpCnct && needForTmpCnct.getIn(['connections', connectionUri]);
             if(unsortedAdHocConnection) {
-                // connection was established from scratch without having a connection uri. now that we have the uri, we can store it (see connectAdHoc)
+                // connection was established from scratch without having a
+				// connection uri. now that we have the uri, we can store it
+				// (see connectAdHoc)
                 var needUri = needForTmpCnct.get('uri');
                 if(!needForTmpCnct.get('ownNeed')) {
                     throw new Exception('Trying to add/change connection for need that\'s not an "ownNeed".');
@@ -186,19 +201,18 @@ export default function(allNeedsInState = initialState, action = {}) {
         case actionTypes.messages.close.success:
             return changeConnectionState(allNeedsInState,  action.payload.getReceiver(), won.WON.Closed);
 
-        //NEW MESSAGE STATE UPDATES
+        // NEW MESSAGE STATE UPDATES
         case actionTypes.messages.connectionMessageReceived:
-            //ADD RECEIVED CHAT MESSAGES
-            //payload; { events }
+            // ADD RECEIVED CHAT MESSAGES
+            // payload; { events }
             return addMessage(allNeedsInState, action.payload, false, true);
 
         case actionTypes.connections.sendChatMessage:
-            //ADD SENT TEXT MESSAGE
-            /*payload: {
-                eventUri: optimisticEvent.uri,
-                message,
-                optimisticEvent,
-             }*/
+            // ADD SENT TEXT MESSAGE
+            /*
+			 * payload: { eventUri: optimisticEvent.uri, message,
+			 * optimisticEvent, }
+			 */
             console.log("sendChatMessage: ", action.payload.optimisticEvent);
             return addMessage(allNeedsInState, action.payload.optimisticEvent, true, true);
 
@@ -210,10 +224,11 @@ export default function(allNeedsInState = initialState, action = {}) {
             var eventUri = wonMessage.getIsResponseTo();
             var needUri = wonMessage.getReceiverNeed();
             var connectionUri = wonMessage.getReceiver();
-            // we want to use the response date to update the original message date
+            // we want to use the response date to update the original message
+			// date
             // in order to use server timestamps everywhere
             var responseDateOnServer =  msStringToDate(wonMessage.getTimestamp());
-            //make sure we have an event with that uri:
+            // make sure we have an event with that uri:
             var eventToUpdate = allNeedsInState.getIn([needUri, 'connections', connectionUri, 'messages', eventUri]);
             if (eventToUpdate) {
                 allNeedsInState =  allNeedsInState.setIn([needUri, 'connections', connectionUri, 'messages', eventUri, 'date'], responseDateOnServer);
@@ -237,8 +252,15 @@ export default function(allNeedsInState = initialState, action = {}) {
 
 function storeConnectionAndRelatedData(state, connectionWithRelatedData, newConnection) {
     const {ownNeed, remoteNeed, connection} = connectionWithRelatedData;
-    const stateWithOwnNeed = addNeed(state, ownNeed, true); // guarantee that ownNeed is in state
-    const stateWithBothNeeds = addNeed(stateWithOwnNeed, remoteNeed, false); // guarantee that remoteNeed is in state
+    const stateWithOwnNeed = addNeed(state, ownNeed, true); // guarantee that
+															// ownNeed is in
+															// state
+    const stateWithBothNeeds = addNeed(stateWithOwnNeed, remoteNeed, false); // guarantee
+																				// that
+																				// remoteNeed
+																				// is
+																				// in
+																				// state
 
     return addConnectionFull(stateWithBothNeeds, connection, newConnection);
 }
@@ -250,17 +272,44 @@ function addNeed(needs, jsonldNeed, ownNeed) {
     let parsedNeed = parseNeed(jsonldNeed, ownNeed);
 
     if(parsedNeed && parsedNeed.get("uri")) {
-        if(ownNeed && needs.get(parsedNeed.get("uri"))){ //If need is already present and the need is claimed as an own need we set have to set it
-            newState = needs.setIn([parsedNeed.get("uri"), "ownNeed"], ownNeed);
-        }else{
-            newState = setIfNew(needs, parsedNeed.get("uri"), parsedNeed);
+    	let existingNeed = needs.get(parsedNeed.get("uri"));
+        if(ownNeed && existingNeed){ // If need is already present and the
+										// need is claimed as an own need we set
+										// have to set it
+        	if (existingNeed.get("beingCreated")){
+        		// replace it
+        		parsedNeed = parsedNeed.set("connections", existingNeed.get("connections"));
+        		return needs.setIn([parsedNeed.get("uri")], parsedNeed);
+        	} else {
+        		// just be sure we mark it as own need
+        		return needs.setIn([parsedNeed.get("uri"), "ownNeed"], ownNeed);	
+        	}
+        } else {
+            return setIfNew(needs, parsedNeed.get("uri"), parsedNeed);
         }
     } else {
         console.error('Tried to add invalid need-object: ', jsonldNeedImm.toJS());
         newState = needs;
     }
+    return newState;
+}
 
-
+function addNeedInCreation(needs, needInCreation, needUri) {
+    let newState;
+    let need = Immutable.fromJS(needInCreation);
+    if(need) {
+        need = need.set("beingCreated",true);
+        need = need.set("ownNeed", true);
+        need = need.set("needUri", needUri);
+        need = need.set("connections", Immutable.Map());
+        if (need.get("whatsAround")){
+        	need = need.set("isWhatsAround", true);
+        }
+    	newState = needs.setIn([needUri], need);
+    } else {
+        console.error('Tried to add invalid need-object: ', needInCreation);
+        newState = needs;
+    }
     return newState;
 }
 
@@ -278,6 +327,7 @@ function storeConnectionsData(state, connectionsToStore, newConnections) {
 
 /**
  * Add's the connection to the needs connections.
+ * 
  * @param state
  * @param connection
  * @param newConnection
@@ -285,14 +335,22 @@ function storeConnectionsData(state, connectionsToStore, newConnections) {
  */
 function addConnectionFull(state, connection, newConnection) {
 
-    //console.log("Adding Full Connection");
+    // console.log("Adding Full Connection");
     if(newConnection === undefined) {
-      newConnection = !!selectNeedByConnectionUri(state, connection.uri || connection.get('uri')); // do we already have a connection like that?
+      newConnection = !!selectNeedByConnectionUri(state, connection.uri || connection.get('uri')); // do
+																									// we
+																									// already
+																									// have
+																									// a
+																									// connection
+																									// like
+																									// that?
     }
     let parsedConnection = parseConnection(connection, newConnection);
 
     if(parsedConnection){
-        //console.log("parsedConnection: ", parsedConnection.toJS(), "immutable ", parsedConnection);
+        // console.log("parsedConnection: ", parsedConnection.toJS(), "immutable
+		// ", parsedConnection);
 
         const needUri = parsedConnection.get("belongsToUri");
         let connections = state.getIn([needUri, 'connections']);
@@ -304,14 +362,16 @@ function addConnectionFull(state, connection, newConnection) {
             console.error("Couldnt add valid connection - missing need data in state", needUri, "parsedConnection: ", parsedConnection.toJS());
         }
     }else{
-        //console.log("No connection parsed, add no connection to this state: ", state);
+        // console.log("No connection parsed, add no connection to this state:
+		// ", state);
     }
     return state;
 }
 
 function addMessage(state, wonMessage, outgoingMessage, newMessage) {
     if (wonMessage.getTextMessage()) {
-        // we only want to add messages to the state that actually contain text content.
+        // we only want to add messages to the state that actually contain text
+		// content.
         // (no empty connect messages, for example)
         let parsedMessage = parseMessage(wonMessage, outgoingMessage, newMessage);
 
@@ -319,10 +379,10 @@ function addMessage(state, wonMessage, outgoingMessage, newMessage) {
             const connectionUri = parsedMessage.get("belongsToUri");
             let needUri = null;
             if (outgoingMessage) {
-                //needUri is the message's hasSenderNeed
+                // needUri is the message's hasSenderNeed
                 needUri = wonMessage.getSenderNeed();
             } else {
-                //needUri is the remote message's hasReceiverNeed
+                // needUri is the remote message's hasReceiverNeed
                 needUri = wonMessage.getReceiverNeed();
             }
             if (needUri) {
@@ -351,9 +411,9 @@ function addMessages(state, wonMessages) {
 
 function setIfNew(state, path, obj){
     return state.update(path, val => val ?
-        //we've seen this need before, no need to overwrite it
+        // we've seen this need before, no need to overwrite it
         val :
-        //it's the first time we see this need -> add it
+        // it's the first time we see this need -> add it
         Immutable.fromJS(obj))
 }
 
@@ -381,7 +441,7 @@ function changeNeedState(state, needUri, newState) {
 
 function parseConnection(jsonldConnection, newConnection) {
     const jsonldConnectionImm = Immutable.fromJS(jsonldConnection);
-    //console.log("Connection to parse: ", jsonldConnectionImm.toJS());
+    // console.log("Connection to parse: ", jsonldConnectionImm.toJS());
 
     let parsedConnection = {
         belongsToUri: undefined,
@@ -407,7 +467,12 @@ function parseConnection(jsonldConnection, newConnection) {
         parsedConnection.data.remoteNeedUri = remoteNeedUri;
         parsedConnection.data.remoteConnectionUri = remoteConnectionUri;
 
-        const creationDate = jsonldConnectionImm.get("dct:created"); //THIS IS NOT IN THE DATA
+        const creationDate = jsonldConnectionImm.get("dct:created"); // THIS
+																		// IS
+																		// NOT
+																		// IN
+																		// THE
+																		// DATA
         if(creationDate){
             parsedConnection.data.creationDate = creationDate;
         }
@@ -423,7 +488,7 @@ function parseConnection(jsonldConnection, newConnection) {
             parsedConnection.data.state = state;
         }else{
             console.error('Cant parse connection, data is an invalid connection-object: ', jsonldConnectionImm.toJS());
-            return undefined; //FOR UNKNOWN STATES
+            return undefined; // FOR UNKNOWN STATES
         }
 
         return Immutable.fromJS(parsedConnection);
@@ -502,10 +567,11 @@ function parseNeed(jsonldNeed, ownNeed) {
         }
 
         /*
-        The following code-snippet is solely to determine if the parsed need is a special "whats around"-need,
-        in order to do this we have to make sure that the won:hasFlag is checked in two forms, both as a string
-        and an immutable object
-        */
+		 * The following code-snippet is solely to determine if the parsed need
+		 * is a special "whats around"-need, in order to do this we have to make
+		 * sure that the won:hasFlag is checked in two forms, both as a string
+		 * and an immutable object
+		 */
         const wonHasFlags = jsonldNeedImm.get("won:hasFlag");
         const isWhatsAround = wonHasFlags && wonHasFlags
                 .filter(function(flag) {
@@ -523,7 +589,9 @@ function parseNeed(jsonldNeed, ownNeed) {
         }
 
         const state = jsonldNeedImm.getIn([won.WON.isInStateCompacted, "@id"]);
-        if(state === won.WON.ActiveCompacted){ //we use to check for active state and everything else will be inactive
+        if(state === won.WON.ActiveCompacted){ // we use to check for active
+												// state and everything else
+												// will be inactive
             parsedNeed.state = state;
         } else {
             parsedNeed.state = won.WON.InactiveCompacted;
@@ -561,7 +629,7 @@ function parseNeed(jsonldNeed, ownNeed) {
 }
 
 function parseLocation(jsonldLocation) {
-    if(!jsonldLocation) return undefined; //NO LOCATION PRESENT
+    if(!jsonldLocation) return undefined; // NO LOCATION PRESENT
 
     const jsonldLocationImm = Immutable.fromJS(jsonldLocation);
 
@@ -608,8 +676,11 @@ function parseLocation(jsonldLocation) {
 
 /**
  * Get the need for a given connectionUri
- * @param state to retrieve data from
- * @param connectionUri to find corresponding need for
+ * 
+ * @param state
+ *            to retrieve data from
+ * @param connectionUri
+ *            to find corresponding need for
  */
 function selectNeedByConnectionUri(allNeedsInState, connectionUri){
     return allNeedsInState.filter(need =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -213,7 +213,6 @@ export default function(allNeedsInState = initialState, action = {}) {
 			 * payload: { eventUri: optimisticEvent.uri, message,
 			 * optimisticEvent, }
 			 */
-            console.log("sendChatMessage: ", action.payload.optimisticEvent);
             return addMessage(allNeedsInState, action.payload.optimisticEvent, true, true);
 
         // update timestamp on success response

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -526,10 +526,6 @@ import won from './won.js';
         }
 
 
-        if(partialFetch) {
-            console.log('won.ensureLoaded: loading partial ressource ', fetchParams);
-        }
-
         cacheItemMarkFetching(uri);
         return won.fetch(uri, fetchParams )
             .then(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1293,7 +1293,6 @@ import won from './won.js';
     };
 
     won.getEnvelopeDataforNewConnection = function(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri) {
-    	console.log("getEnvelopeDataforNewConnection");
         if (!ownNeedUri){
         	console.log("no own need uri");
             throw {message : "getEnvelopeDataforNewConnection: ownNeedUri must not be null"};
@@ -1302,7 +1301,6 @@ import won from './won.js';
         	console.log("no remote need uri");
             throw {message : "getEnvelopeDataforNewConnection: theirNeedUri must not be null"};
         }
-        console.log("returning a normal envelope");
         return {
             [won.WONMSG.hasSenderNeed]: ownNeedUri,
             [won.WONMSG.hasSenderNode]: ownNodeUri,
@@ -1331,7 +1329,7 @@ import won from './won.js';
             [won.WONMSG.hasReceiverNode]: theirNodeUri,
         };
         try {
-            if (theirConnectionUri != null) {
+            if (theirConnectionUri) {
                 ret[won.WONMSG.hasReceiver] = theirConnectionUri;
             }
         } catch(err){}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1296,20 +1296,23 @@ import won from './won.js';
         return Promise.resolve(ret);
     };
 
-    won.getEnvelopeDataforNewConnection = async function(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri) {
+    won.getEnvelopeDataforNewConnection = function(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri) {
+    	console.log("getEnvelopeDataforNewConnection");
         if (!ownNeedUri){
+        	console.log("no own need uri");
             throw {message : "getEnvelopeDataforNewConnection: ownNeedUri must not be null"};
         }
         if (!theirNeedUri){
+        	console.log("no remote need uri");
             throw {message : "getEnvelopeDataforNewConnection: theirNeedUri must not be null"};
         }
-
-        return Promise.resolve({
+        console.log("returning a normal envelope");
+        return {
             [won.WONMSG.hasSenderNeed]: ownNeedUri,
             [won.WONMSG.hasSenderNode]: ownNodeUri,
             [won.WONMSG.hasReceiverNeed]: theirNeedUri,
             [won.WONMSG.hasReceiverNode]: theirNodeUri,
-        })
+        }
     };
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/message-builder.js
@@ -81,8 +81,6 @@ import won from './won.js';
             }
         ];
 
-        console.log('message-builder.js:buildMessageRdf:attachmentBlankNodes: ', attachmentBlankNodes);
-        console.log('message-builder.js:buildMessageRdf:envelopeGraph: ', envelopeGraph.concat(attachmentBlankNodes));
 
         msgGraph.push({
             // msg envelope

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -89,7 +89,6 @@ import won from './won.js';
      */
     won.buildNeedRdf = function(args){
 
-        console.log('need-builder.js:buildNeedRdf:attachmentUris', args.attachmentUris);
 
         if(hasAttachmentUrls(args)) {
             var attachmentUrisTyped = args.attachmentUris.map(function (uri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1628,7 +1628,6 @@ import jsonld from 'jsonld';
             return this;
         },
         build: function () {
-            console.log("built this message:" + JSON.stringify(this.data));
             return this.data;
         }
     };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -44,7 +44,6 @@ export function dispatchEvent(elem, eventName, eventData) {
         event = new Event(eventName);
     }
     elem.dispatchEvent(event);
-    //console.log('dispatching');
 }
 
 /*
@@ -318,7 +317,6 @@ export function concatTags(tags) {
 // This scrolling function
 // is from http://www.itnewb.com/tutorial/Creating-the-Smooth-Scroll-Effect-with-JavaScript
 export function scrollTo(eID) {
-    console.log("SCROLL TO METHOD");
     var startY = currentYPosition();
     var stopY = elmYPosition(eID);
     var distance = stopY > startY ? stopY - startY : startY - stopY;
@@ -589,7 +587,6 @@ export function searchNominatim(searchStr) {
     var url = "https://nominatim.openstreetmap.org/search" +
         "?q=" + encodeURIComponent(searchStr) +
         "&format=json";
-    console.log("About to query nominatim: " + url);
     return fetchJSON(url);
 }
 
@@ -603,7 +600,6 @@ export function reverseSearchNominatim(lat, lon, zoom) {
     if(!isNaN(zoom)) {
         url += "&zoom=" + Math.max(0, Math.min(zoom, 18));
     }
-    console.log("About to do reverse lookup on nominatim: " + url);
 
     let json = fetchJSON((url)).catch(function(e){
         var distance = 0.2;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -127,20 +127,6 @@ export function buildOpenNeedMessage(needUri, wonNodeUri){
 }
 
 
-/**
- * Creates json-ld for a connect-message, where there's no connection yet (i.e. we
- * only know which own we want to connect with which remote need)
- * @param ownNeedUri
- * @param theirNeedUri
- * @param textMessage
- * @returns {{eventUri, message}|*}
- */
-export async function buildAdHocConnectMessage(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, textMessage) {
-    return won.getEnvelopeDataforNewConnection(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri)
-    .then(envelopeData =>
-        buildConnectMessageForEnvelopeData(envelopeData, textMessage)
-    );
-}
 
 /**
  * Builds json-ld for a connect-message in reaction to a need.
@@ -148,28 +134,21 @@ export async function buildAdHocConnectMessage(ownNeedUri, theirNeedUri, ownNode
  * @param textMessage
  * @returns {{eventUri, message}|*}
  */
-export async function buildConnectMessage(connectionUri, ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, theirConnectionUri, textMessage){
-    return won.getEnvelopeDataforConnection(connectionUri, ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, theirConnectionUri)
-    .then(envelopeData =>
-        buildConnectMessageForEnvelopeData(envelopeData, textMessage)
-    );
-}
-
-function buildConnectMessageForEnvelopeData(envelopeData, textMessage) {
+export function buildConnectMessage(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, textMessage){
+    const envelopeData = won.getEnvelopeDataforNewConnection(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri);
     //TODO: use event URI pattern specified by WoN node
     var eventUri = envelopeData[won.WONMSG.hasSenderNode] + "/event/" +  getRandomPosInt();
     var message = new won.MessageBuilder(won.WONMSG.connectMessage)
         .eventURI(eventUri)
         .forEnvelopeData(envelopeData)
-        .hasFacet(won.WON.OwnerFacet) //TODO: looks like a copy-paste-leftover from connect
-        .hasRemoteFacet(won.WON.OwnerFacet)//TODO: looks like a copy-paste-leftover from connect
+        .hasFacet(won.WON.OwnerFacet) 
+        .hasRemoteFacet(won.WON.OwnerFacet)
         .hasTextMessage(textMessage)
         .hasOwnerDirection()
         .hasSentTimestamp(new Date().getTime().toString())
         .build();
 
-    //var callback = createMessageCallbackForRemoteNeedMessage(eventUri, won.EVENT.CONNECT_SENT);
-    return {eventUri:eventUri,message:message};
+    return {eventUri:eventUri,message:message};  
 }
 
 export function buildChatMessage(chatMessage, connectionUri, ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, theirConnectionUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -134,8 +134,11 @@ export function buildOpenNeedMessage(needUri, wonNodeUri){
  * @param textMessage
  * @returns {{eventUri, message}|*}
  */
-export function buildConnectMessage(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, textMessage){
+export function buildConnectMessage(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri, textMessage, optionalOwnConnectionUri){
     const envelopeData = won.getEnvelopeDataforNewConnection(ownNeedUri, theirNeedUri, ownNodeUri, theirNodeUri);
+    if (optionalOwnConnectionUri){
+       envelopeData[won.WONMSG.hasSender] = optionalOwnConnectionUri;
+    }
     //TODO: use event URI pattern specified by WoN node
     var eventUri = envelopeData[won.WONMSG.hasSenderNode] + "/event/" +  getRandomPosInt();
     var message = new won.MessageBuilder(won.WONMSG.connectMessage)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -18,7 +18,6 @@ export function initLeaflet(mapMount) {
 
     const baseMaps = initLeafletBaseMaps();
 
-    console.log("Mounting map into: ", mapMount);
     const map = L.map(mapMount,{
         center: [37.44, -42.89], //centered on north-west africa
         zoom: 1, //world-map


### PR DESCRIPTION
* Optimistically add need immediately after posting

* New chaining mechanism for actions
  Allows for executing actions when a success/failure response for
  a given message is received

* Use chaining mechanism to wait for success of AdHoc need creation,
  then send a connect message

* Refactored use of connect and open (connect requires no existing
  connection

* What's around need creation now only deactivates all existing *active*
  what's around needs, instead of all of them (which is wasteful)

* Removed some excessive log output (still more to be done there)