### PR TITLE
Uki domain change to line.uki.or.at

### DIFF
--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     environment:
       - "key_store_password=$uki_certificate_passwd"
       - "domain_params=-d line.uki.or.at"
+      - "key_pem_file=/etc/letsencrypt/live/line.uki.or.at/privkey.pem"
+      - "cert_pem_file=/etc/letsencrypt/live/line.uki.or.at/fullchain.pem"
+      - "pfx_store_file=/etc/letsencrypt/live/line.uki.or.at/t-key-cert.pfx"
+      - "jks_store_file=/etc/letsencrypt/live/line.uki.or.at/t-keystore.jks"
     volumes:
       - $base_folder/letsencrypt/certs:/etc/letsencrypt
       - $base_folder/letsencrypt/acme-challenge:/usr/share/nginx/html

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - "80:80"
       - "443:443"
       - "61616:61616"
-      - "51616:51616"
+      - "61626:61626"
     volumes:
       - $base_folder/letsencrypt/certs:/etc/letsencrypt/
       - $base_folder/nginx.conf:/etc/nginx/nginx.conf

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -27,6 +27,16 @@ services:
       - $base_folder/letsencrypt/certs:/etc/letsencrypt
       - $base_folder/letsencrypt/acme-challenge:/usr/share/nginx/html
 
+  letsencrypt_uki:
+    build: ../../image/letsencrypt
+    image: webofneeds/letsencrypt:live
+    environment:
+      - "key_store_password=$uki_certificate_passwd"
+      - "domain_params=-d line.uki.or.at"
+    volumes:
+      - $base_folder/letsencrypt/certs:/etc/letsencrypt
+      - $base_folder/letsencrypt/acme-challenge:/usr/share/nginx/html
+
   # owner server self-signed certificate for communication with wonnode
   gencert:
     build: ../../image/gencert

--- a/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
@@ -36,12 +36,12 @@ services:
       - "db.sql.user=won"
       - "db.sql.password=$postgres_db_passwd"
       - "CERTIFICATE_PASSWORD=$uki_certificate_passwd"
-      - "activemq.broker.port=51616"
+      - "activemq.broker.port=61626"
       - "client.authentication.behind.proxy=true"
       - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
     ports:
       - "8443:8443"
-      - "51617:51616"
+      - "61627:61626"
     volumes:
       - $base_folder/letsencrypt/certs/live/line.uki.or.at/fullchain.pem:/usr/local/tomcat/conf/ssl/t-cert.pem
       - $base_folder/letsencrypt/certs/live/line.uki.or.at/privkey.pem:/usr/local/tomcat/conf/ssl/t-key.pem

--- a/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   gencert:
     build: ../../image/gencert
     environment:
-      - "CN=uki.matchat.org"
-      - "PASS=file:/usr/local/certs/out/won_certificate_passwd_file"
+      - "CN=line.uki.or.at"
+      - "PASS=file:/usr/local/certs/out/uki_certificate_passwd_file"
       - "OPENSSL_CONFIG_FILE=/usr/local/openssl.conf"
     volumes:
       - $base_folder/won-server-certs:/usr/local/certs/out/
@@ -23,19 +23,19 @@ services:
     ports:
       - "5433:5432"
 
-  # wonnode with nginx proxy => https://node.uki.matchat.org
+  # wonnode with nginx proxy => https://line.uki.or.at/won
   wonnode:
     build: ../../image/wonnode
     environment:
-      - "uri.host=node.uki.matchat.org"
-      - "uri.prefix=https://node.uki.matchat.org/won"
+      - "uri.host=line.uki.or.at"
+      - "uri.prefix=https://line.uki.or.at/won"
       - "http.port=8443"
       - "db.sql.jdbcDriverClass=org.postgresql.Driver"
       - "db.sql.jdbcUrl=jdbc:postgresql://satvm06.researchstudio.at:5433/won_node"
       - "db.ddl.strategy=validate"
       - "db.sql.user=won"
       - "db.sql.password=$postgres_db_passwd"
-      - "CERTIFICATE_PASSWORD=$won_certificate_passwd"
+      - "CERTIFICATE_PASSWORD=$uki_certificate_passwd"
       - "activemq.broker.port=51616"
       - "client.authentication.behind.proxy=true"
       - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
@@ -43,10 +43,10 @@ services:
       - "8443:8443"
       - "51617:51616"
     volumes:
