### PR TITLE
Fix  positioning of chat title when dropdown menu is open.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -70,8 +70,8 @@ function genComponentConf() {
                 hide-image="::true">
             </won-post-header>
             <svg class="pm__header__icon__small clickable"
-                style="--local-primary:#var(--won-secondary-color);" 
-                ng-show="!self.contextMenuOpen" 
+                style="--local-primary:#var(--won-secondary-color);"
+                ng-style="{'visibility': !self.contextMenuOpen}"
                 ng-click="self.contextMenuOpen = true">
                     <use href="#ico16_arrow_down"></use>
             </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -84,6 +84,8 @@
 
       .pm__header__contextmenu .content {
         max-width: 10rem;
+        position: absolute;
+        right: 0;
 
         button {
           margin-top: 0.5rem;


### PR DESCRIPTION
When the chat context menu was open it would push the title text to the side. Now it cleanly overlays.

Also the down-caret is now invisible instead of not-displayed so the layout of the title stays exactly the same whether the dropdown menu is opened or closed.