### PR TITLE
Added missing peer dependency for webpack build.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -35,6 +35,7 @@
     "clean": "gulp clean"
   },
   "devDependencies": {
+    "@uirouter/angularjs": "^1.0.15",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",


### PR DESCRIPTION
`redux-ui-router` depends on the new `@uirouter/angularjs` (formerly `angular-ui-router`)