-      - $base_folder/letsencrypt/certs/live/matchat.org/fullchain.pem:/usr/local/tomcat/conf/ssl/t-cert.pem
-      - $base_folder/letsencrypt/certs/live/matchat.org/privkey.pem:/usr/local/tomcat/conf/ssl/t-key.pem
-      - $base_folder/letsencrypt/certs/live/matchat.org/t-key-cert.pfx:/usr/local/tomcat/conf/ssl/t-key-cert.pfx
-      - $base_folder/letsencrypt/certs/live/matchat.org/t-keystore.jks:/usr/local/tomcat/conf/ssl/t-keystore.jks
+      - $base_folder/letsencrypt/certs/live/line.uki.or.at/fullchain.pem:/usr/local/tomcat/conf/ssl/t-cert.pem
+      - $base_folder/letsencrypt/certs/live/line.uki.or.at/privkey.pem:/usr/local/tomcat/conf/ssl/t-key.pem
+      - $base_folder/letsencrypt/certs/live/line.uki.or.at/t-key-cert.pfx:/usr/local/tomcat/conf/ssl/t-key-cert.pfx
+      - $base_folder/letsencrypt/certs/live/line.uki.or.at/t-keystore.jks:/usr/local/tomcat/conf/ssl/t-keystore.jks
       - $base_folder/won-client-certs/wonnode:/usr/local/tomcat/won/client-certs/
     depends_on:
       - postgres_node
@@ -62,22 +62,22 @@ services:
     ports:
       - "5432:5432"
 
-  # owner with nginx proxy (https://uki.matchat.org)
+  # owner with nginx proxy (https://line.uki.or.at/owner)
   owner:
     build: ../../image/owner
     environment:
-      - "node.default.host=node.uki.matchat.org"
-      - "uri.host=uki.matchat.org"
+      - "node.default.host=line.uki.or.at"
+      - "uri.host=line.uki.or.at"
       - "http.port=8082"
       - "node.default.http.port=443"
-      - "uri.prefix=https://uki.matchat.org/uki"
-      - "uri.prefix.node.default=https://node.uki.matchat.org/won"
+      - "uri.prefix=https://line.uki.or.at/owner"
+      - "uri.prefix.node.default=https://line.uki.or.at/won"
       - "db.sql.jdbcDriverClass=org.postgresql.Driver"
       - "db.sql.jdbcUrl=jdbc:postgresql://satvm06.researchstudio.at:5432/won_owner"
       - "db.ddl.strategy=validate"
       - "db.sql.user=won"
       - "db.sql.password=$postgres_db_passwd"
-      - "CERTIFICATE_PASSWORD=$won_certificate_passwd"
+      - "CERTIFICATE_PASSWORD=$uki_certificate_passwd"
       - "email.from.won.user=$MAIL_USER"
       - "email.from.won.password=$MAIL_PASS"
       - "email.from.won.smtp.host=$MAIL_HOST"
@@ -100,15 +100,15 @@ services:
     ports:
       - "10000:9999"
 
-  # matcher service connect with wonnode on node.uki.matchat.org and node.matchat.org
+  # matcher service connect with wonnode on line.uki.or.at and node.matchat.org
   matcher_service:
     build: ../../image/matcher-service
     environment:
       - "node.host=satvm06.researchstudio.at"
-      - "matcher.uri=https://uki.matchat.org/matcher_service"
+      - "matcher.uri=https://line.uki.or.at/matcher_service"
       - "cluster.seedNodes=satvm06.researchstudio.at:2561,satvm06.researchstudio.at:2562"
       - "uri.sparql.endpoint=http://satvm06.researchstudio.at:10000/bigdata/namespace/kb/sparql"
-      - "wonNodeController.wonNode.crawl=https://node.uki.matchat.org/won/resource,https://node.matchat.org/won/resource" # crawl uki won node and matchat won node
+      - "wonNodeController.wonNode.crawl=https://line.uki.or.at/won/resource,https://node.matchat.org/won/resource" # crawl uki won node and matchat won node
       - "cluster.local.port=2561"
       - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
     ports:
@@ -157,15 +157,15 @@ services:
     volumes:
       - $base_folder/mongodb/data/db:/data/db
 
-  # debug bot used to test need communication, connect to wonnodes (proxied: node.uki.matchat.org)
+  # debug bot used to test need communication, connect to wonnodes (proxied: line.uki.or.at)
   debug_bot:
     build: ../../image/bots
     environment:
-      - "uri.prefix.owner=https://uki.matchat.org/debug_bot"  # set this for the trust store alias
-      - "node.default.host=node.uki.matchat.org"
+      - "uri.prefix.owner=https://line.uki.or.at/debug_bot"  # set this for the trust store alias
+      - "node.default.host=line.uki.or.at"
       - "node.default.http.port=443"
