### PR TITLE
Feat sharelink component

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-state.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-state.js
@@ -21,7 +21,7 @@ import {
 const serviceDependencies = ['$ngRedux', '$scope'];
 function genComponentConf() {
     let template = `
-        <div class="cs__state" title="{{self.labels.connectionState[self.type]}}">
+        <div class="cs__state" title="{{self.labels.connectionState[self.state]}}">
             <svg class="cs__state__icon" style="--local-primary:var(--won-primary-color);" ng-if="self.unread && self.state === self.WON.Suggested">
                  <use href="#ico36_match"></use>
             </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
@@ -60,10 +60,10 @@
         <won-create-post></won-create-post>
     </div>
     <div class="post__contentside" ng-if="!self.selectedPost && !self.showCreateView && self.connection && self.connectionType !== self.WON.Closed">
-        <won-send-request include-header="true" ng-if="self.connectionType === self.WON.Suggested"></won-send-request>
+        <won-send-request include-header="::true" ng-if="self.connectionType === self.WON.Suggested"></won-send-request>
         <won-post-messages ng-if="self.connectionType === self.WON.Connected || self.connectionType === self.WON.RequestReceived || self.connectionType === self.WON.RequestSent"></won-post-messages>
     </div>
     <div class="post__contentside" ng-if="self.selectedPost && !self.showCreateView">
-        <won-post-info include-header="true"></won-post-info>
+        <won-post-info include-header="::true"></won-post-info>
     </div>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -9,6 +9,7 @@ import angular from 'angular';
 import postSeeksInfoModule from './post-seeks-info.js';
 import postIsInfoModule from './post-is-info.js';
 import postHeaderModule from './post-header.js';
+import postShareLinkModule from './post-share-link.js';
 
 import { attach, } from '../utils.js';
 import won from '../won-es6.js';
@@ -101,15 +102,10 @@ function genComponentConf() {
             </a>
         </div>
         <div class="post-info__footer">
-            <div class="post-info__footer__link" ng-if="self.post.get('state') !== self.WON.InactiveCompacted">
-                <p class="post-info__footer__link__text" ng-if="self.post.get('connections').size == 0 && self.post.get('ownNeed')">
-                    Your posting has no connections yet. Consider sharing the link below in social media, or wait for matchers to connect you with others.
-                </p>
-                <p class="post-info__footer__link__text" ng-if="(self.post.get('connections').size != 0 && self.post.get('ownNeed')) || !self.post.get('ownNeed')">
-                    Know someone who might also be interested in this posting? Consider sharing the link below in social media.
-                </p>
-                <input class="post-info__footer__link__input" value="{{self.linkToPost}}" disabled type="text">
-            </div>
+            <won-post-share-link
+                ng-if="self.post.get('state') !== self.WON.InactiveCompacted"
+                post-uri="self.post.get('uri')">
+            </won-post-share-link>
         </div>
     `;
 
@@ -119,7 +115,7 @@ function genComponentConf() {
 
             this.is = 'is';
             this.seeks = 'seeks';
-           
+
             const selectFromState = (state) => {
                 const postUri = selectOpenPostUri(state);
                 const post = state.getIn(["needs", postUri]);
@@ -152,7 +148,6 @@ function genComponentConf() {
                     ),
                     createdTimestamp: post && post.get('creationDate'),
                     shouldShowRdf: state.get('showRdf'),
-                    linkToPost: post && new URL("/owner/#!post/?postUri="+encodeURI(post.get('uri')), window.location.href).href,
                 }
             };
             connect2Redux(selectFromState, actionCreators, ['self.includeHeader'], this);
@@ -193,7 +188,8 @@ return {
 export default angular.module('won.owner.components.postInfo', [ 
 		postIsInfoModule,
 		postSeeksInfoModule,
-        postHeaderModule
+        postHeaderModule,
+        postShareLinkModule
 	])
     .directive('wonPostInfo', genComponentConf)
     .name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-share-link.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-share-link.js
@@ -1,0 +1,85 @@
+import angular from 'angular';
+import ngAnimate from 'angular-animate';
+import { actionCreators }  from '../actions/actions.js';
+import {
+    attach,
+} from '../utils.js';
+
+import {
+    connect2Redux,
+} from '../won-utils.js';
+
+const serviceDependencies = ['$scope', '$ngRedux', '$element'];
+function genComponentConf() {
+    let template = `
+        <p class="psl__text" ng-if="self.post.get('connections').size == 0 && self.post.get('ownNeed')">
+            Your posting has no connections yet. Consider sharing the link below in social media, or wait for matchers to connect you with others.
+        </p>
+        <p class="psl__text" ng-if="(self.post.get('connections').size != 0 && self.post.get('ownNeed')) || !self.post.get('ownNeed')">
+            Know someone who might also be interested in this posting? Consider sharing the link below in social media.
+        </p>
+        <input class="psl__link" value="{{self.linkToPost}}" readonly type="text" ng-click="self.selectLink()">
+        <p class="psl__info" ng-if="!self.isCopied">Click the Link above to copy it to the clipboard.</p>
+        <p class="psl__info" ng-if="self.isCopied">Link copied to the clipboard.</p>
+    `;
+
+    class Controller {
+        constructor() {
+            attach(this, serviceDependencies, arguments);
+
+            const selectFromState = (state) => {
+                const post = this.postUri && state.getIn(["needs", this.postUri]);
+
+                return {
+                    post,
+                    linkToPost: post && new URL("/owner/#!post/?postUri="+encodeURI(post.get('uri')), window.location.href).href,
+                }
+            };
+            connect2Redux(selectFromState, actionCreators, ['self.postUri'], this);
+        }
+
+        getLinkField() {
+            if(!this._linkField) {
+                this._linkField = this.$element[0].querySelector('.psl__link');
+            }
+            return this._linkField;
+        }
+
+        selectLink() {
+            const linkEl = this.getLinkField();
+            if(linkEl) {
+                linkEl.setSelectionRange(0, linkEl.value.length); //refocus so people can keep writing
+
+                try {
+                    var successful = document.execCommand('copy');
+                    if (!successful) throw successful;
+                    this.isCopied = true;
+                    linkEl.setSelectionRange(0,0);
+                    //prompt that it has been copied to the clipboard otherwise and remove the selection
+                } catch (err) {
+                    window.prompt("Copy to clipboard: Ctrl+C, Enter", linkEl.value);
+                }
+            }
+        }
+    }
+    Controller.$inject = serviceDependencies;
+
+    return {
+        restrict: 'E',
+        controller: Controller,
+        controllerAs: 'self',
+        bindToController: true, //scope-bindings -> ctrl
+        scope: {
+            postUri: "=",
+            connectionUri: '=',
+        },
+        template: template
+    }
+}
+
+export default angular.module('won.owner.components.postShareLink', [
+    ngAnimate,
+])
+    .directive('wonPostShareLink', genComponentConf)
+    .name;
+

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -5,6 +5,6 @@
 </header>
 <main class="postcontent">
     <!-- Post info view when there's no connection-state/-type selected -->
-    <won-send-request include-header="false" ng-if="self.post && !self.isOwnPost"></won-send-request>
+    <won-send-request include-header="::false" ng-if="self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
     <button ng-click="self.goToOwnPost()" ng-if="self.post && self.isOwnPost " class="won-button--filled red">GO TO POST VIEW TODO: AUTOMATICALLY DO THIS</button>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -6,6 +6,7 @@ import postHeaderModule from './post-header.js';
 import feedbackGridModule from './feedback-grid.js';
 import postSeeksInfoModule from './post-seeks-info.js';
 import postIsInfoModule from './post-is-info.js';
+import postShareLinkModule from './post-share-link.js';
 import labelledHrModule from './labelled-hr.js';
 import chatTextFieldSimpleModule from './chat-textfield-simple.js';
 
@@ -98,12 +99,10 @@ function genComponentConf() {
             </a>
         </div>
         <div class="post-info__footer">
-            <div class="post-info__footer__link" ng-if="self.suggestedPost.get('state') !== self.WON.InactiveCompacted">
-                <p class="post-info__footer__link__text">
-                    Know someone who might also be interested in this posting? Consider sharing the link below in social media.
-                </p>
-                <input class="post-info__footer__link__input" value="{{self.linkToPost}}" disabled type="text">
-            </div>
+            <won-post-share-link
+                ng-if="self.suggestedPost.get('state') !== self.WON.InactiveCompacted"
+                post-uri="self.suggestedPost && self.suggestedPost.get('uri')">
+            </won-post-share-link>
             <won-labelled-hr label="::'Or'" class="post-info__footer__labelledhr"></won-labelled-hr>
 
             <won-feedback-grid ng-if="self.connection && !self.connection.get('isRated')" connection-uri="self.connectionUri"></won-feedback-grid>
@@ -161,9 +160,7 @@ function genComponentConf() {
                     }: undefined,
                     suggestedPost,
                     lastUpdateTimestamp: connection && connection.get('lastUpdateDate'),
-                    connectionUri,
                     postUriToConnectTo,
-                    linkToPost: suggestedPost && new URL("/owner/#!post/?postUri="+encodeURI(suggestedPost.get('uri')), window.location.href).href,
                     friendlyTimestamp: suggestedPost && relativeTime(
                         selectLastUpdateTime(state),
                         suggestedPost.get('creationDate')
@@ -213,7 +210,7 @@ function genComponentConf() {
         controllerAs: 'self',
         bindToController: true, //scope-bindings -> ctrl
         scope: {
-            includeHeader: '='
+            includeHeader: '=' //only read once
         },
         template: template
     }
@@ -226,6 +223,7 @@ export default angular.module('won.owner.components.sendRequest', [
     feedbackGridModule,
     labelledHrModule,
     chatTextFieldSimpleModule,
+    postShareLinkModule
 ])
     .directive('wonSendRequest', genComponentConf)
     .name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -18,6 +18,18 @@ won-post-info {
   box-sizing: border-box;
   padding: $gridRowGap;
 
+  &.won-post-info--noheader,
+  &.won-send-request--noheader {
+    grid-template-areas: "main" "footer";
+    grid-template-rows: minmax(10rem, 1fr) min-content;
+
+    .post-info__content {
+      border-top: none;
+      padding-top: 0;
+    }
+  }
+
+
   @media (max-width : $responsivenessBreakPoint) {
     border-left: none;
     border-right: none;
@@ -131,16 +143,6 @@ won-post-info {
 
     &__labelledhr span {
       background: white;
-    }
-
-    &__link {
-      &__text {
-        font-size: $smallFontSize;
-        padding-bottom: 0.5rem;
-      }
-      &__input {
-        width: 100%;
-      }
     }
 
     &__button {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-share-link.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-share-link.scss
@@ -1,0 +1,21 @@
+@import 'won-config';
+@import 'animate';
+
+won-post-share-link {
+  .psl__info,
+  .psl__text {
+    font-size: $smallFontSize;
+  }
+
+  .psl__text {
+    padding-bottom: 0.5rem;
+  }
+
+  .psl__info {
+    padding-top: 0.5rem;
+  }
+
+  .psl__link {
+    width: 100%;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -167,3 +167,4 @@ svg {
 @import 'covering-dropdown';
 @import 'tab';
 @import 'connection-indicators';
+@import 'post-share-link';


### PR DESCRIPTION
fixes #1560 autoselect link and copy it to clipboard
fixes #1591 cant select visitor link in firefox

implements a different styling for the visitor link (border of post-info is removed when inlcudeheader is set to false)