### PR TITLE
Feat  show all needs in overview

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -69,7 +69,7 @@ function genComponentConf() {
                 </div>
             </div>
             <won-connection-selection-item
-                ng-if="self.isOpen(need.get('uri'))"
+                ng-if="self.isOpen(need.get('uri')) && self.showConnectionsDropdown(need)"
                 ng-repeat="conn in self.getOpenConnectionsArraySorted(need)"
                 on-selected-connection="self.selectConnection(connectionUri)"
                 connection-uri="conn.get('uri')"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -42,10 +42,10 @@ function genComponentConf() {
                     timestamp="'TODOlatestOfThatType'">
                 </won-post-header>
                 <won-connection-indicators on-selected-connection="self.selectConnection(connectionUri)" need-uri="need.get('uri')"></won-connection-indicators>
-                <img class="covw__arrow" ng-show="self.isOpen(need.get('uri'))"
+                <img class="covw__arrow" ng-show="self.isOpen(need.get('uri')) && self.hasRelevantConnections(need)"
                     ng-class="{'clickable' : !self.isOpenByConnection(need.get('uri'))}"
                     src="generated/icon-sprite.svg#ico16_arrow_up" ng-click="self.closeConnections(need.get('uri'))"/>
-                <img class="covw__arrow clickable" ng-show="!self.isOpen(need.get('uri'))"
+                <img class="covw__arrow clickable" ng-show="!self.isOpen(need.get('uri')) && self.hasRelevantConnections(need)"
                     src="generated/icon-sprite.svg#ico16_arrow_down" ng-click="self.openConnections(need.get('uri'))"/>
             </div>
             <won-connection-selection-item
@@ -69,16 +69,19 @@ function genComponentConf() {
             const selectFromState = (state)=> {
                 //Select all needs with at least one connection
                 const relevantOwnNeeds = selectAllOwnNeeds(state).filter(need => need.get("connections").filter(conn => conn.get("state") !== won.WON.Closed).size > 0);
+                //Select all needs, regardless of connections
+                const allOwnNeeds = selectAllOwnNeeds(state).filter(need => need.get("connections"));
                 const routerParams = selectRouterParams(state);
                 const connUriInRoute = routerParams && decodeURIComponent(routerParams['connectionUri']);
                 const needImpliedInRoute = connUriInRoute && selectNeedByConnectionUri(state, connUriInRoute);
                 const needUriImpliedInRoute = needImpliedInRoute && needImpliedInRoute.get("uri");
 
-                let sortedNeeds = sortByDate(relevantOwnNeeds);
+                let sortedNeeds = sortByDate(allOwnNeeds);
 
                 return {
                     needUriImpliedInRoute,
                     sortedNeeds: sortedNeeds,
+                    relevantOwnNeeds,
                 }
             };
             connect2Redux(selectFromState, actionCreators, ['self.connectionUri'], this);
@@ -102,6 +105,10 @@ function genComponentConf() {
 
         selectConnection(connectionUri) {
             this.onSelectedConnection({connectionUri}); //trigger callback with scope-object
+        }
+
+        hasRelevantConnections(need){
+            return need.get("connections").filter(conn => conn.get("state") !== won.WON.Closed).size > 0;
         }
 
         getOpenConnectionsArraySorted(need){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -41,11 +41,15 @@ function genComponentConf() {
                     need-uri="need.get('uri')"
                     timestamp="'TODOlatestOfThatType'">
                 </won-post-header>
-                <won-connection-indicators on-selected-connection="self.selectConnection(connectionUri)" need-uri="need.get('uri')"></won-connection-indicators>
-                <img class="covw__arrow" ng-show="self.isOpen(need.get('uri')) && self.hasRelevantConnections(need)"
+                <won-connection-indicators 
+                    ng-show="need.get('state') === self.WON.ActiveCompacted"
+                    on-selected-connection="self.selectConnection(connectionUri)" 
+                    need-uri="need.get('uri')">
+                </won-connection-indicators>
+                <img class="covw__arrow" ng-show="self.isOpen(need.get('uri')) && self.showConnectionsDropdown(need)"
                     ng-class="{'clickable' : !self.isOpenByConnection(need.get('uri'))}"
                     src="generated/icon-sprite.svg#ico16_arrow_up" ng-click="self.closeConnections(need.get('uri'))"/>
-                <img class="covw__arrow clickable" ng-show="!self.isOpen(need.get('uri')) && self.hasRelevantConnections(need)"
+                <img class="covw__arrow clickable" ng-show="!self.isOpen(need.get('uri')) && self.showConnectionsDropdown(need)"
                     src="generated/icon-sprite.svg#ico16_arrow_down" ng-click="self.openConnections(need.get('uri'))"/>
             </div>
             <won-connection-selection-item
@@ -62,6 +66,7 @@ function genComponentConf() {
         constructor() {
             attach(this, serviceDependencies, arguments);
             this.open = open;
+            this.WON = won.WON;
             //this.labels = labels;
             window.co4dbg = this;
 
@@ -112,8 +117,8 @@ function genComponentConf() {
             return openNeeds.concat(closedNeeds);
         }
 
-        hasRelevantConnections(need){
-            return need.get("connections").filter(conn => conn.get("state") !== won.WON.Closed).size > 0;
+        showConnectionsDropdown(need){
+            return need.get("state") === won.WON.ActiveCompacted && need.get("connections").filter(conn => conn.get("state") !== won.WON.Closed).size > 0;
         }
 
         getOpenConnectionsArraySorted(need){

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.html
@@ -3,8 +3,8 @@
     <won-overview-title-bar selection="self.selection" ng-if="!self.post"></won-overview-title-bar>
     <won-owner-title-bar selection="self.ownerSelection" ng-if="self.post"></won-owner-title-bar>
 </header>
-<main class="overviewincomingrequestscontent" ng-class="{'empty' : !self.hasOpenConnections}">
-    <div class="opc__inner empty" ng-if="!self.hasOpenConnections">
+<main class="overviewincomingrequestscontent" ng-class="{'empty' : !self.hasConnections}">
+    <div class="opc__inner empty" ng-if="!self.hasConnections">
         <div class="opc__empty">
             <div class="opc__empty__description">
                 <svg class="opc__empty__description__icon"
@@ -34,7 +34,7 @@
         <won-send-request ng-if="self.connectionType === self.WON.Suggested"></won-send-request>
         <won-post-messages ng-if="self.connectionType === self.WON.Connected"></won-post-messages>
     </div>
-    <div class="post__contentside post__contentside--empty" ng-if="self.hasOpenConnections && (!self.connection || self.connectionType === self.WON.Closed)"
+    <div class="post__contentside post__contentside--empty" ng-if="self.hasConnections && (!self.connection || self.connectionType === self.WON.Closed)"
                ng-class="{'hidden' : self.connectionUri === undefined}">
         <span class="post__contentside__description__text">
             No Element selected

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview-incoming-requests/overview-incoming-requests.js
@@ -46,7 +46,8 @@ class IncomingRequestsController {
                     connection,
                     connectionType,
                     //hasRequests: connections.filter(conn => conn.get("state") === won.WON.RequestReceived).size > 0,
-                    hasOpenConnections: connections.filter(conn => conn.get("state") !== won.WON.Closed).size > 0,
+                    //hasOpenConnections: connections.filter(conn => conn.get("state") !== won.WON.Closed).size > 0,
+                    hasConnections: connections.size > 0,
                     open,
                 };
             }else{

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -24,7 +24,7 @@ const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
       <won-square-image
-        ng-class="{'bigger' : self.biggerImage}"
+        ng-class="{'bigger' : self.biggerImage, 'inactive' : self.need.get('state') === self.WON.InactiveCompacted}"
         src="self.need.get('TODO')"
         title="self.need.get('title')"
         uri="self.needUri"
@@ -61,6 +61,7 @@ function genComponentConf() {
             attach(this, serviceDependencies, arguments);
             window.ph4dbg = this;
             this.labels = labels;
+            this.WON = won.WON;
             const selectFromState = (state) => {
                 const need = state.getIn(['needs', this.needUri]);
 


### PR DESCRIPTION
Verify that all needs (closed, open with and without connections) are shown in overview, that inactive needs are listed below active needs and that there are no additional/missing indicators, visible conversations, dropdown arrows, ...