-      - "uri.prefix.node.default=https://node.uki.matchat.org/won"
-      - "won.node.uris=https://node.uki.matchat.org/won/resource"
+      - "uri.prefix.node.default=https://line.uki.or.at/won"
+      - "won.node.uris=https://line.uki.or.at/won/resource"
       - "botContext.impl=mongoBotContext"
       - "botContext.mongodb.user=won"
       - "botContext.mongodb.pass=$mongo_db_passwd"

--- a/webofneeds/won-docker/deploy_uki.sh
+++ b/webofneeds/won-docker/deploy_uki.sh
@@ -5,24 +5,24 @@ set -e
 export base_folder=/usr/share/webofneeds/uki
 export live_base_folder=/home/won/matchat
 
-# create a password file for the certificates, variable ${won_certificate_passwd} must be set from outside the script
+# create a password file for the certificates, variable ${uki_certificate_passwd} must be set from outside the script
 # note: name of the password file is fixed in won-docker/image/nginx/nginx.conf
-echo ${won_certificate_passwd} > won_certificate_passwd_file
+echo ${uki_certificate_passwd} > uki_certificate_passwd_file
 ssh won@satvm06 mkdir -p $base_folder/won-server-certs
-scp won_certificate_passwd_file won@satvm06:$base_folder/won-server-certs/won_certificate_passwd_file
-rm won_certificate_passwd_file
+scp uki_certificate_passwd_file won@satvm06:$base_folder/won-server-certs/uki_certificate_passwd_file
+rm uki_certificate_passwd_file
 
 # copy the openssl.conf file to the server where the certificates are generated
 # the conf file is needed to specify alternative server names, see conf file in won-docker/image/gencert/openssl.conf
-# for entries of alternative server names: matchat.org, uki.matchat.org, satvm06.researchstudio.at
+# for entries of alternative server names: line.uki.or.at, satvm06.researchstudio.at
 scp $WORKSPACE/webofneeds/won-docker/image/gencert/openssl-uki.conf won@satvm06:$base_folder/openssl.conf
 
 # copy the nginx.conf file to the proxy server
 scp $WORKSPACE/webofneeds/won-docker/image/nginx/nginx-uki-http.conf won@satvm01:$live_base_folder/nginx-uki-http.conf
 
 # copy letsencrypt certificate files from satvm01 (live/matchat) to satvm06
