### PR TITLE
refactors newMessage and newConnection parameters in state to "unread…

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -110,14 +110,14 @@ $ngRedux.getState()
                     [messageUri]: {
                         connectMessage: true|false, //whether or not this was the connectMessage(a.k.a firstMessage)
                         date: date, //creation Date of this message
-                        newMessage: true|false, //whether or not this message is new (or already seen if you will)
+                        unread: true|false, //whether or not this message is new (or already seen if you will)
                         outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
                         text: string, //message text
                         uri: string //unique identifier of this message
                     }
                     ...
                 },
-                newConnection: true|false, //whether or not this connection is new (or already seen if you will)
+                unread: true|false, //whether or not this connection is new (or already seen if you will)
                 isRated: true|false, //whether or not this connection has been rated yet
                 remoteNeedUri: string, //corresponding remote Need identifier
                 state: string, //state of the connection
@@ -127,6 +127,7 @@ $ngRedux.getState()
         },
         creationDate: Date, //creationDate of this need
         lastUpdateDate: date, //date of lastUpdate of this need (last date of the message or connection that was added)
+        unread: true|false, //whether or not this need has new information that has not been read yet
         description: string, //description of the need as a string (non mandatory, empty if not present)
         location: { //non mandatory but if present it contains all elements below
             address: string, //address as human readable string
@@ -164,7 +165,7 @@ $ngRedux.getState()
 As you can see in this State all "visible" Data is stored within the needs and the corresponding connections and messages are stored within this tree.
 Example: If you want to retrieve all present connections for a given need you will access it by ````$ngRedux.getState().getIn(["needs", [needUri], "connections"])````.
 
-All The DataParsing happens within the ```need-reducer.js``` and should only be implemented here, in their respective Methods ```parseNeed(jsonLdNeed, ownNeed)```, ```parseConnection(jsonLdConnection, newConnection)``` and ```parseMessage(jsonLdMessage, outgoingMessage, newMessage)```.
+All The DataParsing happens within the ```need-reducer.js``` and should only be implemented here, in their respective Methods ```parseNeed(jsonLdNeed, ownNeed)```, ```parseConnection(jsonLdConnection, unread)``` and ```parseMessage(jsonLdMessage, outgoingMessage, unread)```.
 It is very important to not parse needs/connections/messages in any other place or in any other way to make sure that the structure of the corresponding items is always the same, and so that the Views don't have to implement fail-safes when accessing elements, e.g. a Location is only present if the whole location data can be parsed/stored within the state, otherwise the location will stay empty.
 This is also true for every message connection and need, as soon as the data is in the state you can be certain that all the mandatory values are set correctly.
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -247,7 +247,7 @@ function genComponentConf() {
         }
 
         markAsRead(){
-            if(this.message && this.message.get("newMessage")){
+            if(this.message && this.message.get("unread")){
                 const payload = {
                     messageUri: this.message.get("uri"),
                     connectionUri: this.connectionUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
@@ -53,6 +53,7 @@ function genComponentConf() {
                 const theirNeed = connection && selectAllTheirNeeds(state).get(connection.get("remoteNeedUri"));
 
                 return {
+                    WON: won.WON,
                     ownNeed,
                     connection,
                     openConnectionUri: selectOpenConnectionUri(state),
@@ -75,7 +76,7 @@ function genComponentConf() {
         }
 
         markAsRead(){
-            if(this.connection && this.connection.get("newConnection")){
+            if(this.connection && this.connection.get("unread") && this.connection.get("state") !== won.WON.Connected){
                 const payload = {
                     connectionUri: this.connection.get("uri"),
                     needUri: this.ownNeed.get("uri")

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection.js
@@ -31,7 +31,7 @@ function genComponentConf() {
         ng-repeat="conn in self.connectionsArray"
         on-selected-connection="self.setOpen(connectionUri)"
         connection-uri="conn.get('uri')"
-        ng-class="{'won-unread': conn.get('newConnection')}">
+        ng-class="{'won-unread': conn.get('unread')}">
       </won-connection-selection-item>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -32,6 +32,7 @@ function genComponentConf() {
     let template = `
       <div ng-repeat="need in self.relevantOwnNeeds">
         <div class="covw__own-need clickable"
+          ng-class="{'won-unread': need.get('unread')}"
           ng-click="self.toggleConnections(need.get('uri'))">
           <won-post-header
             need-uri="need.get('uri')"
@@ -51,7 +52,7 @@ function genComponentConf() {
           ng-repeat="conn in self.getOpenConnectionsArray(need)"
           on-selected-connection="self.selectConnection(connectionUri)"
           connection-uri="conn.get('uri')"
-          ng-class="{'won-unread': conn.get('newConnection')}">
+          ng-class="{'won-unread': conn.get('unread')}">
         </won-connection-selection-item>
       </div>
     `;
@@ -92,7 +93,7 @@ function genComponentConf() {
             return need.get('connections').filter(conn => conn.get('state') !== won.WON.Closed).toArray();
         }
         getUnreadConnectionsCountFilteredByType(need){
-            return need.get('connections').filter(conn => conn.get('newConnection') && conn.get('state') !== won.WON.Closed).size;
+            return need.get('connections').filter(conn => conn.get('unread') && conn.get('state') !== won.WON.Closed).size;
         }
     }
     Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/feed-item.js
@@ -142,8 +142,8 @@ function genComponentConf() {
                 const connections = ownNeed && ownNeed.get("connections");
                 const connectionsWithoutClosed = connections && connections.filter(conn => conn.get("state") !== won.WON.Closed);
 
-                const unreadMatchesCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.Suggested).size;
-                const unreadRequestsCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("newConnection") && conn.get("state") === won.WON.RequestReceived).size;
+                const unreadMatchesCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("unread") && conn.get("state") === won.WON.Suggested).size;
+                const unreadRequestsCount = connectionsWithoutClosed && connectionsWithoutClosed.filter(conn => conn.get("unread") && conn.get("state") === won.WON.RequestReceived).size;
 
                 return {
                     ownNeed,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-title-bar.js
@@ -72,9 +72,9 @@ function genComponentConf() {
                 const allConnections = selectAllConnections(state);
                 const allMessages = selectAllMessages(state);
 
-                const nrOfUnreadMessages= allMessages && allMessages.filter(msg => !msg.get("outgoingMessage") && msg.get("newMessage")).size; //only count incoming messages
+                const nrOfUnreadMessages= allMessages && allMessages.filter(msg => !msg.get("outgoingMessage") && msg.get("unread")).size; //only count incoming messages
                 const nrOfNeedsWithUnreadEvents= undefined; //TODO: COUNT HOW MANY NEEDS HAVE AT LEAST ONE NEW CONNECTION OR ONE NEW MESSAGE
-                const nrOfUnreadConnections = allConnections && allConnections.filter(conn => conn.get("state") !== won.WON.Closed && conn.get("newConnection")).size;
+                const nrOfUnreadConnections = allConnections && allConnections.filter(conn => conn.get("state") !== won.WON.Closed && conn.get("unread")).size;
 
                 return {
                     hasPosts: ownNeeds && ownNeeds.size > 0,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/owner-title-bar.js
@@ -120,8 +120,8 @@ function genComponentConf() {
 
                 const openConnections = post && post.get("connections").filter(conn => conn.get("state") !== won.WON.Closed);
                 const messages = selectAllMessagesByNeedUriAndConnected(state, postUri);
-                const unreadConnectionCount = openConnections && openConnections.filter(conn => conn.get("state") !== won.WON.Connected && conn.get('newConnection')).size;
-                const unreadMessagesCount = messages && messages.filter(msg => msg.get('newMessage') && !msg.get("connectMessage")).size;
+                const unreadConnectionCount = openConnections && openConnections.filter(conn => conn.get("state") !== won.WON.Connected && conn.get('unread')).size;
+                const unreadMessagesCount = messages && messages.filter(msg => msg.get('unread') && !msg.get("connectMessage")).size;
                 const unreadConnectionsCount = unreadConnectionCount + unreadMessagesCount;
 
                 return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-item-line.js
@@ -147,9 +147,9 @@ function genComponentConf() {
                 const requests = allConnectionsByNeedUri && allConnectionsByNeedUri.filter(conn => conn.get("state") === won.WON.RequestReceived);
                 const matches = allConnectionsByNeedUri && allConnectionsByNeedUri.filter(conn => conn.get("state") === won.WON.Suggested);
 
-                const unreadConversationsCount = conversations && conversations.filter(conn => (conn.get("messages").filter(msg => msg.get("newMessage")).size > 0)).size;
-                const unreadRequestsCount = requests && requests.filter(conn => conn.get("newConnection")).size;
-                const unreadMatchesCount = matches && matches.filter(conn => conn.get("newConnection")).size;
+                const unreadConversationsCount = conversations && conversations.filter(conn => (conn.get("messages").filter(msg => msg.get("unread")).size > 0)).size;
+                const unreadRequestsCount = requests && requests.filter(conn => conn.get("unread")).size;
+                const unreadMatchesCount = matches && matches.filter(conn => conn.get("unread")).size;
 
                 return {
                     need,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -112,7 +112,7 @@ function genComponentConf() {
                 connection-uri="self.connectionUri"
                 message-uri="msg.get('uri')"
                 ng-class="{
-                    'won-unread' : msg.get('newMessage'),
+                    'won-unread' : msg.get('unread'),
                     'won-cm--left' : !msg.get('outgoingMessage'),
                     'won-cm--right' : msg.get('outgoingMessage')
                 }"


### PR DESCRIPTION
…" and add "unread" to the need in the state as well.

this is so we can make sure to add the won-unread class to needs as well....

additionally the need and connections will be set to read if there are no unread subelements left (e.g a need is unread=false if there are no connections with unread=true within this need, and the same goes for connections and their respective messages... for connections that have the state "connected" we will not set them to read immediately after clicking on the element anymore