### PR TITLE
add hint filtering for context matching

### DIFF
--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import won.matcher.solr.config.SolrMatcherConfig;
 import won.matcher.solr.hints.HintBuilder;
+import won.matcher.solr.query.factory.MatchingContextQueryFactory;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor
     SolrQuery query = new SolrQuery();
     log.debug("use query: {} with filters {}", queryString, filterQueries);
     query.setQuery(queryString);
-    query.setFields("id", "score", HintBuilder.WON_NODE_SOLR_FIELD, HintBuilder.HAS_FLAG_SOLR_FIELD);
+    query.setFields("id", "score", HintBuilder.WON_NODE_SOLR_FIELD, HintBuilder.HAS_FLAG_SOLR_FIELD, MatchingContextQueryFactory.MATCHING_CONTEXT_SOLR_FIELD);
     query.setRows(config.getMaxHints());
 
     if (filterQueries != null) {

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/MatchingContextQueryFactory.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/MatchingContextQueryFactory.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class MatchingContextQueryFactory extends SolrQueryFactory {
 
-    private static final String MATCHING_CONTEXT_SOLR_FIELD = "_graph.http___purl.org_webofneeds_model_hasMatchingContext";
+    public static final String MATCHING_CONTEXT_SOLR_FIELD = "_graph.http___purl.org_webofneeds_model_hasMatchingContext";
 
     Collection<String> matchingContexts;
 


### PR DESCRIPTION
this is a fix to the mataching context feature added in the matcher. 
in addition to querying the solr with matching context filter, we also need to filter out hints before sending them to both needs. only send hints to both needs if there matching contexts overlap (OR policy) and always send a hint to a need that has not specified a matching context. 
This can be tested by creating needs with different/overlapping/no matching contexts and check if the hints are send correctly to both needs