### PR TITLE
Fix whatsaround

### DIFF
--- a/webofneeds/conf/matcher-solr/matcher-solr.properties
+++ b/webofneeds/conf/matcher-solr/matcher-solr.properties
@@ -24,8 +24,11 @@ matcher.solr.test.core=wontest
 # public accessible uri that specifies which matcher instance created hints
 matcher.solr.uri.solr.server.public=http://localhost:8983/solr/
 
-# maximum number of hints published to the matching service by the matcher per need
+# maximum number of hints to be received by a need upon creation/activation
 matcher.solr.query.maxHints=20
+
+# maximum number of counterpart needs that should receive hints upon need creation/activation
+matcher.solr.query.maxHintsForCounterparts=50
 
 # parameter is used for Kneedle knee detection algorithm that searches knee/elbow points in our score results
 matcher.solr.query.cutAfterIthElbowInScore=1

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/SolrMatcherActor.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/SolrMatcherActor.java
@@ -137,7 +137,7 @@ public class SolrMatcherActor extends UntypedActor {
 
             // execute the query
             log.info("query Solr endpoint {} for need {} and need list 1 (without NoHintForCounterpart)", config.getSolrEndpointUri(usedForTesting), needEvent.getUri());
-            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, null, filterQueries.toArray(new String[filterQueries.size()]));
+            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, config.getMaxHints(),null, filterQueries.toArray(new String[filterQueries.size()]));
             if (docs != null) {
 
                 // generate hints for current need (only generate hints for current need, suppress hints for matched needs,
@@ -173,7 +173,7 @@ public class SolrMatcherActor extends UntypedActor {
 
             // execute the query
             log.info("query Solr endpoint {} for need {} and need list 2 (without NoHintForSelf, excluding WhatsAround needs)", config.getSolrEndpointUri(usedForTesting), needEvent.getUri());
-            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, null, filterQueries.toArray(new String[filterQueries.size()]));
+            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, config.getMaxHintsForCounterparts(), null, filterQueries.toArray(new String[filterQueries.size()]));
             if (docs != null) {
 
                 // generate hints for matched needs (suppress hints for current need, only generate hints for matched needs, perform knee detection)
@@ -207,7 +207,7 @@ public class SolrMatcherActor extends UntypedActor {
 
             // execute the query
             log.info("query Solr endpoint {} for need {} and need list 3 (without NoHintForSelf that are only WhatsAround needs)", config.getSolrEndpointUri(usedForTesting), needEvent.getUri());
-            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, null, filterQueries.toArray(new String[filterQueries.size()]));
+            SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, config.getMaxHintsForCounterparts(), null, filterQueries.toArray(new String[filterQueries.size()]));
             if (docs != null) {
 
                 // generate hints for matched needs (suppress hints for current need, only generate hints for matched needs, do not perform knee detection)

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/SolrMatcherActor.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/SolrMatcherActor.java
@@ -200,6 +200,11 @@ public class SolrMatcherActor extends UntypedActor {
         }
         if (!needModelWrapper.hasFlag(WON.NO_HINT_FOR_COUNTERPART)) {
 
+            // hints for WhatsAround Needs should not have the keywords from title, description, tags etc.
+            // this can prevent to actually find WhatsAround needs.
+            // Instead create a WhatsAround query (query without keywords, just location) to find other WhatsAround needs
+            queryString = (new WhatsAroundQueryFactory(dataset)).createQuery();
+
             // execute the query
             log.info("query Solr endpoint {} for need {} and need list 3 (without NoHintForSelf that are only WhatsAround needs)", config.getSolrEndpointUri(usedForTesting), needEvent.getUri());
             SolrDocumentList docs = queryExecutor.executeNeedQuery(queryString, null, filterQueries.toArray(new String[filterQueries.size()]));

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/config/SolrMatcherConfig.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/config/SolrMatcherConfig.java
@@ -28,6 +28,9 @@ public class SolrMatcherConfig
   @Value("${matcher.solr.query.maxHints}")
   private int maxHints;
 
+  @Value("${matcher.solr.query.maxHintsForCounterparts}")
+  private int maxHintsForCounterparts;
+
   @Value("${matcher.solr.index.commit}")
   private boolean commitIndexedNeedImmediately;
 
@@ -51,6 +54,10 @@ public class SolrMatcherConfig
   public int getMaxHints() {
     return maxHints;
   }
+
+    public int getMaxHintsForCounterparts() {
+        return maxHintsForCounterparts;
+    }
 
   public boolean isCommitIndexedNeedImmediately() {
     return commitIndexedNeedImmediately;

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
@@ -37,7 +37,7 @@ public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor {
     }
 
     @Override
-    public SolrDocumentList executeNeedQuery(String queryString, SolrParams params, String... filterQueries)
+    public SolrDocumentList executeNeedQuery(String queryString, int maxHints, SolrParams params, String... filterQueries)
             throws IOException, SolrServerException {
 
         if (queryString == null) {
@@ -49,7 +49,7 @@ public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor {
         log.debug("use query: {} with filters {}", queryString, filterQueries);
         query.setQuery(queryString);
         query.setFields("id", "score", HintBuilder.WON_NODE_SOLR_FIELD, HintBuilder.HAS_FLAG_SOLR_FIELD, MatchingContextQueryFactory.MATCHING_CONTEXT_SOLR_FIELD);
-        query.setRows(config.getMaxHints());
+        query.setRows(maxHints);
 
         if (filterQueries != null) {
             query.setFilterQueries(filterQueries);

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/SolrMatcherQueryExecutor.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/SolrMatcherQueryExecutor.java
@@ -11,6 +11,6 @@ import java.io.IOException;
  */
 public interface SolrMatcherQueryExecutor
 {
-  SolrDocumentList executeNeedQuery(String queryString, SolrParams params, String... filterQueries)
+  SolrDocumentList executeNeedQuery(String queryString, int maxHints, SolrParams params, String... filterQueries)
     throws IOException, SolrServerException;
 }

--- a/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/SolrMatcherQueryTest.java
+++ b/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/SolrMatcherQueryTest.java
@@ -2,7 +2,6 @@ package won.matcher.solr;
 
 import com.github.jsonldjava.core.JsonLdError;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
@@ -47,7 +46,7 @@ public class SolrMatcherQueryTest {
                 String query = needQuery.createQuery();
                 System.out.println("execute query: " + query);
 
-                SolrDocumentList docs = queryExecutor.executeNeedQuery(query, null, new BasicNeedQueryFactory(ds).createQuery());
+                SolrDocumentList docs = queryExecutor.executeNeedQuery(query, 20, null, new BasicNeedQueryFactory(ds).createQuery());
                 SolrDocumentList matchedDocs = hintBuilder.calculateMatchingResults(docs);
                 System.out.println("Found docs: " + ((docs != null) ? docs.size() : 0) + ", keep docs: " + ((matchedDocs != null) ? matchedDocs.size() : 0));
                 if (docs == null) {

--- a/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
+++ b/webofneeds/won-matcher-solr/src/test/java/won/matcher/solr/evaluation/SolrMatcherEvaluation.java
@@ -4,7 +4,6 @@ import com.github.jsonldjava.core.JsonLdError;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.rdf.model.Model;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
@@ -203,7 +202,7 @@ public class SolrMatcherEvaluation
     TestNeedQueryFactory needQuery = new TestNeedQueryFactory(need);
 
     SolrDocumentList docs = queryExecutor.executeNeedQuery(
-      needQuery.createQuery(), null, new BasicNeedQueryFactory(need).createQuery());
+      needQuery.createQuery(), 20 ,null, new BasicNeedQueryFactory(need).createQuery());
 
     SolrDocumentList matchedDocs = hintBuilder.calculateMatchingResults(docs);
 


### PR DESCRIPTION
* whatsaround needs should get hints now also from needs that were created later, fixes #1662 
* there is a config parameter set to 50 currently that defines how many counterpart needs should receive hints => this also applies for the whatsaround needs 