-ssh won@satvm06 mkdir -p $base_folder/letsencrypt/certs/live/matchat.org
-scp -3 won@satvm01:$live_base_folder/letsencrypt/certs/live/matchat.org/* won@satvm06:$base_folder/letsencrypt/certs/live/matchat.org/
+ssh won@satvm06 mkdir -p $base_folder/letsencrypt/certs/live/line.uki.or.at
+scp -3 won@satvm01:$live_base_folder/letsencrypt/certs/live/line.uki.or.at/* won@satvm06:$base_folder/letsencrypt/certs/live/line.uki.or.at/
 
 # create the solr data directories (if not available yet) with full rights for every user.
 # This is done so that the directory on the host can be written by the solr user from inside the container

--- a/webofneeds/won-docker/image/gencert/openssl-uki.conf
+++ b/webofneeds/won-docker/image/gencert/openssl-uki.conf
@@ -353,6 +353,6 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 				
 [ alt_names ]
 
-DNS.1 = uki.matchat.org
+DNS.1 = line.uki.or.at
 DNS.2 = satvm06.researchstudio.at
 

--- a/webofneeds/won-docker/image/letsencrypt/Dockerfile
+++ b/webofneeds/won-docker/image/letsencrypt/Dockerfile
@@ -15,7 +15,7 @@ ENV webroot_dir="/usr/share/nginx/html"
 # mail address that gets informed when the certificate is about to run out
 ENV certificate_email=florian.kleedorfer@researchstudio.at
 
-ENV domain_params=-d matchat.org -d www.matchat.org -d node.matchat.org
+ENV domain_params="-d matchat.org -d www.matchat.org -d node.matchat.org"
 
 # java key store password
 ENV key_store_password=changeit

--- a/webofneeds/won-docker/image/letsencrypt/Dockerfile
+++ b/webofneeds/won-docker/image/letsencrypt/Dockerfile
@@ -15,6 +15,8 @@ ENV webroot_dir="/usr/share/nginx/html"
 # mail address that gets informed when the certificate is about to run out
 ENV certificate_email=florian.kleedorfer@researchstudio.at
 
+ENV domain_params=-d matchat.org -d www.matchat.org -d node.matchat.org
+
 # java key store password
 ENV key_store_password=changeit
 

--- a/webofneeds/won-docker/image/letsencrypt/certificate-request-and-renew.sh
+++ b/webofneeds/won-docker/image/letsencrypt/certificate-request-and-renew.sh
@@ -1,6 +1,6 @@
 echo renew letsencrypt certificate
 certbot certonly --webroot -w /usr/share/nginx/html --email $certificate_email --text --non-interactive --agree-tos \
--d matchat.org -d www.matchat.org -d node.matchat.org -d uki.matchat.org -d node.uki.matchat.org
+$domain_params
 
 # create pfx key store
 echo create pfx key store: $pfx_store_file

--- a/webofneeds/won-docker/image/nginx/nginx-uki-http.conf
+++ b/webofneeds/won-docker/image/nginx/nginx-uki-http.conf
@@ -1,15 +1,15 @@
-# this config file describes the behavior of the uki.matchat.org behavior.
+# this config file describes the behavior of the line.uki.or.at behavior.
 # It is included by the main matchat "nginx.conf" file in the http section
 
 
 # ==============================================
-# uki owner config
+# uki owner and node config
 # ==============================================
 
 # redirect all http requests to https
 server {
     listen          80;
-    server_name     uki.matchat.org;
+    server_name     line.uki.or.at;
     root            /data;
 
     # configuration for letsencrypt certbot ssl challenge
@@ -27,11 +27,19 @@ server {
     ssl                 on;
     listen              443 ssl;
     root                /data;
-    server_name         uki.matchat.org;
+    server_name         line.uki.or.at;
+
+    # request the client certificate but does not require it to be signed by a trusted CA certificate
+    ssl_verify_client optional_no_ca;
+
+    # add for web socket compatibility
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
 
     # certificate data
-    ssl_certificate     /etc/letsencrypt/live/matchat.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/matchat.org/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/line.uki.or.at/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/line.uki.or.at/privkey.pem;
 
     location /owner {
         proxy_pass https://satvm06.researchstudio.at:8082/owner;
@@ -49,55 +57,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-
-    location / {
-        # here we do a redirect to /owner uri prefix since we want the owner application to be the default
-        # application on this server. We didn't figure out how to use proxy_cookie_path exactly to handle
-        # sessions correctly when webapp is accessed in two ways: with and without /owner prefix => so redirect
-        # seems to be the easiest solution for now
-        return 301 https://$server_name/owner$request_uri;
-    }
-}
-
-
-# ==============================================
-# uki wonnode config
-# ==============================================
-
-# redirect all http requests to https
-server {
-    listen          80;
-    server_name     node.uki.matchat.org;
-    root            /data;
-
-    # configuration for letsencrypt certbot ssl challenge
-    location /.well-known/acme-challenge {
-        root    /usr/share/nginx/html;
-    }
-
-    location / {
-        return  301 https://$server_name$request_uri;
-    }
-}
-
-# pass https requests to node instances
-server {
-    ssl                 on;
-    listen              443 ssl;
-    root                /data;
-    server_name         node.uki.matchat.org;
-
-    # request the client certificate but does not require it to be signed by a trusted CA certificate
-    ssl_verify_client optional_no_ca;
-
-    # add for web socket compatibility
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
-    # certificate data
-    ssl_certificate     /etc/letsencrypt/live/matchat.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/matchat.org/privkey.pem;
 
     location /won {
         # set the client certificate in this header when the certificate was already validated by nginx
@@ -117,6 +76,10 @@ server {
     }
 
     location / {
-        return 301 https://$server_name/won$request_uri;
+        # here we do a redirect to /owner uri prefix since we want the owner application to be the default
+        # application on this server. We didn't figure out how to use proxy_cookie_path exactly to handle
+        # sessions correctly when webapp is accessed in two ways: with and without /owner prefix => so redirect
+        # seems to be the easiest solution for now
+        return 301 https://$server_name/owner$request_uri;
     }
 }

--- a/webofneeds/won-docker/image/nginx/nginx.conf
+++ b/webofneeds/won-docker/image/nginx/nginx.conf
@@ -24,7 +24,7 @@ stream {
         proxy_pass satvm01.researchstudio.at:61617;
     }
 
-    # pass tcp jms messages to uki.matchat.org
+    # pass tcp jms messages to line.uki.or.at
     server {
         listen 51616;
         proxy_pass satvm06.researchstudio.at:51617;

--- a/webofneeds/won-docker/image/nginx/nginx.conf
+++ b/webofneeds/won-docker/image/nginx/nginx.conf
@@ -26,8 +26,8 @@ stream {
 
     # pass tcp jms messages to line.uki.or.at
     server {
-        listen 51616;
-        proxy_pass satvm06.researchstudio.at:51617;
+        listen 61626;
+        proxy_pass satvm06.researchstudio.at:61627;
     }
 }
 


### PR DESCRIPTION
change the uki deployment to use the domain "line.uki.or.at", continues or fixes #1355 