### PR TITLE
remove new lines from debugbot message since our jsonld.js is not abl…

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/DebugBot.java
@@ -16,61 +16,34 @@
 
 package won.bot.impl;
 
-import java.net.URI;
-
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotAction;
 import won.bot.framework.eventbot.action.impl.MultipleActions;
 import won.bot.framework.eventbot.action.impl.RandomDelayedAction;
-import won.bot.framework.eventbot.action.impl.debugbot.AnswerWithElizaAction;
-import won.bot.framework.eventbot.action.impl.debugbot.CreateDebugNeedWithFacetsAction;
-import won.bot.framework.eventbot.action.impl.debugbot.DebugBotIncomingMessageToEventMappingAction;
-import won.bot.framework.eventbot.action.impl.debugbot.MessageTimingManager;
-import won.bot.framework.eventbot.action.impl.debugbot.OpenConnectionDebugAction;
-import won.bot.framework.eventbot.action.impl.debugbot.PublishSetChattinessEventAction;
-import won.bot.framework.eventbot.action.impl.debugbot.RecordMessageReceivedTimeAction;
-import won.bot.framework.eventbot.action.impl.debugbot.RecordMessageSentTimeAction;
-import won.bot.framework.eventbot.action.impl.debugbot.SendChattyMessageAction;
-import won.bot.framework.eventbot.action.impl.debugbot.SendNDebugMessagesAction;
-import won.bot.framework.eventbot.action.impl.debugbot.SetChattinessAction;
+import won.bot.framework.eventbot.action.impl.debugbot.*;
 import won.bot.framework.eventbot.action.impl.matcher.RegisterMatcherAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.ConnectWithAssociatedNeedAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.HintAssociatedNeedAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendMultipleMessagesAction;
-import won.bot.framework.eventbot.behaviour.BotBehaviour;
-import won.bot.framework.eventbot.behaviour.CloseBevahiour;
-import won.bot.framework.eventbot.behaviour.ConnectionMessageBehaviour;
-import won.bot.framework.eventbot.behaviour.DeactivateNeedBehaviour;
-import won.bot.framework.eventbot.behaviour.EagerlyPopulateCacheBehaviour;
+import won.bot.framework.eventbot.behaviour.*;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.command.close.CloseCommandSuccessEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.ConnectDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.MessageToElizaEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.NeedCreatedEventForDebugConnect;
-import won.bot.framework.eventbot.event.impl.debugbot.NeedCreatedEventForDebugHint;
-import won.bot.framework.eventbot.event.impl.debugbot.SendNDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.SetCacheEagernessCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.SetChattinessDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.UsageDebugCommandEvent;
+import won.bot.framework.eventbot.event.impl.debugbot.*;
 import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
 import won.bot.framework.eventbot.event.impl.matcher.MatcherRegisterFailedEvent;
 import won.bot.framework.eventbot.event.impl.matcher.NeedCreatedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.wonmessage.CloseFromOtherNeedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherNeedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherNeedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.OpenFromOtherNeedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.WonMessageReceivedOnConnectionEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.WonMessageSentOnConnectionEvent;
+import won.bot.framework.eventbot.event.impl.wonmessage.*;
 import won.bot.framework.eventbot.filter.impl.NeedUriInNamedListFilter;
 import won.bot.framework.eventbot.filter.impl.NotFilter;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.protocol.model.FacetType;
+
+import java.net.URI;
 
 /**
  * Bot that reacts to each new need that is created in the system by creating two needs, it sends a connect message from
@@ -105,8 +78,8 @@ public class DebugBot extends EventBot {
 
     @Override
     protected void initializeEventListeners() {
-        String welcomeMessage = "Greetings! \nI am the DebugBot. I " +
-                "can simulate multiple other users so you can test things. I understand a few commands. \nTo see which ones, " +
+        String welcomeMessage = "Greetings! I am the DebugBot. I " +
+                "can simulate multiple other users so you can test things. I understand a few commands. To see which ones, " +
                 "type 'usage'.";
         String welcomeHelpMessage = "When connecting with me, you can say 'ignore', or 'deny' to make me ignore or deny requests, and 'wait N' to make me wait N seconds (max 99) before reacting.";
 


### PR DESCRIPTION
omits the occurence of the n-quad parsing issue in #1579  (problem would still exist and can still be reproduced but the debugbot will not cause it anylonger)