### PR TITLE
- removes obsolete watch (moved to ng-class in post-messages.js)

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -36,12 +36,6 @@ import {
 } from '../selectors.js';
 import autoresizingTextareaModule from '../directives/textarea-autogrow.js';
 
-
-const align = deepFreeze({
-    left:  "won-cm--left",
-    right: "won-cm--right",
-});
-
 const MESSAGE_READ_TIMEOUT = 1500;
 
 const serviceDependencies = ['$ngRedux', '$scope', '$element'];
@@ -56,7 +50,7 @@ function genComponentConf() {
             ng-show="!self.message.get('outgoingMessage')">
         </won-square-image>
         <div class="won-cm__center"
-                ng-class="{'won-cm__center--nondisplayable': !self.text, 'won-cm__center--unread' : self.message.get('newMessage')}"
+                ng-class="{'won-cm__center--nondisplayable': !self.text}"
                 in-view="$inview && self.markAsRead()">
 
             <div 
@@ -176,11 +170,6 @@ function genComponentConf() {
 
             connect2Redux(selectFromState, actionCreators, ['self.connectionUri', 'self.messageUri'], this);
 
-            this.$scope.$watch(
-                () => this.message.get('outgoingMessage'),
-                (newVal, oldVal) => this.updateAlignment(newVal)
-            )
-
             // gotta do this via a $watch, as the whole message parsing before 
             // this point happens synchronously but jsonLdToTrig needs to be async.
             /*
@@ -232,17 +221,6 @@ function genComponentConf() {
         	this.onUpdate();
         }
 
-        updateAlignment(isOutgoingMessage) {
-            const classes = this.$element[0].classList;
-            if(isOutgoingMessage) {
-                classes.remove(align.left);
-                classes.add(align.right);
-            } else {
-                classes.add(align.left);
-                classes.remove(align.right);
-            }
-        }
-
         rdfToString(jsonld){
         	return JSON.stringify(jsonld);
         }
@@ -264,7 +242,6 @@ function genComponentConf() {
         controllerAs: 'self',
         bindToController: true, //scope-bindings -> ctrl
         scope: { 
-            message: '=',
             messageUri: '=',
             connectionUri: '=',
             /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -78,7 +78,11 @@ function genComponentConf() {
                 ng-repeat="msg in self.chatMessages"
                 connection-uri="self.connectionUri"
                 message-uri="msg.get('uri')"
-                message="msg"
+                ng-class="{
+                    'won-unread' : msg.get('newMessage'),
+                    'won-cm--left' : !msg.get('outgoingMessage'),
+                    'won-cm--right' : msg.get('outgoingMessage')
+                }"
                 on-update="::self.showAgreementData = false">
             </won-connection-message>
             <div class="pm__content__agreement" ng-if="self.showAgreementData && self.agreementDataIsValid()">           	

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -3,7 +3,7 @@
 @import 'square-image';
 
 won-connection-message {
-    margin: 0.5rem 0;
+    padding: 0.5rem 1rem;
     @include square-image($postIconSize, 0, 0.5rem, 0, 0);
     display: grid;
     grid-template-areas: "icon content";
@@ -56,12 +56,6 @@ won-connection-message {
             .won-cm__center__bubble {
                 background-color: white; // like the error toast-notifications
                 color: #8f8f8f;
-            }
-        }
-
-        &.won-cm__center--unread {
-            .won-cm__center__bubble {
-                //add any styling you seem fit for messages that are unread
             }
         }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -104,7 +104,7 @@ $messageBoxPadding: 0.5rem;
     }
 
     .pm__content {
-      padding: 1rem;
+      padding: 1rem 0;
       background: white;
       border: $thinGrayBorder;
       overflow: auto;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -16,7 +16,7 @@ $won-subtitle-gray: var(--won-subtitle-gray);
 $won-helpbox-yellow: var(--won-helpbox-yellow);
 $won-dark-purple: var(--won-dark-purple);
 $won-dark-gray: var(--won-dark-gray);
-
+$won-unread: var(--won-helpbox-yellow);
 
 // sizes
 $hugeiconSize: 5rem;
@@ -41,6 +41,8 @@ $boldBorderWidth: 0.1875rem; /* 3px @ 100% */
 $thinGrayBorder: $thinBorderWidth solid $won-line-gray;
 $thinRedBorder: $thinBorderWidth solid $won-primary-color;
 $thinDarkBorder: $thinBorderWidth solid $won-dark-gray;
+
+
 
 @mixin carretSized { //the small down-arrow
   /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -16,7 +16,7 @@ $won-subtitle-gray: var(--won-subtitle-gray);
 $won-helpbox-yellow: var(--won-helpbox-yellow);
 $won-dark-purple: var(--won-dark-purple);
 $won-dark-gray: var(--won-dark-gray);
-$won-unread: var(--won-helpbox-yellow);
+$won-unread: var(--won-lighter-gray);
 
 // sizes
 $hugeiconSize: 5rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -154,6 +154,11 @@ a {
   }
 }
 
+.won-unread {
+  //Default Styling of everything that is unread
+  background-color: $won-unread;
+}
+
 @import 'gallery';
 @import 'post-info';
 @import 'post-messages';


### PR DESCRIPTION
- adds "won-unread" class to messages that are "unread"
- adds default styling of a class .won-unread in won.scss (sets background color in this iteration, further styling possible)
- adds won-unread color -> currently set to the helpbox yellow
-altered padding/margin in connection-message and post-messages