### PR TITLE
Fix route change blocked #1367

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -396,9 +396,5 @@ export function needsClose(needUri) {
                 }
             })
         )
-        .then(() =>
-            // go back to overview
-            dispatch(actionCreators.router__stateGoResetParams('overviewPosts'))
-        )
     }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -48,16 +48,7 @@ export function needCreate(draft, nodeUri) {
                 if (currentState === 'landingpage') {
                     return dispatch(actionCreators.router__stateGoAbs('feed'))
                 } else if (currentState === 'createNeed') {
-                    /*
-                     * go to view that was open before the create-view was opened, but
-                     * don't revert any new privateID or remove the create-gui from the
-                     * history stack.
-                     */
-                    if(prevState)  {
-                        return dispatch(actionCreators.router__stateGoAbs(prevState, prevParams))
-                    } else {
-                        return dispatch(actionCreators.router__stateGoDefault())
-                    }
+                    return dispatch(actionCreators.router__stateGoDefault())
                 }
             })
             .then(() => {


### PR DESCRIPTION
fixes #1367 

problem was that there was a routechange when closing a need, and a route change when a need is created, however creating a whatsaround need closes all preexisting whatsaround needs and due to the asyncronous behaviour of routechanges there was an overlap in the transitions resulting in the described error.

Fix was: remove the routechange in the need close action, and make a routechange for createneed that always goes to the feed when a need is about to be created (thats currently our defaultRoute)