### PR TITLE
Feat store read in localstorage

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -117,6 +117,7 @@ $ngRedux.getState()
                     }
                     ...
                 },
+                isLoading: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
                 unread: true|false, //whether or not this connection is new (or already seen if you will)
                 isRated: true|false, //whether or not this connection has been rated yet
                 remoteNeedUri: string, //corresponding remote Need identifier

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -12,7 +12,7 @@ import {
     selectOpenPostUri,
     selectRemoteEvents,
     selectConnection,
-} from '../selectors.js';
+    } from '../selectors.js';
 
 import {
     is,
@@ -22,20 +22,20 @@ import {
     jsonld2simpleFormat,
     cloneAsMutable,
     delay,
-} from '../utils.js';
+    } from '../utils.js';
 
 import {
-   makeParams,
-} from '../configRouting.js';
+    makeParams,
+    } from '../configRouting.js';
 
 import {
     ensureLoggedIn,
-} from './account-actions';
+    } from './account-actions';
 
 import {
     actionTypes,
     actionCreators,
-} from './actions.js';
+    } from './actions.js';
 
 import {
     buildCreateMessage,
@@ -45,50 +45,50 @@ import {
     buildRateMessage,
     buildConnectMessage,
     buildAdHocConnectMessage,
-} from '../won-message-utils.js';
+    } from '../won-message-utils.js';
 
 export function connectionsChatMessage(chatMessage, connectionUri, isTTL=false) {
-   return (dispatch, getState) => {
+    return (dispatch, getState) => {
 
-       const ownNeed = getState().get("needs").filter(need => need.getIn(["connections", connectionUri])).first();
-       const theirNeedUri = getState().getIn(["needs", ownNeed.get("uri"), "connections", connectionUri, "remoteNeedUri"]);
-       const theirNeed = getState().getIn(["needs", theirNeedUri]);
-       const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
+        const ownNeed = getState().get("needs").filter(need => need.getIn(["connections", connectionUri])).first();
+        const theirNeedUri = getState().getIn(["needs", ownNeed.get("uri"), "connections", connectionUri, "remoteNeedUri"]);
+        const theirNeed = getState().getIn(["needs", theirNeedUri]);
+        const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
 
-       buildChatMessage({
-            chatMessage: chatMessage, 
+        buildChatMessage({
+            chatMessage: chatMessage,
             connectionUri,
-            ownNeedUri: ownNeed.get("uri"), 
+            ownNeedUri: ownNeed.get("uri"),
             theirNeedUri: theirNeedUri,
-            ownNodeUri: ownNeed.get("nodeUri"), 
-            theirNodeUri: theirNeed.get("nodeUri"), 
+            ownNodeUri: ownNeed.get("nodeUri"),
+            theirNodeUri: theirNeed.get("nodeUri"),
             theirConnectionUri,
             isTTL,
         })
-       .then(msgData =>
-            Promise.all([won.wonMessageFromJsonLd(msgData.message), msgData.message]))
-       .then(([optimisticEvent, jsonldMessage]) => {
-           // dispatch(actionCreators.messages__send(messageData));
-           dispatch({
-               type: actionTypes.connections.sendChatMessage,
-               payload: {
-                   eventUri: optimisticEvent.getMessageUri(),
-                   message: jsonldMessage,
-                   optimisticEvent,
-                }
+            .then(msgData =>
+                Promise.all([won.wonMessageFromJsonLd(msgData.message), msgData.message]))
+            .then(([optimisticEvent, jsonldMessage]) => {
+                // dispatch(actionCreators.messages__send(messageData));
+                dispatch({
+                    type: actionTypes.connections.sendChatMessage,
+                    payload: {
+                        eventUri: optimisticEvent.getMessageUri(),
+                        message: jsonldMessage,
+                        optimisticEvent,
+                    }
+                });
+            })
+            .catch(e => {
+                console.error('Error while processing chat message: ', e);
+                dispatch({
+                    type: actionTypes.connections.sendChatMessageFailed,
+                    payload: {
+                        error: e,
+                        message: e.message,
+                    }
+                });
             });
-       })
-       .catch(e => {
-           console.error('Error while processing chat message: ', e);
-           dispatch({
-               type: actionTypes.connections.sendChatMessageFailed,
-               payload: {
-                   error: e,
-                   message: e.message,
-                }
-            });
-       });
-   }
+    }
 }
 
 export function connectionsFetch(data) {
@@ -101,29 +101,29 @@ export function connectionsFetch(data) {
 }
 
 
-export function connectionsOpen(connectionUri, textMessage) {	
+export function connectionsOpen(connectionUri, textMessage) {
     return async (dispatch, getState) => {
-    	 const state = getState();
-         const ownNeed = getState().get("needs").filter(need => need.getIn(["connections", connectionUri])).first();
-         const theirNeedUri = getState().getIn(["needs", ownNeed.get("uri"), "connections", connectionUri, "remoteNeedUri"]);
-         const theirNeed = getState().getIn(["needs", theirNeedUri]);
-         const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
+        const state = getState();
+        const ownNeed = getState().get("needs").filter(need => need.getIn(["connections", connectionUri])).first();
+        const theirNeedUri = getState().getIn(["needs", ownNeed.get("uri"), "connections", connectionUri, "remoteNeedUri"]);
+        const theirNeed = getState().getIn(["needs", theirNeedUri]);
+        const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
 
-         const openMsg = await buildOpenMessage(connectionUri, ownNeed.get("uri"), theirNeedUri, ownNeed.get("nodeUri"), theirNeed.get("nodeUri"), theirConnectionUri, textMessage);
-         
-         const optimisticEvent = await won.wonMessageFromJsonLd(openMsg.message);
+        const openMsg = await buildOpenMessage(connectionUri, ownNeed.get("uri"), theirNeedUri, ownNeed.get("nodeUri"), theirNeed.get("nodeUri"), theirConnectionUri, textMessage);
 
-         dispatch({
-             type: actionTypes.connections.open,
-             payload: {
-                 connectionUri,
-                 textMessage,
-                 eventUri: openMsg.eventUri,
-                 message: openMsg.message,
-                 optimisticEvent,
-             }
-         });
-         
+        const optimisticEvent = await won.wonMessageFromJsonLd(openMsg.message);
+
+        dispatch({
+            type: actionTypes.connections.open,
+            payload: {
+                connectionUri,
+                textMessage,
+                eventUri: openMsg.eventUri,
+                message: openMsg.message,
+                optimisticEvent,
+            }
+        });
+
         dispatch(actionCreators.router__stateGoCurrent({
             connectionUri: optimisticEvent.getSender(),
         }));
@@ -136,66 +136,66 @@ export function connectionsConnectAdHoc(theirNeedUri, textMessage) {
 }
 function connectAdHoc(theirNeedUri, textMessage, dispatch, getState) {
     ensureLoggedIn(dispatch, getState)
-    .then(() => {
-        const state = getState();
-        const theirNeed = getIn(state, ['needs', theirNeedUri]);
-        const adHocDraft = generateResponseNeedTo(theirNeed);
-        const nodeUri = getIn(state, ['config', 'defaultNodeUri']);
-        const { message, eventUri, needUri } = buildCreateMessage(adHocDraft, nodeUri);
-        const cnctMsg = buildConnectMessage({
-            ownNeedUri: needUri,
-            theirNeedUri: theirNeedUri,
-            ownNodeUri: nodeUri,
-            theirNodeUri: theirNeed.get("nodeUri"),
-            textMessage: textMessage,
-        });
-        
-        won.wonMessageFromJsonLd(cnctMsg.message)
-        .then(optimisticEvent => {
-        
-            // connect action to be dispatched when the 
-            // ad hoc need has been created: 
-            const connectAction = {
-                type: actionTypes.needs.connect, 
-                payload: {
-                    eventUri: cnctMsg.eventUri,
-                    message: cnctMsg.message,
-                    optimisticEvent: optimisticEvent,
-                }
-            }
-            
-            // register a "stateGoCurrent" action to be dispatched messages-actions 
-            // after connectionUri is available
-            dispatch({
-                type: actionTypes.messages.dispatchActionOn.registerSuccessRemote,
-                payload: {
-                    eventUri: cnctMsg.eventUri,
-                    actionToDispatch: {
-                        effect: "stateGoCurrent",
-                        connectionUri: "responseEvent::receiverUri",
-                        postUri: theirNeed,
-                        needUri: needUri,
-                    } 
-                }
-            })
-
-            // register the connect action to be dispatched when 
-            // need creation is successful
-            dispatch({
-                type: actionTypes.messages.dispatchActionOn.registerSuccessOwn, 
-                payload: {
-                    eventUri: eventUri,
-                    actionToDispatch: connectAction,
-                }
-            })
-            
-            // create the new need
-            dispatch({
-                type: actionTypes.needs.create, // TODO custom action
-                payload: {eventUri, message, needUri, need: adHocDraft}
+        .then(() => {
+            const state = getState();
+            const theirNeed = getIn(state, ['needs', theirNeedUri]);
+            const adHocDraft = generateResponseNeedTo(theirNeed);
+            const nodeUri = getIn(state, ['config', 'defaultNodeUri']);
+            const { message, eventUri, needUri } = buildCreateMessage(adHocDraft, nodeUri);
+            const cnctMsg = buildConnectMessage({
+                ownNeedUri: needUri,
+                theirNeedUri: theirNeedUri,
+                ownNodeUri: nodeUri,
+                theirNodeUri: theirNeed.get("nodeUri"),
+                textMessage: textMessage,
             });
+
+            won.wonMessageFromJsonLd(cnctMsg.message)
+                .then(optimisticEvent => {
+
+                    // connect action to be dispatched when the
+                    // ad hoc need has been created:
+                    const connectAction = {
+                        type: actionTypes.needs.connect,
+                        payload: {
+                            eventUri: cnctMsg.eventUri,
+                            message: cnctMsg.message,
+                            optimisticEvent: optimisticEvent,
+                        }
+                    }
+
+                    // register a "stateGoCurrent" action to be dispatched messages-actions
+                    // after connectionUri is available
+                    dispatch({
+                        type: actionTypes.messages.dispatchActionOn.registerSuccessRemote,
+                        payload: {
+                            eventUri: cnctMsg.eventUri,
+                            actionToDispatch: {
+                                effect: "stateGoCurrent",
+                                connectionUri: "responseEvent::receiverUri",
+                                postUri: theirNeed,
+                                needUri: needUri,
+                            }
+                        }
+                    })
+
+                    // register the connect action to be dispatched when
+                    // need creation is successful
+                    dispatch({
+                        type: actionTypes.messages.dispatchActionOn.registerSuccessOwn,
+                        payload: {
+                            eventUri: eventUri,
+                            actionToDispatch: connectAction,
+                        }
+                    })
+
+                    // create the new need
+                    dispatch({
+                        type: actionTypes.needs.create, // TODO custom action
+                        payload: {eventUri, message, needUri, need: adHocDraft}
+                    });
+                });
         });
-    });
 
 }
 
@@ -249,16 +249,16 @@ export function connectionsClose(connectionUri) {
         const theirConnectionUri = ownNeed.getIn(["connections", connectionUri, "remoteConnectionUri"]);
 
         buildCloseMessage(connectionUri, ownNeed.get("uri"), theirNeedUri, ownNeed.get("nodeUri"), theirNeed.get("nodeUri"), theirConnectionUri)
-        .then(closeMessage => {
-            dispatch(actionCreators.messages__send({
-                eventUri: closeMessage.eventUri,
-                message: closeMessage.message
-            }));
-            dispatch({
-                type: actionTypes.connections.close,
-                payload: {connectionUri}
-            })
-        });
+            .then(closeMessage => {
+                dispatch(actionCreators.messages__send({
+                    eventUri: closeMessage.eventUri,
+                    message: closeMessage.message
+                }));
+                dispatch({
+                    type: actionTypes.connections.close,
+                    payload: {connectionUri}
+                })
+            });
     }
 }
 
@@ -304,7 +304,7 @@ export function connectionsRate(connectionUri,rating) {
                         message: action.message
                     })
                 )
-            );
+        );
     }
 }
 
@@ -329,13 +329,12 @@ export function showLatestMessages(connectionUriParam, numberOfEvents){
         if (!connectionUri || !connection) return;
 
         const connectionMessages = connection.get('messages');
-        if (connection.get('loadingEvents') || !connectionMessages || connectionMessages.size > 0) return; // only start loading once. //TODO: PENDING IS CURRENTLY NOT IMPLEMENTED IN THE NEW STATE
+        if (connection.get('isLoading') || !connectionMessages || connectionMessages.size > 0) return; // only start loading once.
 
         dispatch({
             type: actionTypes.connections.showLatestMessages,
-            payload: Immutable.fromJS({connectionUri, pending: true}),
+            payload: Immutable.fromJS({connectionUri, isLoading: true}),
         });
-
 
         won.getWonMessagesOfConnection(
             connectionUri,
@@ -345,25 +344,25 @@ export function showLatestMessages(connectionUriParam, numberOfEvents){
                 deep: true
             }
         )
-        .then(events =>
-            dispatch({
-                type: actionTypes.connections.showLatestMessages,
-                payload: Immutable.fromJS({
-                    connectionUri: connectionUri,
-                    events: events,
+            .then(events =>
+                dispatch({
+                    type: actionTypes.connections.showLatestMessages,
+                    payload: Immutable.fromJS({
+                        connectionUri: connectionUri,
+                        events: events,
+                    })
                 })
-            })
         )
-        .catch(error => {
-            console.error('Failed loading the latest events: ', error);
-            dispatch({
-                type: actionTypes.connections.showLatestMessages,
-                payload: Immutable.fromJS({
-                    connectionUri: connectionUri,
-                    error: error,
+            .catch(error => {
+                console.error('Failed loading the latest events: ', error);
+                dispatch({
+                    type: actionTypes.connections.showLatestMessages,
+                    payload: Immutable.fromJS({
+                        connectionUri: connectionUri,
+                        error: error,
+                    })
                 })
-            })
-        });
+            });
     }
 }
 
@@ -376,28 +375,27 @@ export function showLatestMessages(connectionUriParam, numberOfEvents){
  * @return {*}
  */
 /*
-function getEvents(connectionUri, params) {
-    const eventP = won
-        .getNode(connectionUri, params)
-        .then(cnct =>
-            won.getNode(cnct.hasEventContainer, params)
-        )
-        .then(eventContainer => is('Array', eventContainer.member) ?
-            eventContainer.member :
-            [eventContainer.member]
-        )
-        .then(eventUris => urisToLookupMap(
-            eventUris,
-            uri => won.getEvent(
-                uri,
-                { requesterWebId: params.requesterWebId }
-            )
-        ));
+ function getEvents(connectionUri, params) {
+ const eventP = won
+ .getNode(connectionUri, params)
+ .then(cnct =>
+ won.getNode(cnct.hasEventContainer, params)
+ )
+ .then(eventContainer => is('Array', eventContainer.member) ?
+ eventContainer.member :
+ [eventContainer.member]
+ )
+ .then(eventUris => urisToLookupMap(
+ eventUris,
+ uri => won.getEvent(
+ uri,
+ { requesterWebId: params.requesterWebId }
+ )
+ ));
 
-    return eventP;
-}
-*/
-
+ return eventP;
+ }
+ */
 
 /**
  * @param connectionUri
@@ -416,18 +414,21 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
         const connectionUri = connectionUriParam || selectOpenConnectionUri(state);
         const need = connectionUri && selectNeedByConnectionUri(state, connectionUri);
         const needUri = need && need.get("uri");
-        const events = state.getIn(["needs", needUri, "connections", connectionUri, "messages"]) || Immutable.List();
+        const connection = need && need.getIn(["connections", connectionUri]);
+        const connectionMessages = connection && connection.get("messages");
+
+        if (connection.get('isLoading')) return; // only start loading once.
 
         // determine the oldest loaded event
-        const sortedOwnEvents = events.valueSeq().sort( (event1, event2) => event1.get('date') - event2.get('date'));
-        const oldestEvent = sortedOwnEvents.first();
+        const sortedConnectionMessages = connectionMessages.valueSeq().sort( (msg1, msg2) => msg1.get('date') - msg2.get('date'));
+        const oldestMessage = sortedConnectionMessages.first();
 
-        const eventHashValue = oldestEvent && oldestEvent
+        const messageHashValue = oldestMessage && oldestMessage
                 .get('uri')
                 .replace(/.*\/event\/(.*)/, '$1'); // everything following the `/event/`
         dispatch({
             type: actionTypes.connections.showMoreMessages,
-            payload: Immutable.fromJS({connectionUri, pending: true}),
+            payload: Immutable.fromJS({connectionUri, isLoading: true}),
         });
 
         won.getWonMessagesOfConnection(
@@ -436,31 +437,31 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
                 requesterWebId: needUri,
                 pagingSize: numOfEvts2pageSize(numberOfEvents),
                 deep: true,
-                resumebefore: eventHashValue,
+                resumebefore: messageHashValue,
             }
         ).then(events =>
-            dispatch({
-                type: actionTypes.connections.showMoreMessages,
-                payload: Immutable.fromJS({
-                    connectionUri: connectionUri,
-                    events: events,
+                dispatch({
+                    type: actionTypes.connections.showMoreMessages,
+                    payload: Immutable.fromJS({
+                        connectionUri: connectionUri,
+                        events: events,
+                    })
                 })
-            })
         )
-        .catch(error => {
-            console.error('Failed loading more events: ', error);
-            dispatch({
-                type: actionTypes.connections.showMoreMessages,
-                payload: Immutable.fromJS({
-                    connectionUri: connectionUri,
-                    error: error,
+            .catch(error => {
+                console.error('Failed loading more events: ', error);
+                dispatch({
+                    type: actionTypes.connections.showMoreMessages,
+                    payload: Immutable.fromJS({
+                        connectionUri: connectionUri,
+                        error: error,
+                    })
                 })
-            })
-        });
+            });
     }
 }
 
 function numOfEvts2pageSize(numberOfEvents) {
-     // `*3*` to compensate for the *roughly* 2 additional success events per chat message
+    // `*3*` to compensate for the *roughly* 2 additional success events per chat message
     return numberOfEvents * 3;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -264,9 +264,22 @@ export default function(allNeedsInState = initialState, action = {}) {
 
         case actionTypes.connections.showLatestMessages:
         case actionTypes.connections.showMoreMessages:
-            var loadedEvents = action.payload.get('events');
-            if(loadedEvents){
-                allNeedsInState = addMessages(allNeedsInState, loadedEvents);
+            var isLoading = action.payload.get('isLoading');
+            var connectionUri = action.payload.get('connectionUri');
+
+            if(isLoading && connectionUri){
+                allNeedsInState = setConnectionLoading(allNeedsInState, connectionUri, true);
+            }
+
+            var loadedMessages = action.payload.get('events');
+            if(loadedMessages){
+                allNeedsInState = addMessages(allNeedsInState, loadedMessages);
+                allNeedsInState = setConnectionLoading(allNeedsInState, connectionUri, false);
+            }
+            const error = action.payload.get('error');
+
+            if(error && connectionUri){
+                allNeedsInState = setConnectionLoading(allNeedsInState, connectionUri, false);
             }
 
             return allNeedsInState;
@@ -462,9 +475,9 @@ function changeConnectionState(state, connectionUri, newState) {
 
 function markMessageAsRead(state, messageUri, connectionUri, needUri) {
 
-    let need = state.get(needUri);
-    let connection = need && need.getIn(["connections", connectionUri]);
-    let message = connection && connection.getIn(["messages", messageUri]);
+    const need = state.get(needUri);
+    const connection = need && need.getIn(["connections", connectionUri]);
+    const message = connection && connection.getIn(["messages", messageUri]);
 
     markUriAsRead(messageUri);
 
@@ -483,8 +496,8 @@ function markMessageAsRead(state, messageUri, connectionUri, needUri) {
 }
 
 function markConnectionAsRead(state, connectionUri, needUri) {
-    let need = state.get(needUri);
-    let connection = need && need.getIn(["connections", connectionUri]);
+    const need = state.get(needUri);
+    const connection = need && need.getIn(["connections", connectionUri]);
 
     markUriAsRead(connectionUri);
 
@@ -502,8 +515,21 @@ function markConnectionAsRead(state, connectionUri, needUri) {
     return state;
 }
 
+function setConnectionLoading(state, connectionUri, isLoading) {
+    const need = connectionUri && selectNeedByConnectionUri(state, connectionUri);
+    const needUri = need && need.get("uri");
+    const connection = need && need.getIn(["connections", connectionUri]);
+
+    if(!connection) {
+        console.error("no connection with connectionUri: <", connectionUri,"> found within needUri: <", needUri, ">");
+        return state;
+    }
+
+    return state.setIn([needUri, "connections", connectionUri, "isLoading"], isLoading);
+}
+
 function markNeedAsRead(state, needUri) {
-    let need = state.get(needUri);
+    const need = state.get(needUri);
 
     if(!need) {
         console.error("no need with needUri: <", needUri, ">");
@@ -563,6 +589,7 @@ function parseConnection(jsonldConnection) {
             lastUpdateDate: undefined,
             unread: undefined,
             isRated: false,
+            isLoading: false,
         }
     };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1161,3 +1161,52 @@ export function clamp(value, lower, upper) {
         return upper
     return value
 }
+
+const READ_URIS = "wonReadUris";
+
+export function markUriAsRead(uri) {
+    //TODO: BETTER IMPL
+    if(!isUriRead(uri)){
+        console.log("mark uri:", uri, " as read");
+
+        let readUrisString = window.localStorage.getItem(READ_URIS);
+        if(!readUrisString){
+            readUrisString = JSON.stringify([uri]);
+        }else{
+            try{
+                let readUriList = JSON.parse(readUrisString);
+                readUriList.push(uri);
+                readUrisString = JSON.stringify(readUriList);
+            }catch(e) {
+                console.error("readUris could not be parsed, resetting the item in localstorage");
+                resetUrisRead();
+                readUrisString = JSON.stringify([uri]);
+            }
+        }
+
+        window.localStorage.setItem(READ_URIS, readUrisString);
+    }
+}
+
+export function isUriRead(uri) {
+    //TODO: BETTER IMPL
+    let readUrisString = window.localStorage.getItem(READ_URIS);
+
+    if(readUrisString) {
+        let readUriList = JSON.parse(readUrisString);
+
+        for(var i=0; i < readUriList.length; i++){
+            if(readUriList[i] === uri) {
+                console.log("checking if uri: ", uri, " is read -> true");
+                return true;
+            }
+        }
+    }
+    console.log("checking if uri: ", uri, " is read -> false");
+    return false;
+}
+
+export function resetUrisRead() {
+    console.log("resetting read uris");
+    window.localStorage.removeItem(READ_URIS);
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1167,8 +1167,6 @@ const READ_URIS = "wonReadUris";
 export function markUriAsRead(uri) {
     //TODO: BETTER IMPL
     if(!isUriRead(uri)){
-        console.log("mark uri:", uri, " as read");
-
         let readUrisString = window.localStorage.getItem(READ_URIS);
         if(!readUrisString){
             readUrisString = JSON.stringify([uri]);
@@ -1178,7 +1176,6 @@ export function markUriAsRead(uri) {
                 readUriList.push(uri);
                 readUrisString = JSON.stringify(readUriList);
             }catch(e) {
-                console.error("readUris could not be parsed, resetting the item in localstorage");
                 resetUrisRead();
                 readUrisString = JSON.stringify([uri]);
             }
@@ -1197,16 +1194,13 @@ export function isUriRead(uri) {
 
         for(var i=0; i < readUriList.length; i++){
             if(readUriList[i] === uri) {
-                console.log("checking if uri: ", uri, " is read -> true");
                 return true;
             }
         }
     }
-    console.log("checking if uri: ", uri, " is read -> false");
     return false;
 }
 
 export function resetUrisRead() {
-    console.log("resetting read uris");
     window.localStorage.removeItem(READ_URIS);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -7,7 +7,7 @@ won-connection-message {
         background-color: $won-unread;
     }
 
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0;
     @include square-image($postIconSize, 0, 0.5rem, 0, 0);
     display: grid;
     grid-template-areas: "icon content";

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -122,7 +122,7 @@
 
     .pm__content {
       grid-area: main;
-      padding: 1rem 0;
+      padding: 0.5rem;
       background: white;
       border: $thinGrayBorder;
       overflow: auto;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -127,7 +127,16 @@
       border: $thinGrayBorder;
       overflow: auto;
       flex-grow: 1;
-      
+
+      &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
+      &__loadspinner {
+        width: 100%;
+        height: 3rem;
+        padding: .66em 2em;
+        text-align: center;
+        box-sizing: border-box;
+      }
+
       &__agreement {
         @include speech-bubble-bottom($won-light-gray, $won-line-gray, 0.3125rem, $thinBorderWidth, 0.5rem);
         margin: 0 0.5rem;


### PR DESCRIPTION
- Saves the read connection/message uris in the localstorage to remove the unread status of read messages when reloading the page or after a login (is not the implementation of #1457)  -> yet we should probably still use it in master/matchat for now as it is a way better user experience as the current one which marks everything as unread on login or reload

fixes #1584 
implements a new/working load Messages behaviour with spinner -> stores parameter "isLoading" in the state of the connection, so we know when a connection is currently Loading messages -> this parameter should also be used while loading/calculating agreement/proposals and should be used in favor of the "loading" in post-messsages.js, 
