### PR TITLE
adapted no-textmessage message

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -194,8 +194,8 @@ function genComponentConf() {
 
             self.noTextPlaceholder = 
                         '«This message couldn\'t be displayed as it didn\'t contain text! ' +
-                        'Click on the \"RDF\"-logo at ' + 
-                        'the bottom of screen to see the \"raw\" message-data.»'
+                        'Click on the \"RDF\"-logo in ' +
+                        'the context-menu on the right side of the header to see the \"raw\" message-data.»'
 
             const selectFromState = state => {
                 /*


### PR DESCRIPTION
Adapted the text of the no-text-message message -> fixes #1590 

if the message is not sufficient or explanatory enough to the reviewer, the reviewer should change the message accordingly and merge the pull afterwards