### PR TITLE
Fixed indicator row size in responsive mode.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-indicators.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-indicators.scss
@@ -7,13 +7,6 @@ won-connection-indicators {
   display: flex;
   flex-direction: row;
 
-  @media (max-width: $responsivenessBreakPoint) {
-    padding-top: 0.5rem;
-    justify-content: space-between;
-    width: 75%;
-  }
-
-
   .indicators__item {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
Fixes #1550

Was caused by a seemingly stray selector.
Does not seem to have been important but should probably be checked.