### PR TITLE
Fix  chat dropdown position

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
@@ -10,9 +10,10 @@ won-connections-overview {
   .covw__own-need {
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
+    align-items: center;
 
     padding: 0.5rem 0; // vert horiz
+    padding-right: 0.5rem;
 
     border-bottom: $thinGrayBorder;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
@@ -13,7 +13,6 @@ won-connections-overview {
     align-items: center;
 
     padding: 0.5rem 0; // vert horiz
-    padding-right: 0.5rem;
 
     border-bottom: $thinGrayBorder;
 
@@ -35,5 +34,8 @@ won-connections-overview {
 
   .covw__arrow {
     @include carretSized;
+    // results in a clickable area as large as indicators
+    // TODO: make the value less rigid
+    padding: 0.625em;
   }
 }


### PR DESCRIPTION
Move the show-connections caret in the chat view to the center of the line to make it more clickable, less visually distracting.

Also vertically centers the other elements in the need row removing some asymmetry of the indicators.