### PR TITLE
Fix indicator bubbles being hidden behind connection icons.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-selection-item-line.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-selection-item-line.scss
@@ -20,6 +20,7 @@ won-connection-selection-item {
     position: absolute;
     left: 0.25rem;
     top: 0.25rem;
+    z-index: 1;
 
     svg {
       @include fixed-square(1.5rem);


### PR DESCRIPTION
Fixes #1553 

Probably caused by out-of-order rendering of the bubbles by angular.