### PR TITLE
Refac rateconnection

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -118,6 +118,7 @@ $ngRedux.getState()
                     ...
                 },
                 newConnection: true|false, //whether or not this connection is new (or already seen if you will)
+                isRated: true|false, //whether or not this connection has been rated yet
                 remoteNeedUri: string, //corresponding remote Need identifier
                 state: string, //state of the connection
                 uri: string //unique identifier of this connection

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -109,6 +109,7 @@ const actionHierarchy = {
         showLatestMessages: cnct.showLatestMessages,
         showMoreMessages: cnct.showMoreMessages,
         markAsRead: INJ_DEFAULT,
+        markAsRated: INJ_DEFAULT,
     },
     needs: {
         received: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feedback-grid.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feedback-grid.js
@@ -53,10 +53,13 @@ function genComponentConf() {
         }
 
         rateMatch(rating) {
+
+
             switch(rating) {
                 case 0:
                     console.log("RATE GOOD");
                     this.connections__rate(this.connectionUri, won.WON.binaryRatingGood);
+                    this.connections__markAsRated({connectionUri: this.connectionUri});
                     break;
                 /*case 1:
                     //OPTION OK WILL NOT BE IMPLEMENTED ANYMORE

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -45,15 +45,23 @@ function genComponentConf() {
       </won-post-content>
 
       <div class="request__footer">
+        <won-feedback-grid ng-if="!self.sendAdHocRequest && !self.connection.get('isRated')" connection-uri="self.connectionUri"></won-feedback-grid>
         <input
           type="text"
+          ng-if="self.sendAdHocRequest || self.connection.get('isRated')"
           ng-model="self.message"
           placeholder="Request Message (optional)"/>
-        <div class="flexbuttons">
+        <div class="flexbuttons" ng-if="self.sendAdHocRequest || self.connection.get('isRated')">
+          <button
+            ng-if="!self.sendAdHocRequest"
+            class="won-button--filled black"
+            ng-click="self.closeRequest()">
+              Remove
+          </button>
           <button
             class="won-button--filled red"
             ng-click="self.sendRequest(self.message)">
-              Chat
+              Send Request
           </button>
         </div>
         <a target="_blank"
@@ -82,6 +90,7 @@ function genComponentConf() {
 
                 return {
                     connection,
+                    connectionUri,
                     ownNeed,
                     sendAdHocRequest,
                     lastUpdateTimestamp: connection && connection.get('lastUpdateDate'),
@@ -110,8 +119,13 @@ function genComponentConf() {
                 		this.connectionUri,
                 		this.ownNeed.getIn(['connections',this.connectionUri]).get("remoteNeedUri"), 
                 		message);
-                this.router__stateGoCurrent({connectionUri: null})
+                this.router__stateGoCurrent({connectionUri: this.connectionUri})
             }
+        }
+
+        closeRequest(){
+            this.connections__close(this.connectionUri);
+            this.router__stateGoCurrent({connectionUri: null});
         }
     }
     Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -118,7 +118,6 @@ export default function(allNeedsInState = initialState, action = {}) {
         // NEW CONNECTIONS STATE UPDATES
         case actionTypes.connections.close:
             return changeConnectionState(allNeedsInState, action.payload.connectionUri, won.WON.Closed);
-
      
         case actionTypes.needs.connect: // user has sent a connect request
         	
@@ -223,6 +222,8 @@ export default function(allNeedsInState = initialState, action = {}) {
             return markMessageAsRead(allNeedsInState, action.payload.messageUri, action.payload.connectionUri, action.payload.needUri);
         case actionTypes.connections.markAsRead:
             return markConnectionAsRead(allNeedsInState, action.payload.connectionUri, action.payload.needUri);
+        case actionTypes.connections.markAsRated:
+            return markConnectionAsRated(allNeedsInState, action.payload.connectionUri);
 
         // NEW MESSAGE STATE UPDATES
         case actionTypes.messages.connectionMessageReceived:
@@ -475,9 +476,6 @@ function markMessageAsRead(state, messageUri, connectionUri, needUri) {
 }
 
 function markConnectionAsRead(state, connectionUri, needUri) {
-    let tmpNeedUri;
-    let tmpConnectionUri;
-
     let need = state.get(needUri);
     let connection = need && need.getIn(["connections", connectionUri]);
 
@@ -487,6 +485,18 @@ function markConnectionAsRead(state, connectionUri, needUri) {
     }
 
     return state.setIn([needUri, "connections", connectionUri, "newConnection"], false);
+}
+
+function markConnectionAsRated(state, connectionUri) {
+    let need = connectionUri && selectNeedByConnectionUri(state, connectionUri);
+    let connection = need && need.getIn(["connections", connectionUri]);
+
+    if(!connection) {
+        console.error("no connection with connectionUri: <", connectionUri,"> found within needUri: <", need.get("uri"), ">");
+        return state;
+    }
+
+    return state.setIn([need.get("uri"), "connections", connectionUri, "isRated"], true);
 }
 
 function changeConnectionStateByFun(state, connectionUri, fun) {
@@ -527,6 +537,7 @@ function parseConnection(jsonldConnection, newConnection) {
             creationDate: undefined,
             lastUpdateDate: undefined,
             newConnection: !!newConnection,
+            isRated: false,
         }
     };
 


### PR DESCRIPTION
This PR allows the user to rate a suggested connection within the chat Tab (after the suggested connection is selected), it also removes the ability to rate connections more than once by adding a isRated flag in the connection state -> after a suggested connection has been rated it is possible to close the connection after all or connect with it