### PR TITLE
Fix #1682 - retract/reject fails for proposeToCancel

### DIFF
--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessage.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessage.java
@@ -638,6 +638,32 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 	private Object messageUriOrNullString(ConversationMessage message) {
 		return message != null? message.getMessageURI():"null";
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((messageURI == null) ? 0 : messageURI.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ConversationMessage other = (ConversationMessage) obj;
+		if (messageURI == null) {
+			if (other.messageURI != null)
+				return false;
+		} else if (!messageURI.equals(other.messageURI))
+			return false;
+		return true;
+	}
+	
 	
 	
 }

--- a/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetAgreementsTests.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetAgreementsTests.java
@@ -401,16 +401,7 @@ public class GetAgreementsTests {
 				expectedOutputFolder + "one-agreement-proposaltocancel-retracted.trig");
 		test(input, expectedOutput);
 	}
-
-	// This retracts a proposaltocancel before the accept message
-	@Test
-	public void retractProposalTocancelBeforeAccept() throws IOException {
-		Dataset input = loadDataset(inputFolder + "one-agreement-proposaltocancel-retracted-b4-accept.trig");
-		Dataset expectedOutput = loadDataset(
-				expectedOutputFolder + "one-agreement-proposaltocancel-retracted-b4-accept.trig");
-		test(input, expectedOutput);
-	}
-
+	
 	@Test
 	public void oneProposalRejectedBeforeAccept() throws IOException {
 		Dataset input = loadDataset(inputFolder + "one-proposal-rejected-before-accept.trig");

--- a/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetProposalsTests.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetProposalsTests.java
@@ -53,27 +53,51 @@ public class GetProposalsTests {
 	@BeforeClass
 	public static void setLogLevel() {
 		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.INFO);
+		root.setLevel(Level.DEBUG);
 	}
 
 	
 	// This is the case where there are no agreements, that is no predicates from
-		// the agreement protocol. The output should be nothing...
-		@Test
-		public void noAgreementsTest() throws IOException {
-			Dataset input = loadDataset(inputFolder + "no-agreements.trig");
-			Dataset expectedOutput = loadDataset(expectedOutputFolder + "no-agreements.trig");
-			test(input, expectedOutput);
-		}
+	// the agreement protocol. The output should be nothing...
+	@Test
+	public void noAgreementsTest() throws IOException {
+		Dataset input = loadDataset(inputFolder + "no-agreements.trig");
+		Dataset expectedOutput = loadDataset(expectedOutputFolder + "no-agreements.trig");
+		test(input, expectedOutput);
+	}
 
-		// This is the case where there is one agreement. That is one proposal and one
-		// accept making one agreement. The output should be an agreement.
-		@Test
-		public void oneAgreementTest() throws IOException {
-			Dataset input = loadDataset(inputFolder + "one-agreement.trig");
-			Dataset expectedOutput = loadDataset(expectedOutputFolder + "one-agreement.trig");
-			test(input, expectedOutput);
-		}
+	// This is the case where there is one agreement. That is one proposal and one
+	// accept making one agreement. The output should be an agreement.
+	@Test
+	public void oneAgreementTest() throws IOException {
+		Dataset input = loadDataset(inputFolder + "one-agreement.trig");
+		Dataset expectedOutput = loadDataset(expectedOutputFolder + "one-agreement.trig");
+		test(input, expectedOutput);
+	}
+	
+	
+	@Test
+	public void oneAgreementProposalToCancelRetractedTest() throws IOException {
+		Dataset input = loadDataset(inputFolder + "one-agreement-proposaltocancel-retracted.trig");
+		Dataset expectedOutput = loadDataset(expectedOutputFolder + "one-agreement-proposaltocancel-retracted.trig");
+		test(input, expectedOutput);
+	}
+	
+	
+	@Test
+	public void oneAgreementProposalToCancelRetractedBeforeAcceptTest() throws IOException {
+		Dataset input = loadDataset(inputFolder + "one-agreement-proposaltocancel-retracted-b4-accept.trig");
+		Dataset expectedOutput = loadDataset(expectedOutputFolder + "one-agreement-proposaltocancel-retracted-b4-accept.trig");
+		test(input, expectedOutput);
+	}
+	
+	@Test
+	public void oneAgreementProposalToCancelRejectedBeforeAcceptTest() throws IOException {
+		Dataset input = loadDataset(inputFolder + "one-agreement-proposaltocancel-rejected-b4-accept.trig");
+		Dataset expectedOutput = loadDataset(expectedOutputFolder + "one-agreement-proposaltocancel-rejected-b4-accept.trig");
+		test(input, expectedOutput);
+	}
+				
 	
 	private static boolean passesTest(Dataset input, Dataset expectedOutput) {
 		Dataset actual = HighlevelFunctionFactory.getAgreementFunction().apply(input);

--- a/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetProposalsTests.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/java/won/protocol/highlevel/GetProposalsTests.java
@@ -53,7 +53,7 @@ public class GetProposalsTests {
 	@BeforeClass
 	public static void setLogLevel() {
 		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
+		root.setLevel(Level.INFO);
 	}
 
 	

--- a/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/expected/one-agreement-proposaltocancel-rejected-b4-accept.trig
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/expected/one-agreement-proposaltocancel-rejected-b4-accept.trig
@@ -1,0 +1,9 @@
+<https://localhost:8443/won/resource/event/1107469913331435500> {
+    <https://localhost:8443/won/resource/event/6149800720990867000>
+            <http://purl.org/webofneeds/model#hasFacet>
+                    <http://purl.org/webofneeds/model#OwnerFacet> ;
+            <http://purl.org/webofneeds/model#hasRemoteFacet>
+                    <http://purl.org/webofneeds/model#OwnerFacet> ;
+            <http://purl.org/webofneeds/model#hasTextMessage>
+                    "Hello, debugbot!" .
+}

--- a/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/expected/one-agreement-proposaltocancel-retracted-b4-accept.trig
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/expected/one-agreement-proposaltocancel-retracted-b4-accept.trig
@@ -1,0 +1,9 @@
+<https://localhost:8443/won/resource/event/1107469913331435500> {
+    <https://localhost:8443/won/resource/event/6149800720990867000>
+            <http://purl.org/webofneeds/model#hasFacet>
+                    <http://purl.org/webofneeds/model#OwnerFacet> ;
+            <http://purl.org/webofneeds/model#hasRemoteFacet>
+                    <http://purl.org/webofneeds/model#OwnerFacet> ;
+            <http://purl.org/webofneeds/model#hasTextMessage>
+                    "Hello, debugbot!" .
+}

--- a/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-rejected-b4-accept.trig
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-rejected-b4-accept.trig
@@ -314,7 +314,8 @@
 <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> {
     event:1tr3o22co1907d6b6n7s
             won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." ;
-            agr:accepts  event:8863100035920837000 .
+            agr:rejects event:8863100035920837000 .
+
 }
 
 <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> {
@@ -8558,8 +8559,7 @@
 
 <https://localhost:8443/won/resource/event/6834006177130613000#content> {
     event:6834006177130613000
-            won:hasTextMessage  "validate" ;
-            mod:retracts event:8863100035920837000 .
+            won:hasTextMessage  "validate" .
 }
 
 <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> {
@@ -8711,7 +8711,8 @@
 
 <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> {
     event:i3k0giied2bgp0p44h7u
-            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while.";
+            agr:accepts  event:8863100035920837000 . 
 }
 
 <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> {

--- a/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-retracted-b4-accept.trig
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-retracted-b4-accept.trig
@@ -1,0 +1,10419 @@
+@prefix msg:   <http://purl.org/webofneeds/message#> .
+@prefix conn:  <https://localhost:8443/won/resource/connection/> .
+@prefix woncrypt: <http://purl.org/webofneeds/woncrypt#> .
+@prefix need:  <https://localhost:8443/won/resource/need/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix cert:  <http://www.w3.org/ns/auth/cert#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix local: <https://localhost:8443/won/resource/> .
+@prefix sig:   <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#> .
+@prefix geo:   <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix s:     <http://schema.org/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix won:   <http://purl.org/webofneeds/model#> .
+@prefix ldp:   <http://www.w3.org/ns/ldp#> .
+@prefix event: <https://localhost:8443/won/resource/event/> .
+@prefix sioc:  <http://rdfs.org/sioc/ns#> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix mod:   <http://purl.org/webofneeds/modification#> .
+@prefix agr: <http://purl.org/webofneeds/agreement#> .
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> {
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+}
+
+<https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> {
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eyrx1pzifelg0uwuz7pe .
+    
+    event:eyrx1pzifelg0uwuz7pe
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9uyongxoip0kz7t9tsa8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:3v08br9ub79spo7ol4v0 ;
+            msg:hasReceivedTimestamp     1513170818141 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:cbcccoqqqbec6bxkl3y3 ;
+            msg:isResponseTo             event:3v08br9ub79spo7ol4v0 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGF3VchNz9iYkK3toAZFEWmCeFaei34McWjdhF33BnCGUFUh3SW8li0+iupxE2FiHwIxAPJdRlHPz1WG2lAO9mgXZYVrbpkg7/qgyHCczRI5PUCp3HM+V7rLdt2s1szonfHWnw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ff41bBHDJlUrjTZFwKRSGgce+udO3zlBjuCFz9I7BJijc0C3jmSq49OKje37j0Uy1QWfCzLoB5/nyP6XUhNyoFt6e6NXYWvgya+oENsYYj8KVt2PXzTVbeNZEo5A7kaU68gwPYFhCdQb9YgDz6Iyz6JYj+P/IJz8TqyLUxuXsf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> {
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+    
+    event:353368844400623600
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fn87pwzr9g4a9v368h4m ;
+            msg:hasPreviousMessage    event:beyjpryu04ao4on0z22u ;
+            msg:hasReceivedTimestamp  1513171226308 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/353368844400623600#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> , <https://localhost:8443/won/resource/event/353368844400623600#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:353368844400623600 .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjFF4qmm9yDjgFym1rxcrrPczw4asfpc5cIREjSpRz4plnNkzWXpAqTLXx0crGcIcCMQC2KU27qjj6QliJ7tBU6dPQEoH9qhAtSLiIHrfSHgSHVAPxUTWzGt0Gpc0NO3w56ik=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AJNjIsybmU+PVTivdMs0p5oGU8de6XOkMgLHkYPjhFm02y0luUf+jXIE1RE0EFXOoNxTJG8wJxm93i8ZlMr+JM1Mv/XmdQyyVZ+RnuEAmTchTJCqkBel8rB/mWaXrCRG+eatRgef7yfYtEw2Obt5xSBVH4cHht+A9FcnxawOYPaa" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#data> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> {
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig> {
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMB3v1uvK7ZQKv5J8peoRrM3QJ3vrHDt4aAaYf/XSvgdkvnS9eE0nG4dWK0iZ+89WggIxANMFZTf5a04Z/4HzdoS/9USIew9vMhxCz3JTLJ+pvcTXvt2tbKYMFnmZWSlcfw1ftg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QKPFiihEYejQ8pZ+LiHl9Hq/R7dx24hXYk0hqLHD/xygPDJqZbevicX9Si4tiHrS48TLzTlEyb8AezLF41DCmAW/4n0tHmwFafZZb3CQm4u1vq9zq9ghLRCYhQth6L2Bxs9ENUHaR0k+BH5hDo6t4C5FJRw5DMtFdxtcVGbK8Es=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> .
+}
+
+<https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> {
+    event:htpqlj3ablwc32xmfh9r
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5151909952739158000 ;
+            msg:hasReceivedTimestamp     1513173165842 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5151909952739158000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:htpqlj3ablwc32xmfh9r .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> {
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig> , <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:00zilsxex8tqjumh6fi8 .
+    
+    event:00zilsxex8tqjumh6fi8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:zpvc6zv244tfxddbhi6a ;
+            msg:hasReceivedTimestamp  1513173166297 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNOuZJN/EjQhXcyyaharVkVWElGP+UrKcV61VZwvq/9F/ySUbRPJvA7xQiZTVm/6YCMAiXn87dK9myidhS+oaAJNI31Gk36dUEkpvvfP5Jjri0A8AFBuGKOy/NbklcERJ1bQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "C1hP4y5BjEEX2bx85xBfPkWuMvbJ6biu90L7JtdSpeCubGmwzVHKmC5zce/C8pVGLCeYytAjiinds89/Ys16psbEI+2sX939L3RIyDnBqzJV1eTo8Keze85FntjhuhshI7ubotO49DY6GbqY4Gqo5lV7h9+6CarHCW92ilpc/ic=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF82EfmZ2nH99uwru+lXx1HXwaUc4D0MbVdYiwxYrxo6KRARqVaQdXsrlY+zT5FXkgIwMF+rIhuswyy4xjyToiWwNW3Ya/aZSqrbXZpUXsi6Dw66AoprFW9IRcj5eDp3diYd" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKAv/4NAErt537EnlTVnwGud/XRIS6GIRy3cE6SvjPHOBuBAWkqqogx2BGcUEorx2r0BdcpWv+m6qpg0BKaanPoYBYoPerpg+sp4eDd8l+HJ5OngO5jKVRd8dbFq0NQXnYY305UzoavEXn54WzHySfUP4ujBUKZ0zZn2tKc4Uq+Y" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> .
+}
+
+<https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> {
+    event:wlv9kjrh93gfzetdojp4
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:gi8wvgu0xrwk42ccs4qo ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:hasReceivedTimestamp     1513170797868 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6149800720990867000 ;
+            msg:isResponseTo             event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:isResponseToMessageType  msg:ConnectMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:wlv9kjrh93gfzetdojp4 .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCCVmBe777XXxKIzx8GiXnqPZVV60dE87A2nb49MdVWm5Asx0HZLMbWZuzDPSs/GWMCMGXDZjTxeON8vVOLL3PlYpwWLPl/HKkzfJGW4lHxLTpEqJp0htNhwv3o9MWmv3zcyg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XjKa5OuETtNcwonuZ0UKP9rDYaxbAwZszdvVg1GLrMBaAe7PQKWahapA0/9w3IvoUu4gaThNhLkeq5OQ8k7tTeaUubo4lnQ4PhrRRYosfaburuqxBezmgiriqECOAVLnjvzuwHmcxruBk1IrMgeU1IUf1je/xi5bGJenm3a4pDc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> {
+    event:253k6pqq8gyttmmfxc7l
+            won:hasTextMessage  "    'connect':     create a new need and send connection request to it" .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> {
+    event:o73qpj11bouvhv9pfmhx
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:7kbdyf9ffr2q657gkgte ;
+            msg:hasReceivedTimestamp  1513170819024 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> , <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:o73qpj11bouvhv9pfmhx .
+    
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDbngdqD17UV5n0LH8/y3RmoH0caBdEhAp4cw6suIsMzT1N9TRGHKDRwBT1k5aeh9AIxAKyCS1a2XhFIEbW3tavbCcushSyOa95yObGopKNa5fGLh4iOPDUm2vZU+VdnJKqqZw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKCC0Q/RiyFivxS1yrtkGQ+45CEvx5O5mmRYNq/k5lz7CNe0EFiTkRVkoWsjoGH3Gm2QzHWs8okw2dLGTb97Ygi8drOisdHwPWMZKr1XgFkn733eYOwEGlLquys5XLwNcAqaggE7m9Enq4u7mcorKQLdvwfg2pRmSWb/y/JCwo/I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> {
+    event:obhgk474mxybc4fobdub
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5693603251585579000 , event:kv6651s4ochvsbafubzm ;
+            msg:hasReceivedTimestamp  1513172392332 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> , <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8-sig> , <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obhgk474mxybc4fobdub .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF+gtWhYGIkWVND+wUxgvTbc96ydFhlayW1i0SWsF+Aviux6ovD22fZvQVL70uGKIAIxAOxQVBPeM5mvSKuDWVbzXI5p1wWo3bqRkFDv2YaPgxk7m6YrvziTzaDbMoq3OL9m+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XZQP60xWiAzR5BDTOeaawiLfVFfFJP4hCSsm7ZK8JXrfxF9viw2utC6zZDTenLCzmQM9nlzAl7nZdhkpGubdJ8Afs3goe8Itrn4m30GI5sIoLPYi8NN6rT5GUvNFYuVpnwk7Eb4bhSYE/YwRPQ5kFXJ8/5LviPgv8MReIOEcjFs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> .
+    
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDAYu+iwuVxn+iNMkc4L0fs+on/mVIZCFOji+O+vCzNXzj5lfoN6kNNBVOh30sox+4CMCj1NZS7eWslazm6cTDzC6dIZoTA/HbDmsoHhjrScMjszSKg2YWK2l+XmVSY+z6Q3Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TXmnN+JgFn7q4Fiqaup2b5+b0EJi5ml25hgsrE8Fgp11XS7srsuTx1SmoMWMfNT+XZcslr6jelRBzHNvw+ruNv63jvMRsHhCQwz4wTpVumclOxK3XYUnXv231zSCiaSP1BhVZZlLxeVMWwVuXWiOK2b8nIp8sTsXpoJ7efixUCc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> {
+    event:4xjx598ewu7579zpl64p
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:k175l3od8wq1w0s2uy9e ;
+            msg:hasSentTimestamp  1513170818697 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4xjx598ewu7579zpl64p .
+    
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> {
+    event:1tr3o22co1907d6b6n7s
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+
+}
+
+<https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> {
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> {
+    event:to3x48329wwbanylmar0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:pj2n6r9g6jt39rv99xh0 , event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasReceivedTimestamp  1513170854798 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> , <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig> , <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:to3x48329wwbanylmar0 .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC7M5OdrUd53lIitnywJXohxT2HIa2cUtjM9Ff7i9kcHmRjU3JJoV30nniKIfPmHFsCMEsk74RAYg+LlL2vHmZxJzGsQQ+GhnhySy6O8xU7dI/GO34gDhwLFcH+U3PHZkDWfA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YsZP7L8khHhwtpozr8pM7tHONg7AMhpxd0PVbP2n4kpKkdq4UGqHExLU+akvLGErmneYgKCcG7HStRH4OVhVasSsN0iYmP7AmKJ2beNdlKc70mDDUA6dh9d0y45KTipjKxRZtfp/tUAcpar1D5tpwzCQGG8g7fpA2oikVNBHSB0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDY0AYY8X1zn0j3mPD2Snl05cmhqELtKlL+hLMU+KKLhoK01DCQecwGI/9jxsxGndwCMQC0lpHDe0/jOwLvhKKMwty/8h0/I+kjFAHEIAj7AVHK5bXooXsErL++jaMCfI5ufug=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JZe9wg2r5Ttue4frxUSYKW8YJJNnm9nAqXodCgoHFZa6/OxOBNJrcgapk39l/yz6yGdVicOB9SsVtR4Tuok2jwmn6N2VJUM53j5KjgGVC0kpiINBzrHe0RT9coOcipVXEaiEYmCIy1yRd4FqtJG4u7pdH6xhqFoN6wTiwmAE1qM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> .
+}
+
+<https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nop2f4uemehxb73r1r6a .
+    
+    event:nop2f4uemehxb73r1r6a
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:x7cjarywf0513459swe0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:qyg9hv3nohv4ykv8ryev ;
+            msg:hasReceivedTimestamp     1513170842109 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:uu3ciy3btq6tg90crr3b ;
+            msg:isResponseTo             event:qyg9hv3nohv4ykv8ryev ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCG+VNiKA4S0uVRH8WlJIEmLexRHRX5PQ9nP4zNw2jvSXA7/5ZvMh9hSq1sOmQOBNwIxAIABDOVT3EbMjsXeqlyEgYFXl/iDmZWHyy4bSQMJj2JgvkKyAokZoxX64r4S9XcggQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZOkmpJI43GASvxA65flR5o5niMxaPUld0mFv+RbcxJdwWbjr4VDEOGb5m+IXWCOlLJrvHlQAY9PI4jk61mbRodUI5GaJB8+I6NLw+vCYvvoaKZkijuzfgAVxvsQzo+zP7RYizptH4Y9GbtMfH/EVTPXUpEha1bo9aOZ/KUJjAG4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig> {
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCG2rGSj81rzhPOgphwNGDprwQDnYa6v4vmiURfxoK35k5Ot4iIRYisycowAEwstMYCMGvCf8cJt5uzYi3QBJ3kFGsyeYm6n2AdS+M2AeGOzXl1s6cmJIZBvWi0Nj+wC+yekA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ts/IRXsq00oSzXho352YoQkBH5CBw+mNTmD9is1ypvznH9qrw6ZQyWW5eSMKXkxHHwlqkiyG1bcjr5gvV3I15RnHcCh9JkpBH9snd3F90zHdKqh7PfwLa9MSm219Pgbgxs4la/biGYsFhDeZtb/fiRrwP3kNRaFF8sz9lP0SA48=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> {
+    event:csridlusp0h45v9gf9v6
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:alif190jj9we7toczas8 ;
+            msg:hasReceivedTimestamp  1513170830749 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig> , <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csridlusp0h45v9gf9v6 .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC/F/NI/VX6ASFjJdeDRH7jIQdMlB9h9vRhLpDxk6B6SZS5GbR21Jmi0FkeLEI2ddACMDRCYOUb+G+m3xYGgSnX7fdy7no747rU0fv06q1EA4lumW0xmIicFp5/UUR4CF5jKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FeYE3UT6mrctO35PUk5kNdyjMgkPcgIMGahGbwUFhSuhXAuQ7VAsnkkoR6cZrzjrwsB1X08GsGcqhDb7S6JLDvQcu+iy2x9hn92M9kI85P3Gil04V1qFzcNYR0/VL9LG56gbWrTRlQppMn6i1aGcKT6KyHuPk/yXp05+HWkhUAk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFg2Ko/r6aL9vHEoHeoBIfQfvHEwWyqAW2RR0zEIgnkprvJG+hI9kNSUULPSzf0y+wIxAIUN8eFhLyrVo6PxEcn3vSqw64IXRaExDyxJOCoBohgLAeLPAdo6v+LWlNfM1xkOUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYW/pYgf4FwuwCLLR2rVrAcor8p/5vvGmREH+rVV5JCeDlS0yC5QKJBqzUOLOXcd4hvo/BIHmuvzRTGA2SLFM/GZw2mF30bZXRnBg/xDcEb9AEZoSMki4i8Mp927CJcv/cyTR3027Od8LymojkChLZFgj14JOMEwKK4OC/Burin" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig> {
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCxiytXBuh5w3NE7kdsAUsVjzJGK+tF2KgU5+AEyO3DTzGigsBoen0nQUM1l/n09XQIxAOnJ3IidktXW2rZHoBql+fazmmhrqXnDffE9Us5ux/rL+izk9q94Z/T8BcUHiKSzmQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bm/4QvtUDDVrZLPsj72ecL/AEWekrp27ZkOyAwdYk8gvcmIXDSgFqqiLc1HuR8NQSEM1ZNP8xPFKSC2uWiOFiscTul+6HVBmISweVHKVWabTBFcp+7uMkhxBRM1E+djcfk8KJ3RAKYCQcNF2lpa+rrtKGR9uKwe/gmDFxZqe9gg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> {
+    event:1tr3o22co1907d6b6n7s
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:f9zpvftok83vya1djrg9 ;
+            msg:hasPreviousMessage    event:s9zfgm2iika5vgvayt7h ;
+            msg:hasReceivedTimestamp  1513170866283 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> , <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1tr3o22co1907d6b6n7s .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHlXdh4PDaivQDbpAUaN7uk4OY/LEy7TLlTzeeFoA+gHdQ/16dYAdEyFl+utA1x4CMQC9pJnrKbsOyBo75bsYlQU1iH6dj+aEJdQd8c2bKX8urihpLBn8Py9MD8Kd3/P/5W4=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJtgISvxbKMYSw5wwDON6UnxFkcE5urYBldCg8jlipY/87mBrYT9GSI/T8x6d0lZuysmqA9oOFTW93FGzi0jFeXL+vFWxdjvpy8Jfm6divcclA4X+gCG+bVTjjwQgcXjNO50Zuq4C6rUpAb3fERMoralHEKPtfxJ5skjTsIUBZbJ" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> {
+    event:fits98gjdl4ybaudq5oj
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:2uf9sj4itmz9fpas7suo ;
+            msg:hasSentTimestamp  1513171153830 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fits98gjdl4ybaudq5oj .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> {
+    event:8c6o81ry6mxeetm2d2pf
+            won:hasTextMessage  "    'chatty on|off': (do not) send chat messages spontaneously every now and then (default: on)" .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> {
+    event:0uouhqi6aym8jad508kd
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8mr0p8ua2srgw0zw69lc ;
+            msg:hasPreviousMessage    event:xu87g40eu8cx053lad08 ;
+            msg:hasReceivedTimestamp  1513172392467 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> , <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0uouhqi6aym8jad508kd .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGYfd/07vhRBXWBEYVHZo92QrXUt3xbTjVHRu7eCqLRnFwR69bHJPgB5rpJGyBWRHQIxAO5DGEmWwv5hiYLRIDob7aHdJ7Y0mw1an0WDq/epeIqw4/VV2st7eCzDrUQEOFonBQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALBVWMmZgH9Y801Tvr81laSwORXlC6JzlG5UA8Aj3sdjke1lCC/f3xgGmWYI6SdefVgAvkYFgXd6mFZTw4amQokbNu1uSds1+q7yTZBkQW5ubfPQkVqofbiBGK/rrZ+/j6G6AUzBUtlIZD1aOcachoU1HQ5wltgknDIaB67bXd+M" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> .
+}
+
+<https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig> {
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBuXv823DJnc0Gy/hyx37tadJtAcEMhnJZVt/pNvhd6zFqT0eF+nWMRtXyrWyUoSwgIwOtYJWYw585IWoWy63tL9+QqIQKthFe0mry2n5kdV73A5ytfDOX213DGz95WGGbPO" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKijqTKR104eXXLrK+ZKsQZU6H1W858mHLkxcm5YdXq0JGqty8hJ0rmy74/j+VUTaDbj5O84D8+hNPFQibObM6emitgNZSgHBBsBqYxdAaisjX8CjekBZxnOwrLMFYan9qVlDSKJdovOqGezO8d2w3jv4u9YeukUi64EYFCxR3/q" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> {
+    event:pi2jpw9a1q00d11kr9ez
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:49hcv8na1594ijbpx3hp ;
+            msg:hasSentTimestamp  1513170819628 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pi2jpw9a1q00d11kr9ez .
+    
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> {
+    event:cbcccoqqqbec6bxkl3y3
+            won:hasTextMessage  "You are connected to the debug bot. You can issue commands that will cause interactions with your need." ;
+            agr:accepts event:1107469913331435500 .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> {
+    event:8h7v5ml1aflqmoyem61a
+            won:hasTextMessage  "Usage:" .
+}
+
+<https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> {
+    event:59gtirhola4ydvddyo0k
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:mthg8rh8r4grme5ph2eh , event:m8b6jvgclclzy48p7wqd ;
+            msg:hasReceivedTimestamp     1513170818019 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:m8b6jvgclclzy48p7wqd ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:59gtirhola4ydvddyo0k .
+    
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEvWR/fHCOdGj/uM5AChtdhVB006Hq0TpUIqkazxmdzzhGqEonoxPJWBwx5thvc/gAIwLjD7QXA9jnarEQ6zdtH/aa/BfBaBkE3/GtC38UtFyylcywQ239p/rMGf9Caos9X7" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "L7ZDsU+JNUesAdJuZXheut2HyOwcDSJlEYCiPwF3sbNJsaZRaxGBXQQzUziJNb+8tUw/ADfUVt1hT1egjBF1T3PqDMeTJrvo3SjW3k+b81deyIEV4ffjS0TyAMVAQC5EFz5JeIgZ3I3Qf8iT/Es5VOnnQBTJCUTp0tAcBHoqxNg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> .
+}
+
+<https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+    
+    event:49hcv8na1594ijbpx3hp
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:pi2jpw9a1q00d11kr9ez ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8950tg6pjze6lr52pq3y , event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasReceivedTimestamp     1513170819409 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:eczqg8lp7xbukpzikd41 ;
+            msg:isResponseTo             event:8950tg6pjze6lr52pq3y ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:49hcv8na1594ijbpx3hp .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> {
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> {
+    event:8mr0p8ua2srgw0zw69lc
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0uouhqi6aym8jad508kd ;
+            msg:hasSentTimestamp  1513172392503 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8mr0p8ua2srgw0zw69lc .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#content> {
+    event:6928365067343411000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> {
+    event:238289506881087500
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6fvg967tlh9rho8axvbs ;
+            msg:hasPreviousMessage    event:wpcsl4dxaxpdxbxpfo3r ;
+            msg:hasReceivedTimestamp  1513170861045 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/238289506881087500#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#data-sig> , <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:238289506881087500 .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDdIR3opcXKb2SnMN44B/J8mjfMvviY+pNa9fft3uE3wQ/MoIArpR1xtw+kfJfy4eECMQDAWIsMCIVY1l6WAcY2Q7/VkEOBYhxsBJxXYx1H0DQLdEEIL5zy8+RO5Nr2lSON++4=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "DjGixwtI2DKuOpxkV+Uto/esUSuyemhhtFPogVg1j3xluW07KdPzkcCD0JRK7EddoW80PHV86Ffqo01vQ/d7YYXiJlkdfHoAtmhJWTIR6r4rofUkThqzEth8mCrFrUA4IxHdFjpe/AEFZZS4xuUj+74nb7jaOM5r/0tHsc05ObY=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#data> .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+}
+
+<https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig> {
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDX5Gvhbn/4eqif270CyZ92VUF72HMPRH4nzJjR/0S3YJ6vpVMJaBAP8HA17FpOkJACMBJVIkW2/XVbP3BzDA9KJzd9x6hLSMIEieYqQZWtbbzgQme8aZ/ymxskMJcw9wdEog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK0bVFozUzO5otj38hi+R4s8pIBDzD8jrzbOxet9iD6wR1LQPjI5Zf/z5d3Xix27tMUadjGAfR0fv56v33HxLf+OV7behKNrupdUdqQyRk7QokfPM/8uYzIC2UYR7cECZajbYDWsQYgZMRH7y4PqYq1g3zh0ufckqMmlADswXW+u" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> {
+    event:m4nq3rl0m1br8bea2n72
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:j0oj37oa9ry8lzmm26ul ;
+            msg:hasPreviousMessage    event:eia6yrvml8v995ueq65m ;
+            msg:hasReceivedTimestamp  1513170819448 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig> , <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m4nq3rl0m1br8bea2n72 .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDmjl9AY6pbq2C/8sQMSFIsWV3MVDZQYD7goKYKGL4t1aT8GIhCVRtl/ntRdTmuIJsCMQD9/CSmj5RXzqCIgENqaB1/iYL7zVpltQFlkCepuK1UnLLXCLZUoJdSr5FXofBIzN0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "E+jWMjmUNdTGMbDubZ+R1SNOSdhPp8Nv3LMxZEAUNzR5GSEgsw/Ng9nWpudHpzb+CpOBhmuPHTdKPBbmhVnh739jmTxyCzzC4yzfO3WBONondQlmoSLyz1DYveT0topDoDpxr7bJQVHAP7YYbs47kLcEWCFNJkV9LMgHpkjbn2U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDTDqXh5NHy4Mu0Fo2L+ncmg5E2UG3/RbjT62eSf+vQUxs6ooKn7eAUFMR+VAuaNKUCMGb3KFVlWxOi9YJcgf0NlypAQjQJzzoZS7ewJKF8Szx9TJ4CDTohfU5zdlkuqN4G9Q==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJvEKrhS8chrZa7ZNvu8KejC55X7nsV8NjF9xi1zjL4SmoEKptrD78cKF8zmGx2Ka3nLswC1KEFngwjVTWLc7Q7p/hY6p/TP2rirpvVI5zh6LZCa0iFPryfb+2ibOeeVTipQvsILnkiUFm+HN9athmA3cgdyucNACnwoAi1oqst9" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> .
+}
+
+<https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> {
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> {
+    event:9uyongxoip0kz7t9tsa8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eyrx1pzifelg0uwuz7pe ;
+            msg:hasSentTimestamp  1513170818318 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9uyongxoip0kz7t9tsa8 .
+    
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> {
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    event:00zilsxex8tqjumh6fi8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:h6c8epmrvb3gxqrvs81d ;
+            msg:hasSentTimestamp  1513173166250 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:00zilsxex8tqjumh6fi8 .
+}
+
+<https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> {
+    event:cw64ogmt2lv6n4kdjdxh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:s9a226k3n70ihhaurhdp ;
+            msg:hasReceivedTimestamp     1513172280997 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:s9a226k3n70ihhaurhdp ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cw64ogmt2lv6n4kdjdxh .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> {
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig> , <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f9zpvftok83vya1djrg9 .
+    
+    event:f9zpvftok83vya1djrg9
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:pha7cg4ilx4j23f8xo0l ;
+            msg:hasReceivedTimestamp  1513170866345 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMB3v1uvK7ZQKv5J8peoRrM3QJ3vrHDt4aAaYf/XSvgdkvnS9eE0nG4dWK0iZ+89WggIxANMFZTf5a04Z/4HzdoS/9USIew9vMhxCz3JTLJ+pvcTXvt2tbKYMFnmZWSlcfw1ftg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QKPFiihEYejQ8pZ+LiHl9Hq/R7dx24hXYk0hqLHD/xygPDJqZbevicX9Si4tiHrS48TLzTlEyb8AezLF41DCmAW/4n0tHmwFafZZb3CQm4u1vq9zq9ghLRCYhQth6L2Bxs9ENUHaR0k+BH5hDo6t4C5FJRw5DMtFdxtcVGbK8Es=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA2qoxUmShJK9ond6yEWrlqlKdnkbHKGUNsl/bJN7V5fyD2EZfJeupX5vsAQ/mggbQIxAMfm1V8D8X4rnD5gBvVOCTNWxd2F8YXAqPz5hHjACqIe6bewi/UScY64bG46yivwBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cQG4rhVLelkgR1mfHT319pa7TwwzgPC0BqwFs1WYXSxFyWU78Wp6bYGtiPGOhB6XQ7fBr8rK/rSJWV7JMsurHJtAvwvJk/mIzMUDs7UQWa6JK+NZorUemxeiF18iUoHITP2RyqpSeQsGswLSb1ziBh0mcbQ511oMirvDvyr0oMk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> {
+    event:d5whye2xxe5kofpdojs8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8863100035920837000 , event:uonv0x93cu72oy531390 ;
+            msg:hasReceivedTimestamp  1513170841891 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> , <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig> , <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d5whye2xxe5kofpdojs8 .
+    
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZu1xW/5P9mo82xJEBHM1TWxCTw7GIp1uwRlg4/Vt6rg5trZirrsJWzZdBoVRCLmgIwBGBnQQkFD4Y15co1lqV1+KhWf1ZpK7j8mTtVwn/PBGAZEALi7pfD091aQnZAUZkn" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIy+T8J7/o5ATgD94rearSfd16+Ne1MwcM8mXK6RigcjoD+vl9BdbN8dkPwr7eK9kr2TVJtJDgSBoK7AK6OuOWzQvhDlSzqZINmaeZVHUwqj2rKV/vwGJdbIqYqolOfdrqLd1bZ4kJr/p3PBneFdlPqzA8BkO0UzYNt3IZ8XAbEe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCZsHeRtInUDFy+XK+zg6Wbop8iTFcWbm4CrZjbVl+RVhRDxaQ23YJWktMGoCcNuy8CMGZq5wgmYvFTa4uvG3NrKCo+U8kK40sjkMMMRfqZfvLBuS8N4q/oPRGCefiDqPMJFw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OihtDnGIMIKIvo2DGfHAAd81n7Ch2hucexWveHGNxK4vY+fa0t7+PaROKj8KvGYhET5GWBcLxwUBbAcm7+E4T77t1NCaIsvAvlNitEWm9EzH0aMhyG27vJV11mkUZSikx4bYRPKZE4gw1emPwC2NSZ9DI8RUZ3oHqUldIxeKQjA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> .
+}
+
+<https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> {
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig> {
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNOuZJN/EjQhXcyyaharVkVWElGP+UrKcV61VZwvq/9F/ySUbRPJvA7xQiZTVm/6YCMAiXn87dK9myidhS+oaAJNI31Gk36dUEkpvvfP5Jjri0A8AFBuGKOy/NbklcERJ1bQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "C1hP4y5BjEEX2bx85xBfPkWuMvbJ6biu90L7JtdSpeCubGmwzVHKmC5zce/C8pVGLCeYytAjiinds89/Ys16psbEI+2sX939L3RIyDnBqzJV1eTo8Keze85FntjhuhshI7ubotO49DY6GbqY4Gqo5lV7h9+6CarHCW92ilpc/ic=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> .
+}
+
+<https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig> {
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHTGw+8qqLFv0gG34cliPPDKseheKGzGBbEwdZIaoP74lyRKUoR4NGg2G7l0Nm1hAIxAOP37UK+mVzE8mYUTOrCJlbc7W0msIsz0lzqZAnkShAMmsTAVkf9Ba+YPYJVVd3bqw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JRMvZZd/sedPNFM42HIM2smPs8J9Y5qkbjT7ymSriQ/Espd4doT4E22uxx39RRnOMtFn2h4H8DicAmCBFizHPmVNHwCvRT9OtcPGMzH/XRJsfWaiICmSNOuwOUEiEGA2ro1IZzsAxrpInIZXeROH0HLophyUomju10CeXitwk7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> .
+}
+
+<https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> {
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6928365067343411000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> , <https://localhost:8443/won/resource/event/6928365067343411000#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6928365067343411000 .
+    
+    event:6928365067343411000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:vj2yzrtlf700wixuxujw ;
+            msg:hasPreviousMessage    event:guewg0q3l68ts1ud5u2h ;
+            msg:hasReceivedTimestamp  1513172274108 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCeRd2nF9yPn5bFCH0+0t6ZrYe7WqT4cZAk7VSpd1U/aAFOaITrBDz7WbZZ1IsKLbACMDZQtbTxKDaHfgwTL2G0kakh2y5/6J2ecCJCGBlj546dKYeLYpsirqo82+EEos5Pcw==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AJCAsG1BRKFN5Vn1USw4fGf6MDlDH8jkpgjxp782OZp7LykrTKd+hm2zkrbgrUADEFYOcr/ypn1/Rj3herC5+6L9XLGiWmWyfrp36KLDzh3YvpPutTF87WVb6WyKDbR9zuyDTXu4Dz5f02bHoBlqx7+lhfAVRzjzXg9XqnUisOrX" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#data> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> {
+    event:cgqt5h004iql2003me2n
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fdxtdqeonqc6mk01crog ;
+            msg:hasPreviousMessage    event:4ongmje7w2v03mp7ztex ;
+            msg:hasReceivedTimestamp  1513170830935 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> , <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cgqt5h004iql2003me2n .
+    
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD294EsdG+qfoKWoYGdaA0Z1Lqwr+9tLMUVZl6I+BczmCDiuKkbG6D5wfOSACkKAMkCMGLYQR4SqhPp1+L2Lz50fBQ6dVHgIXt3VaKIlhUr6kdOTSLEA0VwbkD36b4hrU/5OA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "U0JYsmifD7KyVKwwCusil+rgbjaRIvpgLgpTJV9T74Ospw13bOC/D2vw+pybsKAIc9OQtbrSMhAP95dubz1txVpScHovb2f1xU7YZ4MJd3cqmdJOmWKXqrvc7SJ0ZNEgFwUi1ErDuXiGHw2/LeCAPDGAWQ3lngT2MuaU9Ruiun8=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> {
+    event:qi81r6ggzy26wznv94dq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:353368844400623600 , event:ilkgs5gp030i06fb97j2 ;
+            msg:hasReceivedTimestamp  1513171226510 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> , <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig> , <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qi81r6ggzy26wznv94dq .
+    
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD2EfKVsS4PSlEqSB+/gjEiRmdCKO5s7WDv/eAbfiaDutf2XB9FOqWPMRLn9OaC0IYCMQDYF3W4pZ8zyng2pjF/1MUHYpxAeNCFBR2z9dB9Vy0YwYd7/CSHx9lKK1p7fK2K3AM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DdTwy8dZPDZTlZWA5NMwp3LViu06y+ocwZ5yhXihMFQ1J0TPqsakf+ol+m7HOENv+xfT1fuwe3D2a9ejfee52VLPRtWTcONC8cLkXAKE330uDgX8MX+H7YYH3EPyjcbscFVY2APMIy7rMzPxRwclRk2J9sDXeC+bXI6NhozZSnI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD+3CNFDHthV3Vn5PB+BR+dT6b/OBZsx5PDjpVXzX5rjrCm8Q5sQkysHZlD1p/N1BwIxAMMh3il4u8MosyGfIXmCr2oQul39GNDJkbGypjtQmfIuXDyYY/Aw1axtqglSsKz4+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HiweOlaDhhm0keZ5TnFFBqqLyzmT3R6b27hc0IVKroXQ+Sw6PcxBx/HA+FTDNjgzPvrf3WAwQv4xjIG4+MyKvqXJvcm++e63UXMDV7/gMybncycSdkFfCSN2ltFloF4BMH8XZXyskcAP6Wtwunc6Pkxr4EvGb/ytOQSO+UbXU/s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> {
+    event:4xjx598ewu7579zpl64p
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8c6o81ry6mxeetm2d2pf , event:m8b6jvgclclzy48p7wqd ;
+            msg:hasReceivedTimestamp  1513170818893 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> , <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4xjx598ewu7579zpl64p .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgKnq4EDYR+SMGTKgb59SfJSbLJk0L8Bt6WkOTYkgApqhakfjT+zAC2xK2PMRcCBgCMESgxIN4jOiT2bFE5w23xuLAKthRTWr4uPSyt9kTpW7C2rT543PAS4rrXkzPME2blA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jmige85EQwkKUxCvIUfdjSDMCw7siH1XnL/x8fXcRawXbgxd7S37zID1pj2ThVgRTHY5vCP3bhKbTgHWLGmPbklkRUTauJO/ikV3HePX62Xgfvt5ZHVNEg/KBB67zYz3hVL3b6ONvC/wHGWxlSDZIttsFWvNDNRNgE111sNKZ3Q=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#data> {
+    event:4055709708568209400
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/4055709708568209400#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170830600" .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4055709708568209400 .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBGZEyzBNQoBo/SxnEs7g2yPQ3L/qmvGBCm+SR4P1QsDr8Sk9k4b8b2Flvx14qgcLgIxAKK5TXq8+pmZi/zM4RCCL3+Q+lVUu2Tls2wgdfAhnfe39vTQPa1/5+gGqHj9uxBnQQ==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "CDwKELeyG6rRzI//kXCKbh7FtE4/W4NScjeF/ijjjlSbpdn9c75CWFTQbqieDQVeAFcOAXFVUyUFfuAGOmuMAA==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#content> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+    
+    event:1107469913331435500
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:hasPreviousMessage    event:6l5bwv7tkxg2g0bosl1u ;
+            msg:hasReceivedTimestamp  1513170817310 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1107469913331435500#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> , <https://localhost:8443/won/resource/event/1107469913331435500#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1107469913331435500 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMChQDAK7nu50KwlobNd/fOjqeGKaxNSqsZTXdlAVvJeh6znXsW8lPDhZhaYONlAuzAIwcSrXZuutp+ypskjxfva4yV0sEkga9yj8m9DywzOd9Zrqt7O3NsitP29s0hSTjUYq" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AIBFdQ+952HZxpSjc8sJ//3lEZz2GmHSZ9tFse3l0u7GOaYjBETsSyWmbwUZzr2qKlSgSCpdXrafvxVxWjHPLMKMi00wMuk3CiggCE64Wz5f9KOZEP0vq3JBMJCF1qn1Mizp1w+3PqWya/bckFaDiNTlKNrEFwfLjbrDgyFXEs6N" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#data> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> {
+    event:orj8iruy8pcer6zzxlra
+            won:hasTextMessage  "    'close':       close the current connection" .
+}
+
+<https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> {
+    event:xpspyx3bpyev5v5p1vf6
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8ksy3mzfwa3n937tm3vc ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:mmdq8395owv3xy9iyl5q ;
+            msg:hasReceivedTimestamp     1513171118969 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6834006177130613000 ;
+            msg:isResponseTo             event:mmdq8395owv3xy9iyl5q ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDl/hkfSe2IwapaBDzFRoEhZxrP2P9YiY8FgbkWqMWkdIAH/a3Wgvbwb24hYx4FynQIxAKP1xxubuFoR9g1b8Xh8kJv3O7/KYozptOVpnNp9iReJA29oOpvaHR9FhaFCLmgWNA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YAkN2j98/s4Fn+0Fy/PxrHUyKfFw9WSxxd4naB3aRJLYAYUg4+FMAZlJs5oZW2l7vUxGx0RF3VzaH9Hr4X7xLIrcCvi2/+b4itdM4OYgXCKtbyFVzLBrRKfxpdITVNQVRAX0zSOVF3yuOLMBORgePpYb50hHU7i2F4hjq8iwScI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> .
+    
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xpspyx3bpyev5v5p1vf6 .
+}
+
+<https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig> {
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvj13J9u1HocJCN/w81lIYFGNWyZJX/dfwoRkQLpfvzv2LKF7otZjJFOu5c1UMiwUCMAsXxui7cf5cSeb1oomocs6tfKRD8WmtRAnh9OrOuBzS7Lo8wG5B3mhL+k21rQ2N+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTR7wRzkvfsriFv555SSYyIEHHrE5p7o5hg8Fo8Zx9GUHhuj9hTICRytZoHkX+0huhWWDeLS35FeRKNIahwwkXmV5nwUcbCyGQmbuYvVz2oz1YDpZ5LbSLPP3rGbvl9a6kAK/zpftZQ5v0hBRevTP4kGh/U3EsO5ADd24Ck0BkH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> {
+    event:2sbarcz1yu7cenpcghay
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8863100035920837000 ;
+            msg:hasSentTimestamp  1513170841716 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2sbarcz1yu7cenpcghay .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> {
+    event:yrizizmtaxehctdi1m1n
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8h7v5ml1aflqmoyem61a ;
+            msg:hasSentTimestamp  1513170817983 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yrizizmtaxehctdi1m1n .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> {
+    event:csvglzqkcoddoreep5w0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8h7v5ml1aflqmoyem61a , event:eczqg8lp7xbukpzikd41 ;
+            msg:hasReceivedTimestamp  1513170818656 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> , <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csvglzqkcoddoreep5w0 .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD5iKF9xDc3tvNBF4dHuCZmNjdnO0p6ZfaRud2VlEB+0J/OOociScKi9VVk8hGA6e0CMQD6vwM9R3yWAdW+XZmAcuy5ybquxQLfY2D2z9VLLaqiRcNL3Ad+FkOQzVAc/Btl69U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1+bdzByvtPu+f66FFM4UKUxV/XijX7SldvSaLVGyen0Zc8W/oc7Vuo5xBG3L+55zsHt0DB/CyevQ2WGing+Dtc8vPMP8VBFIB6gF2w8plzjbaTAql1wrcs8jFUtvDY2eTelmW2m1jsyKbyTEcuDXEYDG24/5s8VmCNdoBwD3f4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig> {
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGF3VchNz9iYkK3toAZFEWmCeFaei34McWjdhF33BnCGUFUh3SW8li0+iupxE2FiHwIxAPJdRlHPz1WG2lAO9mgXZYVrbpkg7/qgyHCczRI5PUCp3HM+V7rLdt2s1szonfHWnw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ff41bBHDJlUrjTZFwKRSGgce+udO3zlBjuCFz9I7BJijc0C3jmSq49OKje37j0Uy1QWfCzLoB5/nyP6XUhNyoFt6e6NXYWvgya+oENsYYj8KVt2PXzTVbeNZEo5A7kaU68gwPYFhCdQb9YgDz6Iyz6JYj+P/IJz8TqyLUxuXsf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#content> {
+    event:5693603251585579000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4055709708568209400#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#data-sig> , <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4055709708568209400 .
+    
+    event:4055709708568209400
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:csridlusp0h45v9gf9v6 ;
+            msg:hasPreviousMessage    event:1d5xlvosu9j6umgi8r47 ;
+            msg:hasReceivedTimestamp  1513170830672 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMALIKnnIRaKQjZs83Bc39Pwa2IfhY+Q02q43CeHao/UtVg6l7+gIjI6H+W9mukoZrQIwLoZ9/ZeFiW+luWeOcR/zkhqDM0CXUkiFIZJUUVFantwX08Fp7jtdyLRk4pcAZDO8" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AsCLcT5P/nIlP+4GTQHgqxGpSFxjoon4wxOT9BlwPKrl+eG8qUyo+wAtbWujGgx0tMU8kTXzRfzHc5bHeJayCFuj8QAzobp+GStZu3qYmKTug1epXFJCwX7HIata0sFU8Vwr1Mg55XMQLKAaYB0Fkys0wxhqBKkpA//KqWOBcI8=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#data> .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+}
+
+<https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1> {
+    event:5cdkigzbdsxk44iw2kai
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:h2lo8jybm27ouaa4wuqs ;
+            msg:hasReceivedTimestamp     1513170782686 ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:h2lo8jybm27ouaa4wuqs ;
+            msg:isResponseToMessageType  msg:CreateMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+    
+    <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5cdkigzbdsxk44iw2kai .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> {
+    event:4e2ws6ap0hp93iv0oyu2
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xbhopokox5b4vz78e59w ;
+            msg:hasReceivedTimestamp  1513170817403 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCE6+fv3kekPziO6ycHrssyEPEmVd3+oedrFW0bzWh05yKvDWVgTawfoW168fvCVj8CMHB35gY1CVGJGhMaDqsC4Ij3v+se7tRt86ZbNfRsv6ZQ/pAq0b4Qp0P7I39JyT+k8g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3lUhvyoQ1vICrN7gzkfdE4ambRm2eLkGGMC5N3tEXO1GEgLl6Qu5cEaolyp+5DBjamJB2NyaF687kwMhJez51KQQucfYUTcLWlHSoTkX6DX0FcW7ZgJucNoRdOkp9mcaheChQBrrFpRNwt/PuKJa4nKnzYPz0WoFzzFHuQ29p0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig> , <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4e2ws6ap0hp93iv0oyu2 .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhv80xGjobHk9r7vQX+McR2wiOCJXPodiIui1eIHR9W02uRlq+zv0RqWodRbwYslUCMQDiPbcDWowHJMewwxaKF2rAAQcm8miycbtKV+NviIYkVQisk0oN/1VxBvN5MO19DCU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XxM7zCnJIW4y07OSZcLUGUSrdVeAUu5S0b7oOEETklf1Bmp687v2FCANxAzi/UdJlU6Dx/TxNtPo3XZ/EXRFQfK9Whpbxc6wV8w32mIHsjo6Ry/WV7yPX4j4d6lq4M2cA6b9qC1JSsh/Rl+JBEKRco/RKF9wWLE1E/mSdl6WjWs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> {
+    event:uu3ciy3btq6tg90crr3b
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig> {
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBXqkcO99XGnV+YwaJ1ktvwST2X0u8mjorTyzgemi6jHvs8KfOg88N59La+eixSXgCMEiKSr4QwXjOrBopK6jL08VDbe/IkTMra3HxZMPcpFyUBszqTDKWpE8q12Xukpsung==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaqMTIy9jfUs2aJIvLranFeghQreF4PVVO+HmRC9x4KJPDjGwxNc53t2SHnx1TNgK5g7sLpYg8dSvF1wkmTRO5sltpYPMwriQZ++e9cHY5zxMqH3SYsA544nyIp4dIbOshMngRrgh//iAMoQ3SdiAgfWWdetYUzlPDB7jv9D67x" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> {
+    event:6fvg967tlh9rho8axvbs
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:to3x48329wwbanylmar0 ;
+            msg:hasReceivedTimestamp  1513170861124 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig> , <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6fvg967tlh9rho8axvbs .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC5MQPvfy1x5k+OvV2xOi9t0g8RUlM/eyeY6jr7p9dyt5+cyP9Ldy+UEVquCMHWUOMCMB/gyfb4C8vyD2HAa/ZRs487vk/Dbh3quHgx8fDU21htaIFoyHU50Jgo8AQjgLd93w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Uexg5eLuuTMWEWLquFb48wGaVDbBK8b2hF03TV6zJeGaLub9f4QxuiOdLgHeOEymmsyD7SHAPTGZvjV6A7dYz9tnv1mlKr3l4Htno/iidmzucvXcNhjwyHG0Vold2yayG4K8u64VWf4CpxLlJ+GXI6UCg4a2HIT5S/PV5Zus1GE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHHQuJZA1ugQxmuBH4pZD0UNdVJJHW7VOnxbubHnnPzdLhcRZlUD4enP17gsXVbyGAIxAL1WMthQR1doJOT4d6D9Y6XKuuLnZVrOr6sO3FgTunXyhW6b/2KsgrVSYbg7DMWvxw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WtPRb+DdBiqYWF+037X1S3XXq7rFS9jqo9CbCI6F9MelU6a63N96TcNANgidAOSX2kRQ2uK/yUD2kMLQ7UkF8fWkyHMRxSKM+jAk1iDVIipcqaXXzWv/wYRCYDwoUmmnfZix5hE6Bp4LOfHr1N58uNDWBZg7p+1Dl4/7+tDEM70=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig> {
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCCVmBe777XXxKIzx8GiXnqPZVV60dE87A2nb49MdVWm5Asx0HZLMbWZuzDPSs/GWMCMGXDZjTxeON8vVOLL3PlYpwWLPl/HKkzfJGW4lHxLTpEqJp0htNhwv3o9MWmv3zcyg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XjKa5OuETtNcwonuZ0UKP9rDYaxbAwZszdvVg1GLrMBaAe7PQKWahapA0/9w3IvoUu4gaThNhLkeq5OQ8k7tTeaUubo4lnQ4PhrRRYosfaburuqxBezmgiriqECOAVLnjvzuwHmcxruBk1IrMgeU1IUf1je/xi5bGJenm3a4pDc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#content> {
+    event:5151909952739158000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> {
+    event:xqsfn58cdatb7ryp8lzt
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:beyjpryu04ao4on0z22u ;
+            msg:hasSentTimestamp  1513171153991 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xqsfn58cdatb7ryp8lzt .
+    
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+}
+
+<https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> {
+    event:rd1ryd06xejacyss9qy5
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:93e94yjsmx9l4lg8lu1b ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0esqgu17b6xqppmgbty7 ;
+            msg:hasReceivedTimestamp     1513170820500 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:xsbbah2dhkcg6d3h13gk ;
+            msg:isResponseTo             event:0esqgu17b6xqppmgbty7 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rd1ryd06xejacyss9qy5 .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDkAsWJNhJ4vgEXszJAYhawhUpCxKy6T0L6aej2zf1VNWfTY2UiUs6MiRkuSgXhaD8CMQCKSK4jrDUFeUU3clg3gOHiunLiSnyqhQIzrcczi61R3T3W/WokLNqfo0V6pm/6P8E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJm5X4PgCEbGpl0P+o4wU7nS7eyQaESRJUvMonGOhwiN/bwawK4q8BCV7nBgvddCs2XDsbp5jhXNZYf6Fe3giBH4THN4l1dFsadUUD0vEMzDm6dqZQ0tjYeafNADDL2473Yy565WPi2RDb9ZY0GEDP9HYndAcNox1QUtqoY3gSUO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> {
+    event:8863100035920837000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:2sbarcz1yu7cenpcghay ;
+            msg:hasPreviousMessage    event:5iw37ggk8ccrcxxf8f8c ;
+            msg:hasReceivedTimestamp  1513170841699 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8863100035920837000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#data-sig> , <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8863100035920837000 .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEiE6twdZFUkDBBY2vuEj/RAQhLv39WGk6+cGxQoqAEieZ689MQle2YtHOwAtWFsIAIxAJMIOl6fU9d+IBhL35WgYGuVryEORnQLqAbKYzM34uwwdJK40FvQA1Bjgj/zCThhUA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AKdVS8hsY6VEkKdYebf1BKhXkI0G8Gn89xf8hbdhSE8oG1BUBCpxZUxa3OHfILF/hVlgqotFsIvv0bskwUWch+XyTINro6tUYVIKbJDVzF3dJCKGRHM2LMk7YJepufmawvWxI9xLJ0YpS1/mt0MHuTVkgMQOLgwcqp9WeEbJyJaS" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#data> .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> {
+    event:xp44teiwtooczc14npe2
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:l8d77tygvfnfycfu5201 ;
+            msg:hasSentTimestamp  1513172281124 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xp44teiwtooczc14npe2 .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> {
+    event:xbhopokox5b4vz78e59w
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6l5bwv7tkxg2g0bosl1u ;
+            msg:hasSentTimestamp  1513170798500 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xbhopokox5b4vz78e59w .
+    
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> {
+    event:5151909952739158000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:collk6egdkt2tey39h8z ;
+            msg:hasPreviousMessage    event:fd3jtdrkpb1x61pl2ix6 ;
+            msg:hasReceivedTimestamp  1513173165818 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5151909952739158000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> , <https://localhost:8443/won/resource/event/5151909952739158000#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5151909952739158000 .
+    
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEqzRgvERJtgtwOacQhc9pE1wQRrvroX6xajDMdSjo6dd78wY88HsJUUvPkLjKrrhwIxAJRCaoGBPn1fN0mZQrJ2yMPC6xTPBpTTNbTzTyH0F61evbw9jFEpHp+8GPs2jVxfdA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "L0ZT6rEbaOcyGa+LSJROskZ/Ry/8TC3bDnmKq7VHDWdObCDBmSae0Djw5wFyXCtOs1cEHRkefIrPMS23H3FrVpR3FGUU+705agbcu4O/YLLnKM0azhTM5zE4wUlfsyuOy8hzD9uJA166oOXg/jFtBsAh4AVN7/DwyGXvFZB9rpo=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#data> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig> {
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCqxhC3517LBpbtOcLhszKeyH9ew5sTZh++ScjSzOHLPI82Pyc8YC+66XbT4mgkHaAIxAPdvDR4aClT7FPnMUK/FIKrrSi8pH4Wbcn5JgJHcFB/clPGw6SEQDsLD84kXw5PQIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HqdIh6BzCNaM4CQRLxv8Ad1C5CYQq2fr4YuinR+brNGgT/mhpNCsRyqRgBUWQudZx7tNRqdzcS7HLXjWeuArqXyqoBCxBdNw5l/IhvQev/DHRoB6hLb0/LCgYnXoG+0dmvlPhWVQ+5IEGwS8yYFaNVgmOxFwSAYNtn/kfJYqxa8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> .
+}
+
+<https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig> {
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGGOm0c3hHknNaKBAv0zxIguzu8eQqvLMx7dNDe0zSy/s4Uf7TcCWv19Emcn9/t3eQIwJtxpIHkqR/Ii0DjNeTrITbWqGyEBTFpbq6Hrlfr3WtUqHPVquK8wtQtzIx7Xu0E/" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RndohTRpkC6s6vDZ5dm0xCJBcZgV8ArF69EYgiCOBnIOO51iekDiMawPF0AES5kJeFL+mZElzH4lwis/PnbAbmsgLwEsm2rQeBCVczD8EpCKjRvqxO/qqjvv7NghG78ZODutp55kAI+k5vy9WS/bDCdOoUIql6P+aAafXTONZ9k=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> {
+    event:eia6yrvml8v995ueq65m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:tlyivx8nn93zw41ujn1o , event:253k6pqq8gyttmmfxc7l ;
+            msg:hasReceivedTimestamp  1513170819301 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> , <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> , <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eia6yrvml8v995ueq65m .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDZPgijwM5VGNMalStQ66YP1Lr1QvPY6sYmspv9+qO65sQ52M/7HbFZfnnGciCaaqUCMQCqZ80t+1Uqf+vekrTBuuattLKvUeY0bqTri2vsx/XznubPvW5AYX05tnpD9u1BXUU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RYZQidg7f7S3YC6/GHy7+5Y6OfzP5wrjkDovd7p6HbbYT30mQGfngpNflthUZcdGHGWIXYkAQH46rMmKcodPZQbh73LKNg2UA1fWNEwXnK/HEOnHM/6OBk7nGFFs6bw6an2o4onEsAfIU4mbz4MrlCfsSUU51Ig+v1hETlPK1VE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> .
+}
+
+<https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> {
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> {
+    event:4kx7gixf60v34gg65z8x
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:tlyivx8nn93zw41ujn1o ;
+            msg:hasSentTimestamp  1513170819555 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4kx7gixf60v34gg65z8x .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> {
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#data> {
+    event:353368844400623600
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/353368844400623600#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513171226208" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:353368844400623600 .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDdhndpE6qnodUqyVhP2lwVjP1xVbqAsHuU+sYebMLvly1KRoaF4mhDy3lyM+CFWtMCMBYU3lmh9NM2LVi3u6mkaWCppsJU0v0vV11V6nt3tsYJDt2tzaozWAD0p9MuPAUBww==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUBevQq6bQVMJ9epvzUUF7oK/mw7IW0opUcvLDg78BaDJWZd7R/pEzy14k6WrL+V69ObdyC7fqqFwHs7ex6KHx" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#content> .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> {
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> {
+    event:xsbbah2dhkcg6d3h13gk
+            won:hasTextMessage  "    'usage':       display this message" .
+}
+
+<https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> {
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+    
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ilkgs5gp030i06fb97j2 .
+    
+    event:ilkgs5gp030i06fb97j2
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:353368844400623600 ;
+            msg:hasReceivedTimestamp     1513171226327 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:353368844400623600 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> {
+    event:v66scoiidw56iam8q86p
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:cbcccoqqqbec6bxkl3y3 ;
+            msg:hasReceivedTimestamp     1513170817838 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:cbcccoqqqbec6bxkl3y3 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+    
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:v66scoiidw56iam8q86p .
+}
+
+<https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> {
+    event:mthg8rh8r4grme5ph2eh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:m8b6jvgclclzy48p7wqd , event:8h7v5ml1aflqmoyem61a ;
+            msg:hasReceivedTimestamp     1513170817982 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8h7v5ml1aflqmoyem61a ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mthg8rh8r4grme5ph2eh .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> {
+    event:i3k0giied2bgp0p44h7u
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:c6ldwevakufr94hrcn97 ;
+            msg:hasPreviousMessage    event:zvx39rdagwj6o7nfiw1r ;
+            msg:hasReceivedTimestamp  1513171230616 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s-sig> , <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i3k0giied2bgp0p44h7u .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD4cxhvphteBLJTo8dmYvzIjDYS8rpXu0T+wzbqFVt6l6d+2NcFKQ6jUbP//FDjY4YCME5vw/5vh0f0zXShG2TgC8/i+z2TA5ezh+RgqK0Nj8FMj6lcTXXPFemK+dl/Unfcww==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "DreNypCKIpV3qhvc4YzTpWFDH4AfqCaptFGaTp65bXQ1t5GYcbR+QY+vuD7Gr2enUellb5tXW8vKUJ2BLYkuVkrMk/+OQpzuIzgOzWzMDYS0q/pVIcNla1g3MTrpJI7EDDzqGW23hdhqfvCyK6DxJ3G87DLYdaXMWACtkXN+F0k=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> .
+    
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> {
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+    
+    event:9787whuvh3bufzx5xm8z
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xkeovy4cf48spd5euwj1 ;
+            msg:hasSentTimestamp  1513170817456 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9787whuvh3bufzx5xm8z .
+}
+
+<https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig> {
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHT/EdDamdgV2Mtqg/N8H7Bc+zwJILV9ZJI2xXyFboHdegN1jgF4ZCxOYrDkHr505AIwBEkbtiI/muBDvAmot4lye+KnfiHZEylmA3Og82JD3ccn87oHyo56glBhCYDaKVnW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhNqR6Q6taN6WmAYlTzL8zrft8avQOyGzeihDyINuppG6eGXkABaDOLCsLhmGaQ/XuO+EemjK8sYgWM39AKlkKIfbSiXY34QcSb37pis7mAHkqqX0iKrQAPmvSbb/fBvXy5BaS8nBIv06LoyU/GbjqRSf4oEoWMOcE1OWYqHUvs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> .
+}
+
+<https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> {
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fd3jtdrkpb1x61pl2ix6 .
+    
+    event:fd3jtdrkpb1x61pl2ix6
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:ih9v6gyllshhvo5kxyv0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8mr0p8ua2srgw0zw69lc ;
+            msg:hasReceivedTimestamp     1513172392597 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:0uouhqi6aym8jad508kd ;
+            msg:isResponseTo             event:8mr0p8ua2srgw0zw69lc ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4j+rDkXxIN1TWTiX2FmPFQzLVWqfHqmmVmXfhOlT+WRlEu1IhiKwmtCcaOR1bD28CMGRu2E80fqL/sZyAo9dbJmLlXKWzleyNe8ELfgUqfpCGXfDlnePlDum255WD9rRdGg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJqyzUBUhStwyRnZXFDykPEVIBMBNtMij53h0S0Rgae1FaaC5bbngcWo3Im01f0xgZEPmB521cSAr0sXPYmOwcTxzhnZiZq+cC9Y6jnfubnHZxxYY964fw/OZ1lTEPW+z5KT7PDt2aIDzJM1n7xUyYDZE9/wzEdP6nO7t/6ytb0T" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig> {
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCBVurkxeedg4BOOrXm9NFSQAyZfz8YtNKWbq6QdzE4EqlUnjNGUY4gmOK+bav+ArICMEwVIwNn1iqo4xeG/AgvGg7APx53GjdVRT9xlEr9gGgYLNjFzlPUUBjgU7/LemJEHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RgI5acuaUt+lXrCKO8yEMr2+H20QhOkZSHVSCeHEG3bs1JjkgSUrqYVrJJy3oX7fqrVLa+ZGsm4NeVsCBeJobfAWavZHlykHdRdQMlRTqM14CoeE8h5+nlh8xDZhjc3xG4EfzoOjS2NTaQcx3BvZSn7yKX2AV2JSLTl9m2p+C9w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> {
+    event:5r6qvd7rennbi148vunk
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fk1a2jb7ortt8q14tcrb ;
+            msg:hasSentTimestamp  1513170866390 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5r6qvd7rennbi148vunk .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> {
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> {
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> {
+    event:xsbbah2dhkcg6d3h13gk
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0esqgu17b6xqppmgbty7 ;
+            msg:hasPreviousMessage    event:66nnn87elpe5995a5wjv ;
+            msg:hasReceivedTimestamp  1513170819637 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig> , <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xsbbah2dhkcg6d3h13gk .
+    
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCC6D307Lv5MzLutxg1KXUt+zR2Zwdrr9znEQqdMeBR7DVK6fsXypGeyeDJs2jOW4sCMQDLdydp0WInEodU0NRfYPX8hVB5j2cxSOyEUkHFi9tPMVa/PezteiikUTYLcC25DkM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ydoog51McxPJnLHQtQysJfmTPxn9t0sqIsCV3mcS5JcVt3h9euQ7MXfqjpJ55BrtwiyXzkbwsGftRi87A9WeREXhKdKRfZwAx4VeeHjxs8cI35ilfhEUYLK2EJ11BqhYGxl/a7Oq6/yzZTa31EqemFBLzEKQtllAWUAPw0Oy+94=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAFi/eyVUc/OGE3FUzVcjUs1guX7nBHOl6+Y8Y36/f4BVt+EU/m/RWnpG3d3bTfJpQIwcKCuoDCPI6WnnnfGPO3dpFl/KXJiOfKs5uunTQtjUY2MPx14jO6pfC5FOtrqKyaU" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "I/mRBA5Xn4voYymmrr8fknaGBWuacNDHWaLgaIwv6rd7P4XcjbkgVRmW2z6mMM7czSLAykoHdFtvMnm19vc4ADVPHDP5zPbOhFY4Eyc1eBzEmY/eM0ia23pv6Q8i8iKIEu4txknJxda1i0ESCft8zxyKDCd8TBUMhWrfiM+iPyE=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> {
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig> {
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDR1xb+ezOAzterooaxqminnZhxZ3ZjYwCSg4bL5EV7bHVizu3iTgKsm6iCa7mIdWAIwRkKyiq1Mk7tBAbc1TES1v8XaHFEk/p1VOEwOiskWC29sSUTOk30mMXlKkZYs36/W" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DxpG7VpU9zHMsUytfLtbLtoTkX4Rvo7gsi5pANfpiXNutiAr/7jlOeke3UaDHEZqYB4621NumM8IemdYjCbF/RjUtbPcv/rDKs252ShC3UA74bvbKFrsPiVd7klS+7csc5rEqd0pcPWXC878nNBIg8TGwdgf7d32Mikwj/jX2jk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+    
+    event:9787whuvh3bufzx5xm8z
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:1107469913331435500 , event:84bls7ssc3hfvt38vxr3 ;
+            msg:hasReceivedTimestamp  1513170817501 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> , <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig> , <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9787whuvh3bufzx5xm8z .
+    
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHT/EdDamdgV2Mtqg/N8H7Bc+zwJILV9ZJI2xXyFboHdegN1jgF4ZCxOYrDkHr505AIwBEkbtiI/muBDvAmot4lye+KnfiHZEylmA3Og82JD3ccn87oHyo56glBhCYDaKVnW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhNqR6Q6taN6WmAYlTzL8zrft8avQOyGzeihDyINuppG6eGXkABaDOLCsLhmGaQ/XuO+EemjK8sYgWM39AKlkKIfbSiXY34QcSb37pis7mAHkqqX0iKrQAPmvSbb/fBvXy5BaS8nBIv06LoyU/GbjqRSf4oEoWMOcE1OWYqHUvs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDnyteCF9KSTtbrsYFmRbZZ4ZNdnd1emM4ebceI6HeLNbsvUIn/fwsqR0c4GX0SshICMQCv744cBU9UEAX+NCbaYWGsBXQ2aMEi8w4SZBH066tSvoto5F0zMtBDg/RNW8Od/YM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKps/NCCOmxsm1SX9VlVmiTT2B1ZXMISJWueiRkERBLcwipaUlalOiyl3JIg4mt0hEzH3ARL/0AB3y8CVxZqj6dxouukL1POLUIgAEfu7EQcsA1hURMsefQMZM1jvHwcJY/pkiK9Bk7iDxdFsvexIZqDeD2IxO/IV6rpDr95/oaX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig> {
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAJDEJld2ndIaCn6/1kRsp4kfm7HZT2fvH77JQ8s0zZUhQWyrBgXZRhiJrEBUIMZDwIxAMeCP4ugC6Et/yhH5xEdoiEoseTRJCw92Naa+b1yJptL8HGS6KyvC51/j0RbowFziw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "c0UEvfRWh/PcqHUGJZf8M8e0Oyoi9txmVMj5sRI0cnHfvY+ukgrlV5fTYIHMssQiyNQZKXomAMSgqlrllbY6hE0OAoBCsakCOZUvU6Dp0t996nSWJulqZbS0r4xCFn2LvVsUJ0hsv1M34w5dhkTjM67Xr+WYCHzqN3jsw2/kR5Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> {
+    event:4rit8itn4uyigyesq90s
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:p6x8qvs5m46mxw4jb7z5 ;
+            msg:hasReceivedTimestamp  1513170830179 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig> , <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4rit8itn4uyigyesq90s .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCtkFefE2I/jB6DpPOGarUrocUvk9wsq0eP5/sbYKnSul8I/fLoX9EI0nymhdwR20cCMQC0s09oW9Nxljq0VW/f+sHUjD7IXfa/8JCJ5WB67mzwikUUeXZyG2n1WUrefr/AN4U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Acv3A8Qod4xRE79i9TlRvAjNBNXrmZAmLgOIsvygmGmm9CkqJXsrAQZc8Dk6u49OkoJy25Rnb5CuVPc+HlhNkdIqLJHcMAZp9FurP/NU/gazz4tmlDIhovAiCwqhs+st5D9s5QuvQrOZSVQLohPI9AHz67Cmp/oi/ndwSB2OZqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCoqhvm2FD5Rqva7L71+Yp7neTxS3q20cnC6uDUvBDQGr3zyIUHhaI//qg2Yg8H7ugCMF+u/pBV+83p8mIAvN1y854tkyUcZDT3RuZ5hPbd344MBPqPT5Hv6YjlNdBDAuxoaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VWnF24UOUawtWVnzlAgCv5wRAMUrwFeauW2b2ws4/LA51c8s0QEN9157Cm5ueYFznh/ZLvse5tmKdklDej5i7T+DnRBWt5GqqEIdEmmSdfD5m5oiDg+lD5EPl+IzI2gzARU0odj6S6KpEO6hMQVdyOuG09zPYSpco7rDnUm4okI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig> {
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDf4Jiz6qEsxagnd32M27/KFDT4A8MrcpzmvLk9vJylevVEL/xRCPyIDpHVrN09m44CMBL8DlDPGzk/uINXaaOEFAujBOL/asEqNclcxcjfjF4XTH3MtRorUOv0iM2SS7N73Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Wj8ziPrZiyJHDhh+M6SeMCUQZulwT/3T3XFRkAUfaJIZdct90zT8XJmWFeX1TXO+M8EJtVGIWd8UbIUg+EiUllQdMp5qF2hlHGGke8FiSMMbeGEvozbp97W58+tTE8pDIHBJLO4qRvZg59Bu8uYRBIjWSh6WkhGaLKrv2DzUZ3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> {
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+    
+    event:qi81r6ggzy26wznv94dq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zvx39rdagwj6o7nfiw1r ;
+            msg:hasSentTimestamp  1513171226453 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qi81r6ggzy26wznv94dq .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> {
+    event:u3op66771mcm3ibsrr31
+            won:hasFacet             won:OwnerFacet ;
+            won:hasMatchCounterpart  need:ekdwt2a60tesl77r13mu ;
+            won:hasMatchScore        "0.9"^^xsd:double ;
+            won:hasRemoteFacet       won:OwnerFacet .
+}
+
+<https://localhost/won/resource/connection/lhrkbkodc0y4rmc7z51y/events#data> {
+    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events>
+            a            won:EventContainer ;
+            rdfs:member  event:kaj9nimgw0lkcgmb1asf , event:h6c8epmrvb3gxqrvs81d , event:f3u4lc7l1czvps18lemf , event:ivr0xermk4aeb3yhohk4 , event:v5rvsrlg0x3ogdqyfuy4 , event:u02ulpncdj9l8ae8x2aq , event:cbcccoqqqbec6bxkl3y3 , event:i1frxy9ikewwjuyjcznt , event:59gtirhola4ydvddyo0k , event:xbhopokox5b4vz78e59w , event:tlyivx8nn93zw41ujn1o , event:csvglzqkcoddoreep5w0 , event:alif190jj9we7toczas8 , event:mmdq8395owv3xy9iyl5q , event:lur3g5en41crth556538 , event:i3k0giied2bgp0p44h7u , event:253k6pqq8gyttmmfxc7l , event:vj2yzrtlf700wixuxujw , event:t87usy00t0o9h4f0d1p3 , event:s9a226k3n70ihhaurhdp , event:4e2ws6ap0hp93iv0oyu2 , event:6fvg967tlh9rho8axvbs , event:xqsfn58cdatb7ryp8lzt , event:8c6o81ry6mxeetm2d2pf , event:ofx1afjv35cwpppp0wyg , event:cw64ogmt2lv6n4kdjdxh , event:v66scoiidw56iam8q86p , event:2uf9sj4itmz9fpas7suo , event:wlv9kjrh93gfzetdojp4 , event:to3x48329wwbanylmar0 , event:pj2n6r9g6jt39rv99xh0 , event:mv0xoe06cxsxt08s7guf , event:6m7oi7hxwvoi2pmguo6d , event:2sbarcz1yu7cenpcghay , event:xu87g40eu8cx053lad08 , event:x7cjarywf0513459swe0 , event:iasuj1z9fva0svkfqb79 , event:8gvplnjrinoqay8ycrc2 , event:9uyongxoip0kz7t9tsa8 , event:1tr3o22co1907d6b6n7s , event:mthg8rh8r4grme5ph2eh , event:5s66o8cqv4rxv74xfepg , event:orj8iruy8pcer6zzxlra , event:zvx39rdagwj6o7nfiw1r , event:m8b6jvgclclzy48p7wqd , event:4y6xcnpgc0xk4relqfox , event:t6d7eq3cq6nq54a16k1w , event:izq6icbkftfbzm0clxeu , event:cgqt5h004iql2003me2n , event:152dum7y56zn95qyernf , event:9oa8ktxu7tqzll06rhw9 , event:rig33yoxaetjw059bzuw , event:0uouhqi6aym8jad508kd , event:ck5071fsyaned6upryxj , event:xsbbah2dhkcg6d3h13gk , event:s9zfgm2iika5vgvayt7h , event:8h7v5ml1aflqmoyem61a , event:0s55ww5ae82lf3j3gwaq , event:n5rqfwjqbcpdwqjjwpdw , event:eczqg8lp7xbukpzikd41 , event:5r6qvd7rennbi148vunk , event:fn87pwzr9g4a9v368h4m , event:csridlusp0h45v9gf9v6 , event:xpspyx3bpyev5v5p1vf6 , event:pi2jpw9a1q00d11kr9ez , event:joo1uifc1fc2k6fk5z8t , event:plmfevq4c12f8itbisjf , event:xp44teiwtooczc14npe2 , event:4xjx598ewu7579zpl64p , event:bxwevm9gzqconmzxji4u , event:gv6zk2yqk6o8bl574n36 , event:ggbuodgi1pykilp8znve , event:collk6egdkt2tey39h8z , event:93e94yjsmx9l4lg8lu1b , event:eia6yrvml8v995ueq65m , event:cvloufr7mmg0siwflisg , event:xkeovy4cf48spd5euwj1 , event:4ongmje7w2v03mp7ztex , event:m4nq3rl0m1br8bea2n72 , event:eue8ar55z7as596cu33m , event:273p25fz6re5tp6drfsd , event:66nnn87elpe5995a5wjv , event:uu3ciy3btq6tg90crr3b , event:d3jq9fgiu47gdhclj7h0 , event:ih9v6gyllshhvo5kxyv0 , event:sdt7yr7q7t9iw8wcuu3m , event:dhdnzy40wlrnxh7ymr2b , event:cqvzpvoqvtkylzdybhej .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig> {
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHjnW7jow/Z7aL1QDqTFMpP+uUJK8at6ss5OZuet6gmrixv01UBKjCGc1IcJi2QP3QIxAKLau2w3EYVaNhiwbBvszShChrvxT7r///J2xtTY/nogW4LhF9XYHuO+POgxhB4ajA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VyoehYH0+v21MhUknlbDkitBJGdeDF/s45ZAHERkECa5rhyIeX5JdqiSIECSPn5+cSAH8BkNxf4BI8gM9hCIDNQyEXWnhSLcOJFshwCaQcFVyEunib8w+gc0HCrLM63xSQpwcSqjfTT/OTnQVWpuSIx8Zs9Qa6cHgEpPK++pxjU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> {
+    event:yrizizmtaxehctdi1m1n
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eyrx1pzifelg0uwuz7pe ;
+            msg:hasReceivedTimestamp  1513170818228 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> , <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yrizizmtaxehctdi1m1n .
+    
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH1yqqC7WG23lSs7lfYHqQYbfZoyzWv8pzkkY7KSy56/AtWes84THcr7OVjTgFhWwAIxANcFPCOQuk5+gcfnhKsxV5/euIxAInNmqLhNLlDVPX8CgC5ewaKeicWGzuD5L1lKCg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKrtZAmszTea8/mPmW40rtOPdVCYdADMnlLMbfhdufAvhnsFfwmpD7sxyoJ3BFX10CelmVx+XCGfgyekenV+xitpxAWEv32JMY6V0YLySwq2qustxP04XCNbDXceXk7p3eRFoVubLoVs5JPs/aDJ7OKEKVHP4WRTFYbVvvixZ+9S" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> {
+    event:u02ulpncdj9l8ae8x2aq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:guewg0q3l68ts1ud5u2h ;
+            msg:hasSentTimestamp  1513172264009 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u02ulpncdj9l8ae8x2aq .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> {
+    event:joo1uifc1fc2k6fk5z8t
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:jbr090p3fhvimrc65vis ;
+            msg:hasSentTimestamp  1513170819518 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:joo1uifc1fc2k6fk5z8t .
+    
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig> {
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDu8Gc/sKjgG1IFj1EYn2U2ruwOs17PSjlxgfmBHGcPuieyEIfzxA+kJKyLCuaB6y4CMQDz/tcSb5hCsQHYCqx8Hddv3pqV+P/wALc2mcaLoU0VbwUV2gD3c7QHtTfnjMCKb18=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Je1aXzcwnCLWttG4jcpWK1Ab18FJsLtCKX8hqJhjlvKMuiuICUU0Q/zEnU4qPOZH933RbMXCgYvAgfz4oI0oXus6FRWxCqB4uiR1UnVzEmVnMdlGeDXvosJUmWiCb0j7qOa1afsmvXVv+IWLfuIUre9RxyxFLIfImnf4WsYVwDg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> .
+}
+
+<https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> {
+    event:xu87g40eu8cx053lad08
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:obhgk474mxybc4fobdub ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:rig33yoxaetjw059bzuw ;
+            msg:hasReceivedTimestamp     1513172392256 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:5693603251585579000 ;
+            msg:isResponseTo             event:rig33yoxaetjw059bzuw ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xu87g40eu8cx053lad08 .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDVdxsx8AMqDVkLxwHHXe2EYoQfGTBPY/v0e03jny8i4Ji/btvU7i8IJb7o5KqOqvkCMFcDtdofYkQmTCtm9v4C4PbDnUXPrg+2rgSFIMF8E0z9qFAi0I6HcK2hFif6WDBF9Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIuO1GUXQ+n2hND0rBXn+YcBU+teqinFMEfnpxVOryDDyFTvYOdyFrRLr1erJ2VAn5trfyMVKpwwUMBdo3guZbsZ0K8MejqJ2x0WjSXHPYAU/sNyXGFtnsvamakkABV4phNySgVeYd9dScP0xAzd7RdXed70M1/njJrrmI5DObej" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> {
+    event:m8b6jvgclclzy48p7wqd
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817724 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m8b6jvgclclzy48p7wqd .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCnsID0qvu46i7S4kE7ivXBYihYjaVPQt7m5/z65xpzOuVY3/zvuTykONy+sgYSRnoCMQDfEi9MOkCz48aE/gAj2SuyI7oa7oSV5S4G4qpHdWg18wk8WNydf1RzoDNL3PbXjyM=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AwA/ynkGKwkxX/wASKNrWxbMgGDl81rf14nSUIq9WgQOJxYMshKI6mfMschKonv31zVm30AI4DdOkl88kw97lw==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> {
+    event:0uouhqi6aym8jad508kd
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> {
+    event:s9a226k3n70ihhaurhdp
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172280941 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9a226k3n70ihhaurhdp .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAZv36c/hMNuKFQRqHi7olfOEK0YoIWyCS/81rW12ia+oWHICFTWtwp+TqUNBtrUsQIxAP8MEFJ4X3aqvkGbVldPiixoCuwLiPRtiJyShNoNWVPsI0fIzVzDo95192mLkrjmPQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBY9JWyOJyn1czcCRyXLWrla726vdsImsV2DjBK1jqQnHZvqmgvJTFCxPCmsqWYyrkxInFKFpaItjfvXSZWK//7" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> {
+    event:orj8iruy8pcer6zzxlra
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:o73qpj11bouvhv9pfmhx ;
+            msg:hasPreviousMessage    event:t87usy00t0o9h4f0d1p3 ;
+            msg:hasReceivedTimestamp  1513170818418 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s-sig> , <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:orj8iruy8pcer6zzxlra .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCq/UEt3SVh+dO9rhDLTfATgqXjmIyEeOzeBKtN5LUHusk+vFlQrG37XszBI/XU89oCMB4TqqFhs3Jf6V7HDmwHi6yrs/DoP0iFKSByargEF7yBHVVPv4WDIoWmkiTbR3AbCg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AIyD2cyKqc1wBTQfwBIlhvgrFzvLQDBM288k20GVQCQ6G7GAAQs3TVlQU++TOktTpkiQcR5xRSRFdjuD3ff7t3hrNazlLpCtG/H5lb6U/1hbKjIaDbsFrN4nwax9YY093V2IzgXTcn1FQCrS9UUSeF9aQJqGfbhl+FxrlaQ43kJJ" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> .
+    
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHTGw+8qqLFv0gG34cliPPDKseheKGzGBbEwdZIaoP74lyRKUoR4NGg2G7l0Nm1hAIxAOP37UK+mVzE8mYUTOrCJlbc7W0msIsz0lzqZAnkShAMmsTAVkf9Ba+YPYJVVd3bqw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JRMvZZd/sedPNFM42HIM2smPs8J9Y5qkbjT7ymSriQ/Espd4doT4E22uxx39RRnOMtFn2h4H8DicAmCBFizHPmVNHwCvRT9OtcPGMzH/XRJsfWaiICmSNOuwOUEiEGA2ro1IZzsAxrpInIZXeROH0HLophyUomju10CeXitwk7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> {
+    event:xqsfn58cdatb7ryp8lzt
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:2uf9sj4itmz9fpas7suo , event:8gvplnjrinoqay8ycrc2 ;
+            msg:hasReceivedTimestamp  1513171154033 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> , <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig> , <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xqsfn58cdatb7ryp8lzt .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvj13J9u1HocJCN/w81lIYFGNWyZJX/dfwoRkQLpfvzv2LKF7otZjJFOu5c1UMiwUCMAsXxui7cf5cSeb1oomocs6tfKRD8WmtRAnh9OrOuBzS7Lo8wG5B3mhL+k21rQ2N+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTR7wRzkvfsriFv555SSYyIEHHrE5p7o5hg8Fo8Zx9GUHhuj9hTICRytZoHkX+0huhWWDeLS35FeRKNIahwwkXmV5nwUcbCyGQmbuYvVz2oz1YDpZ5LbSLPP3rGbvl9a6kAK/zpftZQ5v0hBRevTP4kGh/U3EsO5ADd24Ck0BkH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGo+08Xgqf5uyZxGpCKf9oCBd8jRm1yKRDRXeMwENg7ie1w3jgv6AiAuK/1g6JFXywIxAL+YftISq1QlqQr/yZNjLRExXa+BgWIfIGrbOKD2hH33Q1QfHLuGMpgX0oEgzZnEjQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALGkx5gB2jaxOK4WZw05ONiVUCA0spS4tv/y7Wx8VlqoslJFh0/rzrpESQqtMqC44E8XzxTOjSPG5iT55wLTkhgEuxjlqTN+2NHgp/9xJwj0dGPIPK936ufMiRymLE+BJaXBZXIhT90SSCt8mEKJsFvXL6qeYt20n3f+A07X3ibq" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> {
+    event:sdt7yr7q7t9iw8wcuu3m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6149800720990867000 ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSentTimestamp  1513170797721 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:sdt7yr7q7t9iw8wcuu3m .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> {
+    event:8h7v5ml1aflqmoyem61a
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817636 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8h7v5ml1aflqmoyem61a .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDS2lnRcxWk4keWqWlX8RHQ0BTt3c1k/o6As0XSY2NztaS24r/AFzbZpxtLt5X5CucCMQCXzHRcnH5E0pJxqO1TRDLsvsKKuymdz+FQjb0xce5UAvWAMRReKz0xNBDoHy17DbQ=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUubCGkTGd2y8+GCNPbbEM8/+UerqGfN6RGo2WGk92LeLs6ELo+7IA+gB/WPAKhdLzOl4/USD/1LCd6Of9HyZg" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> {
+    event:csvglzqkcoddoreep5w0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rjc2w35typgyljixk4qo ;
+            msg:hasSentTimestamp  1513170818495 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csvglzqkcoddoreep5w0 .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> {
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+    
+    event:p6x8qvs5m46mxw4jb7z5
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:plmfevq4c12f8itbisjf ;
+            msg:hasSentTimestamp  1513170829846 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:p6x8qvs5m46mxw4jb7z5 .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig> {
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHDVEddJe7NmoiYbu1p+JiMoEVtLRur/+Yu0sFLq5DUIrrWrtdLK6f+prO8pKIdnOAIwOTKM8iqIJl5RCRTU1empKnTMdVGqYNnugzvjxmcJYcHlB3kEcJZB01RpgP4jXIiF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "BCqG99LdFS9ele8EvqJAKMSeLJhmvMv8EYQE5Ni7NpgpIlHWsUe9/VO+cD6uuuHHSCaOvn2v7Qpx4yxY1MJGPmc3EMhoELJYWIHnHCJDLdEWPPPZmLMlOd0p8TsDM58KKsaFHjQ8y6LYBomosNL8tVb2wxHGagv6/mWpsyY7ph0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> .
+}
+
+<https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> {
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vuhyvj1n1x01t4jeddkq .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBHsVzk0iN445oPyFMjO4YrLujaO4utwthhSOruN/uzhzNRcd1wsw7mntJM9pCUCoCMFI5C0YEt9A/unTNjITIMj1Eh0OI++zgD8XkJLQTcLdKyQxHFYRm0NmRVcogmyA15Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALHVkRX/E8lVerdgh+TvBnCbKecI1GN3o8zyTyztkQWeM5iwxeTTTlqHanvi+A32SJ/7GOQgPIO8snBg7LnoiW1n+m9RTiS9UKu/vNue1cAGLH8mgNEvEwPAwPlcwK8UOpj36RZ+h9XYIMOtkl+jUQ0yUU3sWTlYOlaajOGNFV7R" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> .
+    
+    event:vuhyvj1n1x01t4jeddkq
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:kaj9nimgw0lkcgmb1asf ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:00zilsxex8tqjumh6fi8 ;
+            msg:hasReceivedTimestamp     1513173166315 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:h6c8epmrvb3gxqrvs81d ;
+            msg:isResponseTo             event:00zilsxex8tqjumh6fi8 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> {
+    event:0o2v37foaz8bog1diet9
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:yqq73ffvbhkpyq3x3lxp ;
+            msg:hasReceivedTimestamp  1513172263949 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> , <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0o2v37foaz8bog1diet9 .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDV77PAf9ssu3lxleSAQuZBLb3R7NWUH/elcIVzZIE+VJUiOzAy7dfrxWonPLFBKfUCMEw4+jfWtx3cbKJ+Np+HTrlrDDdMo/+YqvWUicU1HW0ktQx9w9a5B+44ZJhA2d1CZA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "S5Q/lUSCYab2QN7DDA8bWo6kCEjM8IRf2xAM3KDz4oFpPkhDmY+qZyb/QdlzajEQkNuMhRH9WdYxQhZBCLqglMyTULbaJedYQY+QgxLR5es5gpZxh2GsElRrJ/gHVSMBTLaW+gfKU5/5E27NY74E4grCciIuscwWAMRE1KSDWrk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> .
+}
+
+<https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig> {
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCBzp1cAZP2R1cbcA+652mwXk4lOWb0noZmHYLFYB2maq+8BUQzaX97MnZyDFdmjdgIwTjdph52OJLgePV/du4zmDS1riW0qJEZoOgk3bDb1wFH/17wD0NBcX3rmsl4zAJKB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK4rRGDfNdW3i+RZ5TwMnjsRW5+oWCcyQUMKY8CQBOrt7M+StvhcSfKBRZbS0FvOHNo3SMAKMeLaBgfSpySwD0MDu+ErpXCYkye36db6t00XK+t43cYjJzOGLCOkP9BlpcA22JNVP/rZ1tyo1UgV920Jhmjr44xn/d00EPDXffzM" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> .
+}
+
+<https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> {
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> {
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> {
+    event:2uf9sj4itmz9fpas7suo
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513171153765 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2uf9sj4itmz9fpas7suo .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDlJ8alK9WP4ufsqQh8RvipZ7EOuLOA4jPmHo0J4ezb0WdYWoZDzJEEux5sa/ui2gwCMC1J+CJz816CzdZysOmc5K3bMGsW1n8S2Ra7/VaXBWmjfTCJ0vG9NWlujzUDOsp9nw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AqS2mysRS1IdtBgqynREUiir00HptjHq3nc+/Uq7tQNsy04le+2wIl7VkJxMLAyFJpHk10D9u01x2sr9F7CncA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig> {
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSScApJPZ8R7ecbEmjmoEu+pxkflMao560sVd3mK2alK8CPTRNoLg/oJQUxa4lqt4CMQDl6yHyqxvxqh+t/13iDG2uWEvqvA8TgR1P2eJIAvxbxg7pVc1XQ0UMGnHml7Zk4uo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MlLaQmKaG9RTw6byp/UmeWfM40JbjgQaSFTd5NFvssErRCjo1yVuoLAXI1iruqGepB6lIGSRN1S0hsatgpmvcmWoXkzUevzbgiED6gNpCycenfAl118R4lamQ0Ku1SnaTx+1VWfWgnaahTRxeUkYlzUaNiciDCfsmg2OLikWzfU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> {
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> {
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+    
+    event:5l16wlgqmeu6z6rt90ca
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4ongmje7w2v03mp7ztex ;
+            msg:hasSentTimestamp  1513170830791 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5l16wlgqmeu6z6rt90ca .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+    
+    event:pha7cg4ilx4j23f8xo0l
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:238289506881087500 , event:z1emzo49olrm66x3ukkt ;
+            msg:hasReceivedTimestamp  1513170861247 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> , <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p-sig> , <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pha7cg4ilx4j23f8xo0l .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCuvcWOxQN2mBUQaLRxsJ5TOyGMRkQtbiwPGIKzIFMsFPci17spJyFKKxRDWelhq8kCMAlGuvVsFORNb/0TffuZtSU4kGfZ1JmafuesYG28KvAl6sydOYPx0XqIdxvd5WoooQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dza8LDmsxsZD4jcuV1OBZi+CYtB5HvHMl0zDmPvgPPC/YulCTn42n0b+FWooo6TFUPiIqEsneu0/Sen8YBgXNvZZmAaiyrBlw/5a2oyX64lWmz+IkZvccI/QyTQ9aSylPPyL1ziUj7B68mecA8ttyOORTxM/2GsZBzk/cy9QYQE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> .
+    
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDz34ndLZblqDWzmN4IE0ahv/7VeImWvkBu6pk7SDkk5zLl2iQOE4Yu0aDvq4S31d4CMAIdswiC5QuD8U5s36cQF9nqg0nYrwluQc/eixpAu14IsDF8Pzq/DIDDxmQOISwoUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UhIQ0cDKkvvxNoq5BNt40MGAuljOdnbBzrXJzaYTQ+OiSLfI7muzlgg1lDfKZrSWnXNKyXA9YK8giQNR8CLvAgyknhXX+G8GK7VkEBqFAtKPyg2QPE5QTledobFugn3+N4B8JIP7f7hKa0LWEQ67s3FvE/wdfgwQvbBylfMppL8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig> {
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCZ9Mu9e3c3q0zVLHnTFS+4h+xQ9q4QDfDeu1sdAxAWl1NNNdQ9KisDKBtmXYiivLoCMQCyE15ceoMvLAWACEeQHL5IATn12jdRR1NMBGUx8ilvEnCJbHckFRU9BeRHxPnHobM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fdzV80NOcs/SSJHtD8oi8qgp4L3ZQCIehVau8zZwy4E0FPwJc158UWDXK9kNTIwzgaAgPUsgDgOTUW5rBYnlpHU6BRzy/3AWKJHElR/niJdH7VxQuB5jwES7c/F6BdfcCfyc+GH/RkP/qvRQA7bB3t00YUX4T+VnU5UsRyJtMAQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> .
+}
+
+<https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6l5bwv7tkxg2g0bosl1u .
+    
+    event:6l5bwv7tkxg2g0bosl1u
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xbhopokox5b4vz78e59w ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:l27gk9ia5beeuyjqfp7j ;
+            msg:hasReceivedTimestamp     1513170798458 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:gv6zk2yqk6o8bl574n36 ;
+            msg:isResponseTo             event:l27gk9ia5beeuyjqfp7j ;
+            msg:isResponseToMessageType  msg:OpenMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCBVurkxeedg4BOOrXm9NFSQAyZfz8YtNKWbq6QdzE4EqlUnjNGUY4gmOK+bav+ArICMEwVIwNn1iqo4xeG/AgvGg7APx53GjdVRT9xlEr9gGgYLNjFzlPUUBjgU7/LemJEHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RgI5acuaUt+lXrCKO8yEMr2+H20QhOkZSHVSCeHEG3bs1JjkgSUrqYVrJJy3oX7fqrVLa+ZGsm4NeVsCBeJobfAWavZHlykHdRdQMlRTqM14CoeE8h5+nlh8xDZhjc3xG4EfzoOjS2NTaQcx3BvZSn7yKX2AV2JSLTl9m2p+C9w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> .
+}
+
+<https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> {
+    event:beyjpryu04ao4on0z22u
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xqsfn58cdatb7ryp8lzt ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fits98gjdl4ybaudq5oj ;
+            msg:hasReceivedTimestamp     1513171153959 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:2uf9sj4itmz9fpas7suo ;
+            msg:isResponseTo             event:fits98gjdl4ybaudq5oj ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:beyjpryu04ao4on0z22u .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME6PUbGpR+88/oQwBXRk18e95b+xrq28z/UNp/4GpxPG3XsShzIIh6RK/AYv6DpiBwIxALSmb+2M0+RbNzRg09jvW8E3CsS6Sxp8Iu67CllaLoAA4lw0ZN03UcbfZHCUfUykWA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XcLVrPuTUW/lSNQHtRCZ/eTaMVjFKB2J0IPlkvpvURyDmYhInqV7qmuIzruckTqTnkEB+27Vq5HZWsq2sbnD/l3Ib0MOp5BsiM+pRy0DzESrBcXDGKTCHzQEYL+M2Vj+KyZG20d4YZPbC9KR/PtLTp9tcU/uwY8QbVHFdilAhcU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> {
+    event:uu3ciy3btq6tg90crr3b
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:qyg9hv3nohv4ykv8ryev ;
+            msg:hasPreviousMessage    event:n5rqfwjqbcpdwqjjwpdw ;
+            msg:hasReceivedTimestamp  1513170841991 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> , <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uu3ciy3btq6tg90crr3b .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF4dFbf5fOJmIfPsLXTr/EfkuFinogPj6z8Mxfd24lZ8LhPw9E9izMeh6/N8yax+gQIwSxo/wfNve/d/MEBKITOoEI/3XMO1wp/KftE6PPxhHOtgFNnGtmLFgP2EpxFEKP9/" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ILuPWX/yMTCM6qyWob9ws8umhOD5VluyqBCCTl/Y/gheY14CAgMJZvfIKxzW0P35Lr4f1DS1Uo+VNX4qoytpfXkbpTt+B3sWZUoTlIdRDF1nAM4TlMrbfWvXwyqf/B86aRsy+UzCnawS0/dxfL11a87Tx0Ey9YeW2XG6od0JWk0=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig> {
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFpDF1mYWD8hsoHDb5v8FiRwj0S8R84+myfMvroW9NG7WZP3J4Uq8Oo7ztiE2ETW6AIwaZU+/I2JMbidZbneEo0kjTxb2sM3wCjiFdP7Jmv6FbtSFXw4KokasNsW4cpFLCEw" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EyqBQx0oUFQxEvOyh8QjiXjwS4TM3FVB45C5vTBNlJHUI+fwdSV/pDYLjvsbRlq1VY5n0z9HhUKjVo2y58VlzYTUQcu5vtLPHz8uGdwRlYCBUz4f4zez0SYMtRcco1EUCd4l1ZIdbA/TZ9/8mZV/1e0aGwrE34oqJrolb4U7CWY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> {
+    event:h2lo8jybm27ouaa4wuqs
+            a                         msg:FromOwner ;
+            msg:hasReceivedTimestamp  1513170782659 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCVhsAY7hBLadu1CWFOu4afRRKrTYxjbOa+uQ31OD7eTUoEggVuksPbJHT04zYkicsCMEw3BFMumDIgvhFMCvK7nyc99PoEk9uDykKS7L2auJJYJPsp78yPD5j4XL4xkBmjBg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "SstIdyZUGtr5VqtVkIWuL3OMF2/dL34GwjscGyw+R3V4XlTZRKP0ggomWl/12nrpoe++P3eaYAFT+9Fb0auyUO7INcceZWRmiziQ4sb6GGflQl8ExrmvkSjMIFFobzDT370BPe0VME2mqwO1/yB78clzqPGTsiWGb3FRIR+SUWI=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h2lo8jybm27ouaa4wuqs .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> {
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+}
+
+<https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig> {
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCzVV6qy/HjxXrIWL9hs1+f/M/FPuSZtI4i+MhrYwE47CUSRkQMYbmynjgYkXxEUjAIxAIeZy9h1/tAtQ7q4pwo+/ZQaFhdTItJ9EmDiMboW+I6n9dvtA/R7rqIcBKsXQqPwtQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RVUfEg72U0ax0YXBiJKk/HV8qGYUOubZdp8FJoUajOkfgmO3tZz4Wo2axeQZFJ5Qh4/zebyAifBAM5VM3c7KxKJOAcwkNT8OHmCsSdQVyu0L47UFJ6i1EB2X6m1bZCCo/tNZ+wQEcvDcFkhcwwel2BDApSbeI7ugj79I84UDSdQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> {
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> {
+    event:8c6o81ry6mxeetm2d2pf
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasPreviousMessage    event:ofx1afjv35cwpppp0wyg ;
+            msg:hasReceivedTimestamp  1513170818806 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig> , <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8c6o81ry6mxeetm2d2pf .
+    
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD3Y4a6E2HjiNdeqmuVGUAG+ff5QyFv8kzV1IWNr3oVnr0AbrEPWwzU3QHZzOcCftwCMQDLqHtPRB9OrdYV6n2vgeGoAcPBqg3TXBl9kTRSbdC7pkDV5+yidHEnyyHnJhroob0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fDvAR88Emuh73Vpv3kuUyeJUgqsbQd0XhuQ+ysVkAUe5Rti/URLo2IeHRKwHYvfd/FRFIKhTpxs09BRTjWL6sXP3lGoSEND6tjTjn//tHFuhpszlkEVvIQ06T5Nh5J11bPgQ+cSR9Cw18NY+/GmgYvJHtlCcwoFokdPTEbGJj/Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGypuqyt94/PYVVaK+FiSdvTIuCPqu7hSy0ozpPbhMFU5VmUJayI6Q1Y3syEFWSkGgIxAIaKJBOM8cVFb8bF/c+NxaoIsFfxt0CzSi9v681Y6kb9VLMC1Tdo6hE5VvO4dtmm+g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "TI4AzNDNulLi/PdeCHG0fua1XfEE7k2ZUVbYDsUVCzal1MUm6SzCUNl2PjIjXq/I7HuSck9RWc1w1hS5MDpAOije9FeYgZ7tEw+XFuUuCgIv0vkGDzSp/yWZRIeu1ypoScwLqrYnfFyG8ly7BnOLOA+mvhngM6DGqTH8ia9FoTA=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#need> {
+    need:2615528351738345500
+            a             won:Need ;
+            won:hasFacet  won:OwnerFacet ;
+            won:hasFlag   won:UsedForTesting ;
+            won:is        [ dc:title  "Burritos" ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "7db388b31fe1d8cb937115552ad0ce6b7d024c52e369f53917f4d432089c3b6f2052cd941cf3b1824aa77d6e96a3875a" ;
+                                              woncrypt:ecc_qy         "c39dd3edb8065ddb1e45764e0914a7d6e6e38656b87be285c4b8f14eaa698c05fda664cfa425827e5e9aae5d637ba5d5"
+                                            ] ] .
+}
+
+<https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> {
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+}
+
+<https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> {
+    event:v5rvsrlg0x3ogdqyfuy4
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:i3k0giied2bgp0p44h7u ;
+            msg:hasReceivedTimestamp     1513171230641 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:i3k0giied2bgp0p44h7u ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:v5rvsrlg0x3ogdqyfuy4 .
+}
+
+<https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> {
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig> {
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC8rfzC1UxD2WrZenm5CVJfUP3ol7NowZWmXKfMHriGAcSYy2RT44iF/fMzN8mWkkgIxAJauw05Yvyrmx6sphnq6aOZfaV2qNdLoHVULPZ8SRCaxr7toyEYrkOaV43FhjuGo7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IeDXUfVl45MiAtq39VW2HNKe+oMy6hiyun0lewEvcMq8xJe4dFToUmHFkCAv5KQPU7xsvPtBg3gMaiIZEfMeDJNAcNF8/wgc8FfY8NRcdxkGMozlzgnX83mrQxWqfYWbO/CkFrKLi7lY/iFmj1EXfPl0xaOyDHUqzuFa4iC2H44=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> .
+}
+
+<https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> {
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:7kbdyf9ffr2q657gkgte .
+    
+    event:7kbdyf9ffr2q657gkgte
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eia6yrvml8v995ueq65m ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:9se5txpx8xf4olwlettr ;
+            msg:hasReceivedTimestamp     1513170818853 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:253k6pqq8gyttmmfxc7l ;
+            msg:isResponseTo             event:9se5txpx8xf4olwlettr ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC7PJ7D9z0Q0ccZZEuB2vHZ1rBRfNDpVeNmMbdqfLOPPGqdkIU5Qez/dJHJeCJRyeQIxAIOe/nWDQ5WxlmVw5+HDacLChnsjhrdg0jIye7G4uNQlLKT9cWm1BK6AQeiPLjDVew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bR96WPKD4wLl4hy2Sj5/vx4sic3VOjSs627ORzkgsATQ3aBnedmyoJI9DaC8ayTNHwigNdopWvBgAcjYqm+JBR7WlfxZX0BD/svSHs8fJZvFpMdocD74OJwVynjlSbab2imPv3bMEuBKpGF2QjRPefwrFN32XY1+0LXa5RZlE5o=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> .
+}
+
+<https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> {
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> {
+    event:to3x48329wwbanylmar0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:wpcsl4dxaxpdxbxpfo3r ;
+            msg:hasSentTimestamp  1513170854756 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:to3x48329wwbanylmar0 .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> {
+    event:eue8ar55z7as596cu33m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:n0k3zboeco26jrnxa7l5 ;
+            msg:hasSentTimestamp  1513170819854 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eue8ar55z7as596cu33m .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+}
+
+<https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig> {
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCC6D307Lv5MzLutxg1KXUt+zR2Zwdrr9znEQqdMeBR7DVK6fsXypGeyeDJs2jOW4sCMQDLdydp0WInEodU0NRfYPX8hVB5j2cxSOyEUkHFi9tPMVa/PezteiikUTYLcC25DkM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ydoog51McxPJnLHQtQysJfmTPxn9t0sqIsCV3mcS5JcVt3h9euQ7MXfqjpJ55BrtwiyXzkbwsGftRi87A9WeREXhKdKRfZwAx4VeeHjxs8cI35ilfhEUYLK2EJ11BqhYGxl/a7Oq6/yzZTa31EqemFBLzEKQtllAWUAPw0Oy+94=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> .
+}
+
+<https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+    
+    event:rjc2w35typgyljixk4qo
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:csvglzqkcoddoreep5w0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:r5hu2rq515sq6wzgdjov , event:yrizizmtaxehctdi1m1n ;
+            msg:hasReceivedTimestamp     1513170818401 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8h7v5ml1aflqmoyem61a ;
+            msg:isResponseTo             event:yrizizmtaxehctdi1m1n ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> , <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rjc2w35typgyljixk4qo .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> {
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+    
+    event:9se5txpx8xf4olwlettr
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:253k6pqq8gyttmmfxc7l ;
+            msg:hasSentTimestamp  1513170818350 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9se5txpx8xf4olwlettr .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> {
+    event:tlyivx8nn93zw41ujn1o
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818957 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:tlyivx8nn93zw41ujn1o .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEzChG+S2Bdc2nq0KFUxo1ERyqBwysNvBY+GMd4OiuF8HFrKOKlLgTtPYgLh84F6VAIxALRGin/zCSElySh8J5bDbdMEzTLE6ho8BH/ZPgblj8HmBzVg0ErsAZYCjJv2WfuwbA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCZMyF9ad/NBKsrrC6UVyElcIMcEwkAih7PkXdsbJunfl+Arcw7VhXrDHFh+zA0iK0COi9xaagmyNIpU6J3Zd1H" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig> {
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC7PJ7D9z0Q0ccZZEuB2vHZ1rBRfNDpVeNmMbdqfLOPPGqdkIU5Qez/dJHJeCJRyeQIxAIOe/nWDQ5WxlmVw5+HDacLChnsjhrdg0jIye7G4uNQlLKT9cWm1BK6AQeiPLjDVew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bR96WPKD4wLl4hy2Sj5/vx4sic3VOjSs627ORzkgsATQ3aBnedmyoJI9DaC8ayTNHwigNdopWvBgAcjYqm+JBR7WlfxZX0BD/svSHs8fJZvFpMdocD74OJwVynjlSbab2imPv3bMEuBKpGF2QjRPefwrFN32XY1+0LXa5RZlE5o=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> {
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+}
+
+<https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> {
+    event:pj2n6r9g6jt39rv99xh0
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasReceivedTimestamp     1513170854605 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:t6d7eq3cq6nq54a16k1w ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pj2n6r9g6jt39rv99xh0 .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig> {
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDVdxsx8AMqDVkLxwHHXe2EYoQfGTBPY/v0e03jny8i4Ji/btvU7i8IJb7o5KqOqvkCMFcDtdofYkQmTCtm9v4C4PbDnUXPrg+2rgSFIMF8E0z9qFAi0I6HcK2hFif6WDBF9Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIuO1GUXQ+n2hND0rBXn+YcBU+teqinFMEfnpxVOryDDyFTvYOdyFrRLr1erJ2VAn5trfyMVKpwwUMBdo3guZbsZ0K8MejqJ2x0WjSXHPYAU/sNyXGFtnsvamakkABV4phNySgVeYd9dScP0xAzd7RdXed70M1/njJrrmI5DObej" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> .
+}
+
+<https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> {
+    event:273p25fz6re5tp6drfsd
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4y6xcnpgc0xk4relqfox , event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasReceivedTimestamp     1513170819894 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:xsbbah2dhkcg6d3h13gk ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:273p25fz6re5tp6drfsd .
+    
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCKNGoZuX3Cdx/avuEcE54aYkii9K5pEXQK0QWqpK0vVvEqWQvEoFjWBs7SbQV9i/wIwYolGkZVW7A7p1NietYbLCRHcrQEihskE/862juaVTmSe9hhGqisqVNWBxdsTHFwz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJd9IddYTEuf1hfrGTpj5bPbTDamBREL1KktLjF+hYsTc9pWnpYz2u4dL8MA50FLQJVe02vgmseTrrNJOuqQCU5JvmgX+M27x3rDaKDBUYxHmCGBP0N4g+ylfz3kQAb+ziLRg1t82LfBHQX8esySwF7gPWg/EA8yy7Zl1OZJR41j" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> .
+}
+
+<https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> {
+    event:ggbuodgi1pykilp8znve
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:152dum7y56zn95qyernf ;
+            msg:hasReceivedTimestamp     1513170830072 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:152dum7y56zn95qyernf ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ggbuodgi1pykilp8znve .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> {
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+    
+    event:f9zpvftok83vya1djrg9
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1tr3o22co1907d6b6n7s ;
+            msg:hasSentTimestamp  1513170866300 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f9zpvftok83vya1djrg9 .
+}
+
+<https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig> {
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD3Y4a6E2HjiNdeqmuVGUAG+ff5QyFv8kzV1IWNr3oVnr0AbrEPWwzU3QHZzOcCftwCMQDLqHtPRB9OrdYV6n2vgeGoAcPBqg3TXBl9kTRSbdC7pkDV5+yidHEnyyHnJhroob0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fDvAR88Emuh73Vpv3kuUyeJUgqsbQd0XhuQ+ysVkAUe5Rti/URLo2IeHRKwHYvfd/FRFIKhTpxs09BRTjWL6sXP3lGoSEND6tjTjn//tHFuhpszlkEVvIQ06T5Nh5J11bPgQ+cSR9Cw18NY+/GmgYvJHtlCcwoFokdPTEbGJj/Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> {
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    event:rrmkri9cdrtvp1bkjcnl
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8c6o81ry6mxeetm2d2pf ;
+            msg:hasSentTimestamp  1513170819081 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rrmkri9cdrtvp1bkjcnl .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#content> {
+    event:4846251213444807000
+            won:hasTextMessage  "one" .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#data> {
+    event:5151909952739158000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5151909952739158000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513173165626" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5151909952739158000 .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCQAxrKvkz8ahkRV+l2kXYm96j0EKWjR9tcmW6JSbDJZEvCm0ru3Ml7BDxGM5BWQUwCMG1NPtER68ZG/vEPLk1HIm4ZIWtD4WCr03/CGP+/Y8njelREpPYb4h32VSnEswdQvA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCWXkh6V26WyDNU3YcanwYU0+7slq08Ha1JAkdCbnIN6eKCqFB9b9xx5okeVbGLr0A9H0TUe3DxZxzMnf3Dkkht" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#content> .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig> {
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAURI8MSE1aDOt6QXLwIhRRwXspKgKuPIes5snqWi7Y1TqTAhhqFqdHMUsDKyh07gwIwayN+L4mGhAsMx8l30SlvPJZWbFGp6+2vprfrKaf0NLe1+tHwlZPtMDnJy3c7aTcF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "b1DtmHcAiH/o2j+W0Mf82QGRujysJJx4ksmX2/Q96klinAwgDxGuwpG5knAWWMuYMA0xPNZoWc5FOaiWzhvA6dTeQuRBoYXGuNkFeF9EyOcIP6a4S3Rq5E8rUzsnOLWfvzrtHC9mr/1Na/XKa6MbsZ8RyezZMUNHgPXtnHnDIJw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> {
+    event:u3op66771mcm3ibsrr31
+            a                     msg:FromExternal ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> ;
+            msg:hasMessageType    msg:HintMessage ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNode     <http://localhost:8080/matcher> ;
+            msg:hasSentTimestamp  1513170783093 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u3op66771mcm3ibsrr31 .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCPhKlVpokAvnBg1yWJaGLcnwsOAMlMcSlx4qV25ApbgMR+FXqkdf6T0Iof2ubjOTgCMQD9R9tUbEYcpOo7kz+XxmglErHn7pTwSZWXoYBiEav5Uc7za+zZA+HP5zsBHoDIOo8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UXQ3QlriHRK51zq1Z4qPkrefEl9lV4TUhlxrOhe+6oMMZ/gA++drkw6LHXXw5NRXT9y8yvRbIOuvzHxaTDuLpGkI3ViOCcuLy0wWxQaRVqg5eXe2dyVFi+vXBoQnt4zQJ1ZL2d+jUv9lL+Vzt3IF+qaI2qOdTelxG3DZ186GJjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> {
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    event:0esqgu17b6xqppmgbty7
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasSentTimestamp  1513170819894 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0esqgu17b6xqppmgbty7 .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig> {
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDyuk9Ys52EN24nuADsy+4rk5T0oN6jW+wRdNl+DhzrG7aRXyTlbYmzjb+ABB4az7sCMHQpDt/f/Fy9SD14VPHBx08Rah7ymbdvTAjKK8Wk1ZVbleFdp13bLSB8eWDpTSANYg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIqS1qpEjSNioyIptjfNOCVqKRPY2BVaNIa2xWM5eRKUUj1Y+7628nghA67v9zAglRSejaaUhTIZgYx4+qR934t+hsalPzGoOIkH3pmQpHZIVAYE3/w9gKnB8jRosVJ9RDbSy+X73MsuwTTpHr7b2iBPXOjaEmSAqNag/8aVupZc" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> .
+}
+
+<https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+    
+    event:8pk5umtsiiwch3wl0mda
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6928365067343411000 ;
+            msg:hasReceivedTimestamp     1513172274135 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6928365067343411000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8pk5umtsiiwch3wl0mda .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> {
+    event:uu3ciy3btq6tg90crr3b
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170841933 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uu3ciy3btq6tg90crr3b .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZQCIHn4dPNfpNMxcaCNSXB6WjdBkIDLockXJExIYVNcxaGM145hskettGrSOTGfQIwYsFod55NWTupLAvpL/HbTyCR+2bPfScxWcBhBgAZSZGKDR0gPtNkMNRC4KmyD4xi" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "FOTSsWG3Kzbmyk5AHkje+axhoAmUDtaqAQdaUJE8PHx9Dilpl02dDHk1uYwiocvcDkajmgNSPIUsVmSd0wcJOw==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> {
+    event:m4nq3rl0m1br8bea2n72
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170819305 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m4nq3rl0m1br8bea2n72 .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCpehbfjEpX6KpMO3dpQgnngpJpKft5ppiphDInvS1rP+H/fLrxgr/jqTZbfLqI8FQIxAIT75Wi3rkLLkPSZ4g8iXUxIS/fTGvMzfaiDUHRSeVxMmfcL1h1R83vrDivjL+vMJQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCU/j3zZo+jKJnhW2WzKD90qZ+HMLKv0MYwod8CWJxMny7RmXTbXmp1fe6nu+kfmUOpmWqIXdPy7DhBxAUF/vrz" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> .
+}
+
+<https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig> {
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgo/m+wYmUd6CTfd235wU5AJ/REsZo0sWaVkMEp9VlkqYwwCvN2h5DuHp2f9C3ry8CMCRbkLpAGnAcCMusluqPjBPaiknhZiwJBMaOJdxnRv/Bv/I5cK2Ft/pryO7H3GdmPg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTtN07Njly2C1WBmJfeblgc3XM8I7+/hlven2vbL9MehvhDRmkbjHUYDIwSvBqfGETL2qnQdmR9OYl9D1bXAF83CIos8vRHDpNUwbLzmyWKCjfq7PANK+fBfKf0AU5yiEDCYCIlKz+F5/yh6IAknwcZoC/CeNAKSg3kJnnX1/tH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#data> {
+    event:6928365067343411000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6928365067343411000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513172274028" .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6928365067343411000 .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDIqrhtjcBva7tL0tPzK9+M2gnANK57UR7UHqxphiKlWxtVWvAa7KrRh/4Dobje3MwIxALSe6+C1p0a2I50Pj1qwC7TEzFR2SFeT+6h0IkzYDe8gH6YMD/azwEiGulkURxRU9Q==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "OsrZG5MpBoC3NQNpuGZjkbvL2N7hqqs75JxXonfIq1aVz0KfwOqDk1y0zo4An0FHeeTMrgcg8yPMrIVxcHdz4A==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#content> .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig> {
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBy9LDe4v3QpM+qcxrIVJcJM+v8YXmWHhOdSe8pGn2xnjBoOBEAxJ8Ok/7AX2kv58QIwN/dg/aYd5hDfZiQ139gbY7i5qCYd9vVD0L9GMFTRQvi6CmUO59Gws7ag0sVki59f" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvONhdodKnvof2flAEqXkQGHAmXmp0lMRlWwHnGfk+mXgJR9E7ulLyl1/SCqCkqmNU5it0jhespD1x4llp03fLtAqQAYpWJSP/XYRxjAGdXbm6IBLN5ghUgoK/b4FXYt+7dOX1wB/Z5NqKSI2U3zhJxOmz203R7YA53rTfVSAC8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig> {
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD15h8xYe/QPsx68/qkSp4qO2w6/1wPWhzTshQuowE2KXL/mTxwC2u59iXVbB54DoAIxAPawN3dIsZsiqABhitwR8LPf9RK2romuhxgMNkLtRS/fE8zIn1mdlHyxxBUg3d0Nsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aFKX2oNxuURr5F6nG8hm90H2H4A9iXdKKkADgZuhbzRnblRpaQxXyhM1b7g5xFYqPXfw5RiaqdaY+tua0Dae2atRCx4oUKVvgwVCqa1J5DsIRQV+L48EO2cXCZiPV7eBvxWFpmG6vP3wtJoJFw1X5sBNc8McxW7Eaw9zmFGHPUs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> {
+    event:3v08br9ub79spo7ol4v0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:9787whuvh3bufzx5xm8z ;
+            msg:hasReceivedTimestamp  1513170817961 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig> , <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:3v08br9ub79spo7ol4v0 .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDu8Gc/sKjgG1IFj1EYn2U2ruwOs17PSjlxgfmBHGcPuieyEIfzxA+kJKyLCuaB6y4CMQDz/tcSb5hCsQHYCqx8Hddv3pqV+P/wALc2mcaLoU0VbwUV2gD3c7QHtTfnjMCKb18=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Je1aXzcwnCLWttG4jcpWK1Ab18FJsLtCKX8hqJhjlvKMuiuICUU0Q/zEnU4qPOZH933RbMXCgYvAgfz4oI0oXus6FRWxCqB4uiR1UnVzEmVnMdlGeDXvosJUmWiCb0j7qOa1afsmvXVv+IWLfuIUre9RxyxFLIfImnf4WsYVwDg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDNkG9CWsI1Uogugc/23EjKVlb5KIrsz1vdWQVYgq3iBfWQCgW2K2iID6nQKQKi05UCMDHm8owD7nFGbixybU/ZD13oNu05ydBpKm4xMgVN3Of6oovmjjToaNWIqhBbjmBCVA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIERsNHBCiRhH7J9zjCs5epJxSAZRHlzeTXdgeFFq68J4lFS1k8f16p8y5ur9kFYWP7YQazAstTglpUjSJC42Ubm79z6BkMwpz8idVnT8tNwRs2lWuDa0IZltaJwS2q9NlJaDC/tfSGoWtzzEp++GxpXfe3wiHrtOIztXg9cO2R8" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> .
+}
+
+<https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> {
+    event:cqvzpvoqvtkylzdybhej
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eubp8u958hoow90rt9dz ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:vj2yzrtlf700wixuxujw ;
+            msg:hasReceivedTimestamp     1513172274247 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6928365067343411000 ;
+            msg:isResponseTo             event:vj2yzrtlf700wixuxujw ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCj8XzMChHxr1OUg+i9codjorEeEZd6NEjZV6coLw/RVhHXZxpT2zQNHQCmrDfnAEwCMQCj3ztIZuDm1BVd0a+xGJHmDaIsyoFKWHvhFBS/sH1iorGhvMQLVK25Yv8VEpRFIoI=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OQCMclJqUGtvO8kZAcP6j/tZc385dizMr6Hlefne2dP6j9KEJRRIelXbDsYwWUO7SU5rwrgzcn+S3W29JFH3LiSu8/TrpEPkAG3AMX3165zJyJpiy/Ea7ZX7fPHo9H8MDrK+GzVIvX0M0EB3tFBsUnPmK1yahgabhMylNVKIZuc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> .
+    
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cqvzpvoqvtkylzdybhej .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#content> {
+    event:353368844400623600
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> {
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> {
+    event:cgqt5h004iql2003me2n
+            won:hasTextMessage  "Please go on." .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig> {
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCKCBv2TfWVNnEdBNJDP2HnaZ0PMW7L5HNZw9Gmq6CAo9xFL2Bg94Hln8Z3FfWW/1gCMEUR9lzsypqSXorLjR7YOrxCwGJ+TrwijmTypB/OZci9nt4qJxbM71ULf1nCwgmW7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jh4PEReRBiKtSQDmjELuQf13HhqnYQNzCnPuH3OrSjZXEOhXxI9Yq9HBx71f0dHclvOV07maj08KdgsSFlNBir9z/P8Mx19nrME5XrpntImqHAi1qF9Asjb6q6R1qRej7pvC9shbYWfSrOZDv1f9ADqr/O3kv/wKuRVYUjFC6do=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> {
+    event:rig33yoxaetjw059bzuw
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5693603251585579000 ;
+            msg:hasSentTimestamp  1513172392139 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rig33yoxaetjw059bzuw .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig> {
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDG6bzcVyWp6gPmZNoEArnWHnqTUuQk5YPWOzrW/RKSV5jN69wnrrw5JO+1SEcBqTgCMQCW33ygoBCPZm8Mvch+zfj2FaSBhVR5n2mNuwWYvIowwkIsO2/a06uOdcvwwlfJzG8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FP1723BVOeZpLu+ZOeOsl0bDQGHwycSHQa9cdvco/vdOIeBZzu1tIg+FIZRH5UqEOo2huYjHPXcWpJhQzHUbGEYSdymuttq299kanZdze+02sQ63vvM8sCs4MDqwTVoBy3cfOGzlXY74qvsuZ0x68XnoEWba9+A7la6xaLXnjB8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> .
+}
+
+<https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig> {
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC7M5OdrUd53lIitnywJXohxT2HIa2cUtjM9Ff7i9kcHmRjU3JJoV30nniKIfPmHFsCMEsk74RAYg+LlL2vHmZxJzGsQQ+GhnhySy6O8xU7dI/GO34gDhwLFcH+U3PHZkDWfA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YsZP7L8khHhwtpozr8pM7tHONg7AMhpxd0PVbP2n4kpKkdq4UGqHExLU+akvLGErmneYgKCcG7HStRH4OVhVasSsN0iYmP7AmKJ2beNdlKc70mDDUA6dh9d0y45KTipjKxRZtfp/tUAcpar1D5tpwzCQGG8g7fpA2oikVNBHSB0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> .
+}
+
+<https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> {
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ivr0xermk4aeb3yhohk4 .
+    
+    event:ivr0xermk4aeb3yhohk4
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zpvc6zv244tfxddbhi6a ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:collk6egdkt2tey39h8z ;
+            msg:hasReceivedTimestamp     1513173165946 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:5151909952739158000 ;
+            msg:isResponseTo             event:collk6egdkt2tey39h8z ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC8rfzC1UxD2WrZenm5CVJfUP3ol7NowZWmXKfMHriGAcSYy2RT44iF/fMzN8mWkkgIxAJauw05Yvyrmx6sphnq6aOZfaV2qNdLoHVULPZ8SRCaxr7toyEYrkOaV43FhjuGo7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IeDXUfVl45MiAtq39VW2HNKe+oMy6hiyun0lewEvcMq8xJe4dFToUmHFkCAv5KQPU7xsvPtBg3gMaiIZEfMeDJNAcNF8/wgc8FfY8NRcdxkGMozlzgnX83mrQxWqfYWbO/CkFrKLi7lY/iFmj1EXfPl0xaOyDHUqzuFa4iC2H44=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> .
+}
+
+<https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig> {
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDrRHFNN7Mrr9Fxl8NG7H+m4c+xLjSMWGjzuz3HuTXKbablrhTB2t6hfjMT9g2pmvUCMQCH/3cK8O1svZehcINsK4rCvrwYPwfXS0Ndk9B6wHmTy1tsikceEFOk1Ve9aSI7vvA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aDewJVLuaMq36SHgnEVkyxDgvMIYbjcEc0nYbTCxzXoigscEIiNEzFBD+nx+JCFfp7XM6XG3Eqx50KsVJwAMkx4JXBIAZV1gCJqGliP1gYRRrVL9ZDfb2H4SYiz1+WxfjcPFJdmO9uSET9Q1eLaR0zZEgI28CLVnYeKgIj6RvUE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> .
+}
+
+<https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> {
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yqq73ffvbhkpyq3x3lxp .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME35MheS2EarKRP3mQxGF8egj2rBSEwbuiOy3gnSuN7rM1JlzNSCEYONcxO0vYfWsAIwffHlktaF9Ha/U9qyj5POD8XCvaOJ/jtD7wPS+8Sq2Em7upn03egGjTmoArboJKms" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MQ5/EG7giY3bbGN8WrdVv3dqkjH6Jbw5vTsrmhye+Pn4g2lIVFf62IE7mYoFkx9JsMz44qc9QD20xn287dYrNNlkYYYp712APfJyMXPZz8L8GfbVo6Az//HgqDXQG+ypOBNLyQf3wyjHVoBLqJPKad6+Up6idIzYe2hUkNvQu78=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> .
+    
+    event:yqq73ffvbhkpyq3x3lxp
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0s55ww5ae82lf3j3gwaq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:c6ldwevakufr94hrcn97 ;
+            msg:hasReceivedTimestamp     1513171230845 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:i3k0giied2bgp0p44h7u ;
+            msg:isResponseTo             event:c6ldwevakufr94hrcn97 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#data> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6834006177130613000 .
+    
+    event:6834006177130613000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6834006177130613000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513171118697" .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHWptiDnbeFfpm0XFbU4U7FtMipP2DT0AMELJW0vn6wZcQYcqNZ4BSl75kMJnuLSwgIwbYcpqBOYXCeYAKCGxTyr+T0vf+TjLs0IMPNc4WF0xs5wGTA2ie3HJ+9YzHDR8qnE" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUOWQ8sXqnLXVf5APBLDIBor2HTcrmGONf5YfFmBq3JGyxiLb4RBSGWnbin28/LxtrAJuCXDTEL6ggI575O6Ix" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#content> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> {
+    event:8c6o81ry6mxeetm2d2pf
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818518 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8c6o81ry6mxeetm2d2pf .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD445DsCi6vJBK9oR0cSgoRYxOuxMahCXGQfwHh//pMJtJT4oLo/Mg3P/K0AAHCvH8CMQCyhbKD0k/093ANCTa/QEa8EuFgMFXqcw8zJXeQ1pDnFfwxSeEGNLcuJnhlMjzpBBc=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCFEGU+nhG9r9g2KQjFxGGzcxv1MsFv/R6bIiSIerwA+Wa8Iv//kazVRKGu26/bFcwzdIxZ/teK8Swuwkh9seQ3" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> .
+}
+
+<https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> {
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+}
+
+<https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> {
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o> {
+    event:kaj9nimgw0lkcgmb1asf
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:h6c8epmrvb3gxqrvs81d , event:f3u4lc7l1czvps18lemf ;
+            msg:hasReceivedTimestamp  1513173166373 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu-sig> , <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> , <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kaj9nimgw0lkcgmb1asf .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFZdBEa9BXvziatf48ebrukmJRBeZrAcp4N6tXAZPaoQAJhhzT0+dl+nXvZZovTIMwIwNXw4XPAVL/Vwxuu+iS1AGCKTitAyKiObfPr1xRDVhH0Uo+VbFixAFpejItMGX7oJ" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NTP6/pS/OIhohMc/qRBJQJTDm5jgV9k0DhtvfaqvMItowd4jdFtXPAehOlGi0p4VMv/co/uPpbK7tsGdV3DdHMjgK5QgxIGkuJSE5Zx9XOXdKIkJjDdKSLE9r5s80IDwJ++G/sHk6ffYaMceJ+IRIDjeG0ZemmzukfJdAM7m61E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDrRHFNN7Mrr9Fxl8NG7H+m4c+xLjSMWGjzuz3HuTXKbablrhTB2t6hfjMT9g2pmvUCMQCH/3cK8O1svZehcINsK4rCvrwYPwfXS0Ndk9B6wHmTy1tsikceEFOk1Ve9aSI7vvA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aDewJVLuaMq36SHgnEVkyxDgvMIYbjcEc0nYbTCxzXoigscEIiNEzFBD+nx+JCFfp7XM6XG3Eqx50KsVJwAMkx4JXBIAZV1gCJqGliP1gYRRrVL9ZDfb2H4SYiz1+WxfjcPFJdmO9uSET9Q1eLaR0zZEgI28CLVnYeKgIj6RvUE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> {
+    event:orj8iruy8pcer6zzxlra
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818092 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:orj8iruy8pcer6zzxlra .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCMK7RuNV5+k47WMCvyyUxl98M3EEgGNAt6Rnqz3gZMK4SSY7qR2+dmG41lFDRRB50CMQC//R5cq1nBnxvl4VG1X4NBrxyf9tl8hk8XwN8ScKU2UnXpMLctikRK/ltes1cyhw4=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "D2M1sOkfbZZPkyRedB46cx07uTU0YMOLZp0ADViovC/bQs3Bj7NpKqIhLEswlKmteKDVCkRC7nO2mSVnryVDAA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> {
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    event:o73qpj11bouvhv9pfmhx
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:orj8iruy8pcer6zzxlra ;
+            msg:hasSentTimestamp  1513170818700 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:o73qpj11bouvhv9pfmhx .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> {
+    event:1tr3o22co1907d6b6n7s
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170866250 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1tr3o22co1907d6b6n7s .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAYnEfhK33rkMfzhBytn+lHarJWFuyB4qQ6R/YhwjcdhRueRAKsQUYl4Pu1+osqiGgIxAODtffYKrrFMuMZpWt8p5F0AAXis+UJbWtA/S65Q0Brc8mAR38DKb6GCUmC8SfrFCA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "A0t86E+OGat3RoZZhwy54ztHvtPwdTbcIGgVxFdrMN5cOhksn07KlCwwsYgna74/pvCn94cim8hb4YHRJ9cAxA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> {
+    event:j0oj37oa9ry8lzmm26ul
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4kx7gixf60v34gg65z8x ;
+            msg:hasReceivedTimestamp  1513170820071 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> , <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:j0oj37oa9ry8lzmm26ul .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBs2TL0vpH5kgu6PrQf1J6RfZqrhQu6xtrXCBbenSwt15LB7arcNd5PVr73WLxjwBwIxAP9lv9Z9WMsYQVEi6X79D/1MiGUtb0X2BQRg/Zy/0jLLPxpRK2kFqHqF608GNy5dKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJnls0vbJlaZ2SZAarw+ImPLYf1XiKqE5LCo6w5EdKpBlfm2ySRB+RzXOmGC0LzlhqCexxO8y6S5+8GnfcRqX5rCP8VogYUpyTySqt1wsyWeNiyEw/ZbtzZzoRC2bqLKDzVjo30htRdhF1QD9uOpERaq5buoSmETNJXrYDB7CRI3" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> .
+}
+
+<https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> {
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> {
+    event:0s55ww5ae82lf3j3gwaq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:yqq73ffvbhkpyq3x3lxp ;
+            msg:hasSentTimestamp  1513171230879 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0s55ww5ae82lf3j3gwaq .
+    
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> {
+    event:6149800720990867000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:hasPreviousMessage    event:u3op66771mcm3ibsrr31 ;
+            msg:hasReceivedTimestamp  1513170797698 ;
+            msg:hasSender             conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6149800720990867000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#data-sig> , <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6149800720990867000 .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA43eDMmZAjCwD+FvVgefs7Sy0xp08URBsbHq4r0sTvTbZkbDgNWqZ3ihVu0I5+iygIxAMoDwJZt8wUKvp0f0CzshgZZHiXKQVTUrxBEkMYtRzOhScGAQhqqDwOf5S46IuZvKA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "eJ89fIHdYfoIM8kw5sQ+QZD42/KZkE7PEWNs7shS8jiRvDQSATwbBIIPsyUeKArMuJ9m1IRw5kk0YGGYWvCgAq0erHu0+G9cmXZMu/1XdwXVYiwAf070Xh1d8PxikrAFHNaMckOaF0rqnshPJkntlXA3cRB8uaysa4vnOpOzzuM=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#data> .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDC+4nu9BC8IHVTrzaE7dPftFZQqziXbQsxSLMl9opMz9pzBqDUc7U/61dv7oRnoacCMQD/+vbj4G0V32zIb8elUOzFX1RKgSNT/KAaoxCl24MaJj/uaQtB2KHlEnUIH+LAwM8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvO3Mns1yXliZdv702yhaf75l6OPgFiUcbXMMZAntFgmNkKGFeL3DJb+i70ZOLt3f0COtaceXu3WKiYV2rkDnin6Mn2INUKVT/PvXXnVMFzbrz7eN9FXt3kLKj6Vgih5lE5YNpR+QQc0Evu13AR2/54isfIf6UfVIod4scEQn7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> .
+}
+
+<https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> {
+    event:xkeovy4cf48spd5euwj1
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9787whuvh3bufzx5xm8z ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:hasReceivedTimestamp     1513170817429 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:1107469913331435500 ;
+            msg:isResponseTo             event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDaNCV6mOz1hMPBjIwgaK9m7SQ+X5CoMrWQver12d1LLJNDkqi+mxsIQoX7wMIOakICMQDiq2tU3CUAS1RR+Dnjw8SeBlrijUzmrFDligXf4F4e+c4GbEVqX7R+y6zvgnWacZg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FpgaMyJZj+TbzTw5Tzx9QqtHZnB4MZT4JOrsmWnKMcWN7Klz9oEVxsE5LfnpelVKksjYeza5sMqX8hP4gjAJOaUXSmeoJFjh6D3n4DQdYt4wgaU7U5aq1PZ++P4zcjuyV5T89ZrnAi0A78vP1edPe3IkveABG0KfnbO9gqgUDTI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> .
+    
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xkeovy4cf48spd5euwj1 .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> {
+    event:dhdnzy40wlrnxh7ymr2b
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:i1frxy9ikewwjuyjcznt , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp  1513170820580 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDG6bzcVyWp6gPmZNoEArnWHnqTUuQk5YPWOzrW/RKSV5jN69wnrrw5JO+1SEcBqTgCMQCW33ygoBCPZm8Mvch+zfj2FaSBhVR5n2mNuwWYvIowwkIsO2/a06uOdcvwwlfJzG8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FP1723BVOeZpLu+ZOeOsl0bDQGHwycSHQa9cdvco/vdOIeBZzu1tIg+FIZRH5UqEOo2huYjHPXcWpJhQzHUbGEYSdymuttq299kanZdze+02sQ63vvM8sCs4MDqwTVoBy3cfOGzlXY74qvsuZ0x68XnoEWba9+A7la6xaLXnjB8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> , <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig> , <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:dhdnzy40wlrnxh7ymr2b .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDnma5hS7CN+AkrNpGNJfzlU592E1+0JChbJ+2wTlmWsKh85umQ7iE6CxHbR0tykfUCMQDdvmqJudAWOmXBbEBchSdEEWQNFrv7ULAciI0tifFJ1C1guzXK/ZIKNE8FLDmqr/U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FmCWu/7YK8JPCaKf1pHD5Ir2x3stZzUpPsd1t2QaPctrWWbRmA7AC3pXBIJd4v15a36zcWSVBaYbWzUpP50UUoroRqJFRcwLH1lgGtI2UmyOI+TpR5QUAj06YkrMBKoqkSJpl5tEBmc5bL+mElhU633mHAnkaqI2nkdfDF40fv4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> {
+    event:cbcccoqqqbec6bxkl3y3
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:3v08br9ub79spo7ol4v0 ;
+            msg:hasPreviousMessage    event:xkeovy4cf48spd5euwj1 ;
+            msg:hasReceivedTimestamp  1513170817676 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> , <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cbcccoqqqbec6bxkl3y3 .
+    
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDqyb+JuxvjGHc1T0WaKKpDU4Oej68/mGGt2AItm079FNYejuYNFO+HyF+uqIfPCVICMD0BUROi6w5+grv0+JqAuWzyU6/9iYevHZE4H0/4bsxXW0JW8KP3KkqI5Z3ftKaZ0w==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "eJZL/IDDYZjGc6WnmttuOxOxxhnWuiQJPPzmyrq5Vb8QEb6N2/7y7OTx1WMGdcn27QgNnbjn2MXnCHUEaLqnh3/5kf+E9QmUYSQm0TO3hMkda3vPLAHHdS7b5rC3LFtjjkakvErxcVwIjRu2mul7+sEsvXtoxC4wxfa6gpix7jw=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> .
+}
+
+<https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig> {
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCpkOb7e5AdXuk0dkdTvq5EEHbHPFQek+jqslE7ieVGVDK+OWhopzXqsOzVmAjLFJsCMQCP5spWOSsU35tGeXf+5NECMMe9H+shg2ppQe2oRvz1K4FYY+EawU2xrxZ47g9ghgs=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FApA2qocNuxYIXsIvWpkyVGUtz8xrSsE4BKgqzaNZpaDjoD23J7UAkNayg7fq41hPdopEPKHaRlcDIQk05w1ZR4jUpHcdj5aMaYKON9hX2OQ2+Y5l81XPmWkcmwJdph5CBdDaKl7dwhDcej/wafhee6jP8nY6raPXFIoKMrxgjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> {
+    event:lur3g5en41crth556538
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5iw37ggk8ccrcxxf8f8c ;
+            msg:hasSentTimestamp  1513170831123 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:lur3g5en41crth556538 .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> {
+    event:qyg9hv3nohv4ykv8ryev
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:d5whye2xxe5kofpdojs8 ;
+            msg:hasReceivedTimestamp  1513170842081 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig> , <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qyg9hv3nohv4ykv8ryev .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSScApJPZ8R7ecbEmjmoEu+pxkflMao560sVd3mK2alK8CPTRNoLg/oJQUxa4lqt4CMQDl6yHyqxvxqh+t/13iDG2uWEvqvA8TgR1P2eJIAvxbxg7pVc1XQ0UMGnHml7Zk4uo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MlLaQmKaG9RTw6byp/UmeWfM40JbjgQaSFTd5NFvssErRCjo1yVuoLAXI1iruqGepB6lIGSRN1S0hsatgpmvcmWoXkzUevzbgiED6gNpCycenfAl118R4lamQ0Ku1SnaTx+1VWfWgnaahTRxeUkYlzUaNiciDCfsmg2OLikWzfU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBlZjY/dtzOlPi5MdwNN093c8Lc/SHWyYxEtBdN85M4X/q0AOKFRsekcX5G1PPR41gIwdyHP0HZStd6DyRDcUitTk6P0WrYtRTMpRgDo4rEdJldeYgz6j4DoN8+IZi/Ir/g6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJvDQw6CO36riB5SG0Xw+LQAWVp+4ml3RMeE6fwWCuYdwFxGa0SWte74iah6QM3JTZCFzaBKGDHqq9hri4wm0EnoscWKI6kN7ZspdwMHijF2wFDjM/ddDv9Q3xlM9Rz8AmYWkJwFRjLeBq+eOQLZvqnvtRwA7DXM+KLtzxbweZj9" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> .
+}
+
+<https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> {
+    event:4ongmje7w2v03mp7ztex
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5l16wlgqmeu6z6rt90ca ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:csridlusp0h45v9gf9v6 ;
+            msg:hasReceivedTimestamp     1513170830767 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:4055709708568209400 ;
+            msg:isResponseTo             event:csridlusp0h45v9gf9v6 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4ongmje7w2v03mp7ztex .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGNnDwc5YYL933nHtnxFVA8NxJPmQNfPjt8hUwvgsMvaLDx46ML4wY+pYH1ucJ9fCgIxAOilrXvu3vvKLsYDyD7SPEhFHW8/l7l56Q5P265Eq+y5WcpiYj1ZxjhQsPblPwyEdg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dGtyMN8bioDT+K5C1IRYeFks7KsJA4SHKzwPBikY20jzMfMPPit21cM9mBMjS30atk1s+RRjOjImLb8pqLB09JU9eb/j6U51PDhprQ7o3tTK2gNFuOqoZcxZda59EYQxnqHmravRFM13SrCgCz7WGYn+24ctpbypUCRspP26RL4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> .
+}
+
+<https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> {
+    event:6m7oi7hxwvoi2pmguo6d
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0uouhqi6aym8jad508kd ;
+            msg:hasReceivedTimestamp     1513172392503 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:0uouhqi6aym8jad508kd ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6m7oi7hxwvoi2pmguo6d .
+}
+
+<https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig> {
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDAYu+iwuVxn+iNMkc4L0fs+on/mVIZCFOji+O+vCzNXzj5lfoN6kNNBVOh30sox+4CMCj1NZS7eWslazm6cTDzC6dIZoTA/HbDmsoHhjrScMjszSKg2YWK2l+XmVSY+z6Q3Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TXmnN+JgFn7q4Fiqaup2b5+b0EJi5ml25hgsrE8Fgp11XS7srsuTx1SmoMWMfNT+XZcslr6jelRBzHNvw+ruNv63jvMRsHhCQwz4wTpVumclOxK3XYUnXv231zSCiaSP1BhVZZlLxeVMWwVuXWiOK2b8nIp8sTsXpoJ7efixUCc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> {
+    event:x7cjarywf0513459swe0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:cvloufr7mmg0siwflisg , event:uu3ciy3btq6tg90crr3b ;
+            msg:hasReceivedTimestamp  1513170842174 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgo/m+wYmUd6CTfd235wU5AJ/REsZo0sWaVkMEp9VlkqYwwCvN2h5DuHp2f9C3ry8CMCRbkLpAGnAcCMusluqPjBPaiknhZiwJBMaOJdxnRv/Bv/I5cK2Ft/pryO7H3GdmPg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTtN07Njly2C1WBmJfeblgc3XM8I7+/hlven2vbL9MehvhDRmkbjHUYDIwSvBqfGETL2qnQdmR9OYl9D1bXAF83CIos8vRHDpNUwbLzmyWKCjfq7PANK+fBfKf0AU5yiEDCYCIlKz+F5/yh6IAknwcZoC/CeNAKSg3kJnnX1/tH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> , <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig> , <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:x7cjarywf0513459swe0 .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCvtSL//SlDGw/SSFiTHLK4QBUCohHmHPQxczSwFRpDd8tFyvvSCoEfgGydEErd4VwCMQCDGAwBUQYZfMy3zzWLvhDTWUmMeVihx2Kid8iG56zqjmEpPg8SL9zwHmyM6JCpHv0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PuTE0m9yoe7oa58iU7N68MFKRHRxy5pDuaPjhVFvNFjW8OoiZ6Lbwvjw3HeQekdqeLYm0IPwYE6gZwXfcTV2FNmFFUur+k2V/6VQyj8AP9R59zO3LbfuQl52fTj8vuycNnDun08bg4oD1YOSztjHyXbDDq69GC+E0zahf3bZxdY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> .
+}
+
+<https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig> {
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCXu+JCNySc3oh50OlxXAlsAhd2Spt8tI+7F+rZqKZjyKQJejXsFPNNjDwm8C0lG20CMGmv90AfghtrGZWJskhlMhhKDc92BeUg22NxyivMaJfqhHttOEK61XbGcV2KBqIhog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IjtO0ZaLQudoF6JL1+nY//2rbP+PCotIdSeL/rfJSYfAD1HS6zj50ceZ+j1ntDAcNk4CjMWpEp+ymwRIMP49CwrVheoxeAzzW3PqV9dUcSdzCdnaFwDp/+xwwLsStK8eK74GxUXOy6xsvxg0eeY/5qkqX4SBB3few+5ifwkZvso=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig> {
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCONDSxagGTZTEjj9rSbkkoWfOXNPIW1sdqd9aKJnl+KGcj25TmDij/2MvXgpWdPywIxAJlmcegDVi4tT+Jxu+jYm6gYvDfThqxQwUjZtT87sykFSr0NN1vsgbODrJAjiRGYIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kcc/Wqu7WW8J6gi8yhPkceVRBLT4vc2FZfQFIAIFdUO11gbGBWMdmY+53c6IfNntSdSxEHLMsWCrz/GwB04LAt7dS53eMFM0B9RoQEgS5p418U4IMVlcsERYCvISlkBGNfO/bI+sVQ/aIqaAVI2Alc2eOeZBr3j6ist+vkCnsrw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> {
+    event:5r6qvd7rennbi148vunk
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:iasuj1z9fva0svkfqb79 , event:1tr3o22co1907d6b6n7s ;
+            msg:hasReceivedTimestamp  1513170866423 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig> , <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> , <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5r6qvd7rennbi148vunk .
+    
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCBzp1cAZP2R1cbcA+652mwXk4lOWb0noZmHYLFYB2maq+8BUQzaX97MnZyDFdmjdgIwTjdph52OJLgePV/du4zmDS1riW0qJEZoOgk3bDb1wFH/17wD0NBcX3rmsl4zAJKB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK4rRGDfNdW3i+RZ5TwMnjsRW5+oWCcyQUMKY8CQBOrt7M+StvhcSfKBRZbS0FvOHNo3SMAKMeLaBgfSpySwD0MDu+ErpXCYkye36db6t00XK+t43cYjJzOGLCOkP9BlpcA22JNVP/rZ1tyo1UgV920Jhmjr44xn/d00EPDXffzM" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCrZswKls6aL/j5zsSCfhmh9QRjsK1CG4Ux2wXc80SG5HtsGyKRIoRdkDF/s1SeUFoCMFiafK+GGHmu9z/6pqGISCe6977nqbkuUMGuws38YyrfgiuBLZfdeEYOAN96ShRyVQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e9e5V2sdF96q7wSSHitm3xRk+lrmr3NH3OFWx9yBPVA4qGLjKKc9D7dl2dIvMXipsCMxd/mryscAe+eD0tszzrOxD3VY1EOTw9J39iobqBM0ncQ7nhRdGRc9Wq+ov3KL20hNW0C4tY+Un6WrGQ0VD4P23F3sf/cO3v2HH0DNFWE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig> {
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5jl7uZw9ydMiunpmr4V6hPpZIE3ITtsFx958idfjajz8G+XW4MCYKOXez6fRG2+MCMQCI5D0NqeZIPT0a7aBZ2uqdGiv7WZ9Di+i6I7/OOErO7VsY0hPUSO8JxHKXwxZTSM0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MnW1zKO26p9UC5w2C+/gI65yqrKlUipUyVaGrI1+iV7m4chqma5tTT3cWCwSbbUXv4pwvZdHVKc+nQ7E01xTrTMJgYP+syJLOwUDOaNq5m3HgrYnto1TixrsCqMNDLZux7cFojSVOvWmqK1JXuzX2SGujQazKWj4/6dzeuNFRf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#data> {
+    event:5693603251585579000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5693603251585579000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513172392027" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5693603251585579000 .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4kT6piFh5ceXRL5F9yNB0YbuKL1tKXV1S45+0roXuvmyN+i2sWtYe1LK7jgNdBjECMAnQh8vQBg3FntQaEPfbA1nphu8eAhN/VGfo3s13z1kq/nkuOj8xm6QLMnx1RuT2aA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCPVk1s06jP3dBBjhEWN+uyI/MzhPxlTgXK8/mmfruFE6EZOpeGVcEmkKydyQkY2ZCShug6/M92ISdo50dJNGw7" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#content> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> {
+    event:m8b6jvgclclzy48p7wqd
+            won:hasTextMessage  "    'hint':        create a new need and send hint to it" .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> {
+    event:qyg9hv3nohv4ykv8ryev
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:uu3ciy3btq6tg90crr3b ;
+            msg:hasSentTimestamp  1513170842016 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qyg9hv3nohv4ykv8ryev .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> {
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+}
+
+<https://localhost/won/resource/connection/lhrkbkodc0y4rmc7z51y#data> {
+    conn:lhrkbkodc0y4rmc7z51y
+            a                        won:Connection ;
+            <http://purl.org/dc/terms/modified>
+                    "2017-12-13T13:13:18.261Z"^^xsd:dateTime ;
+            won:belongsToNeed        need:ekdwt2a60tesl77r13mu ;
+            won:hasConnectionState   won:Connected ;
+            won:hasEventContainer    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events> ;
+            won:hasFacet             won:OwnerFacet ;
+            won:hasRemoteConnection  conn:b4vtw60q5p3ro3yfjybs ;
+            won:hasRemoteNeed        need:2615528351738345500 ;
+            won:hasWonNode           <https://localhost:8443/won/resource> .
+    
+    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events>
+            a            won:EventContainer ;
+            rdfs:member  event:kaj9nimgw0lkcgmb1asf .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#data> {
+    <https://localhost:8443/won/resource/event/238289506881087500#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:238289506881087500 .
+    
+    event:238289506881087500
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/238289506881087500#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170860967" .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEXMpuV13LSw+vhQyFssnj3izlgi6ep6rVKS99hPT0+GSXSxcOruw8AENRbxWzRSawIxALDoNFBcKsBcxDv0fIoPmKmnDX15YMkxsHWPhCuWfMg8tR/JU/BjBSRyu5Im12q60g==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCT7Pm3XVPMHSKrpAp2Ph53zH5mNrhmO2gIHkN7OI/VcRYW9T31CB2jq5ZGoCvPCiu19+LN0jj5EE0gg0jmJqn3" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#content> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> {
+    event:tlyivx8nn93zw41ujn1o
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4kx7gixf60v34gg65z8x ;
+            msg:hasPreviousMessage    event:bxwevm9gzqconmzxji4u ;
+            msg:hasReceivedTimestamp  1513170819134 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:tlyivx8nn93zw41ujn1o .
+    
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGGOm0c3hHknNaKBAv0zxIguzu8eQqvLMx7dNDe0zSy/s4Uf7TcCWv19Emcn9/t3eQIwJtxpIHkqR/Ii0DjNeTrITbWqGyEBTFpbq6Hrlfr3WtUqHPVquK8wtQtzIx7Xu0E/" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RndohTRpkC6s6vDZ5dm0xCJBcZgV8ArF69EYgiCOBnIOO51iekDiMawPF0AES5kJeFL+mZElzH4lwis/PnbAbmsgLwEsm2rQeBCVczD8EpCKjRvqxO/qqjvv7NghG78ZODutp55kAI+k5vy9WS/bDCdOoUIql6P+aAafXTONZ9k=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNn5OF84hSKR1M5+QMmsCrD5nsLLfv1QUGuf9Qp/KaAXqVZFqbjJPQBoGUyOmtSv0CME1FB3NvrjmUkztVaFT9mIc0APa6AptNXMEEGHgu/NnwJt0Axn8y5mUS4ovHs7fssQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJlbJyNYa7is+vlEstuyD+i5BFl95ImdgqejmYYED7f+LS9qm7jAh1TxudJZroWJi3dlIe7Y3BNKvyxuO/5xzzFLMGbfiiiw6GbqHczNDXHJKcot5RhvMFUvIjMXi2a/LJFnqJQNmzuNGzLvGTI6cy+m3nh/3eKIURIDlYX7xYbB" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> {
+    event:h2lo8jybm27ouaa4wuqs
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> ;
+            msg:hasMessageType    msg:CreateMessage ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170782150 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h2lo8jybm27ouaa4wuqs .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFCXxJ8Aryjno98JuNKS8NjnGUvyI1GMCWiXNupDzsFEW6CNmW5nRkQjmPvLp+3/ewIwD+3BsKHIF7U6X/W98Ae+Byf2yveq3Vwdn4mw6o8lLnPZuGwlUF4Y5FkD0yCiUw3l" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALIdqjgaAkyUcCBsvFuzlu4yHFaiVeI3AxuHigLdQGsLt9W9DKREYG7p/LKF2+Vnc+MdPRM8Q+aiNz4yIgzuvnZLcyu0j6ga1r2tiiMJLjuh5V5BMZ7JgjfPSw10N/UrI8D5VLH5jvH7AwR1BTXHNRZ2E/EcbNNZf1pzJ+/2MTut" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig> {
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8hJnbfiu4bd4ahyykFzDFaJbAJFuHhaU28V62PnTFWgU/+XkupuU9QRcXQ6xpgeAIxALLgmxezekB1EZ6IKblpQhBek/XMGHu/f0xePNoFujsQ8kHs0jtDngXN/9hG1aTu0Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MDOlDmMYJEQQjXNfyUr1vswV1FajVFgBSDGq5LzjRQyzfajr44IbNGiNiPWuDcFTUTKcD9l5Eg76on3viBxwdYroIj13RXj5UmTUvxuPQ8LiVdeShj5byJwmCqVKIaG1znwssf/GLUYQHUmnOZA8GiFjO0RRyL+qaXzWvtfOr2A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> .
+}
+
+<https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#sysinfo> {
+    need:ekdwt2a60tesl77r13mu
+            a                      won:Need ;
+            <http://purl.org/dc/terms/created>
+                    "2017-12-13T13:13:02.665Z"^^xsd:dateTime ;
+            <http://purl.org/dc/terms/modified>
+                    "2017-12-13T13:13:02.669Z"^^xsd:dateTime ;
+            won:hasConnections     <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu/connections> ;
+            won:hasEventContainer  <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#events> ;
+            won:hasWonNode         <https://localhost:8443/won/resource> ;
+            won:isInState          won:Active .
+    
+    <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#events>
+            a            won:EventContainer ;
+            rdfs:member  event:5cdkigzbdsxk44iw2kai , event:h2lo8jybm27ouaa4wuqs .
+}
+
+<https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> {
+    event:ofx1afjv35cwpppp0wyg
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:ck5071fsyaned6upryxj , event:eczqg8lp7xbukpzikd41 ;
+            msg:hasReceivedTimestamp     1513170818746 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:eczqg8lp7xbukpzikd41 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQClAjshUZ0bRIsA4MLnSIeCSIKnyz3LQfuy064CYYIVc1BRB1KIj6ZwqA/F4jxKTekCMQDWMV47lfLGzthNmOR5L2664akDvrymeQXPXlI5PX6MqkafMCAG2+1twjt79ilGxrM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "a1I4RG56IZ0HyXJ5bAiCmKAvAKjJCD2n+BJYyOrexFekGlxTL5ve7W1LnOhHU4Bgs9CxM05U2Yyq+r4/QAyCbKQBIa/f5IPKwDIEqECaQnwZbXZy1gPp6ipOwB648yBVE1oMPAMz2j/4ht2yNZujCdOClZzuM7Ic/YxzmuMOa9Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ofx1afjv35cwpppp0wyg .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#data> {
+    event:6149800720990867000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6149800720990867000#content> ;
+            msg:hasMessageType    msg:ConnectMessage ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170797623" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6149800720990867000 .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDpWngPYUOoTIRzPSCDIRYw7XVL0tHO1EwfFRK7dkpkA5gwLsxFc3Pu8CPX+iRQxLwIxAPhs3h/yiv05AD58V3MkHhidjfwt9UCFMb5N0sKNeioJGcKpB8z+XZTqlq23+3QrhA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALMbzxssxu00LuwJ8o2HWnqftHOW6cbcbwNUuT6Oro62Pc6k1dh3X+HXMqOOmwxcgf/Moo1mHTJyNWt4KOEu1lKt0INBkFslijzRUdkh7rEnZvivUNvyXWUMaYzOoaGIpp+AsuCAxggSXH5YQ9+NgQqIZZBSVqYRhBXmLhdWuwij" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#content> .
+}
+
+<https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> {
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> {
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> {
+    event:rig33yoxaetjw059bzuw
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xp44teiwtooczc14npe2 ;
+            msg:hasReceivedTimestamp  1513172392235 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig> , <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rig33yoxaetjw059bzuw .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF0DQEL7Y6ywH7J86m9iCpaFzzGZMaOTrr3QEP9tYY8+8kNhz6d8cadeFPkrBcv0GwIxALYAOxJGzgzRJfQAPlEGseGQ4x6s8PA+LvNR4X4PRCOVVH7/OgwwEPZpZvdWwggWqg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJk12DIF8BEWSe3NI6LZcq0e7kn5Nr97GglfNbFz1rpAuQzs6dhOaBoQv/SV/CF6Bn/yX2bpIW+3lvH+kvR7Fr5gsTFMopkuausbHAVUArtGgXtGqEmfpdlD3E5tb+/2030uHb24MRNCJiG1aFDcIMU+qJUs7RWVLbwzpTMW3u9d" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME624OmZ/FEY4fVmSysULKZv7UF2tPv0julpk802t18Cmj5eQE2sYLwddLCNdsm5jgIwB3dCBw0HN6cOfhuUhbh/0ePZeD8ldqT8f9TygTfRKnPNShn59CyjyQ63I3z4Xl/G" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bFHeLGQHjvkGb0MENt6ztrtgUZnVVGNnTI29qWrtr1vkncVLt5ODozo5leNGnw3ksN8eQbr75uxvOG0Z3lfb2bSfO5+G4oYD/sX3zGQkNNtYjLhqT3sfxt+laClpFSs0deyza4sK52YcyXNP6kTn3pSHXCD4Ex5AtxSld8I03N4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> {
+    event:cbcccoqqqbec6bxkl3y3
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817596 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cbcccoqqqbec6bxkl3y3 .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCF/hbvuhAlpZgyjBojjTjgXOZbygRAUrc5cpxlUknl+EyVTGDYi4ojz4CKLYDedpwIxAMMaASa3Wb2Hdolj+prcpMwywUzvx7VB6ZTJfijxoMzY2sHqtZH3IC7yN8pzSiavyA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBX1AVUlzqW+eW5b5nKkTjx7UR4BbPW3c7KHpDZnkSDjDLwrUD1nAuweJMbMdgiVaz5SMC0EqKGpuwJjkQnGhh9" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+    
+    event:8ksy3mzfwa3n937tm3vc
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6834006177130613000 , event:d0muf1vbp6zai6jtnp7w ;
+            msg:hasReceivedTimestamp  1513171119069 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> , <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig> , <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8ksy3mzfwa3n937tm3vc .
+    
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDC3N+xh3W+jdNlpXWQFIyMpFAwOCiwmYF9FTDk+/x7R/wRExl0LHcS4L1wpdbNLkwIxAIjEZMM93CfITMqHTOxp4czNtE7YJ9FClCYPq1J3z/skmNBfn7zIJ/gaXnQmTbWTJw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dizt0KyQXdbm30eEGd6SE4UQ1YRO2154dXa/pUYI6ELRRsNQx7sueMtzcjji/RaZjHmb1b4WJdKc0WiTnO7CUpJHC83EqTvJUU6kZbn6IlDR2BEMUZzDXvQyWf97K7woiLonqodIIJEjwmtG1wMsatXNzXK06jnWw1jcQFnNPN0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF7DLztRcCmLvXZxhvUBXDlvuAwdzzydqhf0/3GyUy1jv0iRC5ULzS5c2uX/3WDT1QIxALxm8FV9FDm9BEhqv5py3ynvwRyZnA4LzvcvDJoifRHVCT8JBrtcqSmw/lJh1BBCfw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WCheSd7dCcoXlR3eepBNlMGLCFcSS4TGKJyrwdQ9A+x+pUulYkZUVEOgKnMvGHGY0mDBmM6K1SqkCkSfEBfA4joikWQdpdxshc4Sn5i00Zh8WezXmbhOrdW7uiDsTyJKKbHTfJlDD3WwM0FshYpo/mf7OiCAZQhXw710tgTbMhg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> {
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+    
+    event:0esqgu17b6xqppmgbty7
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:up8o74u1kna29g9phj23 ;
+            msg:hasReceivedTimestamp  1513170820404 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> , <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0esqgu17b6xqppmgbty7 .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDQg5E9atFosQbXDS/s4WZTBkkiRbeoLd7fqQuUuXJwKNwFUTQVC3Nud1pR540kTxUCMCH1aStQszWDJO0ysvhUJp3WyBw+xxD+FLTrU7IV3+HvOjmsPfx3dfMwmuFWtGj/Vw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Qej6eiW8ljLs4wAs/OiYRo71mH8ZMGlOFFaCYWXj0wsyZN23ViwZP/44coSgcirWJ7Yv95NODM7JpAI/ltcdCibZUK0ga0J4+93MrYE0u4DzE6dww6a5Y+qPVJYxolIXk/H5eQTTqVwM/HrphT2HYxQuuc3NWqtfRG1Rop/7nnE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig> {
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCfb9b4/o0eflVtkvJNb2cHEbjJzB+18MenHM3Ma0uzpry9yd4TOWN34UxvgGhCQQ0CMB8fJljugWsUoztFIsYOszwRP/QUOQKQpZNU7QU7V4r0Am1JgIs7vJV8DIWhR9/uaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKb+p4XkNP1ACG5REa7tjbaPwbQ1b05ehepKt1DcGi7nM0Fp+SShOCPUqflEvTThmyZjZEB3g8jUK8ZCC17nVOPUG4BKxao+CfaDllZA0US3vl/QZt3G51YVA6KmiAE+DSG+26DWqO/qDV+gZlubodICXkNp18yEcIwBweT2r4Yy" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig> {
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCBXQAY9JCzR1KytintdoJQqCCijMN4fZh/scIuz+PU1Yo68ES0h/94Wo2DYHGfEVECMQC+YpU2wvl6TAscmFS04k+gOJemoI0/mwztgZPUNfvLmfkjRYorH+DNP15m+Am212w=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nxifj77s222vVKuupybo3fNtjRETwgJdrubPviAO2r6fBRgFSFDZempT2GNWXNKSRFmT+YMMxPs+p/Rcq/CDZ1mZaioBBYlZELSyqOJlj0QxSzIDZnVb64/+bAQYOvJCt7dgtUn5BYW7fHvyYxIcwFSLvmxnqlFbxne8MT8dkTk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> .
+}
+
+<https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> {
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+}
+
+<https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> {
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> {
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+    
+    event:8ksy3mzfwa3n937tm3vc
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xpspyx3bpyev5v5p1vf6 ;
+            msg:hasSentTimestamp  1513171118998 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8ksy3mzfwa3n937tm3vc .
+}
+
+<https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig> {
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA6xk9W0Nm7Q8n7VHBKI+Ffkrgs+R230cvNb2jldpbDuohwXmcEWD24TJc4T6JdlJgIxAP9vYMZbAV2k53k7Mdz+mY+NMy0np7t44P+SBI78Nb5Xt6I1lOP/hkxRfEcpElRSuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "djVOPPlodqPPEVgtuLU1iuOD6Mzo0/fsuipwuW3KTz79Vq48wnNPY4KWBkt/p1w9sOyeV2gsCNmbvtRdeN/UYZ3Sohb1gRmDcLzZyLuya/kKsX9aHr4KJyFXUdOmo+GGfJYkjwxMiS33UCQRRO6z2CyTk3/qdE9+dHr0yqIYhBA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> .
+}
+
+<https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> {
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+    
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uonv0x93cu72oy531390 .
+    
+    event:uonv0x93cu72oy531390
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8863100035920837000 ;
+            msg:hasReceivedTimestamp     1513170841716 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8863100035920837000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> {
+    event:i1frxy9ikewwjuyjcznt
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:tlyivx8nn93zw41ujn1o , event:eue8ar55z7as596cu33m ;
+            msg:hasReceivedTimestamp  1513170820493 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig> , <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i1frxy9ikewwjuyjcznt .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0/xurl/bcm62GLYTMgHO9GJHr0GM3eT66vmp3CE+cRqaGylTxbd9WnyhErYKh/7wIxAPFxaBXKC1CMbFKX0vDGKRlFj8HbCvEJPYv36/y55GUwrW5qVQp5fizvulmNgEfilQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8ScmSRWdh8pqVwh+r3Pk7imDbcNJXLFJ18Jj4DMDEAVMwMma+MKQhdSLlEyDdHl7u17bZaO9MkdFYV418E1BbBOafVwuxHGcFK2FEO0PVDoDOb2DjDLt9Vi00P7fEh/w+t4acnUJXSAWjhRrhpLLFtjSxa4mmB9aHmvcKJGO8s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF37Z3gVis9mUx/5S3OzCCTUKaYpBCQWL+T6mLE7ixgmSCCRoU0DwHC5qqRKDOZJawIwAbJ5aOVdpohOG1PcAkCi/Zo7TszNHMtfFHfqcnU2dQjixFGRnhfy8wFtxAEhnmZW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJwZQomlVyjpYAWnJ4GP32lx3pgwjczAQsd7aVSTL3muqWYb93xfgDKNj9076dNfTHG34TDgYol2kc61Hp4HIz4fAI0O9i5tUYgpsOT3cqqL1y582/Wff19Hzz2u9mWj9tkhUQn+0gSvxVdauQLETpHJ8DvasoYZECKDNDC0vrzO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig> {
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBHsVzk0iN445oPyFMjO4YrLujaO4utwthhSOruN/uzhzNRcd1wsw7mntJM9pCUCoCMFI5C0YEt9A/unTNjITIMj1Eh0OI++zgD8XkJLQTcLdKyQxHFYRm0NmRVcogmyA15Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALHVkRX/E8lVerdgh+TvBnCbKecI1GN3o8zyTyztkQWeM5iwxeTTTlqHanvi+A32SJ/7GOQgPIO8snBg7LnoiW1n+m9RTiS9UKu/vNue1cAGLH8mgNEvEwPAwPlcwK8UOpj36RZ+h9XYIMOtkl+jUQ0yUU3sWTlYOlaajOGNFV7R" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> .
+}
+
+<https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+}
+
+<https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> {
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+}
+
+<https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig> {
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME13EwWl+3unTJ4OvDSR4tdJvf3ApYwf+bkYMhgB0uT3vlii+wc0ryUcWx1OnNI85QIwW76YwTCXbGMLpzjZqko5zswG4YXxNg9Js7qRJO2iUFgYJZVyLeQVeLRgYySdEC3Q" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "flusXaqyQbNDFTPPYD6uspuQqa1LZFSGLK2dnAWz/JJD8pvhLCPSYAYoi2y+Un/YeSRz6sNIjbvn7u4A4wcW7yF9Po0QZty/xzX803jGoXS9kkiQ6SPOe9IVj5yAeld5b5+OfHREyDSSA0+dCMv8ObQt48rnGTN7Zu6cQQZ+5Ek=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> {
+    event:collk6egdkt2tey39h8z
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5151909952739158000 ;
+            msg:hasSentTimestamp  1513173165842 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:collk6egdkt2tey39h8z .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> {
+    event:kaj9nimgw0lkcgmb1asf
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:vuhyvj1n1x01t4jeddkq ;
+            msg:hasSentTimestamp  1513173166337 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kaj9nimgw0lkcgmb1asf .
+    
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAyOw+ekYDcfg4r0O8Z5sWEfgQ+qSw579eBWtO4R6t9gbr/GTBpbJN9N8SJyn0S1oQIwbmbEyAzsKZ2ID47+MjsuxUITfz8OBD0OFSgH4gTHc7CStJY3C0Xxi2r/BcRYx7aG" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Tz6sLpAjgMJqp+zCSpmaUFuG8DFhIz1l3XRkYD7h/mrplkQJVevyOVvQZrQQIPcj2BXtYuHERurq2kSKBmtVfMtp5wEigCp1Pzj9ZP36kk0Q0xVhTayUTQ6uMHfC3Xkg8svYl1EfUga/3X8Cf1H8Xs07qFW0WqBHGRCAPeHdkjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#content> {
+    event:4055709708568209400
+            won:hasTextMessage  "two" .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> {
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig> {
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME35MheS2EarKRP3mQxGF8egj2rBSEwbuiOy3gnSuN7rM1JlzNSCEYONcxO0vYfWsAIwffHlktaF9Ha/U9qyj5POD8XCvaOJ/jtD7wPS+8Sq2Em7upn03egGjTmoArboJKms" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MQ5/EG7giY3bbGN8WrdVv3dqkjH6Jbw5vTsrmhye+Pn4g2lIVFf62IE7mYoFkx9JsMz44qc9QD20xn287dYrNNlkYYYp712APfJyMXPZz8L8GfbVo6Az//HgqDXQG+ypOBNLyQf3wyjHVoBLqJPKad6+Up6idIzYe2hUkNvQu78=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> .
+}
+
+<https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> {
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> {
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> , <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8950tg6pjze6lr52pq3y .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+    
+    event:8950tg6pjze6lr52pq3y
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:o73qpj11bouvhv9pfmhx ;
+            msg:hasReceivedTimestamp  1513170819096 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC8o0Hjeh9ecoNCW5XLtiEBQbrRCF44lke8zWnSHMuH/cAsuf2M+MicjBNlMDmbdxwCMHpBKge8dazpmAv2tFv4lPPifZcrhVLYKICxLrjnZxA/M77pp5FTpivVyRVyHyLcjQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Rr6gPmaT59AOAc6821EUWSw2b1hjh2ALv1uUXvdtmFHhrPvJmkuJyUxuSSH8OUcM9JpOZY0/r1w+85tVQLJI4VQ6xscU8V7pLnCeGx1w0def6DtjeLDW36/Y2aXDePS9Z5GR881EtpH+9tjwRaw6D5X2UVC09uYkso0dSL1pElk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> , <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zquh20fy530jymcv4c7v .
+    
+    event:zquh20fy530jymcv4c7v
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:nop2f4uemehxb73r1r6a ;
+            msg:hasReceivedTimestamp  1513170854693 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGWgSkrKRiOuh3C24gr7VSUArNd8vjLQKIeY43533dY8Omc5SHSzgHodLq6594aMtAIwbSkDvCwHYlON9Jur4hLBJgdjGuIF9rtzB9l5zolia6YRHTcEzP+RAbJMw7kCazRC" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI21b36EZ08kpcBtt+0oJIEwdEoPeYX449cypwX8y+ZEHrmsgqJt7thZTQbMt68NCgRiIkznaNRZ+IQf60Qm+Bma057G1VqKL86LYjhj7l9oPf7fFr8tq44Pc5Q3iYcXfXbFIZ95OARpzja5ytnlD6Sto3ya7Y6H1EVHhJoVp9VZ" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> {
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5946672495584215000#envelope> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#envelope-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5946672495584215000 .
+    
+    event:5946672495584215000
+            a                         msg:FromOwner ;
+            msg:hasReceivedTimestamp  1513170781692 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEK62x8CHo2KNQQXdYyKJF3ccwPoZTkgYIyhyM99q+/p4XzIcnsk64r53wwF+wK8VQIwfChs09aB23WRhKp5qJbDxVzFwFCI5y0jTxXC0OwITZfZUz8zPnNuVa8BxFW3TNJt" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "PcO+QYO+Zam9qNraDy3Pay2+vOUjdM1lIZe3LrSJBNL5w4R0f7UoZzeFo9MgWV5xxDzZP8Bs6/TC+WT99EM7xkqEarDiNdcSaoFWJAZGJ6u53gj6Clx5aTZs6U1GQgCFuMjUFaJVaPGUkAhX+tANIwpC1YLTSobPjCK9UkQncCk=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> {
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+}
+
+<https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig> {
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlJJUwj6rVz5MAYseOY1b6315LTg4MVSYYsYOsSopsFb/fH+nEGmtrM2N02uBWfiYCMQCEePhqHStLwyluUKeNwa+VX+sPhXo5lvblTvnUFKENVHRdRtKHNlocYFocpLruNoM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKpWpWhPq3JF3pYVVgesevrqAR9a4p+eUE3Q/Zz+fcOKwO+g1kOiVjJRpTLjnB00c8bdNNpUD1yQ2X21T7+iUaOdUQ9+SaHnvgVRPLLrzoBtBZbWW6pyaO3237ha2vmxqMdlkC2+UpWRuYkthQlUIgZg5Mwql9N7ttg7vh6ej8yA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> {
+    event:csridlusp0h45v9gf9v6
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4055709708568209400 ;
+            msg:hasSentTimestamp  1513170830692 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csridlusp0h45v9gf9v6 .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+}
+
+<https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig> {
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDC3N+xh3W+jdNlpXWQFIyMpFAwOCiwmYF9FTDk+/x7R/wRExl0LHcS4L1wpdbNLkwIxAIjEZMM93CfITMqHTOxp4czNtE7YJ9FClCYPq1J3z/skmNBfn7zIJ/gaXnQmTbWTJw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dizt0KyQXdbm30eEGd6SE4UQ1YRO2154dXa/pUYI6ELRRsNQx7sueMtzcjji/RaZjHmb1b4WJdKc0WiTnO7CUpJHC83EqTvJUU6kZbn6IlDR2BEMUZzDXvQyWf97K7woiLonqodIIJEjwmtG1wMsatXNzXK06jnWw1jcQFnNPN0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> .
+}
+
+<https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> {
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> {
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+    
+    event:gi8wvgu0xrwk42ccs4qo
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:wlv9kjrh93gfzetdojp4 ;
+            msg:hasSentTimestamp  1513170797893 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gi8wvgu0xrwk42ccs4qo .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> {
+    event:2sbarcz1yu7cenpcghay
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:lur3g5en41crth556538 ;
+            msg:hasReceivedTimestamp  1513170841770 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig> , <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2sbarcz1yu7cenpcghay .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCqxhC3517LBpbtOcLhszKeyH9ew5sTZh++ScjSzOHLPI82Pyc8YC+66XbT4mgkHaAIxAPdvDR4aClT7FPnMUK/FIKrrSi8pH4Wbcn5JgJHcFB/clPGw6SEQDsLD84kXw5PQIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HqdIh6BzCNaM4CQRLxv8Ad1C5CYQq2fr4YuinR+brNGgT/mhpNCsRyqRgBUWQudZx7tNRqdzcS7HLXjWeuArqXyqoBCxBdNw5l/IhvQev/DHRoB6hLb0/LCgYnXoG+0dmvlPhWVQ+5IEGwS8yYFaNVgmOxFwSAYNtn/kfJYqxa8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDU+1XZKyCLiNWRjI0dnbANbLQK+CcbkDPTVgjlOI6aLUGSMigvvxmi6naeQ8KrNwsCMDa7+w7kgqBqTFzr5D6QiwEB8QzD/lYBiW/NgFcKr06KG5+ApzznOAqYh9cQu0pOww==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "N0m+rZLYdstgaD93DOvsVrMAAmX/e7IZ2FRNA+EH722lBIMw8OKlhDbKWfoVS4wz2M70NRIoqaa2kKNJHK/YabZaoxc8OS1TtL7Jqw7mOcZWreBCCrNNEL9nnlOj3I9yL4p5BeeMeEWWnhM5KnHkRFGu06/0L9RnpL9XdS61ExE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> {
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> {
+    event:4kx7gixf60v34gg65z8x
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:n0k3zboeco26jrnxa7l5 ;
+            msg:hasReceivedTimestamp  1513170819805 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> , <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4kx7gixf60v34gg65z8x .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCkZVANrNwPYph3E0i2Z6X+58WwyaIJnb+WWvnBFfz5mySeZO//rMl7lZ6ibLgpFrwIxAMTLpWrUw4dwDbYm99ypBe8lSc1mjOLTm5e+HONsjGzkrMFTqgYXdvJ7JpywSG5aiw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKW9jF1AT+TJt1o0o0ermAVzXYGIrye9XnOkvUuvC4Cc4/lbgWxbrYRpCukHwHqXZTsB+VwkG22f4CTiaJKZNu2ts9Ljo6azpCI/bbW+TJWvCSpfpYw8Mz/3623+0h7NsMKhao4peEqUznRjy09seZv6DJj4xYRPauOsCMQAJk14" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig> {
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDl/hkfSe2IwapaBDzFRoEhZxrP2P9YiY8FgbkWqMWkdIAH/a3Wgvbwb24hYx4FynQIxAKP1xxubuFoR9g1b8Xh8kJv3O7/KYozptOVpnNp9iReJA29oOpvaHR9FhaFCLmgWNA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YAkN2j98/s4Fn+0Fy/PxrHUyKfFw9WSxxd4naB3aRJLYAYUg4+FMAZlJs5oZW2l7vUxGx0RF3VzaH9Hr4X7xLIrcCvi2/+b4itdM4OYgXCKtbyFVzLBrRKfxpdITVNQVRAX0zSOVF3yuOLMBORgePpYb50hHU7i2F4hjq8iwScI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> .
+}
+
+<https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig> {
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH9NsQdN66hMeZ0vk7KT5AnpnohOiS/CB1VnayXxRmxZk77r4a5nomPv4N2iothsEQIxANXYWW1m3iF0BLTa7L3WTsYmkO9tppaIzP7UKVzD2HJI1u/ShW2aFCSrdq9OlD95eQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "X20g3kkDFS9eYgwvoZeOAQD7XF8M9sOWpdHWw0sFEhTNzstHvT4ObDA/Pm4XzGFfuDGmzyrpy2cnLFHqL2G6HapR13nnzzBhuwo90vxf9FwvWD6GcXfD06hI8v/ovCEYkGMqTH/oUGnLK59CGz1Qn+7/qGi//l4v6XLOeorK9rE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> .
+}
+
+<https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+    
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:saegwhiwygztg1mpf4xh .
+    
+    event:saegwhiwygztg1mpf4xh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4846251213444807000 ;
+            msg:hasReceivedTimestamp     1513170829703 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:4846251213444807000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#data> {
+    event:4846251213444807000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/4846251213444807000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170829592" .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4846251213444807000 .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD1XcORU5GxAYutm3D+iOT9nVXbpbeqlSyRB5xlCcMNWBx3pChw1qDOk+NatkxDygUCMQCaGN57aFG9KTWnR/0ZW3DNacwfmKZ3Xcs0PEP3TwCdeK9+8mXhrQ1i9Bd1c5rZTzw=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "CARaNKFJR4joQ+2zDV0VmnwGXZJZzqtWHHFEVQIl659kn+b/jPdbMEEtGAYmwpaOAaRF7xoG1b5PIhuCoC6qgA==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#content> .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> {
+    event:fdxtdqeonqc6mk01crog
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5l16wlgqmeu6z6rt90ca ;
+            msg:hasReceivedTimestamp  1513170831045 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig> , <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fdxtdqeonqc6mk01crog .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHjnW7jow/Z7aL1QDqTFMpP+uUJK8at6ss5OZuet6gmrixv01UBKjCGc1IcJi2QP3QIxAKLau2w3EYVaNhiwbBvszShChrvxT7r///J2xtTY/nogW4LhF9XYHuO+POgxhB4ajA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VyoehYH0+v21MhUknlbDkitBJGdeDF/s45ZAHERkECa5rhyIeX5JdqiSIECSPn5+cSAH8BkNxf4BI8gM9hCIDNQyEXWnhSLcOJFshwCaQcFVyEunib8w+gc0HCrLM63xSQpwcSqjfTT/OTnQVWpuSIx8Zs9Qa6cHgEpPK++pxjU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGCm/09vZEkM4lcNJx+gKm+2Xp6JsebEXr7r8QgeagdTyqm/ijVL6mGgxqG+zV3zFAIxAP9gzNawedUebvkzFjG9dFg5/HT5zfwG+kAZJXejgPAEMr7FcADEHTa3QfbqHLRZ6Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIg6Z6UZE0s2a5I/XlbHdwGWcGeJchlDkWnQIVc2HpNZYcV550t3wHkqij25WSnOJS4MiF3AVR8FmSQFg0yy1GFawoRy7734zeFkA/g2oIYnkSlYtMyzoxc7PDAJPYAUE+DYlgFvU5dE9m0hu6Ml07QzbrxSBzlCi4Dtqv2dV5Qh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> {
+    event:alif190jj9we7toczas8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1d5xlvosu9j6umgi8r47 ;
+            msg:hasSentTimestamp  1513170830228 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:alif190jj9we7toczas8 .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> {
+    event:0s55ww5ae82lf3j3gwaq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:v5rvsrlg0x3ogdqyfuy4 , event:i3k0giied2bgp0p44h7u ;
+            msg:hasReceivedTimestamp  1513171230940 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> , <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig> , <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0s55ww5ae82lf3j3gwaq .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH9NsQdN66hMeZ0vk7KT5AnpnohOiS/CB1VnayXxRmxZk77r4a5nomPv4N2iothsEQIxANXYWW1m3iF0BLTa7L3WTsYmkO9tppaIzP7UKVzD2HJI1u/ShW2aFCSrdq9OlD95eQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "X20g3kkDFS9eYgwvoZeOAQD7XF8M9sOWpdHWw0sFEhTNzstHvT4ObDA/Pm4XzGFfuDGmzyrpy2cnLFHqL2G6HapR13nnzzBhuwo90vxf9FwvWD6GcXfD06hI8v/ovCEYkGMqTH/oUGnLK59CGz1Qn+7/qGi//l4v6XLOeorK9rE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME4zXkSquRnyZGv4WcTZhygFz2y452UP/ifRrvo1RNoeT9OV30kp0VC4o56P8uTjpgIxAKofPRkD1Mc8TKUBra3rPqc6V8syC3FjVGGv3rKMTcukETLdkkHd2mf83OxtHmDhpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GJiojYvJ4MDhMdNmW+xa8K0iV6xCqzBsG4okgSyk5w/SBlyiK81FTHCq+IemlgNWe0UFmTjmYCT5vOLYMgtY79ja+j08xoxt4hkZAP0VfngdipGssZpGVnrm2vEz4kDtw9ny2ti6xe7WedxaocMAPFI21hGzWHC4tYTQ70UXs2M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> .
+}
+
+<https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> {
+    event:wpcsl4dxaxpdxbxpfo3r
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:to3x48329wwbanylmar0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:zquh20fy530jymcv4c7v ;
+            msg:hasReceivedTimestamp     1513170854716 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:t6d7eq3cq6nq54a16k1w ;
+            msg:isResponseTo             event:zquh20fy530jymcv4c7v ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:wpcsl4dxaxpdxbxpfo3r .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDUP/fs+55TXUZubu+45hQ+ta04XzP7sDbwb8ECqWcI8OrsYCadNZ2mdHGuO1n0F/ICMCW87yDqhImKEtP8txkLCdVI8/lkBI3wJ3t1gRSNXC89HTEqo2vvZG377rFgmZnzrQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UkfJOncQPcw65kiy88cWFeApVgVHAnfZfQsjR8MowmZBIKcYUB08bpAaM9t3sQrdqZ0O+3KMYCgDdbxyUIKBeP37e18X7BepkZg70SsiHllnMNXELkRWrIlu3C+VzMRrufK7sMk94N3GSJ/oV0vv+7mpq4yxDc6fSgn5kAevy+A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> .
+}
+
+<https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> {
+    event:izq6icbkftfbzm0clxeu
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasReceivedTimestamp     1513170798286 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:gv6zk2yqk6o8bl574n36 ;
+            msg:isResponseToMessageType  msg:OpenMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:izq6icbkftfbzm0clxeu .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> {
+    event:eczqg8lp7xbukpzikd41
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818470 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eczqg8lp7xbukpzikd41 .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDETQTI4v/b5O62feqQgEyd9wB2tFPfKQ4mGFXq+ur/i5phWiW70pw4BpWgJOhCi+wCMGcsW+IaxMxaBdU38lCsbJPEGFZlBiCVqVCF/ILeQVpGGsp59/oD9VlGRDHLF05e9g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "JyBD6LNYgu8RSOFAfZSgtETg81Y3qQEmD9WaF8U8Wkblw7zJsKi5eFE9nIaF9kKcH8UU2gX9W1uFM/yWfkxMJg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> {
+    event:fn87pwzr9g4a9v368h4m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:353368844400623600 ;
+            msg:hasSentTimestamp  1513171226328 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fn87pwzr9g4a9v368h4m .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> {
+    need:ekdwt2a60tesl77r13mu
+            a             won:Need ;
+            won:hasFacet  won:OwnerFacet ;
+            won:is        _:b0 , _:b1 , _:b2 , _:b3 ;
+            won:seeks     _:b0 , _:b1 , _:b2 , _:b3 ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] .
+    
+    _:b0    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b1    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b2    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b3    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+}
+
+<https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> {
+    event:cvloufr7mmg0siwflisg
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:uu3ciy3btq6tg90crr3b ;
+            msg:hasReceivedTimestamp     1513170842016 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:uu3ciy3btq6tg90crr3b ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cvloufr7mmg0siwflisg .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> {
+    event:xsbbah2dhkcg6d3h13gk
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170819569 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xsbbah2dhkcg6d3h13gk .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC6L2e8HVt8wOr0lgvlozUAghNAC3Z2C3R5JcOhIhzHGRhT7X0+pjTfcCitXpovnc8CMDc2WkWe9j/zaxT1n6c8h+6D8a4FVn6whYSJyConWSf3BGoOOzeBnOChgjp8dgowaA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "BF9GL63mQJd1MXHqDgmIN1m0bvKVCdnAUiDYMSrCdwlWDNF4SfwYKdLq1b6ZC4XsQz71ZPPsLptZl33nTCHYUg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> {
+    event:dhdnzy40wlrnxh7ymr2b
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:up8o74u1kna29g9phj23 ;
+            msg:hasSentTimestamp  1513170820434 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:dhdnzy40wlrnxh7ymr2b .
+    
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> {
+    event:l27gk9ia5beeuyjqfp7j
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:gi8wvgu0xrwk42ccs4qo ;
+            msg:hasReceivedTimestamp  1513170798408 ;
+            msg:hasReceiver           conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig> , <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l27gk9ia5beeuyjqfp7j .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHgabnaxK8IZ9ikFDriWlf959XOzloKYuSCoJCdtZktH4PEFkBZnRrX90zOV5UFs2gIxANBLmS5yXSwLnvatq/MytzaXaz0PYeqpJ26YbR0LLURNFVQ3MrMK4OCGPiJ95dnDMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eG9Ad4ZqtP+ud3nWrJ/Id3P9iQGA7our5i9VvfuqOHpSJOzNwJldplrtxhzqaUp0njmw6G2MVUHYqIQp1CdyBJwKI/VaiSzsAigTId0q8u1BrdiEvnnwZ+QNt27ImYhFEdSZ7U2yPNpXDH2O7s/8RBHbCAdsIOLzZxUDsSijaEY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFOpEhDXHQlQQrLrKC8kisavjQl/HY83X+ABj8ViPD97D/f4ljkAT2t/ayfDFSd6DAIxAJIulYV8llPSx/CHKRtjFehKoXDB6rGACAlPhCR4ugd60Lfazc3eyD5l/N6lLfiwHQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NPN7qjNnc+0mljKwTAQ1h3WRGTRL8AjjMkgWO4IQ4WDWHxRHFJlqK5+VuCVS5oq187os27WjDdxFHYAyuenzKA0IcXcvomHN7lWw6rtTJH5zU/A5vxt4PaYPfb/nRka5hT0t62TsCAkD5mLtPfsSR7PsIvNNzzynXK1Jy/tnHzM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> .
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> {
+    event:c6ldwevakufr94hrcn97
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:qi81r6ggzy26wznv94dq ;
+            msg:hasReceivedTimestamp  1513171230809 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig> , <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:c6ldwevakufr94hrcn97 .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8hJnbfiu4bd4ahyykFzDFaJbAJFuHhaU28V62PnTFWgU/+XkupuU9QRcXQ6xpgeAIxALLgmxezekB1EZ6IKblpQhBek/XMGHu/f0xePNoFujsQ8kHs0jtDngXN/9hG1aTu0Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MDOlDmMYJEQQjXNfyUr1vswV1FajVFgBSDGq5LzjRQyzfajr44IbNGiNiPWuDcFTUTKcD9l5Eg76on3viBxwdYroIj13RXj5UmTUvxuPQ8LiVdeShj5byJwmCqVKIaG1znwssf/GLUYQHUmnOZA8GiFjO0RRyL+qaXzWvtfOr2A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDvhbVMOQ1Ig1IxHqTfkirWvWfxGrW/jnwZzGxJwe9OGv3PUYP0DHgx4ANR1qXIoIcCMDZI0yGgOf86hAxxc5W2su8Iq6vRzzjoW7qO2tmyWn3Alkw8SrbBVKn5oKmZCfvCdA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DMi+xYFaYErTz935OwLrUqPLJfRmggVmjbn6qn6s/alM/Vv00T5p6CiLRhkkFsoiU0IvigIVdu4BWMkQhET7zP6h1yKF5Ojf66KMHEfPVNfyxnCFaTLP8D2vtkhnNAWRzRiFTQQrjA5oqhcZZxqTK53/WmIPZhkOt0UKoFMKHs4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> {
+    event:4rit8itn4uyigyesq90s
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:152dum7y56zn95qyernf ;
+            msg:hasSentTimestamp  1513170830072 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4rit8itn4uyigyesq90s .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> {
+    event:zquh20fy530jymcv4c7v
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasSentTimestamp  1513170854605 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zquh20fy530jymcv4c7v .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> {
+    event:x7cjarywf0513459swe0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:nop2f4uemehxb73r1r6a ;
+            msg:hasSentTimestamp  1513170842138 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:x7cjarywf0513459swe0 .
+    
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> {
+    event:mmdq8395owv3xy9iyl5q
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5r6qvd7rennbi148vunk ;
+            msg:hasReceivedTimestamp  1513171118942 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig> , <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mmdq8395owv3xy9iyl5q .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzFIl4PjdbXYSlD31IrBKQKz6oX5EX0e6NSETXe+NH5SeMZr9HxAfsNPsPf+7BA/ECMQCwUYpJh+5P8VhXoSOuiyFbYUCFS1k8R6gbXVQYvqRTSbG3wWzUVdepkvDGu27og1g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PRF6LjrxSZDoat13nv6Y7NFRoD6H/jvtlfiSrc58fq7CLn3f0MtjH2JtCG6vSGzcXHvJYkvMJKN2LZdHsekkAexWhjmpS+g5Uk5C5r+zWEUbHugv9+EGHlEganamOeo0qgiRTQMFDQS/Qt461zboPint8stjXSQLtlvRnWWMfIY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDp62BWtRF/XSfdNCtz/PUIjVyoE9wOGyFbzZBQHobaEEb9OHPIvK06t0k2VJk5vh4CMAX2Sv0jNjas+T6XhLh18XyxebDaHb9/sd6TSbnGeYWdFyNEkDg5PGjr9Iz7AC6Zfg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PdM/2GWODjO8m3QMMwOaA4zHv7sqjJSoJ77jQSIKHwC6fEpoaHt87Xv4j7VthUb3CNFqGzJ5YGD6RarrFaj6kmzUSwpt//Tig56DxCGYSrXIYQhMQ0/PaC07PKBgO1sg5DNnWKDpn3Di/VHoX0zBmM4vz0il40T5IaLOsEqSIRM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> .
+}
+
+<https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> {
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+    
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+    
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> , <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:up8o74u1kna29g9phj23 .
+    
+    event:up8o74u1kna29g9phj23
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:dhdnzy40wlrnxh7ymr2b ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:j0oj37oa9ry8lzmm26ul , event:obimbxem9rgy4jw669vf ;
+            msg:hasReceivedTimestamp     1513170820361 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:m4nq3rl0m1br8bea2n72 ;
+            msg:isResponseTo             event:j0oj37oa9ry8lzmm26ul ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> {
+    event:f3u4lc7l1czvps18lemf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:h6c8epmrvb3gxqrvs81d ;
+            msg:hasReceivedTimestamp     1513173166250 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:h6c8epmrvb3gxqrvs81d ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f3u4lc7l1czvps18lemf .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> {
+    event:gv6zk2yqk6o8bl574n36
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:l27gk9ia5beeuyjqfp7j ;
+            msg:hasPreviousMessage    event:wlv9kjrh93gfzetdojp4 ;
+            msg:hasReceivedTimestamp  1513170798255 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> , <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gv6zk2yqk6o8bl574n36 .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFokQYOMW3QfdcccXmewxBg2SmvU7gDVqSb4qrv8GA/lM14jXn7yr4Xg23P/vMJ9nAIxAIIM8YLDsgQ+DcgCWGsaOBM15XQmKHX5sHvIolCzj4YjjAcQ7zdHzZ+SBEiquVwV1g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "FiWB68RkVnW++oJwqvTYH8SgokQs+LFiR69MfVtquD/1F/xVLKxfEDK415cBAqf4Gi2aMvEc3SKzM5PfBlpsFptWIyHFQudBSxD5gKaM0hB17KOjhmkfDhNiWHdN0Yw5AF2A1X9qEbBuvv1y6yFtZcO+7TbJ2k5LaT21T9SwW10=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig> {
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXRJYG0ftvSXFMxiOr69/P66KnIv+WcuIt+DWtD7xW7TuTSxe6JGnReuZLuQlmURICMQC1SEOZ00JWARGgxDU6QV5S6iAClzKI4yITVECbU0VTy4PsCkDKx1oxeyehxuoV4dQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VoOyZrxwoqwhIjWwhAx0R885hWG7pYIgPfgtywGWQmN7Fom2vfScNTWH+VnPpaFE+qrQVPHlP6/6ggNyLhsO0WiquMFWqhEebzgo0dOBZyIdGSjPgtFYudNUanngr3rEnZDVBgBh89aM4whZ8QZ9X9xj4HzU9ResMzH9NnwF43U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> {
+    event:j0oj37oa9ry8lzmm26ul
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasSentTimestamp  1513170819786 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:j0oj37oa9ry8lzmm26ul .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> {
+    event:sdt7yr7q7t9iw8wcuu3m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:h2lo8jybm27ouaa4wuqs ;
+            msg:hasReceivedTimestamp  1513170797829 ;
+            msg:hasReceiver           conn:lhrkbkodc0y4rmc7z51y ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> , <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:sdt7yr7q7t9iw8wcuu3m .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMQD985B/e7+8s0S0DsTSmbZJ/CRvTQeArp4jDasIR6UaqnPW1nFAutVAoOo73+mMATICL2aCglPgWcgDH9CcDmw5QhiKcNYWpmTamZ/pXuIngTi1ao29XBfGLIK9sJWxppiN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "T9pYKrAhEd6XyRFR4jaK0E96GEiZGfDYs1XL99FDiWK8622vYjviLUoB/A/k35D97tkaGToid0K6jHFxr8ysKDaw/97ibjv2P4lVX21tLmlQuovxqdb8R4Iiuw8R7KC/Mjutr8PS3xNYPyZYRhYbH2hoKKBLWlabbCHX8+IeU54=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> .
+}
+
+<https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> {
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> {
+    event:eczqg8lp7xbukpzikd41
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8950tg6pjze6lr52pq3y ;
+            msg:hasPreviousMessage    event:9uyongxoip0kz7t9tsa8 ;
+            msg:hasReceivedTimestamp  1513170818537 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eczqg8lp7xbukpzikd41 .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5jl7uZw9ydMiunpmr4V6hPpZIE3ITtsFx958idfjajz8G+XW4MCYKOXez6fRG2+MCMQCI5D0NqeZIPT0a7aBZ2uqdGiv7WZ9Di+i6I7/OOErO7VsY0hPUSO8JxHKXwxZTSM0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MnW1zKO26p9UC5w2C+/gI65yqrKlUipUyVaGrI1+iV7m4chqma5tTT3cWCwSbbUXv4pwvZdHVKc+nQ7E01xTrTMJgYP+syJLOwUDOaNq5m3HgrYnto1TixrsCqMNDLZux7cFojSVOvWmqK1JXuzX2SGujQazKWj4/6dzeuNFRf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzbAQ2BL1n33UuO7acDwtFqTGsERVzhBEJriPEwtuhkshf62BZu4THik6AGkMwt+UCMQD7Fnp2eC7FsmVeYqiePiv14x2xce/zZgRysTL6F94hmkLshiV6Ffe343JXMjcARXw=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AKJs0LL+AXlGVVL+88ZeKmY2UEgj/ztv+GhedA1qhrXkzIN7Ev8xt8ir22bBY86sctFCiiRjuO5Xlx2syxyIN9ExrxpuBMOBourDabW8wg1kiwYvmAGMiIBo0trlai6HY7XI5DulyrHIQVp5FikbcQvzW2bM8esu7aGBsYGPziUO" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> {
+    event:h6c8epmrvb3gxqrvs81d
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513173166148 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h6c8epmrvb3gxqrvs81d .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBPLWbiBlL3DHML6S4bOqD97AS7FvqQT8KCVSN3aRj7QML9LgaohStEHXJM1EPCzmwIwb3sTsIIPAGc9hsBaOEtWpUiDN0SJ5fsADQtgwMHezPgIvSE7vCkpDqSaKHZ+42Oj" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NDEWSk8nJzdGCc/U4AuEr61ph7SIFQCMpTQW8LCNsZtKWmdno43bbN+I1nh7A9Wtx68qlpiJhzhrYUSit3rYtg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#data> {
+    event:1107469913331435500
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/1107469913331435500#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170817192" .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1107469913331435500 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDvWZ9GrBCYmRLDPcf3Zy9ctWbfMLlqB7joijR++XeOKbeJeMOEaaDK8QRltm/0cKgIxALi0Ot4jzL6K+oIPc7qb3SwWcoYPG46sebFqG4MONu5RJMs70g/wIn3SmCun+ERSsw==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCBOuadhn1OsP77rGImWi7xBXcZ4HQgEFNRbBN5T9vCNY5F6dqL970JrEfp+YjgfadY58LtZYn48eT7blzDJZhF" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#content> .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> {
+    event:gv6zk2yqk6o8bl574n36
+            won:hasTextMessage  "Greetings! \nI am the DebugBot. I can simulate multiple other users so you can test things. I understand a few commands. \nTo see which ones, type \n\n'usage'\n\n (without the quotes)." .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> {
+    event:9uyongxoip0kz7t9tsa8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:cbcccoqqqbec6bxkl3y3 , event:orj8iruy8pcer6zzxlra ;
+            msg:hasReceivedTimestamp  1513170818418 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd-sig> , <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9uyongxoip0kz7t9tsa8 .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCeMxqqHKx+Ml7JIz7mKjWcedcLsozemK/bBVrl2p4lw/lgaecozWPNzKVC5yAtEuwCMBwRAUNbLLArWZAQ/EGF/LMIDcHmdOvhlILsKG/AZQpR2Tm+Kum3bp/gkEk/oE0Aig==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJDLony/RWbq7EfC6MKodZ8cGYQwM1AdR+11P3KpljObngoGYvOXteIJ12f1KEXLRlZY2hiixSDXJXzoBYJwLdQy+KjZhWkRv4NkeDNW7cf5ZopLu7EJqNp2BvJEz6qIybWe13J4emEgy+G2NKN5jpZYPW29MivOEx45YM4/WXge" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> {
+    event:nepohymog91pfkznq0ry
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eubp8u958hoow90rt9dz ;
+            msg:hasReceivedTimestamp  1513172281087 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig> , <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nepohymog91pfkznq0ry .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBy9LDe4v3QpM+qcxrIVJcJM+v8YXmWHhOdSe8pGn2xnjBoOBEAxJ8Ok/7AX2kv58QIwN/dg/aYd5hDfZiQ139gbY7i5qCYd9vVD0L9GMFTRQvi6CmUO59Gws7ag0sVki59f" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvONhdodKnvof2flAEqXkQGHAmXmp0lMRlWwHnGfk+mXgJR9E7ulLyl1/SCqCkqmNU5it0jhespD1x4llp03fLtAqQAYpWJSP/XYRxjAGdXbm6IBLN5ghUgoK/b4FXYt+7dOX1wB/Z5NqKSI2U3zhJxOmz203R7YA53rTfVSAC8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAFq603EC4EU6uFiucGDGC4Kz6z45W6jwEYPnVUG+cXO7fuitU4V1ZX/QMcjgf5tFwIwRnJo4nOWOGEYegI9Mn3SudCj+fgsni1oX/cK46lpX5wP7kEQLALOizV5jtjNF5jB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CyXqkmnutKS5HJ2R5hP3CazGJR9hNdyWCUIubajcHbi3qb5Azp3856OhMjkCATsbzo3NteJFdc1PECjEADNIwnnH76f+O9zp4h1S6JBE8ze+bTac3dpy/J2U539/YkG6DkuJ29Pc5dJCfY4vs8m94JEGDIxkHMY77w5TAuvJnYw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> {
+    event:0uouhqi6aym8jad508kd
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172392390 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0uouhqi6aym8jad508kd .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZp0fH74r41wO0vmvM2ND70yepMU8oz1snJq8eu2vldB397rPT7GllTNzemyQuyngIxAJgjMxQupDqsrA0/hOsAkHLl40/EmSjy/zfZSHNWFT1kpiOMpxzHD0fBnFRCIHgIlg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBPyB9ExNzcRs5FE3X1HURk7IrrTzAFrh4ONFbU+mwa6HvrBFW9yEr0og/m4+l2+uh+u2Qz6tvHZbr0NsYj94bV" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> .
+}
+
+<https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> {
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+    
+    event:at9ld2d9yv5dmfmzbxjc
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6149800720990867000 ;
+            msg:hasReceivedTimestamp     1513170797721 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6149800720990867000 ;
+            msg:isResponseToMessageType  msg:ConnectMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:at9ld2d9yv5dmfmzbxjc .
+}
+
+<https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> {
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig> {
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8qI64moKP/D/+XBh+1XDqUAooItSmLoEk/xt7WEH9/zGnX76uGoG6TQ1gbEC2+nQIxAKZGQk3n6IvpdbH4DAugjamtOcgKDDQtGHOuaqhcNnMUtW/3z38CJr1jExlpT44cLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIIUS+7qXLkSoWnELV0FBeAUb8G6KYdsblySs1Z9IQKdQOiKkwbz786HZdTq0+bl3OG4qqXB54TWjT8wmjMkkXLJDkbgxNyZrY0pzVjkGs2VhBe3khTGq2JABzOhDDu5bFKnoYRrYaJPhbA9AMdSrcfYl2dGq6R+pIvRIdi8bKfe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> .
+}
+
+<https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+    
+    event:elqliyw383sgw1gbtxcf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4055709708568209400 ;
+            msg:hasReceivedTimestamp     1513170830692 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:4055709708568209400 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:elqliyw383sgw1gbtxcf .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> {
+    event:93e94yjsmx9l4lg8lu1b
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rd1ryd06xejacyss9qy5 ;
+            msg:hasSentTimestamp  1513170820601 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:93e94yjsmx9l4lg8lu1b .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> {
+    event:u02ulpncdj9l8ae8x2aq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:9oa8ktxu7tqzll06rhw9 , event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasReceivedTimestamp  1513172264092 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> , <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig> , <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u02ulpncdj9l8ae8x2aq .
+    
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBuXv823DJnc0Gy/hyx37tadJtAcEMhnJZVt/pNvhd6zFqT0eF+nWMRtXyrWyUoSwgIwOtYJWYw585IWoWy63tL9+QqIQKthFe0mry2n5kdV73A5ytfDOX213DGz95WGGbPO" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKijqTKR104eXXLrK+ZKsQZU6H1W858mHLkxcm5YdXq0JGqty8hJ0rmy74/j+VUTaDbj5O84D8+hNPFQibObM6emitgNZSgHBBsBqYxdAaisjX8CjekBZxnOwrLMFYan9qVlDSKJdovOqGezO8d2w3jv4u9YeukUi64EYFCxR3/q" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGiDM+RMI0Wdo4q7L9YivAzmnQYWCzxFl9D00cu6uFQUjG1Xv4BJyYK7qkjSpa2CYgIwffRwmUquzxPpz0q/0KYtSmd7BrlNte/zUzWzGiawwAEM+wYf3G0FSvRq+8OeHvck" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FUok+M6VVb8rhkOuJAzjHphvnNEgKgUqV8SQIqJTGUPUVFByOmgFp0KVyfE+c8Aw7aLZcSX+JPLBBNqNQHI5nfjujOxmipWdWDh1HRgfxnSiGdVnVHiUAfulKuFDkfE//9sCHbL+ue7em+kEbKCJjYwOm5HhfxKfWfeK8ICTaL0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> .
+}
+
+<https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> {
+    event:9oa8ktxu7tqzll06rhw9
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasReceivedTimestamp     1513172263229 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:d3jq9fgiu47gdhclj7h0 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9oa8ktxu7tqzll06rhw9 .
+}
+
+<https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> {
+    event:1d5xlvosu9j6umgi8r47
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:alif190jj9we7toczas8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4rit8itn4uyigyesq90s ;
+            msg:hasReceivedTimestamp     1513170830202 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:152dum7y56zn95qyernf ;
+            msg:isResponseTo             event:4rit8itn4uyigyesq90s ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1d5xlvosu9j6umgi8r47 .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFpDF1mYWD8hsoHDb5v8FiRwj0S8R84+myfMvroW9NG7WZP3J4Uq8Oo7ztiE2ETW6AIwaZU+/I2JMbidZbneEo0kjTxb2sM3wCjiFdP7Jmv6FbtSFXw4KokasNsW4cpFLCEw" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EyqBQx0oUFQxEvOyh8QjiXjwS4TM3FVB45C5vTBNlJHUI+fwdSV/pDYLjvsbRlq1VY5n0z9HhUKjVo2y58VlzYTUQcu5vtLPHz8uGdwRlYCBUz4f4zez0SYMtRcco1EUCd4l1ZIdbA/TZ9/8mZV/1e0aGwrE34oqJrolb4U7CWY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> {
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig> {
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC5MQPvfy1x5k+OvV2xOi9t0g8RUlM/eyeY6jr7p9dyt5+cyP9Ldy+UEVquCMHWUOMCMB/gyfb4C8vyD2HAa/ZRs487vk/Dbh3quHgx8fDU21htaIFoyHU50Jgo8AQjgLd93w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Uexg5eLuuTMWEWLquFb48wGaVDbBK8b2hF03TV6zJeGaLub9f4QxuiOdLgHeOEymmsyD7SHAPTGZvjV6A7dYz9tnv1mlKr3l4Htno/iidmzucvXcNhjwyHG0Vold2yayG4K8u64VWf4CpxLlJ+GXI6UCg4a2HIT5S/PV5Zus1GE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig> {
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDaNCV6mOz1hMPBjIwgaK9m7SQ+X5CoMrWQver12d1LLJNDkqi+mxsIQoX7wMIOakICMQDiq2tU3CUAS1RR+Dnjw8SeBlrijUzmrFDligXf4F4e+c4GbEVqX7R+y6zvgnWacZg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FpgaMyJZj+TbzTw5Tzx9QqtHZnB4MZT4JOrsmWnKMcWN7Klz9oEVxsE5LfnpelVKksjYeza5sMqX8hP4gjAJOaUXSmeoJFjh6D3n4DQdYt4wgaU7U5aq1PZ++P4zcjuyV5T89ZrnAi0A78vP1edPe3IkveABG0KfnbO9gqgUDTI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> {
+    event:lur3g5en41crth556538
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:mv0xoe06cxsxt08s7guf , event:cgqt5h004iql2003me2n ;
+            msg:hasReceivedTimestamp  1513170831170 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> , <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig> , <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:lur3g5en41crth556538 .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCXu+JCNySc3oh50OlxXAlsAhd2Spt8tI+7F+rZqKZjyKQJejXsFPNNjDwm8C0lG20CMGmv90AfghtrGZWJskhlMhhKDc92BeUg22NxyivMaJfqhHttOEK61XbGcV2KBqIhog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IjtO0ZaLQudoF6JL1+nY//2rbP+PCotIdSeL/rfJSYfAD1HS6zj50ceZ+j1ntDAcNk4CjMWpEp+ymwRIMP49CwrVheoxeAzzW3PqV9dUcSdzCdnaFwDp/+xwwLsStK8eK74GxUXOy6xsvxg0eeY/5qkqX4SBB3few+5ifwkZvso=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHO2bKj118CBgzgnHPqlUu6JXhyDNe2+bYKinVRk43vhQWSzfvUi94wCRKqF81UPcCMFjdG/ZmPj8mo2RG7r3atUcHiXg0qI8N/BRKxj/C/td73y3ZnrTcGxEfLfj55poOHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VTrT6b/9XG4/gostK5/U5nmNWuvLxzirkwoDlu4QkGeC2kQwzpYjuii2hUAfcdG03yD0V+3v00jz5NPiiPpBymBKDrFQqSE5RKjC5pEvje7V7EEPqoSTjHs+dxMD2v9JDWHn/CWCNq3z/WPyFlDGrtt1N+leDA7/Vb8dz1bn2E4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> .
+}
+
+<https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> {
+    event:iasuj1z9fva0svkfqb79
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:1tr3o22co1907d6b6n7s ;
+            msg:hasReceivedTimestamp     1513170866299 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:1tr3o22co1907d6b6n7s ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:iasuj1z9fva0svkfqb79 .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> {
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+}
+
+<https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> {
+    event:k175l3od8wq1w0s2uy9e
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4xjx598ewu7579zpl64p ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:r5hu2rq515sq6wzgdjov , event:rjc2w35typgyljixk4qo ;
+            msg:hasReceivedTimestamp     1513170818539 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:m8b6jvgclclzy48p7wqd ;
+            msg:isResponseTo             event:r5hu2rq515sq6wzgdjov ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> , <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:k175l3od8wq1w0s2uy9e .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+}
+
+<https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> {
+    event:n5rqfwjqbcpdwqjjwpdw
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:d5whye2xxe5kofpdojs8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:2sbarcz1yu7cenpcghay ;
+            msg:hasReceivedTimestamp     1513170841799 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8863100035920837000 ;
+            msg:isResponseTo             event:2sbarcz1yu7cenpcghay ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:n5rqfwjqbcpdwqjjwpdw .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDyuk9Ys52EN24nuADsy+4rk5T0oN6jW+wRdNl+DhzrG7aRXyTlbYmzjb+ABB4az7sCMHQpDt/f/Fy9SD14VPHBx08Rah7ymbdvTAjKK8Wk1ZVbleFdp13bLSB8eWDpTSANYg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIqS1qpEjSNioyIptjfNOCVqKRPY2BVaNIa2xWM5eRKUUj1Y+7628nghA67v9zAglRSejaaUhTIZgYx4+qR934t+hsalPzGoOIkH3pmQpHZIVAYE3/w9gKnB8jRosVJ9RDbSy+X73MsuwTTpHr7b2iBPXOjaEmSAqNag/8aVupZc" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> .
+}
+
+<https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig> {
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDmUzvYHlnqFhsNhN9yyn+ACcibzuWF90B2IB0Ss3l1lMclmKqZG/mPbYAQhdjq6GwCMEJMC0sdfXllbc11OzyV04BR7bJRGjQdhIDZnqFlBvgd6CQvtxqn2cpoKqjUfbR1nQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Y3/E/xdFsD4nOnjRLgSS9fOotoomwZe1+AhyQKOhq0TLsgci00CR6apNZwVKH4Y//Q/7SUUxLwEnEQj0QTNo7VIFwtqh1xpUlXRycTLgWXttqIYwoGZmqFq9cfI8BQDQrWcqinZ9dE/bqW1chLYBxfOQIR4TYpzfhxpamfa9rUU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> {
+    event:zpvc6zv244tfxddbhi6a
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5151909952739158000 , event:htpqlj3ablwc32xmfh9r ;
+            msg:hasReceivedTimestamp  1513173166031 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig> , <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0-sig> , <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zpvc6zv244tfxddbhi6a .
+    
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME13EwWl+3unTJ4OvDSR4tdJvf3ApYwf+bkYMhgB0uT3vlii+wc0ryUcWx1OnNI85QIwW76YwTCXbGMLpzjZqko5zswG4YXxNg9Js7qRJO2iUFgYJZVyLeQVeLRgYySdEC3Q" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "flusXaqyQbNDFTPPYD6uspuQqa1LZFSGLK2dnAWz/JJD8pvhLCPSYAYoi2y+Un/YeSRz6sNIjbvn7u4A4wcW7yF9Po0QZty/xzX803jGoXS9kkiQ6SPOe9IVj5yAeld5b5+OfHREyDSSA0+dCMv8ObQt48rnGTN7Zu6cQQZ+5Ek=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDU4+jevCEOWc8voQQ8h2nV/Pn4KEDIkNnZIM51tllzHQpijS2qVgqJlxDFiSK8MkACMQCQ6xjJVlvjJ8AmR2OkCOw+yaTrBm5GoVS4ED/UHj6Ccmnv5W7w4RxAa0B+M7NJu3I=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "btzcc4RL5rZYlyeqR+V8TVf20+JX/WBLhUvUz0vdl/rvGZvwbIcvFmN3br9I4KtBNo+I6sIxpoFhNRp9ylrPV5KUdqUkis8itS1a8Yr5+YauN5I2Vz2j+olOko6NiDJ11sCwJtrOxTfdboewzpALPIJHuB3xPw4su1M9fWTbGtE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> , <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:r5hu2rq515sq6wzgdjov .
+    
+    event:r5hu2rq515sq6wzgdjov
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:yrizizmtaxehctdi1m1n ;
+            msg:hasReceivedTimestamp  1513170818340 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFotN5JxE4mPq2QPE5Bf34Y5hpxBkL2HfQtpbb/6UOuZBq/TaxwypQmgty4hmuMa/wIwLuMmn5gohro68KafelelWss14HmLLnZS7tfzN7+isAjYdfH0darmX8KGiiDM5CeA" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YONfOPQ/b4aX1DZZ8n2QxL+c8n5BhtwOfqUTi0/N2+yfTgc5tUKOrF0K0/hY9w1wZn3AnAajGRiJOKzOoqFYdZw9fFH8D/VR9Mq0gJMD7ZxbvEKtXX/jjuINXPIMVpXZJtUd/BxZUp+UqC68NxevmjV8saNdMV+JuCl3D8kf3WU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> {
+    event:pi2jpw9a1q00d11kr9ez
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eczqg8lp7xbukpzikd41 , event:273p25fz6re5tp6drfsd ;
+            msg:hasReceivedTimestamp  1513170819939 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> , <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pi2jpw9a1q00d11kr9ez .
+    
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMA11jGjU5LwcuOW1pdtMWAUHBVeW8Mj6tYN1j0eRWA5MtkXVFdn//7awdr18/zt5bAIwVs6RikAKg8uct0inNm0R/Ryir3Z0yrXO+5nJdn9mLADtuXhG+Uf4saCgT3qlAPuz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYrzqWsP3oknOJwdB1xDEdIeammtUVGiyhQHxEiaQIgTVM7rxDJppG98oxPevBIcaCyMPS1CgnXGP5JhgN5HnSJRKveG2oWzkHlpB+te8i5nTWGWPO1XCJe9PSmOcOEz+JJg0hpS6W8pEwHmc+zlApVoXdK0IgKbonSIEwiXFjx" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCSdoT+ujH2W+HDFJApoyJAzYmi+ZJL+emt1Ry5l99/HHv0sI8FPwc7f4jkksTltLACMHfWEeJNwe05o3IX9/deGxQTzeALz/KUnNXr5r5RLnjvpPie0gZf3/5dhA8rfjGthg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKvqWhwTCfU3z2/KKn+RE1SKV4MdAHGCWm3LiZphtT649dkMwM90w/uqGWHh1KSClOZgtildtzk/1rQx1r9fgWpLi/99mznV0UJfGaQOv1xvrkDHiMYgjWeOlGNFkoBsxSLuqf7mK6eg65+t/82ch1rVdp/c8I/GeggLjSB6twqe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig> {
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzFIl4PjdbXYSlD31IrBKQKz6oX5EX0e6NSETXe+NH5SeMZr9HxAfsNPsPf+7BA/ECMQCwUYpJh+5P8VhXoSOuiyFbYUCFS1k8R6gbXVQYvqRTSbG3wWzUVdepkvDGu27og1g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PRF6LjrxSZDoat13nv6Y7NFRoD6H/jvtlfiSrc58fq7CLn3f0MtjH2JtCG6vSGzcXHvJYkvMJKN2LZdHsekkAexWhjmpS+g5Uk5C5r+zWEUbHugv9+EGHlEganamOeo0qgiRTQMFDQS/Qt461zboPint8stjXSQLtlvRnWWMfIY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> {
+    event:ih9v6gyllshhvo5kxyv0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6m7oi7hxwvoi2pmguo6d , event:0uouhqi6aym8jad508kd ;
+            msg:hasReceivedTimestamp  1513172392668 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> , <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig> , <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ih9v6gyllshhvo5kxyv0 .
+    
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCzVV6qy/HjxXrIWL9hs1+f/M/FPuSZtI4i+MhrYwE47CUSRkQMYbmynjgYkXxEUjAIxAIeZy9h1/tAtQ7q4pwo+/ZQaFhdTItJ9EmDiMboW+I6n9dvtA/R7rqIcBKsXQqPwtQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RVUfEg72U0ax0YXBiJKk/HV8qGYUOubZdp8FJoUajOkfgmO3tZz4Wo2axeQZFJ5Qh4/zebyAifBAM5VM3c7KxKJOAcwkNT8OHmCsSdQVyu0L47UFJ6i1EB2X6m1bZCCo/tNZ+wQEcvDcFkhcwwel2BDApSbeI7ugj79I84UDSdQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCuXHsCdWa/QaVXxEhJBvtYqrihS18odQb8uSDMFY3jCI8WV+gNBJNNDbjbpFsP5g8CMQDgQLhoSISkx5xlw8fHi3Zml3/efYzoxPRiIxgw9OJFP+/LDtVdrSShrLJ5drutYp8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DqKjOpr50a/vT7PPguFuE+qW/PBgx7V0MKwt2FGLGh+r7nN9GLM1zNudnthkqXblz3GAAxqdnREZWeiZrfabwUKjRi3X31j81+d63JCA7LZcj0+g64u4U0Zfq36kWvRvdrNOe+kM5OEFwOjrYbb7IgqTpPCYn4nxnui3fbBtoms=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+}
+
+<https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig> {
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDz34ndLZblqDWzmN4IE0ahv/7VeImWvkBu6pk7SDkk5zLl2iQOE4Yu0aDvq4S31d4CMAIdswiC5QuD8U5s36cQF9nqg0nYrwluQc/eixpAu14IsDF8Pzq/DIDDxmQOISwoUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UhIQ0cDKkvvxNoq5BNt40MGAuljOdnbBzrXJzaYTQ+OiSLfI7muzlgg1lDfKZrSWnXNKyXA9YK8giQNR8CLvAgyknhXX+G8GK7VkEBqFAtKPyg2QPE5QTledobFugn3+N4B8JIP7f7hKa0LWEQ67s3FvE/wdfgwQvbBylfMppL8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig> {
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCG+VNiKA4S0uVRH8WlJIEmLexRHRX5PQ9nP4zNw2jvSXA7/5ZvMh9hSq1sOmQOBNwIxAIABDOVT3EbMjsXeqlyEgYFXl/iDmZWHyy4bSQMJj2JgvkKyAokZoxX64r4S9XcggQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZOkmpJI43GASvxA65flR5o5niMxaPUld0mFv+RbcxJdwWbjr4VDEOGb5m+IXWCOlLJrvHlQAY9PI4jk61mbRodUI5GaJB8+I6NLw+vCYvvoaKZkijuzfgAVxvsQzo+zP7RYizptH4Y9GbtMfH/EVTPXUpEha1bo9aOZ/KUJjAG4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> {
+    event:l27gk9ia5beeuyjqfp7j
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasSentTimestamp  1513170798286 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l27gk9ia5beeuyjqfp7j .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> {
+    event:5s66o8cqv4rxv74xfepg
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4846251213444807000 ;
+            msg:hasSentTimestamp  1513170829703 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5s66o8cqv4rxv74xfepg .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> {
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+    
+    event:obhgk474mxybc4fobdub
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xu87g40eu8cx053lad08 ;
+            msg:hasSentTimestamp  1513172392286 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obhgk474mxybc4fobdub .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> {
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig> , <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fits98gjdl4ybaudq5oj .
+    
+    event:fits98gjdl4ybaudq5oj
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8ksy3mzfwa3n937tm3vc ;
+            msg:hasReceivedTimestamp  1513171153939 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCHuBl4tO52A/cRsD650rSlYaBC+ZLjSbLKeOzaUGI9T3zPQIKyTLaJeHYAXWnj7VAIxAKomPeIcHR1V7C3p/yn8/1gX1T0aLL/rdEqsrzG/WhWoREEshrsOL4CLF+PWdYLqjw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKdr2MpvDM3mISPrzUZV70qaFuJxDW9k7zFCqbWefZUy1wY14OAlAwnyHpWl4pK7a02jzZPo8EDVLE6Xz8ojdEOCKdruBiFpdla0y3dxUD3Npkh82jsQhX/Qu/XK9/wg6aAZm57DqW6DnviPknWZP+9pz8FOY9uD2cQe5i8LucA4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDbZM6sVlcW32kDrUEe0VW4fzvUzT5jFZkFmefSxMIoRAr+UWBHyeqdEwyxI9BphTECMQCnMwL1kWfHr66liiutcer0axqoDHQXCPV0DbO1K2UrOLUxLXm7OpEiutCi7rWJYSM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QSM0k2Wd44jsvKVlw1YCfV5HqCaLiFv/+z3Qa+HdN+nkZIy1A1M55hWq6MGuPX/UwUyYjhApG3n/jajsjcBSgBqaxtVmDBeZbbai1cwacrVaCAMqwMfhGu5Cde+dQURgOcsuz5Ltyus3Z8lTWEoaXKHzxVZGxjAaMkBX4o6WvX8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> .
+}
+
+<https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> {
+    event:s9zfgm2iika5vgvayt7h
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:pha7cg4ilx4j23f8xo0l ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6fvg967tlh9rho8axvbs ;
+            msg:hasReceivedTimestamp     1513170861144 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:238289506881087500 ;
+            msg:isResponseTo             event:6fvg967tlh9rho8axvbs ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvJUwX5io7kRVCpCg0ACH7aHcLJaDpV6xgWnuM8L/J9HJ4L1G0zcb2cOPThKHdjaECMDGsIUf/dAuTnYgKxDJXunm5OaPW/RxtK/UkoeR9LjdH1NZx29k0dK3FX1ucOxQhSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VqBi30b6cD/Tkabv3jR/WYmM2nv0zuxQtPaNP9kPQok1RA3zkXsvsV5jyylmK4h+r+oTW6uDitde/XJy5+lQQZe0AxB8FNXRiR3szQLsg3GnwCM/G3cGQPAgq4bd60+c0/0nztI789MoS72tSiCL9/suHukcvjwyuujrGP54BHU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9zfgm2iika5vgvayt7h .
+}
+
+<https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> {
+    event:4y6xcnpgc0xk4relqfox
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:joo1uifc1fc2k6fk5z8t , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp     1513170819785 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:m4nq3rl0m1br8bea2n72 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCZ9Mu9e3c3q0zVLHnTFS+4h+xQ9q4QDfDeu1sdAxAWl1NNNdQ9KisDKBtmXYiivLoCMQCyE15ceoMvLAWACEeQHL5IATn12jdRR1NMBGUx8ilvEnCJbHckFRU9BeRHxPnHobM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fdzV80NOcs/SSJHtD8oi8qgp4L3ZQCIehVau8zZwy4E0FPwJc158UWDXK9kNTIwzgaAgPUsgDgOTUW5rBYnlpHU6BRzy/3AWKJHElR/niJdH7VxQuB5jwES7c/F6BdfcCfyc+GH/RkP/qvRQA7bB3t00YUX4T+VnU5UsRyJtMAQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig> , <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4y6xcnpgc0xk4relqfox .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> {
+    event:s9a226k3n70ihhaurhdp
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:nepohymog91pfkznq0ry ;
+            msg:hasPreviousMessage    event:cqvzpvoqvtkylzdybhej ;
+            msg:hasReceivedTimestamp  1513172280980 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> , <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9a226k3n70ihhaurhdp .
+    
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDhVjFPfjP1km9KBjY38135O3pJexoUjhco9kXhd7j+wqRIfKIOf9mybc+W7EKhJdECMH7q9BGKHmlvxNln5/FAB1aLl6wYFdk/GCfKlFMx5JnvZeB6f/wIYfeV90CuBsHOdw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJ+Ozvenfm0egS/moNWMp/PVS5IsNX/BrVql5Z251EgtoGxX7K5d96soRNO55JgSS0UIgCQvgNt1i3yDkLcobIViCSZUye1Q7kQ3l1Rx9PmUsJxz+FVD2XnKiKw06ndCXh9E2m5ypOu1FdHaZNNsXhWgUBdo1nFu2oVwVOr4dh16" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> {
+    event:d3jq9fgiu47gdhclj7h0
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172263114 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d3jq9fgiu47gdhclj7h0 .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFE7f+uvuuoRHvEsbHQUjJkzQaHH77SaXWCQQiR2KbGaRqQqifMGRGVaJZLquNrovAIxAKSlku367h1DB3ANA5Pbmx3mbrUoqYz4LfxzgOtzxG0dWPKZc7SDSGxGEYe+3VCe4A==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUNJaixYwyrmDN3xT6gpMsU3LQUlAbM0uAOoPGLHbw9Sb49ikYyd2CiRaj+qF6Fu+4zbTq5Csn6TowAkxZztrj" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#content> {
+    event:6149800720990867000
+            won:hasFacet        won:OwnerFacet ;
+            won:hasRemoteFacet  won:OwnerFacet ;
+            won:hasTextMessage  "Hello, debugbot!" .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> {
+    event:m4nq3rl0m1br8bea2n72
+            won:hasTextMessage  "    'validate':    download the connection data and validate it" .
+}
+
+<https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig> {
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAyOw+ekYDcfg4r0O8Z5sWEfgQ+qSw579eBWtO4R6t9gbr/GTBpbJN9N8SJyn0S1oQIwbmbEyAzsKZ2ID47+MjsuxUITfz8OBD0OFSgH4gTHc7CStJY3C0Xxi2r/BcRYx7aG" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Tz6sLpAjgMJqp+zCSpmaUFuG8DFhIz1l3XRkYD7h/mrplkQJVevyOVvQZrQQIPcj2BXtYuHERurq2kSKBmtVfMtp5wEigCp1Pzj9ZP36kk0Q0xVhTayUTQ6uMHfC3Xkg8svYl1EfUga/3X8Cf1H8Xs07qFW0WqBHGRCAPeHdkjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> {
+    event:8mr0p8ua2srgw0zw69lc
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:obhgk474mxybc4fobdub ;
+            msg:hasReceivedTimestamp  1513172392573 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig> , <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8mr0p8ua2srgw0zw69lc .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDofotudXy7gQL7BNCKdKwmSS5KI+QX61jqaEpMqQMGgk627/jEY6G/G6yGAw8/GYMCMB6S2X1Nmdudwux1SM2YgwY9ZG53NW3Uao83fNoz+bkEaJgJvUkTIYEzj1mJXqMvsQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkUlJaz0b1w22WpXI2eb/G+wDJA97AD9hHhlaeQuqBdgosuyj5xz08VrIJAFI1hflhCXb/2Bf01aiz96lgVU1ouXRY6LMCeNrleoqGSXsNlNFBSKbMU5Z70Fly61hDJ+/gNU4L9D52ge8ADvjyaFaW+RF+0AaFI6//pB76PloeX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCATfMa5FjphJsfba/tJSZX8wTniY3JuBWSzdn3ZbLTiUgyTGbQCSqcE/Nrn8OUfCQCMGE7UsOVIAKElLNp7FLtVxdXXqFR50EzaYDWaQJpUYEGJ8QhDlHatv9lz+jeVOb+yg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dLjzUBcmwvJmTRjHU0jopMjA2uyc6zwzqNWPjOPh6bwoEM0CGBsLo/VDpCIx9SQ+9ucd0hYNy8kWEPiYJCAZLyXyzokBr45AVNDRtOKAE3iv9xvepctyG7EQaFP2jm54aJRJxkMMmI82JDsYKRhvu0CrXjkYQaGl2ajKXESxI/I=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> {
+    event:eue8ar55z7as596cu33m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8c6o81ry6mxeetm2d2pf , event:pi2jpw9a1q00d11kr9ez ;
+            msg:hasReceivedTimestamp  1513170820219 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> , <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig> , <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eue8ar55z7as596cu33m .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCxiytXBuh5w3NE7kdsAUsVjzJGK+tF2KgU5+AEyO3DTzGigsBoen0nQUM1l/n09XQIxAOnJ3IidktXW2rZHoBql+fazmmhrqXnDffE9Us5ux/rL+izk9q94Z/T8BcUHiKSzmQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bm/4QvtUDDVrZLPsj72ecL/AEWekrp27ZkOyAwdYk8gvcmIXDSgFqqiLc1HuR8NQSEM1ZNP8xPFKSC2uWiOFiscTul+6HVBmISweVHKVWabTBFcp+7uMkhxBRM1E+djcfk8KJ3RAKYCQcNF2lpa+rrtKGR9uKwe/gmDFxZqe9gg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvtn4dj/B24YDX5L5WZhNiZ1xGafjJbe4ZKg8VKfoiMtK5T8Wtq8YD/6D06CibIF0CMH8aV5E8b1a0y1oqx12gUpQsuyzna50NYMvu2e33Dr3eoJCaANpfCSiEdpgz1hSTsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SonIgV9p9wtlgZYTYQcGl9CkM4DFLvSd2huqeWYHvRaTjf/6EMIM78oRRH04ORVK/fqK/VerTWBC3tPDKyxhxjHZfzlyj+FsPRL1tWs0LYyIkPSdEaSuRJ3LwdJYsytyLq0zJ3l0puWf4k4VgXOEsl1rKcTgFS7yB0uDlGooQIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> .
+}
+
+<https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> {
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l8d77tygvfnfycfu5201 .
+    
+    event:l8d77tygvfnfycfu5201
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xp44teiwtooczc14npe2 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:nepohymog91pfkznq0ry ;
+            msg:hasReceivedTimestamp     1513172281105 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:s9a226k3n70ihhaurhdp ;
+            msg:isResponseTo             event:nepohymog91pfkznq0ry ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD15h8xYe/QPsx68/qkSp4qO2w6/1wPWhzTshQuowE2KXL/mTxwC2u59iXVbB54DoAIxAPawN3dIsZsiqABhitwR8LPf9RK2romuhxgMNkLtRS/fE8zIn1mdlHyxxBUg3d0Nsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aFKX2oNxuURr5F6nG8hm90H2H4A9iXdKKkADgZuhbzRnblRpaQxXyhM1b7g5xFYqPXfw5RiaqdaY+tua0Dae2atRCx4oUKVvgwVCqa1J5DsIRQV+L48EO2cXCZiPV7eBvxWFpmG6vP3wtJoJFw1X5sBNc8McxW7Eaw9zmFGHPUs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> .
+}
+
+<https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> {
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+}
+
+<https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1-sig> {
+    <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDcZnu4Ah+XglCwi+0reTqdOVei6RvJy4KoEAGAj88SMj2LYRgbBPCaYbxK3qm6kuICMQD1Xt/AQdt1SKM5sbPmc6GOxIJgBSfctClukYXp7rRB6Cl3wapKljH3uKrMR5bWAbc=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JD6mXv4FFd53Gwev8+dWCcuVQUzOdLWvmisb1J1o7fZhsxC27WYduY491AdmcnB0cdq19Y8/nsM6cKDgeIABEKgyIxgyVWGuH7KKkfz4AWjVGxT50ImfhQ5vadP/r/rhtUYxlQEesYH/JWIODxB4zjv/wzfrhzj9OYD12vp/SQA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1> .
+}
+
+<https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> {
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig> {
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDkAsWJNhJ4vgEXszJAYhawhUpCxKy6T0L6aej2zf1VNWfTY2UiUs6MiRkuSgXhaD8CMQCKSK4jrDUFeUU3clg3gOHiunLiSnyqhQIzrcczi61R3T3W/WokLNqfo0V6pm/6P8E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJm5X4PgCEbGpl0P+o4wU7nS7eyQaESRJUvMonGOhwiN/bwawK4q8BCV7nBgvddCs2XDsbp5jhXNZYf6Fe3giBH4THN4l1dFsadUUD0vEMzDm6dqZQ0tjYeafNADDL2473Yy565WPi2RDb9ZY0GEDP9HYndAcNox1QUtqoY3gSUO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> .
+}
+
+<https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig> {
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA4I2mYY9MxqVkhL7VnxgSOAg8JvOsBmH8KT2u3fHVkCzQYnCMElXWrtLDUzg5INdAIxAJCLEkR6Q23dLZwQgK3wBUeHkISwAlOAURLkDQSNo8YlnDTBzyIax637/ti4lxj88g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dy5XCmNEQdZT5t3oLfs48R0qrkleA2+3gLggoLL8FjsDhWBOnjHC6Rf8fVv7vKv6Lzpl8TGzazk+Ypj8+fwukAnH/MNa0lgBMpU0cJi1nFcPWJtCr5XmYfHn0WR99YbRKlyQ3PJ5++M0E9VcBVdMQEoLRNaBjOzE3+t9BBgzuT8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> .
+}
+
+<https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> {
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> , <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obimbxem9rgy4jw669vf .
+    
+    event:obimbxem9rgy4jw669vf
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:i1frxy9ikewwjuyjcznt ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:j0oj37oa9ry8lzmm26ul , event:4kx7gixf60v34gg65z8x ;
+            msg:hasReceivedTimestamp     1513170820250 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:tlyivx8nn93zw41ujn1o ;
+            msg:isResponseTo             event:4kx7gixf60v34gg65z8x ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+}
+
+<https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> {
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+    
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kv6651s4ochvsbafubzm .
+    
+    event:kv6651s4ochvsbafubzm
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5693603251585579000 ;
+            msg:hasReceivedTimestamp     1513172392139 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5693603251585579000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> {
+    event:fk1a2jb7ortt8q14tcrb
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5r6qvd7rennbi148vunk ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:f9zpvftok83vya1djrg9 ;
+            msg:hasReceivedTimestamp     1513170866368 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:1tr3o22co1907d6b6n7s ;
+            msg:isResponseTo             event:f9zpvftok83vya1djrg9 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fk1a2jb7ortt8q14tcrb .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCfb9b4/o0eflVtkvJNb2cHEbjJzB+18MenHM3Ma0uzpry9yd4TOWN34UxvgGhCQQ0CMB8fJljugWsUoztFIsYOszwRP/QUOQKQpZNU7QU7V4r0Am1JgIs7vJV8DIWhR9/uaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKb+p4XkNP1ACG5REa7tjbaPwbQ1b05ehepKt1DcGi7nM0Fp+SShOCPUqflEvTThmyZjZEB3g8jUK8ZCC17nVOPUG4BKxao+CfaDllZA0US3vl/QZt3G51YVA6KmiAE+DSG+26DWqO/qDV+gZlubodICXkNp18yEcIwBweT2r4Yy" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> .
+}
+
+<https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig> {
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhL7kBxvJoqFUG/n2cDN5cQTWIlMtrVoCoPaRxIrOZKKzikjUtlmeTz69tW6rLHrcCMQDUWszGUPxBe+QtahXtaohx26J2IyCYc3Wuisc4qd4bPY3R5mt3l6zghBCQ1n7AaFg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OP5Qzir4GiMtWLFgYEjQ2w2WZW7II57qSGm6NiaKOUpAII3r1ouEUoizjiaQ/M+Hl8iCYjhI3exsuWpZ33s4sNiU31u+7++kGs0uq1VWDxH0V2PI7mnvrs4lkT/aBu8maWbyBKrUqnfoYpu4+OCVsDj0wkCcnnRnMiU55OPCDeA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> {
+    event:tlyivx8nn93zw41ujn1o
+            won:hasTextMessage  "    'send N':      send N messages, one per second. N must be an integer between 1 and 9" .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+    
+    event:p6x8qvs5m46mxw4jb7z5
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4846251213444807000 , event:saegwhiwygztg1mpf4xh ;
+            msg:hasReceivedTimestamp  1513170829891 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> , <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig> , <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:p6x8qvs5m46mxw4jb7z5 .
+    
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBXqkcO99XGnV+YwaJ1ktvwST2X0u8mjorTyzgemi6jHvs8KfOg88N59La+eixSXgCMEiKSr4QwXjOrBopK6jL08VDbe/IkTMra3HxZMPcpFyUBszqTDKWpE8q12Xukpsung==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaqMTIy9jfUs2aJIvLranFeghQreF4PVVO+HmRC9x4KJPDjGwxNc53t2SHnx1TNgK5g7sLpYg8dSvF1wkmTRO5sltpYPMwriQZ++e9cHY5zxMqH3SYsA544nyIp4dIbOshMngRrgh//iAMoQ3SdiAgfWWdetYUzlPDB7jv9D67x" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC4TrUBe7yhKk81J0ZHVTyL2uK/oOAR+e5mz/atdTcA9a2diQyRnMbOAl0v7w5bubkCMQCYsYVBSbr4Ls9gqllIPJuXguklIm8aS8wLdjH6m1pq2vbHooeI79E8GtH/TKVtM94=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nj7I2g36BP67Wydg0TCtQXeDzEce4CnH4PYUWAxFXnjC1rmB8/p17Oy7fgDl8mpqieZGK2mhC3sovuqLTwZyoR5vzG7PHhWDsOzkV10es19ws0eSL7p9qio9/I5lo36Xs51vLjj595MnWo+lFpWknTKBgIXb15OsOdmVZHslFPI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> .
+}
+
+<https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig> {
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQClAjshUZ0bRIsA4MLnSIeCSIKnyz3LQfuy064CYYIVc1BRB1KIj6ZwqA/F4jxKTekCMQDWMV47lfLGzthNmOR5L2664akDvrymeQXPXlI5PX6MqkafMCAG2+1twjt79ilGxrM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "a1I4RG56IZ0HyXJ5bAiCmKAvAKjJCD2n+BJYyOrexFekGlxTL5ve7W1LnOhHU4Bgs9CxM05U2Yyq+r4/QAyCbKQBIa/f5IPKwDIEqECaQnwZbXZy1gPp6ipOwB648yBVE1oMPAMz2j/4ht2yNZujCdOClZzuM7Ic/YxzmuMOa9Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> {
+    event:i1frxy9ikewwjuyjcznt
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:obimbxem9rgy4jw669vf ;
+            msg:hasSentTimestamp  1513170820356 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i1frxy9ikewwjuyjcznt .
+    
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+}
+
+<https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig> {
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMA11jGjU5LwcuOW1pdtMWAUHBVeW8Mj6tYN1j0eRWA5MtkXVFdn//7awdr18/zt5bAIwVs6RikAKg8uct0inNm0R/Ryir3Z0yrXO+5nJdn9mLADtuXhG+Uf4saCgT3qlAPuz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYrzqWsP3oknOJwdB1xDEdIeammtUVGiyhQHxEiaQIgTVM7rxDJppG98oxPevBIcaCyMPS1CgnXGP5JhgN5HnSJRKveG2oWzkHlpB+te8i5nTWGWPO1XCJe9PSmOcOEz+JJg0hpS6W8pEwHmc+zlApVoXdK0IgKbonSIEwiXFjx" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> {
+    event:eia6yrvml8v995ueq65m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:7kbdyf9ffr2q657gkgte ;
+            msg:hasSentTimestamp  1513170819041 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eia6yrvml8v995ueq65m .
+    
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> {
+    event:u3op66771mcm3ibsrr31
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5946672495584215000 ;
+            msg:hasReceivedTimestamp  1513170783148 ;
+            msg:hasReceiver           conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth-sig> , <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u3op66771mcm3ibsrr31 .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDYCgdlasSZIHsMLaov1YMvPZu+76MVfqzGEwkaV8f02BAPQEm1dd0SFrTqRLwgK1UCMQDaqBb9id6PsSflGcZjWdh02so5JJ8zozB36DQGreCxwpy05uVga2SN37Hj+2CXKDE=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Hvar/V/WJcYQrbWIqEXf5J5unb7/rBCQi+rPGyG3hebmf9+bPDexcSmrY4cBYuV1sG47W4LCKYO/UU/LYHai5BeKimCerepWpCsHpyUWscBphyXe+xSeWvnw6jqPobT9q6hu3KEFx1BBGvudTguQ6r3vTjeAWM77uhR9QpBUTAE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o-sig> {
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDUs5usweForoenC6byhbFepj3D/iAJAYLhWF3xO2SW2IATNZWFqeOhbnvLokI7JekCMQD1JanKazkUE5gMmNbAB21GcEd2foNLXddJTccHzISK5W34ZMVU2zeVqaFjYoUXhvM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FS1OEAtteK4qAAa5KV3c5KGTdq1XVw963+nLGc5/UWUhWCkRmhG+fTSwT1Ia8G4nEu/NQFssNUYAB//Lwj6uonyeB+GAlR//CmZDJeWff2Uo7A4f+qNOcltmQhKFOlU1Q7gmwdxCHptOPEXo/Ucrs0sy7HSdrxER9mwpErSNzBI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig> {
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDC+4nu9BC8IHVTrzaE7dPftFZQqziXbQsxSLMl9opMz9pzBqDUc7U/61dv7oRnoacCMQD/+vbj4G0V32zIb8elUOzFX1RKgSNT/KAaoxCl24MaJj/uaQtB2KHlEnUIH+LAwM8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvO3Mns1yXliZdv702yhaf75l6OPgFiUcbXMMZAntFgmNkKGFeL3DJb+i70ZOLt3f0COtaceXu3WKiYV2rkDnin6Mn2INUKVT/PvXXnVMFzbrz7eN9FXt3kLKj6Vgih5lE5YNpR+QQc0Evu13AR2/54isfIf6UfVIod4scEQn7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> .
+}
+
+<https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> {
+    event:bxwevm9gzqconmzxji4u
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8c6o81ry6mxeetm2d2pf , event:4xjx598ewu7579zpl64p ;
+            msg:hasReceivedTimestamp     1513170819081 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8c6o81ry6mxeetm2d2pf ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCf/fdInjdyz1iYLMe7IjMIj0I0s28J9dRIznTow4yPWLMDgAQ1RItVQcNyA4XaGI0CMC7uTiR0R4WG0FZUODUc53CuEZHZDjeN1MXGSVcKtQIcbuzgL/UrsCqoCgKXuwQO+g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aMOZu+pH38S59z1B3bJ6iKvqNphXrUttOzx1TLcbdyaPisvTFn6AlJucTPh25IxSnaHBgIxldTKGM2edcP5O9amOtJroF1HnYBcidn0lT4vMnaEenrP//S4/OATNXQwCktQYvjlwSFj7AmNLo3312oM5TrlVEnKcewtp40iggNQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig> , <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:bxwevm9gzqconmzxji4u .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig> {
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCtkFefE2I/jB6DpPOGarUrocUvk9wsq0eP5/sbYKnSul8I/fLoX9EI0nymhdwR20cCMQC0s09oW9Nxljq0VW/f+sHUjD7IXfa/8JCJ5WB67mzwikUUeXZyG2n1WUrefr/AN4U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Acv3A8Qod4xRE79i9TlRvAjNBNXrmZAmLgOIsvygmGmm9CkqJXsrAQZc8Dk6u49OkoJy25Rnb5CuVPc+HlhNkdIqLJHcMAZp9FurP/NU/gazz4tmlDIhovAiCwqhs+st5D9s5QuvQrOZSVQLohPI9AHz67Cmp/oi/ndwSB2OZqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> .
+}
+
+<https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> {
+    event:guewg0q3l68ts1ud5u2h
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:u02ulpncdj9l8ae8x2aq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0o2v37foaz8bog1diet9 ;
+            msg:hasReceivedTimestamp     1513172263980 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:d3jq9fgiu47gdhclj7h0 ;
+            msg:isResponseTo             event:0o2v37foaz8bog1diet9 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:guewg0q3l68ts1ud5u2h .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDR1xb+ezOAzterooaxqminnZhxZ3ZjYwCSg4bL5EV7bHVizu3iTgKsm6iCa7mIdWAIwRkKyiq1Mk7tBAbc1TES1v8XaHFEk/p1VOEwOiskWC29sSUTOk30mMXlKkZYs36/W" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DxpG7VpU9zHMsUytfLtbLtoTkX4Rvo7gsi5pANfpiXNutiAr/7jlOeke3UaDHEZqYB4621NumM8IemdYjCbF/RjUtbPcv/rDKs252ShC3UA74bvbKFrsPiVd7klS+7csc5rEqd0pcPWXC878nNBIg8TGwdgf7d32Mikwj/jX2jk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#content> {
+    event:238289506881087500
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> {
+    event:t6d7eq3cq6nq54a16k1w
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zquh20fy530jymcv4c7v ;
+            msg:hasPreviousMessage    event:x7cjarywf0513459swe0 ;
+            msg:hasReceivedTimestamp  1513170854581 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCONDSxagGTZTEjj9rSbkkoWfOXNPIW1sdqd9aKJnl+KGcj25TmDij/2MvXgpWdPywIxAJlmcegDVi4tT+Jxu+jYm6gYvDfThqxQwUjZtT87sykFSr0NN1vsgbODrJAjiRGYIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kcc/Wqu7WW8J6gi8yhPkceVRBLT4vc2FZfQFIAIFdUO11gbGBWMdmY+53c6IfNntSdSxEHLMsWCrz/GwB04LAt7dS53eMFM0B9RoQEgS5p418U4IMVlcsERYCvISlkBGNfO/bI+sVQ/aIqaAVI2Alc2eOeZBr3j6ist+vkCnsrw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig> , <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t6d7eq3cq6nq54a16k1w .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAtGq9Gy/I9eAgMSkqKWT8FA1B5cmN3W7XxRpiBS/Quwx4QIohYdUVy9CiBBgjUGkgIxAOUakCQa5nLvKqot8M4Y7Jpli3yYp8ZENbOhM2SLQ5i38M9+m/gcm7OBQ47ApEzUkg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NxdIu/DqqRvVtYUgYyqi1msDWkUJPjIWXs7w4K2tub33wXjYvS/SppMCpg6Y+gZOxFjqKYD2zmVZ6WItsXMrhJHoo0edRkt8CemDzwBSAcz2k4isunhy6FnvLLvADJy9nc6SPbC9Xo3Q1tzQXZfjVVXTdOcKh5oq6lEXJ3+v7bk=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig> {
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCHuBl4tO52A/cRsD650rSlYaBC+ZLjSbLKeOzaUGI9T3zPQIKyTLaJeHYAXWnj7VAIxAKomPeIcHR1V7C3p/yn8/1gX1T0aLL/rdEqsrzG/WhWoREEshrsOL4CLF+PWdYLqjw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKdr2MpvDM3mISPrzUZV70qaFuJxDW9k7zFCqbWefZUy1wY14OAlAwnyHpWl4pK7a02jzZPo8EDVLE6Xz8ojdEOCKdruBiFpdla0y3dxUD3Npkh82jsQhX/Qu/XK9/wg6aAZm57DqW6DnviPknWZP+9pz8FOY9uD2cQe5i8LucA4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#data> {
+    event:8863100035920837000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8863100035920837000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170841624" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8863100035920837000 .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC1SDThUTgri/GJGdlV5Cp+KxU6yvAsl6KsLqJXI2MHHcuWHsbsnwXtEar+rl7b4/YCMQDVKYzOD65kHBfCzFWyjKLj64PzeyBcHhZ7IfDzpAwdw1aPXsKlJGyHKen+iePk0v0=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "RsycxbSmRChDTN8xfCTOI23rtey7Lz44Zmc15K2F4pzs8vZmzTkrdbRDnvx3TlZuZR/+a8Sg1v2GRy1pu5Tnrw==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#content> .
+}
+
+<https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> {
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> {
+    event:d3jq9fgiu47gdhclj7h0
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0o2v37foaz8bog1diet9 ;
+            msg:hasPreviousMessage    event:0s55ww5ae82lf3j3gwaq ;
+            msg:hasReceivedTimestamp  1513172263200 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig> , <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d3jq9fgiu47gdhclj7h0 .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXRJYG0ftvSXFMxiOr69/P66KnIv+WcuIt+DWtD7xW7TuTSxe6JGnReuZLuQlmURICMQC1SEOZ00JWARGgxDU6QV5S6iAClzKI4yITVECbU0VTy4PsCkDKx1oxeyehxuoV4dQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VoOyZrxwoqwhIjWwhAx0R885hWG7pYIgPfgtywGWQmN7Fom2vfScNTWH+VnPpaFE+qrQVPHlP6/6ggNyLhsO0WiquMFWqhEebzgo0dOBZyIdGSjPgtFYudNUanngr3rEnZDVBgBh89aM4whZ8QZ9X9xj4HzU9ResMzH9NnwF43U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGjIKnIbUDCBDKZdQmOhNV2c5iq0hpVmowjeGvvZ2lnXCrTMxLLCRSmyombPKz6n6gIwFjtP17S9ABBLHNpzeWu5VrewI1H3DrqkLylxU+EUV7M2frxvdraAWxElczxmc7ma" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NIDT06nuw03uDm1k9CeTGJxv3BFeo8zKDrPpvWBKcwRkXgoKwLJgTSyy7UsvVti2+BSCKSlHrYwVHq5dsROfmND0aCCMq7c8ZkzCM8YWfzw+HOvEVQmzMcXd95s1vnykGjcf2cosnSQWbtPUjZF7KnFT6MoupZglk6fUrg9iF1A=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> {
+    event:m8b6jvgclclzy48p7wqd
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:r5hu2rq515sq6wzgdjov ;
+            msg:hasPreviousMessage    event:8h7v5ml1aflqmoyem61a ;
+            msg:hasReceivedTimestamp  1513170817902 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> , <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m8b6jvgclclzy48p7wqd .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC9Qs1OFC7hT/dglINmUKi6N5OJtlOptzY1K/UxKmdHBd912QqBeCzC1RRQc9GaoAsCMA4YMBuvTjPA67yfF0Yj5igMGiWWrBXkwjcztvsqpY/bH+TZicgt9ZYZX6eYpTpTjw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "Fs1yj/CFc28ztpE/9zMhiLH1TzvfvJRO43TzZIweuvb/sJdYHCwfkytjQMuDmh0pkEqqH433QsZCZMdQnI0nttJ+/HuI6mS5PJO2IR4rAxFCyab/gwYYiQ6EELTxSLDJPxWQg7CoEzZ0PLPn8yLN2zsSmk3G3xNDM9Wyl0/eyRQ=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> .
+}
+
+<https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> {
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> {
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> {
+    event:4846251213444807000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5s66o8cqv4rxv74xfepg ;
+            msg:hasPreviousMessage    event:rd1ryd06xejacyss9qy5 ;
+            msg:hasReceivedTimestamp  1513170829679 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4846251213444807000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#data-sig> , <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4846251213444807000 .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFCtJwx67CDyzhrZAEaw8/ZaxmMV3OyQiywtLMZvISlw3q2jS1MoUfbjkRvFNaNxNAIwe5zwq9rIoPKsxHYYNzWvs3dXhrFh2UqAb6Sl/pU8DDuKneEgLs5w+VgPzHBKDDxD" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "akHfnW8zEDf9fdAioX2i58sjU+GYPPkiVOfxdKk7QCoB971iT5xdLz/pHXQwEI+dz4aOjXb5osxy4IZk3zVJaEsbVls7KHNN2cXWZRoHzMFsZNa5CxUjjTWZ9yFKobLLaziLlliuRBDrI6WN7lknzTvDfEmGdANkGV0+GweO4Wg=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#data> .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> {
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+}
+
+<https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> {
+    event:66nnn87elpe5995a5wjv
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:tlyivx8nn93zw41ujn1o , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp     1513170819555 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:tlyivx8nn93zw41ujn1o ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:66nnn87elpe5995a5wjv .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> {
+    event:h6c8epmrvb3gxqrvs81d
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:00zilsxex8tqjumh6fi8 ;
+            msg:hasPreviousMessage    event:ivr0xermk4aeb3yhohk4 ;
+            msg:hasReceivedTimestamp  1513173166229 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6-sig> , <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h6c8epmrvb3gxqrvs81d .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDfsOCh04rbw3/fB3x0ouVwKcr6qqU5DWZbYMF5BebZn9phecIzTJTgzLmTk34V1UICMQDiDrlXHXKmmwmx6TZCbfpduj1AaxEbxiqNQHb+//RLDaxwQxfoMXvy0jXM6cH1cMg=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "dlaR30ByFzpxD1F/d7c5Pv1Ieem8i5sRljgxCWxN/YwsWCFOxaJ7wNdJ4hmcuYGdVcNgiP95QmWsvDJ2BODPnJIQ0zDX7pijSRkKCCvrChDIj+v4lsomnDa4xjZ9mPoxNzWZ59pvmsI2l96o16Ysy5ZsH7RcFCGyBaCgEAPTjYA=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> .
+    
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+}
+
+<https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> {
+    event:8gvplnjrinoqay8ycrc2
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:2uf9sj4itmz9fpas7suo ;
+            msg:hasReceivedTimestamp     1513171153830 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:2uf9sj4itmz9fpas7suo ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8gvplnjrinoqay8ycrc2 .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig> {
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDmjl9AY6pbq2C/8sQMSFIsWV3MVDZQYD7goKYKGL4t1aT8GIhCVRtl/ntRdTmuIJsCMQD9/CSmj5RXzqCIgENqaB1/iYL7zVpltQFlkCepuK1UnLLXCLZUoJdSr5FXofBIzN0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "E+jWMjmUNdTGMbDubZ+R1SNOSdhPp8Nv3LMxZEAUNzR5GSEgsw/Ng9nWpudHpzb+CpOBhmuPHTdKPBbmhVnh739jmTxyCzzC4yzfO3WBONondQlmoSLyz1DYveT0topDoDpxr7bJQVHAP7YYbs47kLcEWCFNJkV9LMgHpkjbn2U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> {
+    event:253k6pqq8gyttmmfxc7l
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9se5txpx8xf4olwlettr ;
+            msg:hasPreviousMessage    event:59gtirhola4ydvddyo0k ;
+            msg:hasReceivedTimestamp  1513170818034 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig> , <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:253k6pqq8gyttmmfxc7l .
+    
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA6xk9W0Nm7Q8n7VHBKI+Ffkrgs+R230cvNb2jldpbDuohwXmcEWD24TJc4T6JdlJgIxAP9vYMZbAV2k53k7Mdz+mY+NMy0np7t44P+SBI78Nb5Xt6I1lOP/hkxRfEcpElRSuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "djVOPPlodqPPEVgtuLU1iuOD6Mzo0/fsuipwuW3KTz79Vq48wnNPY4KWBkt/p1w9sOyeV2gsCNmbvtRdeN/UYZ3Sohb1gRmDcLzZyLuya/kKsX9aHr4KJyFXUdOmo+GGfJYkjwxMiS33UCQRRO6z2CyTk3/qdE9+dHr0yqIYhBA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBaVX/GtkSPDECfDSre03q1yLJMnZe860Fc+IuSE3VX3T8hX+FvuWD6hCS8ELyd0uQIxAJB6TrvOCjdNgzT7q+z8WplSqwBmn4D+Z378mCRDI9FOFcjAZq006f1N319lJzZJ9g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AK37HTEODeZyGhL0eitn9Zho4UfFGG1XdKEasi8X6syg3d+rGVIE+4iBGaqncQe2rYDbRgKex31G1lGBEy0ksywrLUGg0UxQwmH+aBl6Osp4G7pzniVsY343UqpgSHgeygapxWRuiynss4/6Am0vm4HTC3Br7unCZp7FXfI1TMzj" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> {
+    event:4e2ws6ap0hp93iv0oyu2
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1107469913331435500 ;
+            msg:hasSentTimestamp  1513170817336 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4e2ws6ap0hp93iv0oyu2 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> {
+    event:xbhopokox5b4vz78e59w
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:izq6icbkftfbzm0clxeu , event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasReceivedTimestamp  1513170798588 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig> , <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> , <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xbhopokox5b4vz78e59w .
+    
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhL7kBxvJoqFUG/n2cDN5cQTWIlMtrVoCoPaRxIrOZKKzikjUtlmeTz69tW6rLHrcCMQDUWszGUPxBe+QtahXtaohx26J2IyCYc3Wuisc4qd4bPY3R5mt3l6zghBCQ1n7AaFg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OP5Qzir4GiMtWLFgYEjQ2w2WZW7II57qSGm6NiaKOUpAII3r1ouEUoizjiaQ/M+Hl8iCYjhI3exsuWpZ33s4sNiU31u+7++kGs0uq1VWDxH0V2PI7mnvrs4lkT/aBu8maWbyBKrUqnfoYpu4+OCVsDj0wkCcnnRnMiU55OPCDeA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCpyW1KNsG2XvRyfQrEZqa9oNGk5eO1boTvEE0raZNapmu9LC8ClT/bGLBaSFkpn+AIxAL42Ave30nZXVRn71OrkTORDwZzXXiFXkY+KDbx06wXZoeUs/MPfWo5fq3EAlFN6qQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AICr3ADiXnr6z7Dlnj8PAlKh7FPT2Hb/ySeQ73ZCjlWKp11r26C+rAUgrKRT08nTBU0SiDwRGKXI57IjA9aWkgAxr50kKDBOrFTzuCL5+ByEHPY4dVZZxU4ymp4bpkkqfz/4DI+lBeXVb2Udm9uq1braHdjfTPuHpG/WgAuMjNjV" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> {
+    event:h6c8epmrvb3gxqrvs81d
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig> {
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEvWR/fHCOdGj/uM5AChtdhVB006Hq0TpUIqkazxmdzzhGqEonoxPJWBwx5thvc/gAIwLjD7QXA9jnarEQ6zdtH/aa/BfBaBkE3/GtC38UtFyylcywQ239p/rMGf9Caos9X7" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "L7ZDsU+JNUesAdJuZXheut2HyOwcDSJlEYCiPwF3sbNJsaZRaxGBXQQzUziJNb+8tUw/ADfUVt1hT1egjBF1T3PqDMeTJrvo3SjW3k+b81deyIEV4ffjS0TyAMVAQC5EFz5JeIgZ3I3Qf8iT/Es5VOnnQBTJCUTp0tAcBHoqxNg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> {
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+    
+    event:rrmkri9cdrtvp1bkjcnl
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:jbr090p3fhvimrc65vis ;
+            msg:hasReceivedTimestamp  1513170819400 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rrmkri9cdrtvp1bkjcnl .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDAzmCOec+6ssyiuQdedN8KjJicgXlwz+dff+ZZ+VSg4PW9rHr/rxu8YuQJqBedIj8CMQC1+6HknafQNMhhuimJsvm38qH4jpevvwFAIBTPw0mozvDA1QYQM5Tz64Spd+pfl3g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NeTl3UL90+SdUaJceBRW8okcZ6jhQYDGgdcE3X1RcwAkz8nztDencdyACYKdxyBbWUT93kZDUGe5PE5DzHQe0gtNS2JfVCq/9ntnQxVXH6zv9YX2YZ4zct8tOEC6sd/S0INEhY7CvazST2xqdXk258IHVHuPICqHzEkBIuqaQa0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig> {
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDsoACeLxf/+IE5gGN5+M8+xdafOXT23XABQv7HN8M9jxmP5HRBnZsD4NYZIPfhdM4CMQCLxNWA8XtkrWqgEfrmS8oiGc57Qxc90xnWcjfqbRwD5htWyf3VysSyaOM5MGdb1lU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbasWeY7409EneTPZB5PGTrRZ87optqYqAJ8K6sxrVaDVI/veZNZXQppInCsGHXnUKsv9b23DKyDd0KFFYFj2YUuNKNz7kwAzIxnKDFI3sBHg8W820U1WqQXudbw3k7gXsE8cFYa9UkgqTJP1yfOit7kAKQ7b07dE3S0FFAaY3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> .
+}
+
+<https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> {
+    event:mv0xoe06cxsxt08s7guf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:cgqt5h004iql2003me2n ;
+            msg:hasReceivedTimestamp     1513170830961 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:cgqt5h004iql2003me2n ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mv0xoe06cxsxt08s7guf .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig> {
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCj8XzMChHxr1OUg+i9codjorEeEZd6NEjZV6coLw/RVhHXZxpT2zQNHQCmrDfnAEwCMQCj3ztIZuDm1BVd0a+xGJHmDaIsyoFKWHvhFBS/sH1iorGhvMQLVK25Yv8VEpRFIoI=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OQCMclJqUGtvO8kZAcP6j/tZc385dizMr6Hlefne2dP6j9KEJRRIelXbDsYwWUO7SU5rwrgzcn+S3W29JFH3LiSu8/TrpEPkAG3AMX3165zJyJpiy/Ea7ZX7fPHo9H8MDrK+GzVIvX0M0EB3tFBsUnPmK1yahgabhMylNVKIZuc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig> {
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC/F/NI/VX6ASFjJdeDRH7jIQdMlB9h9vRhLpDxk6B6SZS5GbR21Jmi0FkeLEI2ddACMDRCYOUb+G+m3xYGgSnX7fdy7no747rU0fv06q1EA4lumW0xmIicFp5/UUR4CF5jKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FeYE3UT6mrctO35PUk5kNdyjMgkPcgIMGahGbwUFhSuhXAuQ7VAsnkkoR6cZrzjrwsB1X08GsGcqhDb7S6JLDvQcu+iy2x9hn92M9kI85P3Gil04V1qFzcNYR0/VL9LG56gbWrTRlQppMn6i1aGcKT6KyHuPk/yXp05+HWkhUAk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> {
+    event:152dum7y56zn95qyernf
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170829995 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:152dum7y56zn95qyernf .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBOnKYKfOVB/cbSmWfIsVk5ReDs+K+W1BA2zWsYyzWdG0Rwz9MQPE2smPmAjQnc5uAIwJGG7428m810arTDwaiPdhpZsPeV3GENizs/ecPWkyYuedUh6WqjZObHJi1/dM430" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBVwCc+0SugMjMe1MtCrTjGMUeRjykYniSY2yRXY0ZKzESrmg6KR4pmbSysyzGw7TtvnekSRZhqz04gafbvlECd" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> {
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> {
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    event:fdxtdqeonqc6mk01crog
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cgqt5h004iql2003me2n ;
+            msg:hasSentTimestamp  1513170830961 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fdxtdqeonqc6mk01crog .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#content> {
+    event:6834006177130613000
+            won:hasTextMessage  "validate" ;
+            mod:retracts event:8863100035920837000 .
+}
+
+<https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> {
+    event:5iw37ggk8ccrcxxf8f8c
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:lur3g5en41crth556538 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fdxtdqeonqc6mk01crog ;
+            msg:hasReceivedTimestamp     1513170831085 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:cgqt5h004iql2003me2n ;
+            msg:isResponseTo             event:fdxtdqeonqc6mk01crog ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5iw37ggk8ccrcxxf8f8c .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCKCBv2TfWVNnEdBNJDP2HnaZ0PMW7L5HNZw9Gmq6CAo9xFL2Bg94Hln8Z3FfWW/1gCMEUR9lzsypqSXorLjR7YOrxCwGJ+TrwijmTypB/OZci9nt4qJxbM71ULf1nCwgmW7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jh4PEReRBiKtSQDmjELuQf13HhqnYQNzCnPuH3OrSjZXEOhXxI9Yq9HBx71f0dHclvOV07maj08KdgsSFlNBir9z/P8Mx19nrME5XrpntImqHAi1qF9Asjb6q6R1qRej7pvC9shbYWfSrOZDv1f9ADqr/O3kv/wKuRVYUjFC6do=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> {
+    event:2uf9sj4itmz9fpas7suo
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig> {
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZu1xW/5P9mo82xJEBHM1TWxCTw7GIp1uwRlg4/Vt6rg5trZirrsJWzZdBoVRCLmgIwBGBnQQkFD4Y15co1lqV1+KhWf1ZpK7j8mTtVwn/PBGAZEALi7pfD091aQnZAUZkn" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIy+T8J7/o5ATgD94rearSfd16+Ne1MwcM8mXK6RigcjoD+vl9BdbN8dkPwr7eK9kr2TVJtJDgSBoK7AK6OuOWzQvhDlSzqZINmaeZVHUwqj2rKV/vwGJdbIqYqolOfdrqLd1bZ4kJr/p3PBneFdlPqzA8BkO0UzYNt3IZ8XAbEe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> .
+}
+
+<https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> {
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> {
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> {
+    event:8950tg6pjze6lr52pq3y
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eczqg8lp7xbukpzikd41 ;
+            msg:hasSentTimestamp  1513170818740 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8950tg6pjze6lr52pq3y .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig> {
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0/xurl/bcm62GLYTMgHO9GJHr0GM3eT66vmp3CE+cRqaGylTxbd9WnyhErYKh/7wIxAPFxaBXKC1CMbFKX0vDGKRlFj8HbCvEJPYv36/y55GUwrW5qVQp5fizvulmNgEfilQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8ScmSRWdh8pqVwh+r3Pk7imDbcNJXLFJ18Jj4DMDEAVMwMma+MKQhdSLlEyDdHl7u17bZaO9MkdFYV418E1BbBOafVwuxHGcFK2FEO0PVDoDOb2DjDLt9Vi00P7fEh/w+t4acnUJXSAWjhRrhpLLFtjSxa4mmB9aHmvcKJGO8s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> .
+}
+
+<https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig> {
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD2EfKVsS4PSlEqSB+/gjEiRmdCKO5s7WDv/eAbfiaDutf2XB9FOqWPMRLn9OaC0IYCMQDYF3W4pZ8zyng2pjF/1MUHYpxAeNCFBR2z9dB9Vy0YwYd7/CSHx9lKK1p7fK2K3AM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DdTwy8dZPDZTlZWA5NMwp3LViu06y+ocwZ5yhXihMFQ1J0TPqsakf+ol+m7HOENv+xfT1fuwe3D2a9ejfee52VLPRtWTcONC8cLkXAKE330uDgX8MX+H7YYH3EPyjcbscFVY2APMIy7rMzPxRwclRk2J9sDXeC+bXI6NhozZSnI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> .
+}
+
+<https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> {
+    event:zvx39rdagwj6o7nfiw1r
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:qi81r6ggzy26wznv94dq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fn87pwzr9g4a9v368h4m ;
+            msg:hasReceivedTimestamp     1513171226426 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:353368844400623600 ;
+            msg:isResponseTo             event:fn87pwzr9g4a9v368h4m ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zvx39rdagwj6o7nfiw1r .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDf4Jiz6qEsxagnd32M27/KFDT4A8MrcpzmvLk9vJylevVEL/xRCPyIDpHVrN09m44CMBL8DlDPGzk/uINXaaOEFAujBOL/asEqNclcxcjfjF4XTH3MtRorUOv0iM2SS7N73Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Wj8ziPrZiyJHDhh+M6SeMCUQZulwT/3T3XFRkAUfaJIZdct90zT8XJmWFeX1TXO+M8EJtVGIWd8UbIUg+EiUllQdMp5qF2hlHGGke8FiSMMbeGEvozbp97W58+tTE8pDIHBJLO4qRvZg59Bu8uYRBIjWSh6WkhGaLKrv2DzUZ3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> {
+    event:i3k0giied2bgp0p44h7u
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while.";
+            agr:accepts  event:8863100035920837000 . 
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> {
+    event:c6ldwevakufr94hrcn97
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:i3k0giied2bgp0p44h7u ;
+            msg:hasSentTimestamp  1513171230641 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:c6ldwevakufr94hrcn97 .
+}
+
+<https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig> {
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME5OBo/oLUcxTC1uP26j4He2vb+W5XANy+mDPS0F9btVzUibk6eojj3qAK7kTBwu4AIxAKAHUS0FJGtZfyV5/A5tEmDUCWAg5Q5pJZ5OOwkISpVgxyz91D+Utm5bISGX93XeYQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XCSe1I+OCINMSa1ce+cdA15F2KD3hNam5XW5gD1OGjA05K1cOtRsplN48SoTEit+zV/g4+5UeWj40FmEif/u0s6IeM922i2LhaOwgh4ZBPaot6UASQW35L5h+d0GT9QfzDaFBC3dm9qplcDRrN9vnFgldw3TNYbCuhLGU8BnkIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> {
+    event:alif190jj9we7toczas8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:152dum7y56zn95qyernf , event:ggbuodgi1pykilp8znve ;
+            msg:hasReceivedTimestamp  1513170830265 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig> , <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> , <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:alif190jj9we7toczas8 .
+    
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDX5Gvhbn/4eqif270CyZ92VUF72HMPRH4nzJjR/0S3YJ6vpVMJaBAP8HA17FpOkJACMBJVIkW2/XVbP3BzDA9KJzd9x6hLSMIEieYqQZWtbbzgQme8aZ/ymxskMJcw9wdEog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK0bVFozUzO5otj38hi+R4s8pIBDzD8jrzbOxet9iD6wR1LQPjI5Zf/z5d3Xix27tMUadjGAfR0fv56v33HxLf+OV7behKNrupdUdqQyRk7QokfPM/8uYzIC2UYR7cECZajbYDWsQYgZMRH7y4PqYq1g3zh0ufckqMmlADswXW+u" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlQS7FI+OrA9G6wWGcyBKhOwYSDbOB1WVVDgRZ63TXp+iwytziBrf4Bj+PPSLj/lQCMQDQ1nDN/LyykB9bfndfUKAH2hgXXYngRTVs53tANB0olGcCDnBKzD8vTMOCi191VNo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UluOM+LB0yMl5C/C55LKx+/dvCiQmfaq1FapfUeOAaXp0chQENwLWp29L7hZ95TzUNW7VIUnqhwI5DTWmLQXm+X7m0wHBNRee8EFM6OlDDMFGxMTU3fmHCNm4JZ+Gs7hsZAJ8yJXGUYlivHPAyUpgHT/0MmAPVjymT3K7Dxh8k8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> {
+    event:152dum7y56zn95qyernf
+            won:hasTextMessage  "I'm not sure I understand you fully." .
+} 
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope> {
+    event:5946672495584215000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5946672495584215000#need> ;
+            msg:hasMessageType    msg:CreateMessage ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170781491 .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#need-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5946672495584215000 .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#need-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDa3BdYxIPv4W98aouZ+UGvM9W44G+HCaINpDstu6t7nNArzMxa+iUWr4m4EP5KC04CMC/75bbMikGWIG4Ff0pE9OdWaXZRQd1sib3DGTAuFrZASO7NxjiZJS0LsBsMYzzZvQ==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "WTNx49tEAUN2Goqf5gd0xOoFC7x0IMNL0fPznqXgkXCYZzDF4hX8RxPXKFIuKcoWanZyW+Qr2SI/tBddp2dUXEKPIg5VqI0XntmIeO3z2Rk8vI9JV1gU99e3NcUAPU02IFO72yYByrI88VfWazhcBXQofouJPKAw4xHxZzOTn+k=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#need> .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6834006177130613000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#data-sig> , <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6834006177130613000 .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMG2QlOJfI7d9PmdICU1aRQLkwcReC74fLXcaOS/rCOI6XSnXVSPBCi3rqE61s8ExagIxALjxXXPj79vi8PAAuHFz4Nm1l6Fpou/LRh8RN9nLW983tmGyI8tacL2Ce8umBR2VaA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "NvqzhZ+xbEj7gLS/NLJ6/hM1ee8wAsA0Xk+nGVs/tgajhEZyCNxhXjv+C3f0XA3Qpc+39PFi6/6Cvt2mQzFlMwKXbhm896P18cS3wtbkU92EgcpirxT85UPyEsgnJQboKIRt9yjKnn21RpY/drNI3YEzZJnIFdOoy8e+boRBb00=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#data> .
+    
+    event:6834006177130613000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:mmdq8395owv3xy9iyl5q ;
+            msg:hasPreviousMessage    event:fk1a2jb7ortt8q14tcrb ;
+            msg:hasReceivedTimestamp  1513171118815 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> {
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> {
+    event:zpvc6zv244tfxddbhi6a
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:ivr0xermk4aeb3yhohk4 ;
+            msg:hasSentTimestamp  1513173165971 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zpvc6zv244tfxddbhi6a .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> {
+    event:gv6zk2yqk6o8bl574n36
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> ;
+            msg:hasMessageType    msg:OpenMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170798149 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gv6zk2yqk6o8bl574n36 .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHLmgtATJOg5y9/mi0r6MhqJKDD+15+geT/EwulSNoj0RoeIXpdtcvcId+m7tp2nGQIwZJskHbS4DploT5N8uKopZYn+7nA5EWp1q6IKaQPh4pPbOd1G/kZs1Al3Cj0PNejg" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCROB64WWTuH/QrNr9odNCnCghI92UXN8sutfQM9UBdhjXYH1a5LzQLBxQCURX7CLKPEB/iKLfhAViJlvbpMP6v" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig> {
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDofotudXy7gQL7BNCKdKwmSS5KI+QX61jqaEpMqQMGgk627/jEY6G/G6yGAw8/GYMCMB6S2X1Nmdudwux1SM2YgwY9ZG53NW3Uao83fNoz+bkEaJgJvUkTIYEzj1mJXqMvsQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkUlJaz0b1w22WpXI2eb/G+wDJA97AD9hHhlaeQuqBdgosuyj5xz08VrIJAFI1hflhCXb/2Bf01aiz96lgVU1ouXRY6LMCeNrleoqGSXsNlNFBSKbMU5Z70Fly61hDJ+/gNU4L9D52ge8ADvjyaFaW+RF+0AaFI6//pB76PloeX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig> {
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME6PUbGpR+88/oQwBXRk18e95b+xrq28z/UNp/4GpxPG3XsShzIIh6RK/AYv6DpiBwIxALSmb+2M0+RbNzRg09jvW8E3CsS6Sxp8Iu67CllaLoAA4lw0ZN03UcbfZHCUfUykWA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XcLVrPuTUW/lSNQHtRCZ/eTaMVjFKB2J0IPlkvpvURyDmYhInqV7qmuIzruckTqTnkEB+27Vq5HZWsq2sbnD/l3Ib0MOp5BsiM+pRy0DzESrBcXDGKTCHzQEYL+M2Vj+KyZG20d4YZPbC9KR/PtLTp9tcU/uwY8QbVHFdilAhcU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> {
+    event:5693603251585579000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rig33yoxaetjw059bzuw ;
+            msg:hasPreviousMessage    event:l8d77tygvfnfycfu5201 ;
+            msg:hasReceivedTimestamp  1513172392116 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5693603251585579000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#data-sig> , <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5693603251585579000 .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCKKn5VjPnHEF20zyDY28FSr1aci71l/dV0vFfxSUE9QcZB5cFXgB4c18aI6cA/9zYCMQCPM/AroctQwY7AGxmmXf2f3qXmW93inrgqLLjEZvFvzpVXLqYXLVNKM1oPCtVAUDk=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "Sg9TJ/GIO0kAFNnD473qStQPI70e5HwM0efS1MU9yqsRjTdHPgIlojw/orXkTbPdLph1+FBGqiPWNcrk5DsNEf3ZtOjFfl085lNZYco2+K3Dwig2ni+g/m5fmt85F4n9hdJOdrzQqo48llHRAa2zrFabi7XMpyQC38w6OJS+5fU=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#data> .
+    
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#content> {
+    event:1107469913331435500
+            won:hasTextMessage  "usage" ;
+            agr:proposes event:6149800720990867000 .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig> {
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF0DQEL7Y6ywH7J86m9iCpaFzzGZMaOTrr3QEP9tYY8+8kNhz6d8cadeFPkrBcv0GwIxALYAOxJGzgzRJfQAPlEGseGQ4x6s8PA+LvNR4X4PRCOVVH7/OgwwEPZpZvdWwggWqg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJk12DIF8BEWSe3NI6LZcq0e7kn5Nr97GglfNbFz1rpAuQzs6dhOaBoQv/SV/CF6Bn/yX2bpIW+3lvH+kvR7Fr5gsTFMopkuausbHAVUArtGgXtGqEmfpdlD3E5tb+/2030uHb24MRNCJiG1aFDcIMU+qJUs7RWVLbwzpTMW3u9d" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig> {
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHgabnaxK8IZ9ikFDriWlf959XOzloKYuSCoJCdtZktH4PEFkBZnRrX90zOV5UFs2gIxANBLmS5yXSwLnvatq/MytzaXaz0PYeqpJ26YbR0LLURNFVQ3MrMK4OCGPiJ95dnDMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eG9Ad4ZqtP+ud3nWrJ/Id3P9iQGA7our5i9VvfuqOHpSJOzNwJldplrtxhzqaUp0njmw6G2MVUHYqIQp1CdyBJwKI/VaiSzsAigTId0q8u1BrdiEvnnwZ+QNt27ImYhFEdSZ7U2yPNpXDH2O7s/8RBHbCAdsIOLzZxUDsSijaEY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> .
+}
+
+<https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> {
+    event:t87usy00t0o9h4f0d1p3
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:253k6pqq8gyttmmfxc7l ;
+            msg:hasReceivedTimestamp     1513170818350 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:253k6pqq8gyttmmfxc7l ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t87usy00t0o9h4f0d1p3 .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+}
+
+<https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> {
+    event:jbr090p3fhvimrc65vis
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:joo1uifc1fc2k6fk5z8t ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:o73qpj11bouvhv9pfmhx , event:8950tg6pjze6lr52pq3y ;
+            msg:hasReceivedTimestamp     1513170819289 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:orj8iruy8pcer6zzxlra ;
+            msg:isResponseTo             event:o73qpj11bouvhv9pfmhx ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> , <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:jbr090p3fhvimrc65vis .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> {
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+    
+    event:nepohymog91pfkznq0ry
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:s9a226k3n70ihhaurhdp ;
+            msg:hasSentTimestamp  1513172280997 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nepohymog91pfkznq0ry .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> {
+    event:joo1uifc1fc2k6fk5z8t
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:orj8iruy8pcer6zzxlra , event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasReceivedTimestamp  1513170819741 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:joo1uifc1fc2k6fk5z8t .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGwqbLwpW7h75OYqpkzBF8x5ZpGgQZgXiwdFwqFkSJUCw9bdGJEWzsuRcrYDrCN+TwIxANOmlsaYfMcyE+GHDnN79OtKmq6srnbsLUH+hIMxsr/GJaL0mA4FPH7wZITyEfXwiA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKOoq+82kojUy70xoxylQPopd92JDIYD+uSJTMAJi0WyMk6i9/t5mJ2W2W0oby24UTyCwZr7BxWjg/jAzefMmTmwXG7BwPUtZMDR1stMOPfuV0hqMI3AbpUpwVi2x2aqnQ/0C4Q5s35LWA0NDwujSbrsJuPcPcqN7moSg2Oy6wx5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> {
+    event:6fvg967tlh9rho8axvbs
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:238289506881087500 ;
+            msg:hasSentTimestamp  1513170861073 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6fvg967tlh9rho8axvbs .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+}
+
+<https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> {
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+    
+    event:5l16wlgqmeu6z6rt90ca
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4055709708568209400 , event:elqliyw383sgw1gbtxcf ;
+            msg:hasReceivedTimestamp  1513170830843 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> , <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig> , <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5l16wlgqmeu6z6rt90ca .
+    
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME5OBo/oLUcxTC1uP26j4He2vb+W5XANy+mDPS0F9btVzUibk6eojj3qAK7kTBwu4AIxAKAHUS0FJGtZfyV5/A5tEmDUCWAg5Q5pJZ5OOwkISpVgxyz91D+Utm5bISGX93XeYQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XCSe1I+OCINMSa1ce+cdA15F2KD3hNam5XW5gD1OGjA05K1cOtRsplN48SoTEit+zV/g4+5UeWj40FmEif/u0s6IeM922i2LhaOwgh4ZBPaot6UASQW35L5h+d0GT9QfzDaFBC3dm9qplcDRrN9vnFgldw3TNYbCuhLGU8BnkIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEUEs4gdCcTLtvr1c1xl45DO2+gi+ezG14jdILaeyPHEbNTm0NNr5D9X9wcqZ+mBMgIwetxyxLDfnU28y8oP8nqeCmOA0FaTphco/v/CA4caZSPjbwOUNCyRVRg8nhHiV9VU" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PlW9+75I67XyYLqU8RST58olXJJOtTORGan06sjFCy1ELEuUtHA12NboMtFnk9CmsglWF2xQgeNWevNm3ChAXthcUeCzHNfgzjk4iF6DzLyN0jtn8XRJNzIwpuKxOZaY6pWQy8VQ37E0JVILyuH7B9PGLNbwfXT3+jabdKHHY2Q=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> {
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> {
+    event:t6d7eq3cq6nq54a16k1w
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170854547 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t6d7eq3cq6nq54a16k1w .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD2O6TSLlLr39EtVJ4/MOsZU7ENZwE7P3rIDsWElT8w2SrpWVUOIhwyab+E+rYPiVQIxAIq2sGyn9IHCo2sn3odNmOuClxoGH0c0dwOx2rJKuNKOEEA2lORukf1rRUNZlNdJ0w==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCAKIo9JS7Wq8xGWO1SXKm2vk6N/oDJXFTfV5k8JCisX+zbeEQQarPbEYlE8AhPtXJKMF2HmnVCoijT+CmkjAEd" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> {
+    event:d3jq9fgiu47gdhclj7h0
+            won:hasTextMessage  "Ok, you've been absent for a while now. I will stop bugging you. If you want me to resume doing that, say 'chatty on'. For more information, say 'usage'" .
+}
+
+<https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> {
+    event:plmfevq4c12f8itbisjf
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:p6x8qvs5m46mxw4jb7z5 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5s66o8cqv4rxv74xfepg ;
+            msg:hasReceivedTimestamp     1513170829815 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:4846251213444807000 ;
+            msg:isResponseTo             event:5s66o8cqv4rxv74xfepg ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAURI8MSE1aDOt6QXLwIhRRwXspKgKuPIes5snqWi7Y1TqTAhhqFqdHMUsDKyh07gwIwayN+L4mGhAsMx8l30SlvPJZWbFGp6+2vprfrKaf0NLe1+tHwlZPtMDnJy3c7aTcF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "b1DtmHcAiH/o2j+W0Mf82QGRujysJJx4ksmX2/Q96klinAwgDxGuwpG5knAWWMuYMA0xPNZoWc5FOaiWzhvA6dTeQuRBoYXGuNkFeF9EyOcIP6a4S3Rq5E8rUzsnOLWfvzrtHC9mr/1Na/XKa6MbsZ8RyezZMUNHgPXtnHnDIJw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> .
+    
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:plmfevq4c12f8itbisjf .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> {
+    event:ih9v6gyllshhvo5kxyv0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fd3jtdrkpb1x61pl2ix6 ;
+            msg:hasSentTimestamp  1513172392622 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ih9v6gyllshhvo5kxyv0 .
+    
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+}
+
+<https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+    
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:84bls7ssc3hfvt38vxr3 .
+    
+    event:84bls7ssc3hfvt38vxr3
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:1107469913331435500 ;
+            msg:hasReceivedTimestamp     1513170817336 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:1107469913331435500 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> {
+    event:pha7cg4ilx4j23f8xo0l
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:s9zfgm2iika5vgvayt7h ;
+            msg:hasSentTimestamp  1513170861163 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pha7cg4ilx4j23f8xo0l .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> {
+    event:gi8wvgu0xrwk42ccs4qo
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6149800720990867000 , event:at9ld2d9yv5dmfmzbxjc ;
+            msg:hasReceivedTimestamp  1513170797993 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> , <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f-sig> , <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gi8wvgu0xrwk42ccs4qo .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDeQT4PpBFqCuzWCiA9uRbwBcoLC4U0dmYghhH4lBNDouUbnUZpFQJd2bgYPM0YHM0CMQCMPwis8TeG9KXgU9XMxS21uteATTNsRzkNJyMuaPzMLRoKzO2Qs0UYtVmzKQ73MsQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TAzAosbG5+RqHAEoDPonQ6ZHEaV1WRkVMeNNEX0xOAiIGRbchUQno0UtbnBRLzH+6XTPP2W+XkDLvoBdKS9jDdSzHlnJPb6++1wcPYHUPOoCsQRjoJQR80tRvs1ix7g91e98ffGhFkGbToRGlpvsA2eYELxbPPl4V7/1X8k6JsM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> .
+    
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA4I2mYY9MxqVkhL7VnxgSOAg8JvOsBmH8KT2u3fHVkCzQYnCMElXWrtLDUzg5INdAIxAJCLEkR6Q23dLZwQgK3wBUeHkISwAlOAURLkDQSNo8YlnDTBzyIax637/ti4lxj88g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dy5XCmNEQdZT5t3oLfs48R0qrkleA2+3gLggoLL8FjsDhWBOnjHC6Rf8fVv7vKv6Lzpl8TGzazk+Ypj8+fwukAnH/MNa0lgBMpU0cJi1nFcPWJtCr5XmYfHn0WR99YbRKlyQ3PJ5++M0E9VcBVdMQEoLRNaBjOzE3+t9BBgzuT8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> .
+}
+
+<https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> {
+    event:ck5071fsyaned6upryxj
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:csvglzqkcoddoreep5w0 , event:orj8iruy8pcer6zzxlra ;
+            msg:hasReceivedTimestamp     1513170818699 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:orj8iruy8pcer6zzxlra ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ck5071fsyaned6upryxj .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHDVEddJe7NmoiYbu1p+JiMoEVtLRur/+Yu0sFLq5DUIrrWrtdLK6f+prO8pKIdnOAIwOTKM8iqIJl5RCRTU1empKnTMdVGqYNnugzvjxmcJYcHlB3kEcJZB01RpgP4jXIiF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "BCqG99LdFS9ele8EvqJAKMSeLJhmvMv8EYQE5Ni7NpgpIlHWsUe9/VO+cD6uuuHHSCaOvn2v7Qpx4yxY1MJGPmc3EMhoELJYWIHnHCJDLdEWPPPZmLMlOd0p8TsDM58KKsaFHjQ8y6LYBomosNL8tVb2wxHGagv6/mWpsyY7ph0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> {
+    event:s9a226k3n70ihhaurhdp
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> {
+    event:fn87pwzr9g4a9v368h4m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xqsfn58cdatb7ryp8lzt ;
+            msg:hasReceivedTimestamp  1513171226407 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCG2rGSj81rzhPOgphwNGDprwQDnYa6v4vmiURfxoK35k5Ot4iIRYisycowAEwstMYCMGvCf8cJt5uzYi3QBJ3kFGsyeYm6n2AdS+M2AeGOzXl1s6cmJIZBvWi0Nj+wC+yekA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ts/IRXsq00oSzXho352YoQkBH5CBw+mNTmD9is1ypvznH9qrw6ZQyWW5eSMKXkxHHwlqkiyG1bcjr5gvV3I15RnHcCh9JkpBH9snd3F90zHdKqh7PfwLa9MSm219Pgbgxs4la/biGYsFhDeZtb/fiRrwP3kNRaFF8sz9lP0SA48=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig> , <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fn87pwzr9g4a9v368h4m .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFUCK6FBLgmf8MmgQJlwTfPJXAEp/JJ5V4r10vU0kc7eBVlaQfGyAyN1M4HAOAjHHgIwT02b49DKEfNDfw/81QEMQYd/HAnsuWdnzgtWngutgz/8cmBBq2i9pOaBW+SEODGj" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K0nhark3Hrpoub3bRUcf7h408RBYkK04XuJBChVB18w4CpqHMOPTV/OCqU4fZ3lz9BodLOEGRqQ09J1SAcZnJkbiUHIuXOqQA4ZCQ6cvpmIZwSQZexhbCr9vmwaXiugqWwnEtxOl8+LyK4PmKul5nm/wqJIZcanR6mrCgKAopME=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig> {
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvJUwX5io7kRVCpCg0ACH7aHcLJaDpV6xgWnuM8L/J9HJ4L1G0zcb2cOPThKHdjaECMDGsIUf/dAuTnYgKxDJXunm5OaPW/RxtK/UkoeR9LjdH1NZx29k0dK3FX1ucOxQhSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VqBi30b6cD/Tkabv3jR/WYmM2nv0zuxQtPaNP9kPQok1RA3zkXsvsV5jyylmK4h+r+oTW6uDitde/XJy5+lQQZe0AxB8FNXRiR3szQLsg3GnwCM/G3cGQPAgq4bd60+c0/0nztI789MoS72tSiCL9/suHukcvjwyuujrGP54BHU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> {
+    event:0o2v37foaz8bog1diet9
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasSentTimestamp  1513172263230 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0o2v37foaz8bog1diet9 .
+}
+
+<https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig> {
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCKNGoZuX3Cdx/avuEcE54aYkii9K5pEXQK0QWqpK0vVvEqWQvEoFjWBs7SbQV9i/wIwYolGkZVW7A7p1NietYbLCRHcrQEihskE/862juaVTmSe9hhGqisqVNWBxdsTHFwz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJd9IddYTEuf1hfrGTpj5bPbTDamBREL1KktLjF+hYsTc9pWnpYz2u4dL8MA50FLQJVe02vgmseTrrNJOuqQCU5JvmgX+M27x3rDaKDBUYxHmCGBP0N4g+ylfz3kQAb+ziLRg1t82LfBHQX8esySwF7gPWg/EA8yy7Zl1OZJR41j" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> {
+    event:xp44teiwtooczc14npe2
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:s9a226k3n70ihhaurhdp , event:cw64ogmt2lv6n4kdjdxh ;
+            msg:hasReceivedTimestamp  1513172281150 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+    
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCpkOb7e5AdXuk0dkdTvq5EEHbHPFQek+jqslE7ieVGVDK+OWhopzXqsOzVmAjLFJsCMQCP5spWOSsU35tGeXf+5NECMMe9H+shg2ppQe2oRvz1K4FYY+EawU2xrxZ47g9ghgs=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FApA2qocNuxYIXsIvWpkyVGUtz8xrSsE4BKgqzaNZpaDjoD23J7UAkNayg7fq41hPdopEPKHaRlcDIQk05w1ZR4jUpHcdj5aMaYKON9hX2OQ2+Y5l81XPmWkcmwJdph5CBdDaKl7dwhDcej/wafhee6jP8nY6raPXFIoKMrxgjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> , <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig> , <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xp44teiwtooczc14npe2 .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHIx7i7d12TqyqQxJOgTP3GOqwsKzyDJNQ2GBZ1LPAkT0X9xkjTWywrqCNuT+o+f0CMB116fNtAT1XTy/RImn1ShbeSfsdIAGua71m80LKnTk/4mv4TMHOkWoQmhPbVgO0Rw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bkVBm69HspJbFkk+BkV8Y4k8t6FSh2K6KjPskLkj7xl1B2KFmVOo5SKjXdZhr7RNv/2iDR3l3JpEFAg99jF5M8KDpyhdMRlj8GavJ3ybG7RG9fudrv4+fapmW3y6H/mpgjouVZTVfDDwxTJScBRNAybAjrvXYUldI6OfyIQtwzY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig> {
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCf/fdInjdyz1iYLMe7IjMIj0I0s28J9dRIznTow4yPWLMDgAQ1RItVQcNyA4XaGI0CMC7uTiR0R4WG0FZUODUc53CuEZHZDjeN1MXGSVcKtQIcbuzgL/UrsCqoCgKXuwQO+g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aMOZu+pH38S59z1B3bJ6iKvqNphXrUttOzx1TLcbdyaPisvTFn6AlJucTPh25IxSnaHBgIxldTKGM2edcP5O9amOtJroF1HnYBcidn0lT4vMnaEenrP//S4/OATNXQwCktQYvjlwSFj7AmNLo3312oM5TrlVEnKcewtp40iggNQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> {
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+    
+    event:9se5txpx8xf4olwlettr
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:k175l3od8wq1w0s2uy9e ;
+            msg:hasReceivedTimestamp  1513170818593 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> , <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9se5txpx8xf4olwlettr .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDKYZO/gMNajY53bT9TTYkQA9LSmNHW9EmTbDTLT/QEBdrcSBOWMnJgBCCFcRJI4jMCMDTvCOYCjx4TrpfNFBPTFhHd3qkU86i8CqUlCGDH77fLUaZqzLVMpOuvqzE7RXZh4Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3sDKWQHYrBUqNvokc5PGD4Sxk7++1qfoEZqwNr8pOQuo2joAFo7oewiKUOt8+5RareGDHysWiWZCOYQBts5CwREyn6LXfxANFp1B/CRnea/lie2GRnct+jVv14RKLrckzaFe5l/k50jQOreyZDrE4pakYCOi2Ph1lH2jDS/+CY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig> {
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCE6+fv3kekPziO6ycHrssyEPEmVd3+oedrFW0bzWh05yKvDWVgTawfoW168fvCVj8CMHB35gY1CVGJGhMaDqsC4Ij3v+se7tRt86ZbNfRsv6ZQ/pAq0b4Qp0P7I39JyT+k8g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3lUhvyoQ1vICrN7gzkfdE4ambRm2eLkGGMC5N3tEXO1GEgLl6Qu5cEaolyp+5DBjamJB2NyaF687kwMhJez51KQQucfYUTcLWlHSoTkX6DX0FcW7ZgJucNoRdOkp9mcaheChQBrrFpRNwt/PuKJa4nKnzYPz0WoFzzFHuQ29p0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> {
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+}
+
+<https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> {
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig> {
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCVhsAY7hBLadu1CWFOu4afRRKrTYxjbOa+uQ31OD7eTUoEggVuksPbJHT04zYkicsCMEw3BFMumDIgvhFMCvK7nyc99PoEk9uDykKS7L2auJJYJPsp78yPD5j4XL4xkBmjBg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "SstIdyZUGtr5VqtVkIWuL3OMF2/dL34GwjscGyw+R3V4XlTZRKP0ggomWl/12nrpoe++P3eaYAFT+9Fb0auyUO7INcceZWRmiziQ4sb6GGflQl8ExrmvkSjMIFFobzDT370BPe0VME2mqwO1/yB78clzqPGTsiWGb3FRIR+SUWI=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> {
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> {
+    event:5s66o8cqv4rxv74xfepg
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:93e94yjsmx9l4lg8lu1b ;
+            msg:hasReceivedTimestamp  1513170829788 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig> , <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5s66o8cqv4rxv74xfepg .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8qI64moKP/D/+XBh+1XDqUAooItSmLoEk/xt7WEH9/zGnX76uGoG6TQ1gbEC2+nQIxAKZGQk3n6IvpdbH4DAugjamtOcgKDDQtGHOuaqhcNnMUtW/3z38CJr1jExlpT44cLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIIUS+7qXLkSoWnELV0FBeAUb8G6KYdsblySs1Z9IQKdQOiKkwbz786HZdTq0+bl3OG4qqXB54TWjT8wmjMkkXLJDkbgxNyZrY0pzVjkGs2VhBe3khTGq2JABzOhDDu5bFKnoYRrYaJPhbA9AMdSrcfYl2dGq6R+pIvRIdi8bKfe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDZTkDgRaF835Oj6UwKOD/ygmD8e4HAxQQwpeLz/jnDc3bWMFGJPg7+m9b+/ICRSbACMDg9WzhntoN3QOFzxb2NpLOgPZw4SuWYnY1UbchtO6up378IyVkcX2Jb5L7if3xIQQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SaS7Juk/DlCPIs/CVazI1urUK5Bln0+qpYMqTnAVvfCdojEkSCgptbjbx+ok154wj3b5AKv5xrHqK59P1Rjr1dXOxVNHwu3h9d+1S128AcgyFoFvxtYK6aqIsfQfdFqOi57vGM0JYu3PQXp8hiSJbsgn7++gXOBheIke6ai0OhU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> {
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> {
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+    
+    event:eubp8u958hoow90rt9dz
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cqvzpvoqvtkylzdybhej ;
+            msg:hasSentTimestamp  1513172274273 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eubp8u958hoow90rt9dz .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> {
+    event:152dum7y56zn95qyernf
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4rit8itn4uyigyesq90s ;
+            msg:hasPreviousMessage    event:plmfevq4c12f8itbisjf ;
+            msg:hasReceivedTimestamp  1513170830048 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> , <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:152dum7y56zn95qyernf .
+    
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvfSPUG9//xVIon8GFe4AsWPaOM/i/MtawDdiFs8J26W2cmkahhmBlVU1+1AS/9pECMGdsE/jBM8Pwt0WYhq61JK8wP8wOKwmf+Ry4jJsAE7ABP+Qk3u0nrKdiH2QHu9cTmw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AKSu7kDaVNwTO76WzYes7L/X1hV6XCnD8JqYvNwdG7uC3b5EYsEmuLPEuOoNx6NDHpX/DDeN2rewpJ5izSCtCKBpa/CWDYRzyv5xNZ6TF2HeYIfxZMXTQi3AmcZsJbkNhSvSDZw3ZSOKJQPZnlk+IjzBxUu7wLcIi/yqCHA6I/cz" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> {
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    event:r5hu2rq515sq6wzgdjov
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:m8b6jvgclclzy48p7wqd ;
+            msg:hasSentTimestamp  1513170818019 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:r5hu2rq515sq6wzgdjov .
+}
+
+<https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> {
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+    
+    event:n0k3zboeco26jrnxa7l5
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eue8ar55z7as596cu33m ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:49hcv8na1594ijbpx3hp , event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasReceivedTimestamp     1513170819716 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8c6o81ry6mxeetm2d2pf ;
+            msg:isResponseTo             event:rrmkri9cdrtvp1bkjcnl ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:n0k3zboeco26jrnxa7l5 .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> {
+    event:253k6pqq8gyttmmfxc7l
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817841 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:253k6pqq8gyttmmfxc7l .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCju3pOuc5FYy92BIFY2oHUlq0NNCrL6bCOgExhY14piu9y7a+n9v9rOerRsCq+NQ8CMB/FTZevtHRqRn0L/viEM3RFIo/QmruTaH7rpFX0zua2HIOertiztyPuwFFijgSyOQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCF3jrMIqN9xNks9z4cBE05d5sVgBAlLgMAlRW12JwpcGR+N5BIBcyPfFn71SXhyWr9mtVM+IWKwsepLEr5BdzS" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig> {
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDUP/fs+55TXUZubu+45hQ+ta04XzP7sDbwb8ECqWcI8OrsYCadNZ2mdHGuO1n0F/ICMCW87yDqhImKEtP8txkLCdVI8/lkBI3wJ3t1gRSNXC89HTEqo2vvZG377rFgmZnzrQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UkfJOncQPcw65kiy88cWFeApVgVHAnfZfQsjR8MowmZBIKcYUB08bpAaM9t3sQrdqZ0O+3KMYCgDdbxyUIKBeP37e18X7BepkZg70SsiHllnMNXELkRWrIlu3C+VzMRrufK7sMk94N3GSJ/oV0vv+7mpq4yxDc6fSgn5kAevy+A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> {
+    event:mmdq8395owv3xy9iyl5q
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6834006177130613000 ;
+            msg:hasSentTimestamp  1513171118837 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mmdq8395owv3xy9iyl5q .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> {
+    event:collk6egdkt2tey39h8z
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:ih9v6gyllshhvo5kxyv0 ;
+            msg:hasReceivedTimestamp  1513173165910 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig> , <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:collk6egdkt2tey39h8z .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCBXQAY9JCzR1KytintdoJQqCCijMN4fZh/scIuz+PU1Yo68ES0h/94Wo2DYHGfEVECMQC+YpU2wvl6TAscmFS04k+gOJemoI0/mwztgZPUNfvLmfkjRYorH+DNP15m+Am212w=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nxifj77s222vVKuupybo3fNtjRETwgJdrubPviAO2r6fBRgFSFDZempT2GNWXNKSRFmT+YMMxPs+p/Rcq/CDZ1mZaioBBYlZELSyqOJlj0QxSzIDZnVb64/+bAQYOvJCt7dgtUn5BYW7fHvyYxIcwFSLvmxnqlFbxne8MT8dkTk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDCGC+fxSUaQjjIuQSVVIigcnCWzEKPveJ9NUSdywX/FT3BMZnMyhYSvdkmhbpTEVICMQCbh2INMmp1jvWD1ynEXIzsqWUQSSOReOq3k2g5P6Ocw4iq5tY9sDrz/DegDrV4aFc=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK+J1W60ORQU0cHT/gegRIlK9tSB1RF7VNTddUPUI0Rv6vG7oVO13Mr/9Vv/a7gNVYpla9j2oXKnb0oPDuxBNtVW9YbhzZwcML+5NJnTCJWbeDLjAIfYEU70BMhGK3CQPXlhjdvs2uNHNaRK8eZ2qX0T1q5mgyx6vqL9dmPGuWGo" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> {
+    event:vj2yzrtlf700wixuxujw
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:u02ulpncdj9l8ae8x2aq ;
+            msg:hasReceivedTimestamp  1513172274227 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig> , <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vj2yzrtlf700wixuxujw .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDsoACeLxf/+IE5gGN5+M8+xdafOXT23XABQv7HN8M9jxmP5HRBnZsD4NYZIPfhdM4CMQCLxNWA8XtkrWqgEfrmS8oiGc57Qxc90xnWcjfqbRwD5htWyf3VysSyaOM5MGdb1lU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbasWeY7409EneTPZB5PGTrRZ87optqYqAJ8K6sxrVaDVI/veZNZXQppInCsGHXnUKsv9b23DKyDd0KFFYFj2YUuNKNz7kwAzIxnKDFI3sBHg8W820U1WqQXudbw3k7gXsE8cFYa9UkgqTJP1yfOit7kAKQ7b07dE3S0FFAaY3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMG3cgv3q5U/BNS/byfl0v5KNgRhpy+NIElWSV5KmTXuyIAnNqgKNMe8VN1u1YybNXgIwCxz6tc4aHvt6naHxzxLbvO+C+04n8RNsVNBqTaXr7FGLowqnIhYqfUMydQ29GOYr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "M2xYxjfxT54CXeLx9x4QCilSOfEbGJF6DIYX5Kq6e4VHf4vX56SORqKnym+728poaqxzv6rd0qV8S2LsQNYCYI+Z7R9CvdYM+hia6dJUNDDE84qhxzBsBXbILV/uJpe43o01tXF1OeV+CEykmjvIRasig2lfrUb9rMEREdZXqj0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> {
+    event:8h7v5ml1aflqmoyem61a
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:yrizizmtaxehctdi1m1n ;
+            msg:hasPreviousMessage    event:v66scoiidw56iam8q86p ;
+            msg:hasReceivedTimestamp  1513170817880 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8h7v5ml1aflqmoyem61a .
+    
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDmUzvYHlnqFhsNhN9yyn+ACcibzuWF90B2IB0Ss3l1lMclmKqZG/mPbYAQhdjq6GwCMEJMC0sdfXllbc11OzyV04BR7bJRGjQdhIDZnqFlBvgd6CQvtxqn2cpoKqjUfbR1nQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Y3/E/xdFsD4nOnjRLgSS9fOotoomwZe1+AhyQKOhq0TLsgci00CR6apNZwVKH4Y//Q/7SUUxLwEnEQj0QTNo7VIFwtqh1xpUlXRycTLgWXttqIYwoGZmqFq9cfI8BQDQrWcqinZ9dE/bqW1chLYBxfOQIR4TYpzfhxpamfa9rUU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDTcDA03QT1luSmHUw8uU2jo+vqHbMxCxB5LRT03w6xLUlIaBLI+qfnHYpHXRdmbxUCMCvfpe9jTMRIlBmKyb1agBotI/xe+iqvzBWCOno3hqPyTKdPDBSTjW7uzymyFhGZTA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AINzmExGAuItVY4iWWX3ka/npoT4mGt4I7PUbuawXKnz0IZOuGTHwkqoFrG2CCFb37sn0BTzblmN2Dpyl/LglekbqhzW0/lnedushkiLv88rsJ3cIpo5pHe81/qQy0l5+UBKIWL0Bb3WD3UVMSc3Q8no+okXcQ5oAN5J3tsSALFT" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> {
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#content> {
+    event:8863100035920837000
+            won:hasTextMessage  "validate" ;
+            agr:proposesToCancel event:1107469913331435500 .
+}
+
+<https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> {
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> {
+    event:i3k0giied2bgp0p44h7u
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513171228916 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i3k0giied2bgp0p44h7u .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSRCvUFmUuUw0S2we23jtPDgtMhNOB8DWHhjz0YLnEzj9/X4WF5WHAu4HhccF/PfoCMQDbLXNse4PXwdoeM586V1kqTqL2wR4okNB19i2CZAbnp+eqUZyhHnWKE1QPo/34YRo=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "EPmfsABiUChbH+MZ+Tyg2eLP5+CMe+9bimftudbsYu2v97a8hGfz2RxISy2cnfuN6NFfmjDLgvj9T6Ru1A/LPA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig> {
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4j+rDkXxIN1TWTiX2FmPFQzLVWqfHqmmVmXfhOlT+WRlEu1IhiKwmtCcaOR1bD28CMGRu2E80fqL/sZyAo9dbJmLlXKWzleyNe8ELfgUqfpCGXfDlnePlDum255WD9rRdGg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJqyzUBUhStwyRnZXFDykPEVIBMBNtMij53h0S0Rgae1FaaC5bbngcWo3Im01f0xgZEPmB521cSAr0sXPYmOwcTxzhnZiZq+cC9Y6jnfubnHZxxYY964fw/OZ1lTEPW+z5KT7PDt2aIDzJM1n7xUyYDZE9/wzEdP6nO7t/6ytb0T" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> .
+}
+
+<https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> {
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> {
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> {
+    event:93e94yjsmx9l4lg8lu1b
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xsbbah2dhkcg6d3h13gk , event:dhdnzy40wlrnxh7ymr2b ;
+            msg:hasReceivedTimestamp  1513170820733 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig> , <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:93e94yjsmx9l4lg8lu1b .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAJDEJld2ndIaCn6/1kRsp4kfm7HZT2fvH77JQ8s0zZUhQWyrBgXZRhiJrEBUIMZDwIxAMeCP4ugC6Et/yhH5xEdoiEoseTRJCw92Naa+b1yJptL8HGS6KyvC51/j0RbowFziw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "c0UEvfRWh/PcqHUGJZf8M8e0Oyoi9txmVMj5sRI0cnHfvY+ukgrlV5fTYIHMssQiyNQZKXomAMSgqlrllbY6hE0OAoBCsakCOZUvU6Dp0t996nSWJulqZbS0r4xCFn2LvVsUJ0hsv1M34w5dhkTjM67Xr+WYCHzqN3jsw2/kR5Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMATMRieaehOcM8oVH/Sle07y55YWY7NKR1wQsRdj5XgEq5vu2AfEuhHzxsGcwVf8TwIwZajvTLPulEPB5McofGo6pVW7z8jDt0aEoLjeD3vMQ0pHKUD70yTK3G7Ekqr3gN0n" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RBs4Wxn4zVx4N3kF5F3vpSkbabHW4pegoL2pD+UPLNeXX/dfzVmdLCGV1wG/oqu9lDStFoE/LrsB/pmq9/rVzKF+gVw9mUKUgxjm7RMkAby5qZNfEiOR2zM/uxEzysxnsCKz8uDkeTYbejTbzQeUg7A4ZK6kJRKGf9fiNbotf08=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> {
+    event:t6d7eq3cq6nq54a16k1w
+            won:hasTextMessage  "Connection https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y is valid: true (downloaded 266 rdf graphs)  " .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+    
+    event:eubp8u958hoow90rt9dz
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6928365067343411000 , event:8pk5umtsiiwch3wl0mda ;
+            msg:hasReceivedTimestamp  1513172274307 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> , <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju-sig> , <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eubp8u958hoow90rt9dz .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDEPR9SsPgvGZynkN63mOr6hsc6bJrqXjutlcM10zXq74ip2DRwtJT6BrFGkx13sgMCMQD8Pdrc6hEKXX3v5okbLALEWoE6ggulF/LaI21XYWqSv5uug3jAN4BpzKuh+tibNqE=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EgnlV48KjV4va4x0JumtL4gy+FJ/E6bq0k3Ltdvb7+6I+4BM3FXerELXTUnlXb3z6pSdKkv3Yowj0e32DhWQSUAqqNf1lFZZjWtmdCLwR0/7N7Z1xZ8Sl3rjdaHiPoLfL7aKgLqpUQaxhsBsjOOMAT9TsqEDaAn+Defq5hGzc3A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> .
+    
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlJJUwj6rVz5MAYseOY1b6315LTg4MVSYYsYOsSopsFb/fH+nEGmtrM2N02uBWfiYCMQCEePhqHStLwyluUKeNwa+VX+sPhXo5lvblTvnUFKENVHRdRtKHNlocYFocpLruNoM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKpWpWhPq3JF3pYVVgesevrqAR9a4p+eUE3Q/Zz+fcOKwO+g1kOiVjJRpTLjnB00c8bdNNpUD1yQ2X21T7+iUaOdUQ9+SaHnvgVRPLLrzoBtBZbWW6pyaO3237ha2vmxqMdlkC2+UpWRuYkthQlUIgZg5Mwql9N7ttg7vh6ej8yA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> {
+    event:cgqt5h004iql2003me2n
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170830888 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cgqt5h004iql2003me2n .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCRdsvIvZ4uX+n/6GKA1FA073rtuWogzDuEy63vcwDXW9tu6DU6Z2ihc9mQZf8gDSwIxAMYtjEYHPqGpYsfF1N+9iTbovSevmcsUrJapZDW1iiAtzFHJrNQgiE58t6KK6ybFSA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCGzNrFfexGiz0TLmOGU9Hv4+o4BbECK7cdgxcYVIlh1YgYo0CO5RBFWoEf98ko6bfTEvFLy8CjQzp0wCK/ESl1" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> {
+    event:eczqg8lp7xbukpzikd41
+            won:hasTextMessage  "    'deactivate':  deactivate remote need of the current connection" .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> {
+    event:2uf9sj4itmz9fpas7suo
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fits98gjdl4ybaudq5oj ;
+            msg:hasPreviousMessage    event:xpspyx3bpyev5v5p1vf6 ;
+            msg:hasReceivedTimestamp  1513171153811 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> , <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2uf9sj4itmz9fpas7suo .
+    
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCHcLhnKBEhtW8uGCiNVUkVb1rTbX8Q3NCKlWI/K9+Vv7XhZB3LZH9RZjI17O+HFrgCMDGmjxPKFbFQAfbU2+3xc4YjJSeYe5Hr1LTIwBWofkxgIU5Vf7P3JZgrGIuE0PUhlA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "LHFtESfrJZ3IfdJ4sFf2wk6+PYJK9RoJ1JGDl262QmCvq5ep7JpfeUlnWN1scMZeIRR7YyZU+NBmFBPu3pa4/a/QgB5YlHpweIgW4gu9l9Oe0X36AhVMA+wFYMZmS83u6tUtU5tEupu2K0hBU2UH830Ng1ernS65RcULeG9URMU=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> {
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+}
+
+<https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+    
+    event:z1emzo49olrm66x3ukkt
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:238289506881087500 ;
+            msg:hasReceivedTimestamp     1513170861073 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:238289506881087500 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:z1emzo49olrm66x3ukkt .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> {
+    event:d5whye2xxe5kofpdojs8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:n5rqfwjqbcpdwqjjwpdw ;
+            msg:hasSentTimestamp  1513170841832 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d5whye2xxe5kofpdojs8 .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> {
+    event:vj2yzrtlf700wixuxujw
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6928365067343411000 ;
+            msg:hasSentTimestamp  1513172274135 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vj2yzrtlf700wixuxujw .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig> {
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGNnDwc5YYL933nHtnxFVA8NxJPmQNfPjt8hUwvgsMvaLDx46ML4wY+pYH1ucJ9fCgIxAOilrXvu3vvKLsYDyD7SPEhFHW8/l7l56Q5P265Eq+y5WcpiYj1ZxjhQsPblPwyEdg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dGtyMN8bioDT+K5C1IRYeFks7KsJA4SHKzwPBikY20jzMfMPPit21cM9mBMjS30atk1s+RRjOjImLb8pqLB09JU9eb/j6U51PDhprQ7o3tTK2gNFuOqoZcxZda59EYQxnqHmravRFM13SrCgCz7WGYn+24ctpbypUCRspP26RL4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> {
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+    
+    event:3v08br9ub79spo7ol4v0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cbcccoqqqbec6bxkl3y3 ;
+            msg:hasSentTimestamp  1513170817835 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:3v08br9ub79spo7ol4v0 .
+}
+
+<https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> {
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+}
+
+<https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+    
+    event:d0muf1vbp6zai6jtnp7w
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6834006177130613000 ;
+            msg:hasReceivedTimestamp     1513171118837 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6834006177130613000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d0muf1vbp6zai6jtnp7w .
+}
+
+
+<https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu-sig> {
+    <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEav2d8Yjom5QcDq1kc1AOAdVN+XfDiOKPTRz+bLL7sc+FFPHri3X8PTHGnq3UxpmQIweUWTRIM7lY8lHX1dTKuEozXbBUC/2X5rRO5RZnfy/A+TrAQmJD1UKCHnz+9jFvzW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIukH4kDFailxHMWUQ2r5cLeeuLc7c6TSE+Ip4kVAOZYPv64d/rrLIq9JbwXTSioDSb5Ju2VOWJUJXOyWqooIdOQjO1/VHUOG0+uVJxUvYRayLtWZgSKlIqaTYX1hBnhcQgLR5Lsa1Pqx3Oi5l3nA2zHNG8UIPKWmR6ZN947IGz6" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu> .
+}
+
+<https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu> {
+    <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qqhehmrwyd15rhzizczp .
+
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+
+    event:qqhehmrwyd15rhzizczp
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5946672495584215000 ;
+            msg:hasReceivedTimestamp     "1513170781771"^^xsd:long ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5946672495584215000 ;
+            msg:isResponseToMessageType  msg:CreateMessage ;
+            msg:protocolVersion          "1.0" .
+}

--- a/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-retracted.trig
+++ b/webofneeds/won-utils/won-utils-conversation/src/test/resources/won/protocol/highlevel/proposals/input/one-agreement-proposaltocancel-retracted.trig
@@ -1,0 +1,10418 @@
+@prefix msg:   <http://purl.org/webofneeds/message#> .
+@prefix conn:  <https://localhost:8443/won/resource/connection/> .
+@prefix woncrypt: <http://purl.org/webofneeds/woncrypt#> .
+@prefix need:  <https://localhost:8443/won/resource/need/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix cert:  <http://www.w3.org/ns/auth/cert#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix local: <https://localhost:8443/won/resource/> .
+@prefix sig:   <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#> .
+@prefix geo:   <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix s:     <http://schema.org/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix won:   <http://purl.org/webofneeds/model#> .
+@prefix ldp:   <http://www.w3.org/ns/ldp#> .
+@prefix event: <https://localhost:8443/won/resource/event/> .
+@prefix sioc:  <http://rdfs.org/sioc/ns#> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix mod:   <http://purl.org/webofneeds/modification#> .
+@prefix agr: <http://purl.org/webofneeds/agreement#> .
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> {
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+}
+
+<https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> {
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eyrx1pzifelg0uwuz7pe .
+    
+    event:eyrx1pzifelg0uwuz7pe
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9uyongxoip0kz7t9tsa8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:3v08br9ub79spo7ol4v0 ;
+            msg:hasReceivedTimestamp     1513170818141 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:cbcccoqqqbec6bxkl3y3 ;
+            msg:isResponseTo             event:3v08br9ub79spo7ol4v0 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGF3VchNz9iYkK3toAZFEWmCeFaei34McWjdhF33BnCGUFUh3SW8li0+iupxE2FiHwIxAPJdRlHPz1WG2lAO9mgXZYVrbpkg7/qgyHCczRI5PUCp3HM+V7rLdt2s1szonfHWnw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ff41bBHDJlUrjTZFwKRSGgce+udO3zlBjuCFz9I7BJijc0C3jmSq49OKje37j0Uy1QWfCzLoB5/nyP6XUhNyoFt6e6NXYWvgya+oENsYYj8KVt2PXzTVbeNZEo5A7kaU68gwPYFhCdQb9YgDz6Iyz6JYj+P/IJz8TqyLUxuXsf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> {
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+    
+    event:353368844400623600
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fn87pwzr9g4a9v368h4m ;
+            msg:hasPreviousMessage    event:beyjpryu04ao4on0z22u ;
+            msg:hasReceivedTimestamp  1513171226308 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/353368844400623600#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> , <https://localhost:8443/won/resource/event/353368844400623600#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:353368844400623600 .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjFF4qmm9yDjgFym1rxcrrPczw4asfpc5cIREjSpRz4plnNkzWXpAqTLXx0crGcIcCMQC2KU27qjj6QliJ7tBU6dPQEoH9qhAtSLiIHrfSHgSHVAPxUTWzGt0Gpc0NO3w56ik=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AJNjIsybmU+PVTivdMs0p5oGU8de6XOkMgLHkYPjhFm02y0luUf+jXIE1RE0EFXOoNxTJG8wJxm93i8ZlMr+JM1Mv/XmdQyyVZ+RnuEAmTchTJCqkBel8rB/mWaXrCRG+eatRgef7yfYtEw2Obt5xSBVH4cHht+A9FcnxawOYPaa" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#data> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> {
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig> {
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMB3v1uvK7ZQKv5J8peoRrM3QJ3vrHDt4aAaYf/XSvgdkvnS9eE0nG4dWK0iZ+89WggIxANMFZTf5a04Z/4HzdoS/9USIew9vMhxCz3JTLJ+pvcTXvt2tbKYMFnmZWSlcfw1ftg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QKPFiihEYejQ8pZ+LiHl9Hq/R7dx24hXYk0hqLHD/xygPDJqZbevicX9Si4tiHrS48TLzTlEyb8AezLF41DCmAW/4n0tHmwFafZZb3CQm4u1vq9zq9ghLRCYhQth6L2Bxs9ENUHaR0k+BH5hDo6t4C5FJRw5DMtFdxtcVGbK8Es=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> .
+}
+
+<https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> {
+    event:htpqlj3ablwc32xmfh9r
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5151909952739158000 ;
+            msg:hasReceivedTimestamp     1513173165842 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5151909952739158000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:htpqlj3ablwc32xmfh9r .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> {
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig> , <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:00zilsxex8tqjumh6fi8 .
+    
+    event:00zilsxex8tqjumh6fi8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:zpvc6zv244tfxddbhi6a ;
+            msg:hasReceivedTimestamp  1513173166297 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNOuZJN/EjQhXcyyaharVkVWElGP+UrKcV61VZwvq/9F/ySUbRPJvA7xQiZTVm/6YCMAiXn87dK9myidhS+oaAJNI31Gk36dUEkpvvfP5Jjri0A8AFBuGKOy/NbklcERJ1bQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "C1hP4y5BjEEX2bx85xBfPkWuMvbJ6biu90L7JtdSpeCubGmwzVHKmC5zce/C8pVGLCeYytAjiinds89/Ys16psbEI+2sX939L3RIyDnBqzJV1eTo8Keze85FntjhuhshI7ubotO49DY6GbqY4Gqo5lV7h9+6CarHCW92ilpc/ic=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF82EfmZ2nH99uwru+lXx1HXwaUc4D0MbVdYiwxYrxo6KRARqVaQdXsrlY+zT5FXkgIwMF+rIhuswyy4xjyToiWwNW3Ya/aZSqrbXZpUXsi6Dw66AoprFW9IRcj5eDp3diYd" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKAv/4NAErt537EnlTVnwGud/XRIS6GIRy3cE6SvjPHOBuBAWkqqogx2BGcUEorx2r0BdcpWv+m6qpg0BKaanPoYBYoPerpg+sp4eDd8l+HJ5OngO5jKVRd8dbFq0NQXnYY305UzoavEXn54WzHySfUP4ujBUKZ0zZn2tKc4Uq+Y" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> .
+}
+
+<https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> {
+    event:wlv9kjrh93gfzetdojp4
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:gi8wvgu0xrwk42ccs4qo ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:hasReceivedTimestamp     1513170797868 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6149800720990867000 ;
+            msg:isResponseTo             event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:isResponseToMessageType  msg:ConnectMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:wlv9kjrh93gfzetdojp4 .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCCVmBe777XXxKIzx8GiXnqPZVV60dE87A2nb49MdVWm5Asx0HZLMbWZuzDPSs/GWMCMGXDZjTxeON8vVOLL3PlYpwWLPl/HKkzfJGW4lHxLTpEqJp0htNhwv3o9MWmv3zcyg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XjKa5OuETtNcwonuZ0UKP9rDYaxbAwZszdvVg1GLrMBaAe7PQKWahapA0/9w3IvoUu4gaThNhLkeq5OQ8k7tTeaUubo4lnQ4PhrRRYosfaburuqxBezmgiriqECOAVLnjvzuwHmcxruBk1IrMgeU1IUf1je/xi5bGJenm3a4pDc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> {
+    event:253k6pqq8gyttmmfxc7l
+            won:hasTextMessage  "    'connect':     create a new need and send connection request to it" .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> {
+    event:o73qpj11bouvhv9pfmhx
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:7kbdyf9ffr2q657gkgte ;
+            msg:hasReceivedTimestamp  1513170819024 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> , <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:o73qpj11bouvhv9pfmhx .
+    
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDbngdqD17UV5n0LH8/y3RmoH0caBdEhAp4cw6suIsMzT1N9TRGHKDRwBT1k5aeh9AIxAKyCS1a2XhFIEbW3tavbCcushSyOa95yObGopKNa5fGLh4iOPDUm2vZU+VdnJKqqZw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKCC0Q/RiyFivxS1yrtkGQ+45CEvx5O5mmRYNq/k5lz7CNe0EFiTkRVkoWsjoGH3Gm2QzHWs8okw2dLGTb97Ygi8drOisdHwPWMZKr1XgFkn733eYOwEGlLquys5XLwNcAqaggE7m9Enq4u7mcorKQLdvwfg2pRmSWb/y/JCwo/I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> {
+    event:obhgk474mxybc4fobdub
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5693603251585579000 , event:kv6651s4ochvsbafubzm ;
+            msg:hasReceivedTimestamp  1513172392332 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> , <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8-sig> , <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obhgk474mxybc4fobdub .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF+gtWhYGIkWVND+wUxgvTbc96ydFhlayW1i0SWsF+Aviux6ovD22fZvQVL70uGKIAIxAOxQVBPeM5mvSKuDWVbzXI5p1wWo3bqRkFDv2YaPgxk7m6YrvziTzaDbMoq3OL9m+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XZQP60xWiAzR5BDTOeaawiLfVFfFJP4hCSsm7ZK8JXrfxF9viw2utC6zZDTenLCzmQM9nlzAl7nZdhkpGubdJ8Afs3goe8Itrn4m30GI5sIoLPYi8NN6rT5GUvNFYuVpnwk7Eb4bhSYE/YwRPQ5kFXJ8/5LviPgv8MReIOEcjFs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> .
+    
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDAYu+iwuVxn+iNMkc4L0fs+on/mVIZCFOji+O+vCzNXzj5lfoN6kNNBVOh30sox+4CMCj1NZS7eWslazm6cTDzC6dIZoTA/HbDmsoHhjrScMjszSKg2YWK2l+XmVSY+z6Q3Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TXmnN+JgFn7q4Fiqaup2b5+b0EJi5ml25hgsrE8Fgp11XS7srsuTx1SmoMWMfNT+XZcslr6jelRBzHNvw+ruNv63jvMRsHhCQwz4wTpVumclOxK3XYUnXv231zSCiaSP1BhVZZlLxeVMWwVuXWiOK2b8nIp8sTsXpoJ7efixUCc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> {
+    event:4xjx598ewu7579zpl64p
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:k175l3od8wq1w0s2uy9e ;
+            msg:hasSentTimestamp  1513170818697 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4xjx598ewu7579zpl64p .
+    
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> {
+    event:1tr3o22co1907d6b6n7s
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> {
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> {
+    event:to3x48329wwbanylmar0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:pj2n6r9g6jt39rv99xh0 , event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasReceivedTimestamp  1513170854798 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> , <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig> , <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:to3x48329wwbanylmar0 .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC7M5OdrUd53lIitnywJXohxT2HIa2cUtjM9Ff7i9kcHmRjU3JJoV30nniKIfPmHFsCMEsk74RAYg+LlL2vHmZxJzGsQQ+GhnhySy6O8xU7dI/GO34gDhwLFcH+U3PHZkDWfA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YsZP7L8khHhwtpozr8pM7tHONg7AMhpxd0PVbP2n4kpKkdq4UGqHExLU+akvLGErmneYgKCcG7HStRH4OVhVasSsN0iYmP7AmKJ2beNdlKc70mDDUA6dh9d0y45KTipjKxRZtfp/tUAcpar1D5tpwzCQGG8g7fpA2oikVNBHSB0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDY0AYY8X1zn0j3mPD2Snl05cmhqELtKlL+hLMU+KKLhoK01DCQecwGI/9jxsxGndwCMQC0lpHDe0/jOwLvhKKMwty/8h0/I+kjFAHEIAj7AVHK5bXooXsErL++jaMCfI5ufug=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JZe9wg2r5Ttue4frxUSYKW8YJJNnm9nAqXodCgoHFZa6/OxOBNJrcgapk39l/yz6yGdVicOB9SsVtR4Tuok2jwmn6N2VJUM53j5KjgGVC0kpiINBzrHe0RT9coOcipVXEaiEYmCIy1yRd4FqtJG4u7pdH6xhqFoN6wTiwmAE1qM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> .
+}
+
+<https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nop2f4uemehxb73r1r6a .
+    
+    event:nop2f4uemehxb73r1r6a
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:x7cjarywf0513459swe0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:qyg9hv3nohv4ykv8ryev ;
+            msg:hasReceivedTimestamp     1513170842109 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:uu3ciy3btq6tg90crr3b ;
+            msg:isResponseTo             event:qyg9hv3nohv4ykv8ryev ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCG+VNiKA4S0uVRH8WlJIEmLexRHRX5PQ9nP4zNw2jvSXA7/5ZvMh9hSq1sOmQOBNwIxAIABDOVT3EbMjsXeqlyEgYFXl/iDmZWHyy4bSQMJj2JgvkKyAokZoxX64r4S9XcggQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZOkmpJI43GASvxA65flR5o5niMxaPUld0mFv+RbcxJdwWbjr4VDEOGb5m+IXWCOlLJrvHlQAY9PI4jk61mbRodUI5GaJB8+I6NLw+vCYvvoaKZkijuzfgAVxvsQzo+zP7RYizptH4Y9GbtMfH/EVTPXUpEha1bo9aOZ/KUJjAG4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig> {
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCG2rGSj81rzhPOgphwNGDprwQDnYa6v4vmiURfxoK35k5Ot4iIRYisycowAEwstMYCMGvCf8cJt5uzYi3QBJ3kFGsyeYm6n2AdS+M2AeGOzXl1s6cmJIZBvWi0Nj+wC+yekA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ts/IRXsq00oSzXho352YoQkBH5CBw+mNTmD9is1ypvznH9qrw6ZQyWW5eSMKXkxHHwlqkiyG1bcjr5gvV3I15RnHcCh9JkpBH9snd3F90zHdKqh7PfwLa9MSm219Pgbgxs4la/biGYsFhDeZtb/fiRrwP3kNRaFF8sz9lP0SA48=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> {
+    event:csridlusp0h45v9gf9v6
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:alif190jj9we7toczas8 ;
+            msg:hasReceivedTimestamp  1513170830749 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig> , <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csridlusp0h45v9gf9v6 .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC/F/NI/VX6ASFjJdeDRH7jIQdMlB9h9vRhLpDxk6B6SZS5GbR21Jmi0FkeLEI2ddACMDRCYOUb+G+m3xYGgSnX7fdy7no747rU0fv06q1EA4lumW0xmIicFp5/UUR4CF5jKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FeYE3UT6mrctO35PUk5kNdyjMgkPcgIMGahGbwUFhSuhXAuQ7VAsnkkoR6cZrzjrwsB1X08GsGcqhDb7S6JLDvQcu+iy2x9hn92M9kI85P3Gil04V1qFzcNYR0/VL9LG56gbWrTRlQppMn6i1aGcKT6KyHuPk/yXp05+HWkhUAk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFg2Ko/r6aL9vHEoHeoBIfQfvHEwWyqAW2RR0zEIgnkprvJG+hI9kNSUULPSzf0y+wIxAIUN8eFhLyrVo6PxEcn3vSqw64IXRaExDyxJOCoBohgLAeLPAdo6v+LWlNfM1xkOUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYW/pYgf4FwuwCLLR2rVrAcor8p/5vvGmREH+rVV5JCeDlS0yC5QKJBqzUOLOXcd4hvo/BIHmuvzRTGA2SLFM/GZw2mF30bZXRnBg/xDcEb9AEZoSMki4i8Mp927CJcv/cyTR3027Od8LymojkChLZFgj14JOMEwKK4OC/Burin" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig> {
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCxiytXBuh5w3NE7kdsAUsVjzJGK+tF2KgU5+AEyO3DTzGigsBoen0nQUM1l/n09XQIxAOnJ3IidktXW2rZHoBql+fazmmhrqXnDffE9Us5ux/rL+izk9q94Z/T8BcUHiKSzmQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bm/4QvtUDDVrZLPsj72ecL/AEWekrp27ZkOyAwdYk8gvcmIXDSgFqqiLc1HuR8NQSEM1ZNP8xPFKSC2uWiOFiscTul+6HVBmISweVHKVWabTBFcp+7uMkhxBRM1E+djcfk8KJ3RAKYCQcNF2lpa+rrtKGR9uKwe/gmDFxZqe9gg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> {
+    event:1tr3o22co1907d6b6n7s
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:f9zpvftok83vya1djrg9 ;
+            msg:hasPreviousMessage    event:s9zfgm2iika5vgvayt7h ;
+            msg:hasReceivedTimestamp  1513170866283 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> , <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1tr3o22co1907d6b6n7s .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHlXdh4PDaivQDbpAUaN7uk4OY/LEy7TLlTzeeFoA+gHdQ/16dYAdEyFl+utA1x4CMQC9pJnrKbsOyBo75bsYlQU1iH6dj+aEJdQd8c2bKX8urihpLBn8Py9MD8Kd3/P/5W4=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJtgISvxbKMYSw5wwDON6UnxFkcE5urYBldCg8jlipY/87mBrYT9GSI/T8x6d0lZuysmqA9oOFTW93FGzi0jFeXL+vFWxdjvpy8Jfm6divcclA4X+gCG+bVTjjwQgcXjNO50Zuq4C6rUpAb3fERMoralHEKPtfxJ5skjTsIUBZbJ" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> {
+    event:fits98gjdl4ybaudq5oj
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:2uf9sj4itmz9fpas7suo ;
+            msg:hasSentTimestamp  1513171153830 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fits98gjdl4ybaudq5oj .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> {
+    event:8c6o81ry6mxeetm2d2pf
+            won:hasTextMessage  "    'chatty on|off': (do not) send chat messages spontaneously every now and then (default: on)" .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> {
+    event:0uouhqi6aym8jad508kd
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8mr0p8ua2srgw0zw69lc ;
+            msg:hasPreviousMessage    event:xu87g40eu8cx053lad08 ;
+            msg:hasReceivedTimestamp  1513172392467 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> , <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0uouhqi6aym8jad508kd .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGYfd/07vhRBXWBEYVHZo92QrXUt3xbTjVHRu7eCqLRnFwR69bHJPgB5rpJGyBWRHQIxAO5DGEmWwv5hiYLRIDob7aHdJ7Y0mw1an0WDq/epeIqw4/VV2st7eCzDrUQEOFonBQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALBVWMmZgH9Y801Tvr81laSwORXlC6JzlG5UA8Aj3sdjke1lCC/f3xgGmWYI6SdefVgAvkYFgXd6mFZTw4amQokbNu1uSds1+q7yTZBkQW5ubfPQkVqofbiBGK/rrZ+/j6G6AUzBUtlIZD1aOcachoU1HQ5wltgknDIaB67bXd+M" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> .
+}
+
+<https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig> {
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBuXv823DJnc0Gy/hyx37tadJtAcEMhnJZVt/pNvhd6zFqT0eF+nWMRtXyrWyUoSwgIwOtYJWYw585IWoWy63tL9+QqIQKthFe0mry2n5kdV73A5ytfDOX213DGz95WGGbPO" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKijqTKR104eXXLrK+ZKsQZU6H1W858mHLkxcm5YdXq0JGqty8hJ0rmy74/j+VUTaDbj5O84D8+hNPFQibObM6emitgNZSgHBBsBqYxdAaisjX8CjekBZxnOwrLMFYan9qVlDSKJdovOqGezO8d2w3jv4u9YeukUi64EYFCxR3/q" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> {
+    event:pi2jpw9a1q00d11kr9ez
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:49hcv8na1594ijbpx3hp ;
+            msg:hasSentTimestamp  1513170819628 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pi2jpw9a1q00d11kr9ez .
+    
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> {
+    event:cbcccoqqqbec6bxkl3y3
+            won:hasTextMessage  "You are connected to the debug bot. You can issue commands that will cause interactions with your need." ;
+            agr:accepts event:1107469913331435500 .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> {
+    event:8h7v5ml1aflqmoyem61a
+            won:hasTextMessage  "Usage:" .
+}
+
+<https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> {
+    event:59gtirhola4ydvddyo0k
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:mthg8rh8r4grme5ph2eh , event:m8b6jvgclclzy48p7wqd ;
+            msg:hasReceivedTimestamp     1513170818019 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:m8b6jvgclclzy48p7wqd ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:59gtirhola4ydvddyo0k .
+    
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEvWR/fHCOdGj/uM5AChtdhVB006Hq0TpUIqkazxmdzzhGqEonoxPJWBwx5thvc/gAIwLjD7QXA9jnarEQ6zdtH/aa/BfBaBkE3/GtC38UtFyylcywQ239p/rMGf9Caos9X7" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "L7ZDsU+JNUesAdJuZXheut2HyOwcDSJlEYCiPwF3sbNJsaZRaxGBXQQzUziJNb+8tUw/ADfUVt1hT1egjBF1T3PqDMeTJrvo3SjW3k+b81deyIEV4ffjS0TyAMVAQC5EFz5JeIgZ3I3Qf8iT/Es5VOnnQBTJCUTp0tAcBHoqxNg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> .
+}
+
+<https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+    
+    event:49hcv8na1594ijbpx3hp
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:pi2jpw9a1q00d11kr9ez ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8950tg6pjze6lr52pq3y , event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasReceivedTimestamp     1513170819409 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:eczqg8lp7xbukpzikd41 ;
+            msg:isResponseTo             event:8950tg6pjze6lr52pq3y ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:49hcv8na1594ijbpx3hp .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> {
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> {
+    event:8mr0p8ua2srgw0zw69lc
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0uouhqi6aym8jad508kd ;
+            msg:hasSentTimestamp  1513172392503 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8mr0p8ua2srgw0zw69lc .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#content> {
+    event:6928365067343411000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> {
+    event:238289506881087500
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6fvg967tlh9rho8axvbs ;
+            msg:hasPreviousMessage    event:wpcsl4dxaxpdxbxpfo3r ;
+            msg:hasReceivedTimestamp  1513170861045 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/238289506881087500#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#data-sig> , <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:238289506881087500 .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDdIR3opcXKb2SnMN44B/J8mjfMvviY+pNa9fft3uE3wQ/MoIArpR1xtw+kfJfy4eECMQDAWIsMCIVY1l6WAcY2Q7/VkEOBYhxsBJxXYx1H0DQLdEEIL5zy8+RO5Nr2lSON++4=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "DjGixwtI2DKuOpxkV+Uto/esUSuyemhhtFPogVg1j3xluW07KdPzkcCD0JRK7EddoW80PHV86Ffqo01vQ/d7YYXiJlkdfHoAtmhJWTIR6r4rofUkThqzEth8mCrFrUA4IxHdFjpe/AEFZZS4xuUj+74nb7jaOM5r/0tHsc05ObY=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#data> .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+}
+
+<https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig> {
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDX5Gvhbn/4eqif270CyZ92VUF72HMPRH4nzJjR/0S3YJ6vpVMJaBAP8HA17FpOkJACMBJVIkW2/XVbP3BzDA9KJzd9x6hLSMIEieYqQZWtbbzgQme8aZ/ymxskMJcw9wdEog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK0bVFozUzO5otj38hi+R4s8pIBDzD8jrzbOxet9iD6wR1LQPjI5Zf/z5d3Xix27tMUadjGAfR0fv56v33HxLf+OV7behKNrupdUdqQyRk7QokfPM/8uYzIC2UYR7cECZajbYDWsQYgZMRH7y4PqYq1g3zh0ufckqMmlADswXW+u" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> {
+    event:m4nq3rl0m1br8bea2n72
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:j0oj37oa9ry8lzmm26ul ;
+            msg:hasPreviousMessage    event:eia6yrvml8v995ueq65m ;
+            msg:hasReceivedTimestamp  1513170819448 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig> , <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m4nq3rl0m1br8bea2n72 .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDmjl9AY6pbq2C/8sQMSFIsWV3MVDZQYD7goKYKGL4t1aT8GIhCVRtl/ntRdTmuIJsCMQD9/CSmj5RXzqCIgENqaB1/iYL7zVpltQFlkCepuK1UnLLXCLZUoJdSr5FXofBIzN0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "E+jWMjmUNdTGMbDubZ+R1SNOSdhPp8Nv3LMxZEAUNzR5GSEgsw/Ng9nWpudHpzb+CpOBhmuPHTdKPBbmhVnh739jmTxyCzzC4yzfO3WBONondQlmoSLyz1DYveT0topDoDpxr7bJQVHAP7YYbs47kLcEWCFNJkV9LMgHpkjbn2U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDTDqXh5NHy4Mu0Fo2L+ncmg5E2UG3/RbjT62eSf+vQUxs6ooKn7eAUFMR+VAuaNKUCMGb3KFVlWxOi9YJcgf0NlypAQjQJzzoZS7ewJKF8Szx9TJ4CDTohfU5zdlkuqN4G9Q==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJvEKrhS8chrZa7ZNvu8KejC55X7nsV8NjF9xi1zjL4SmoEKptrD78cKF8zmGx2Ka3nLswC1KEFngwjVTWLc7Q7p/hY6p/TP2rirpvVI5zh6LZCa0iFPryfb+2ibOeeVTipQvsILnkiUFm+HN9athmA3cgdyucNACnwoAi1oqst9" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> .
+}
+
+<https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> {
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> {
+    event:9uyongxoip0kz7t9tsa8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eyrx1pzifelg0uwuz7pe ;
+            msg:hasSentTimestamp  1513170818318 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9uyongxoip0kz7t9tsa8 .
+    
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2> {
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    event:00zilsxex8tqjumh6fi8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:h6c8epmrvb3gxqrvs81d ;
+            msg:hasSentTimestamp  1513173166250 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-sld2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:00zilsxex8tqjumh6fi8 .
+}
+
+<https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> {
+    event:cw64ogmt2lv6n4kdjdxh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:s9a226k3n70ihhaurhdp ;
+            msg:hasReceivedTimestamp     1513172280997 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:s9a226k3n70ihhaurhdp ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cw64ogmt2lv6n4kdjdxh .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> {
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig> , <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f9zpvftok83vya1djrg9 .
+    
+    event:f9zpvftok83vya1djrg9
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:pha7cg4ilx4j23f8xo0l ;
+            msg:hasReceivedTimestamp  1513170866345 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMB3v1uvK7ZQKv5J8peoRrM3QJ3vrHDt4aAaYf/XSvgdkvnS9eE0nG4dWK0iZ+89WggIxANMFZTf5a04Z/4HzdoS/9USIew9vMhxCz3JTLJ+pvcTXvt2tbKYMFnmZWSlcfw1ftg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QKPFiihEYejQ8pZ+LiHl9Hq/R7dx24hXYk0hqLHD/xygPDJqZbevicX9Si4tiHrS48TLzTlEyb8AezLF41DCmAW/4n0tHmwFafZZb3CQm4u1vq9zq9ghLRCYhQth6L2Bxs9ENUHaR0k+BH5hDo6t4C5FJRw5DMtFdxtcVGbK8Es=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA2qoxUmShJK9ond6yEWrlqlKdnkbHKGUNsl/bJN7V5fyD2EZfJeupX5vsAQ/mggbQIxAMfm1V8D8X4rnD5gBvVOCTNWxd2F8YXAqPz5hHjACqIe6bewi/UScY64bG46yivwBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cQG4rhVLelkgR1mfHT319pa7TwwzgPC0BqwFs1WYXSxFyWU78Wp6bYGtiPGOhB6XQ7fBr8rK/rSJWV7JMsurHJtAvwvJk/mIzMUDs7UQWa6JK+NZorUemxeiF18iUoHITP2RyqpSeQsGswLSb1ziBh0mcbQ511oMirvDvyr0oMk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> {
+    event:d5whye2xxe5kofpdojs8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8863100035920837000 , event:uonv0x93cu72oy531390 ;
+            msg:hasReceivedTimestamp  1513170841891 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> , <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig> , <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d5whye2xxe5kofpdojs8 .
+    
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZu1xW/5P9mo82xJEBHM1TWxCTw7GIp1uwRlg4/Vt6rg5trZirrsJWzZdBoVRCLmgIwBGBnQQkFD4Y15co1lqV1+KhWf1ZpK7j8mTtVwn/PBGAZEALi7pfD091aQnZAUZkn" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIy+T8J7/o5ATgD94rearSfd16+Ne1MwcM8mXK6RigcjoD+vl9BdbN8dkPwr7eK9kr2TVJtJDgSBoK7AK6OuOWzQvhDlSzqZINmaeZVHUwqj2rKV/vwGJdbIqYqolOfdrqLd1bZ4kJr/p3PBneFdlPqzA8BkO0UzYNt3IZ8XAbEe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCZsHeRtInUDFy+XK+zg6Wbop8iTFcWbm4CrZjbVl+RVhRDxaQ23YJWktMGoCcNuy8CMGZq5wgmYvFTa4uvG3NrKCo+U8kK40sjkMMMRfqZfvLBuS8N4q/oPRGCefiDqPMJFw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OihtDnGIMIKIvo2DGfHAAd81n7Ch2hucexWveHGNxK4vY+fa0t7+PaROKj8KvGYhET5GWBcLxwUBbAcm7+E4T77t1NCaIsvAvlNitEWm9EzH0aMhyG27vJV11mkUZSikx4bYRPKZE4gw1emPwC2NSZ9DI8RUZ3oHqUldIxeKQjA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> .
+}
+
+<https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> {
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig> {
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNOuZJN/EjQhXcyyaharVkVWElGP+UrKcV61VZwvq/9F/ySUbRPJvA7xQiZTVm/6YCMAiXn87dK9myidhS+oaAJNI31Gk36dUEkpvvfP5Jjri0A8AFBuGKOy/NbklcERJ1bQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "C1hP4y5BjEEX2bx85xBfPkWuMvbJ6biu90L7JtdSpeCubGmwzVHKmC5zce/C8pVGLCeYytAjiinds89/Ys16psbEI+2sX939L3RIyDnBqzJV1eTo8Keze85FntjhuhshI7ubotO49DY6GbqY4Gqo5lV7h9+6CarHCW92ilpc/ic=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> .
+}
+
+<https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig> {
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHTGw+8qqLFv0gG34cliPPDKseheKGzGBbEwdZIaoP74lyRKUoR4NGg2G7l0Nm1hAIxAOP37UK+mVzE8mYUTOrCJlbc7W0msIsz0lzqZAnkShAMmsTAVkf9Ba+YPYJVVd3bqw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JRMvZZd/sedPNFM42HIM2smPs8J9Y5qkbjT7ymSriQ/Espd4doT4E22uxx39RRnOMtFn2h4H8DicAmCBFizHPmVNHwCvRT9OtcPGMzH/XRJsfWaiICmSNOuwOUEiEGA2ro1IZzsAxrpInIZXeROH0HLophyUomju10CeXitwk7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> .
+}
+
+<https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> {
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6928365067343411000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> , <https://localhost:8443/won/resource/event/6928365067343411000#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6928365067343411000 .
+    
+    event:6928365067343411000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:vj2yzrtlf700wixuxujw ;
+            msg:hasPreviousMessage    event:guewg0q3l68ts1ud5u2h ;
+            msg:hasReceivedTimestamp  1513172274108 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCeRd2nF9yPn5bFCH0+0t6ZrYe7WqT4cZAk7VSpd1U/aAFOaITrBDz7WbZZ1IsKLbACMDZQtbTxKDaHfgwTL2G0kakh2y5/6J2ecCJCGBlj546dKYeLYpsirqo82+EEos5Pcw==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AJCAsG1BRKFN5Vn1USw4fGf6MDlDH8jkpgjxp782OZp7LykrTKd+hm2zkrbgrUADEFYOcr/ypn1/Rj3herC5+6L9XLGiWmWyfrp36KLDzh3YvpPutTF87WVb6WyKDbR9zuyDTXu4Dz5f02bHoBlqx7+lhfAVRzjzXg9XqnUisOrX" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#data> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> {
+    event:cgqt5h004iql2003me2n
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fdxtdqeonqc6mk01crog ;
+            msg:hasPreviousMessage    event:4ongmje7w2v03mp7ztex ;
+            msg:hasReceivedTimestamp  1513170830935 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> , <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cgqt5h004iql2003me2n .
+    
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD294EsdG+qfoKWoYGdaA0Z1Lqwr+9tLMUVZl6I+BczmCDiuKkbG6D5wfOSACkKAMkCMGLYQR4SqhPp1+L2Lz50fBQ6dVHgIXt3VaKIlhUr6kdOTSLEA0VwbkD36b4hrU/5OA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "U0JYsmifD7KyVKwwCusil+rgbjaRIvpgLgpTJV9T74Ospw13bOC/D2vw+pybsKAIc9OQtbrSMhAP95dubz1txVpScHovb2f1xU7YZ4MJd3cqmdJOmWKXqrvc7SJ0ZNEgFwUi1ErDuXiGHw2/LeCAPDGAWQ3lngT2MuaU9Ruiun8=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> {
+    event:qi81r6ggzy26wznv94dq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:353368844400623600 , event:ilkgs5gp030i06fb97j2 ;
+            msg:hasReceivedTimestamp  1513171226510 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> , <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig> , <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qi81r6ggzy26wznv94dq .
+    
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD2EfKVsS4PSlEqSB+/gjEiRmdCKO5s7WDv/eAbfiaDutf2XB9FOqWPMRLn9OaC0IYCMQDYF3W4pZ8zyng2pjF/1MUHYpxAeNCFBR2z9dB9Vy0YwYd7/CSHx9lKK1p7fK2K3AM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DdTwy8dZPDZTlZWA5NMwp3LViu06y+ocwZ5yhXihMFQ1J0TPqsakf+ol+m7HOENv+xfT1fuwe3D2a9ejfee52VLPRtWTcONC8cLkXAKE330uDgX8MX+H7YYH3EPyjcbscFVY2APMIy7rMzPxRwclRk2J9sDXeC+bXI6NhozZSnI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD+3CNFDHthV3Vn5PB+BR+dT6b/OBZsx5PDjpVXzX5rjrCm8Q5sQkysHZlD1p/N1BwIxAMMh3il4u8MosyGfIXmCr2oQul39GNDJkbGypjtQmfIuXDyYY/Aw1axtqglSsKz4+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HiweOlaDhhm0keZ5TnFFBqqLyzmT3R6b27hc0IVKroXQ+Sw6PcxBx/HA+FTDNjgzPvrf3WAwQv4xjIG4+MyKvqXJvcm++e63UXMDV7/gMybncycSdkFfCSN2ltFloF4BMH8XZXyskcAP6Wtwunc6Pkxr4EvGb/ytOQSO+UbXU/s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> {
+    event:4xjx598ewu7579zpl64p
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8c6o81ry6mxeetm2d2pf , event:m8b6jvgclclzy48p7wqd ;
+            msg:hasReceivedTimestamp  1513170818893 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> , <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4xjx598ewu7579zpl64p .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgKnq4EDYR+SMGTKgb59SfJSbLJk0L8Bt6WkOTYkgApqhakfjT+zAC2xK2PMRcCBgCMESgxIN4jOiT2bFE5w23xuLAKthRTWr4uPSyt9kTpW7C2rT543PAS4rrXkzPME2blA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jmige85EQwkKUxCvIUfdjSDMCw7siH1XnL/x8fXcRawXbgxd7S37zID1pj2ThVgRTHY5vCP3bhKbTgHWLGmPbklkRUTauJO/ikV3HePX62Xgfvt5ZHVNEg/KBB67zYz3hVL3b6ONvC/wHGWxlSDZIttsFWvNDNRNgE111sNKZ3Q=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-9o18> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#data> {
+    event:4055709708568209400
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/4055709708568209400#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170830600" .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4055709708568209400 .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBGZEyzBNQoBo/SxnEs7g2yPQ3L/qmvGBCm+SR4P1QsDr8Sk9k4b8b2Flvx14qgcLgIxAKK5TXq8+pmZi/zM4RCCL3+Q+lVUu2Tls2wgdfAhnfe39vTQPa1/5+gGqHj9uxBnQQ==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "CDwKELeyG6rRzI//kXCKbh7FtE4/W4NScjeF/ijjjlSbpdn9c75CWFTQbqieDQVeAFcOAXFVUyUFfuAGOmuMAA==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#content> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+    
+    event:1107469913331435500
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:hasPreviousMessage    event:6l5bwv7tkxg2g0bosl1u ;
+            msg:hasReceivedTimestamp  1513170817310 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1107469913331435500#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> , <https://localhost:8443/won/resource/event/1107469913331435500#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1107469913331435500 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMChQDAK7nu50KwlobNd/fOjqeGKaxNSqsZTXdlAVvJeh6znXsW8lPDhZhaYONlAuzAIwcSrXZuutp+ypskjxfva4yV0sEkga9yj8m9DywzOd9Zrqt7O3NsitP29s0hSTjUYq" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AIBFdQ+952HZxpSjc8sJ//3lEZz2GmHSZ9tFse3l0u7GOaYjBETsSyWmbwUZzr2qKlSgSCpdXrafvxVxWjHPLMKMi00wMuk3CiggCE64Wz5f9KOZEP0vq3JBMJCF1qn1Mizp1w+3PqWya/bckFaDiNTlKNrEFwfLjbrDgyFXEs6N" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#data> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> {
+    event:orj8iruy8pcer6zzxlra
+            won:hasTextMessage  "    'close':       close the current connection" .
+}
+
+<https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> {
+    event:xpspyx3bpyev5v5p1vf6
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8ksy3mzfwa3n937tm3vc ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:mmdq8395owv3xy9iyl5q ;
+            msg:hasReceivedTimestamp     1513171118969 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6834006177130613000 ;
+            msg:isResponseTo             event:mmdq8395owv3xy9iyl5q ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDl/hkfSe2IwapaBDzFRoEhZxrP2P9YiY8FgbkWqMWkdIAH/a3Wgvbwb24hYx4FynQIxAKP1xxubuFoR9g1b8Xh8kJv3O7/KYozptOVpnNp9iReJA29oOpvaHR9FhaFCLmgWNA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YAkN2j98/s4Fn+0Fy/PxrHUyKfFw9WSxxd4naB3aRJLYAYUg4+FMAZlJs5oZW2l7vUxGx0RF3VzaH9Hr4X7xLIrcCvi2/+b4itdM4OYgXCKtbyFVzLBrRKfxpdITVNQVRAX0zSOVF3yuOLMBORgePpYb50hHU7i2F4hjq8iwScI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> .
+    
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xpspyx3bpyev5v5p1vf6 .
+}
+
+<https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig> {
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvj13J9u1HocJCN/w81lIYFGNWyZJX/dfwoRkQLpfvzv2LKF7otZjJFOu5c1UMiwUCMAsXxui7cf5cSeb1oomocs6tfKRD8WmtRAnh9OrOuBzS7Lo8wG5B3mhL+k21rQ2N+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTR7wRzkvfsriFv555SSYyIEHHrE5p7o5hg8Fo8Zx9GUHhuj9hTICRytZoHkX+0huhWWDeLS35FeRKNIahwwkXmV5nwUcbCyGQmbuYvVz2oz1YDpZ5LbSLPP3rGbvl9a6kAK/zpftZQ5v0hBRevTP4kGh/U3EsO5ADd24Ck0BkH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> {
+    event:2sbarcz1yu7cenpcghay
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8863100035920837000 ;
+            msg:hasSentTimestamp  1513170841716 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2sbarcz1yu7cenpcghay .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> {
+    event:yrizizmtaxehctdi1m1n
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8h7v5ml1aflqmoyem61a ;
+            msg:hasSentTimestamp  1513170817983 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yrizizmtaxehctdi1m1n .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> {
+    event:csvglzqkcoddoreep5w0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8h7v5ml1aflqmoyem61a , event:eczqg8lp7xbukpzikd41 ;
+            msg:hasReceivedTimestamp  1513170818656 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> , <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csvglzqkcoddoreep5w0 .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD5iKF9xDc3tvNBF4dHuCZmNjdnO0p6ZfaRud2VlEB+0J/OOociScKi9VVk8hGA6e0CMQD6vwM9R3yWAdW+XZmAcuy5ybquxQLfY2D2z9VLLaqiRcNL3Ad+FkOQzVAc/Btl69U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1+bdzByvtPu+f66FFM4UKUxV/XijX7SldvSaLVGyen0Zc8W/oc7Vuo5xBG3L+55zsHt0DB/CyevQ2WGing+Dtc8vPMP8VBFIB6gF2w8plzjbaTAql1wrcs8jFUtvDY2eTelmW2m1jsyKbyTEcuDXEYDG24/5s8VmCNdoBwD3f4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig> {
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGF3VchNz9iYkK3toAZFEWmCeFaei34McWjdhF33BnCGUFUh3SW8li0+iupxE2FiHwIxAPJdRlHPz1WG2lAO9mgXZYVrbpkg7/qgyHCczRI5PUCp3HM+V7rLdt2s1szonfHWnw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ff41bBHDJlUrjTZFwKRSGgce+udO3zlBjuCFz9I7BJijc0C3jmSq49OKje37j0Uy1QWfCzLoB5/nyP6XUhNyoFt6e6NXYWvgya+oENsYYj8KVt2PXzTVbeNZEo5A7kaU68gwPYFhCdQb9YgDz6Iyz6JYj+P/IJz8TqyLUxuXsf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#content> {
+    event:5693603251585579000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4055709708568209400#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#data-sig> , <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4055709708568209400 .
+    
+    event:4055709708568209400
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:csridlusp0h45v9gf9v6 ;
+            msg:hasPreviousMessage    event:1d5xlvosu9j6umgi8r47 ;
+            msg:hasReceivedTimestamp  1513170830672 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMALIKnnIRaKQjZs83Bc39Pwa2IfhY+Q02q43CeHao/UtVg6l7+gIjI6H+W9mukoZrQIwLoZ9/ZeFiW+luWeOcR/zkhqDM0CXUkiFIZJUUVFantwX08Fp7jtdyLRk4pcAZDO8" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AsCLcT5P/nIlP+4GTQHgqxGpSFxjoon4wxOT9BlwPKrl+eG8qUyo+wAtbWujGgx0tMU8kTXzRfzHc5bHeJayCFuj8QAzobp+GStZu3qYmKTug1epXFJCwX7HIata0sFU8Vwr1Mg55XMQLKAaYB0Fkys0wxhqBKkpA//KqWOBcI8=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#data> .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+}
+
+<https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1> {
+    event:5cdkigzbdsxk44iw2kai
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:h2lo8jybm27ouaa4wuqs ;
+            msg:hasReceivedTimestamp     1513170782686 ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:h2lo8jybm27ouaa4wuqs ;
+            msg:isResponseToMessageType  msg:CreateMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+    
+    <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5cdkigzbdsxk44iw2kai .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> {
+    event:4e2ws6ap0hp93iv0oyu2
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xbhopokox5b4vz78e59w ;
+            msg:hasReceivedTimestamp  1513170817403 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCE6+fv3kekPziO6ycHrssyEPEmVd3+oedrFW0bzWh05yKvDWVgTawfoW168fvCVj8CMHB35gY1CVGJGhMaDqsC4Ij3v+se7tRt86ZbNfRsv6ZQ/pAq0b4Qp0P7I39JyT+k8g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3lUhvyoQ1vICrN7gzkfdE4ambRm2eLkGGMC5N3tEXO1GEgLl6Qu5cEaolyp+5DBjamJB2NyaF687kwMhJez51KQQucfYUTcLWlHSoTkX6DX0FcW7ZgJucNoRdOkp9mcaheChQBrrFpRNwt/PuKJa4nKnzYPz0WoFzzFHuQ29p0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig> , <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4e2ws6ap0hp93iv0oyu2 .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhv80xGjobHk9r7vQX+McR2wiOCJXPodiIui1eIHR9W02uRlq+zv0RqWodRbwYslUCMQDiPbcDWowHJMewwxaKF2rAAQcm8miycbtKV+NviIYkVQisk0oN/1VxBvN5MO19DCU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XxM7zCnJIW4y07OSZcLUGUSrdVeAUu5S0b7oOEETklf1Bmp687v2FCANxAzi/UdJlU6Dx/TxNtPo3XZ/EXRFQfK9Whpbxc6wV8w32mIHsjo6Ry/WV7yPX4j4d6lq4M2cA6b9qC1JSsh/Rl+JBEKRco/RKF9wWLE1E/mSdl6WjWs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> {
+    event:uu3ciy3btq6tg90crr3b
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." ;
+            agr:accepts event:8863100035920837000 .
+}
+
+<https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig> {
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBXqkcO99XGnV+YwaJ1ktvwST2X0u8mjorTyzgemi6jHvs8KfOg88N59La+eixSXgCMEiKSr4QwXjOrBopK6jL08VDbe/IkTMra3HxZMPcpFyUBszqTDKWpE8q12Xukpsung==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaqMTIy9jfUs2aJIvLranFeghQreF4PVVO+HmRC9x4KJPDjGwxNc53t2SHnx1TNgK5g7sLpYg8dSvF1wkmTRO5sltpYPMwriQZ++e9cHY5zxMqH3SYsA544nyIp4dIbOshMngRrgh//iAMoQ3SdiAgfWWdetYUzlPDB7jv9D67x" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> {
+    event:6fvg967tlh9rho8axvbs
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:to3x48329wwbanylmar0 ;
+            msg:hasReceivedTimestamp  1513170861124 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig> , <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6fvg967tlh9rho8axvbs .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC5MQPvfy1x5k+OvV2xOi9t0g8RUlM/eyeY6jr7p9dyt5+cyP9Ldy+UEVquCMHWUOMCMB/gyfb4C8vyD2HAa/ZRs487vk/Dbh3quHgx8fDU21htaIFoyHU50Jgo8AQjgLd93w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Uexg5eLuuTMWEWLquFb48wGaVDbBK8b2hF03TV6zJeGaLub9f4QxuiOdLgHeOEymmsyD7SHAPTGZvjV6A7dYz9tnv1mlKr3l4Htno/iidmzucvXcNhjwyHG0Vold2yayG4K8u64VWf4CpxLlJ+GXI6UCg4a2HIT5S/PV5Zus1GE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHHQuJZA1ugQxmuBH4pZD0UNdVJJHW7VOnxbubHnnPzdLhcRZlUD4enP17gsXVbyGAIxAL1WMthQR1doJOT4d6D9Y6XKuuLnZVrOr6sO3FgTunXyhW6b/2KsgrVSYbg7DMWvxw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WtPRb+DdBiqYWF+037X1S3XXq7rFS9jqo9CbCI6F9MelU6a63N96TcNANgidAOSX2kRQ2uK/yUD2kMLQ7UkF8fWkyHMRxSKM+jAk1iDVIipcqaXXzWv/wYRCYDwoUmmnfZix5hE6Bp4LOfHr1N58uNDWBZg7p+1Dl4/7+tDEM70=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig> {
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCCVmBe777XXxKIzx8GiXnqPZVV60dE87A2nb49MdVWm5Asx0HZLMbWZuzDPSs/GWMCMGXDZjTxeON8vVOLL3PlYpwWLPl/HKkzfJGW4lHxLTpEqJp0htNhwv3o9MWmv3zcyg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XjKa5OuETtNcwonuZ0UKP9rDYaxbAwZszdvVg1GLrMBaAe7PQKWahapA0/9w3IvoUu4gaThNhLkeq5OQ8k7tTeaUubo4lnQ4PhrRRYosfaburuqxBezmgiriqECOAVLnjvzuwHmcxruBk1IrMgeU1IUf1je/xi5bGJenm3a4pDc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#content> {
+    event:5151909952739158000
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> {
+    event:xqsfn58cdatb7ryp8lzt
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:beyjpryu04ao4on0z22u ;
+            msg:hasSentTimestamp  1513171153991 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xqsfn58cdatb7ryp8lzt .
+    
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+}
+
+<https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> {
+    event:rd1ryd06xejacyss9qy5
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:93e94yjsmx9l4lg8lu1b ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0esqgu17b6xqppmgbty7 ;
+            msg:hasReceivedTimestamp     1513170820500 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:xsbbah2dhkcg6d3h13gk ;
+            msg:isResponseTo             event:0esqgu17b6xqppmgbty7 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rd1ryd06xejacyss9qy5 .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDkAsWJNhJ4vgEXszJAYhawhUpCxKy6T0L6aej2zf1VNWfTY2UiUs6MiRkuSgXhaD8CMQCKSK4jrDUFeUU3clg3gOHiunLiSnyqhQIzrcczi61R3T3W/WokLNqfo0V6pm/6P8E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJm5X4PgCEbGpl0P+o4wU7nS7eyQaESRJUvMonGOhwiN/bwawK4q8BCV7nBgvddCs2XDsbp5jhXNZYf6Fe3giBH4THN4l1dFsadUUD0vEMzDm6dqZQ0tjYeafNADDL2473Yy565WPi2RDb9ZY0GEDP9HYndAcNox1QUtqoY3gSUO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> {
+    event:8863100035920837000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:2sbarcz1yu7cenpcghay ;
+            msg:hasPreviousMessage    event:5iw37ggk8ccrcxxf8f8c ;
+            msg:hasReceivedTimestamp  1513170841699 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8863100035920837000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#data-sig> , <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8863100035920837000 .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEiE6twdZFUkDBBY2vuEj/RAQhLv39WGk6+cGxQoqAEieZ689MQle2YtHOwAtWFsIAIxAJMIOl6fU9d+IBhL35WgYGuVryEORnQLqAbKYzM34uwwdJK40FvQA1Bjgj/zCThhUA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "AKdVS8hsY6VEkKdYebf1BKhXkI0G8Gn89xf8hbdhSE8oG1BUBCpxZUxa3OHfILF/hVlgqotFsIvv0bskwUWch+XyTINro6tUYVIKbJDVzF3dJCKGRHM2LMk7YJepufmawvWxI9xLJ0YpS1/mt0MHuTVkgMQOLgwcqp9WeEbJyJaS" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#data> .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> {
+    event:xp44teiwtooczc14npe2
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:l8d77tygvfnfycfu5201 ;
+            msg:hasSentTimestamp  1513172281124 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xp44teiwtooczc14npe2 .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> {
+    event:xbhopokox5b4vz78e59w
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6l5bwv7tkxg2g0bosl1u ;
+            msg:hasSentTimestamp  1513170798500 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xbhopokox5b4vz78e59w .
+    
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> {
+    event:5151909952739158000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:collk6egdkt2tey39h8z ;
+            msg:hasPreviousMessage    event:fd3jtdrkpb1x61pl2ix6 ;
+            msg:hasReceivedTimestamp  1513173165818 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5151909952739158000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> , <https://localhost:8443/won/resource/event/5151909952739158000#data-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5151909952739158000 .
+    
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEqzRgvERJtgtwOacQhc9pE1wQRrvroX6xajDMdSjo6dd78wY88HsJUUvPkLjKrrhwIxAJRCaoGBPn1fN0mZQrJ2yMPC6xTPBpTTNbTzTyH0F61evbw9jFEpHp+8GPs2jVxfdA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "L0ZT6rEbaOcyGa+LSJROskZ/Ry/8TC3bDnmKq7VHDWdObCDBmSae0Djw5wFyXCtOs1cEHRkefIrPMS23H3FrVpR3FGUU+705agbcu4O/YLLnKM0azhTM5zE4wUlfsyuOy8hzD9uJA166oOXg/jFtBsAh4AVN7/DwyGXvFZB9rpo=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#data> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig> {
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCqxhC3517LBpbtOcLhszKeyH9ew5sTZh++ScjSzOHLPI82Pyc8YC+66XbT4mgkHaAIxAPdvDR4aClT7FPnMUK/FIKrrSi8pH4Wbcn5JgJHcFB/clPGw6SEQDsLD84kXw5PQIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HqdIh6BzCNaM4CQRLxv8Ad1C5CYQq2fr4YuinR+brNGgT/mhpNCsRyqRgBUWQudZx7tNRqdzcS7HLXjWeuArqXyqoBCxBdNw5l/IhvQev/DHRoB6hLb0/LCgYnXoG+0dmvlPhWVQ+5IEGwS8yYFaNVgmOxFwSAYNtn/kfJYqxa8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> .
+}
+
+<https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig> {
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGGOm0c3hHknNaKBAv0zxIguzu8eQqvLMx7dNDe0zSy/s4Uf7TcCWv19Emcn9/t3eQIwJtxpIHkqR/Ii0DjNeTrITbWqGyEBTFpbq6Hrlfr3WtUqHPVquK8wtQtzIx7Xu0E/" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RndohTRpkC6s6vDZ5dm0xCJBcZgV8ArF69EYgiCOBnIOO51iekDiMawPF0AES5kJeFL+mZElzH4lwis/PnbAbmsgLwEsm2rQeBCVczD8EpCKjRvqxO/qqjvv7NghG78ZODutp55kAI+k5vy9WS/bDCdOoUIql6P+aAafXTONZ9k=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> {
+    event:eia6yrvml8v995ueq65m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:tlyivx8nn93zw41ujn1o , event:253k6pqq8gyttmmfxc7l ;
+            msg:hasReceivedTimestamp  1513170819301 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> , <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> , <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eia6yrvml8v995ueq65m .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDZPgijwM5VGNMalStQ66YP1Lr1QvPY6sYmspv9+qO65sQ52M/7HbFZfnnGciCaaqUCMQCqZ80t+1Uqf+vekrTBuuattLKvUeY0bqTri2vsx/XznubPvW5AYX05tnpD9u1BXUU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RYZQidg7f7S3YC6/GHy7+5Y6OfzP5wrjkDovd7p6HbbYT30mQGfngpNflthUZcdGHGWIXYkAQH46rMmKcodPZQbh73LKNg2UA1fWNEwXnK/HEOnHM/6OBk7nGFFs6bw6an2o4onEsAfIU4mbz4MrlCfsSUU51Ig+v1hETlPK1VE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> .
+}
+
+<https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> {
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> {
+    event:4kx7gixf60v34gg65z8x
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:tlyivx8nn93zw41ujn1o ;
+            msg:hasSentTimestamp  1513170819555 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4kx7gixf60v34gg65z8x .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> {
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#data> {
+    event:353368844400623600
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/353368844400623600#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513171226208" .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:353368844400623600 .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDdhndpE6qnodUqyVhP2lwVjP1xVbqAsHuU+sYebMLvly1KRoaF4mhDy3lyM+CFWtMCMBYU3lmh9NM2LVi3u6mkaWCppsJU0v0vV11V6nt3tsYJDt2tzaozWAD0p9MuPAUBww==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUBevQq6bQVMJ9epvzUUF7oK/mw7IW0opUcvLDg78BaDJWZd7R/pEzy14k6WrL+V69ObdyC7fqqFwHs7ex6KHx" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#content> .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> {
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> {
+    event:xsbbah2dhkcg6d3h13gk
+            won:hasTextMessage  "    'usage':       display this message" .
+}
+
+<https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> {
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+    
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ilkgs5gp030i06fb97j2 .
+    
+    event:ilkgs5gp030i06fb97j2
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:353368844400623600 ;
+            msg:hasReceivedTimestamp     1513171226327 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:353368844400623600 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> {
+    event:v66scoiidw56iam8q86p
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:cbcccoqqqbec6bxkl3y3 ;
+            msg:hasReceivedTimestamp     1513170817838 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:cbcccoqqqbec6bxkl3y3 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+    
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:v66scoiidw56iam8q86p .
+}
+
+<https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> {
+    event:mthg8rh8r4grme5ph2eh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:m8b6jvgclclzy48p7wqd , event:8h7v5ml1aflqmoyem61a ;
+            msg:hasReceivedTimestamp     1513170817982 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8h7v5ml1aflqmoyem61a ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mthg8rh8r4grme5ph2eh .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> {
+    event:i3k0giied2bgp0p44h7u
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:c6ldwevakufr94hrcn97 ;
+            msg:hasPreviousMessage    event:zvx39rdagwj6o7nfiw1r ;
+            msg:hasReceivedTimestamp  1513171230616 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s-sig> , <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i3k0giied2bgp0p44h7u .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD4cxhvphteBLJTo8dmYvzIjDYS8rpXu0T+wzbqFVt6l6d+2NcFKQ6jUbP//FDjY4YCME5vw/5vh0f0zXShG2TgC8/i+z2TA5ezh+RgqK0Nj8FMj6lcTXXPFemK+dl/Unfcww==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "DreNypCKIpV3qhvc4YzTpWFDH4AfqCaptFGaTp65bXQ1t5GYcbR+QY+vuD7Gr2enUellb5tXW8vKUJ2BLYkuVkrMk/+OQpzuIzgOzWzMDYS0q/pVIcNla1g3MTrpJI7EDDzqGW23hdhqfvCyK6DxJ3G87DLYdaXMWACtkXN+F0k=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> .
+    
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> {
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+    
+    event:9787whuvh3bufzx5xm8z
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xkeovy4cf48spd5euwj1 ;
+            msg:hasSentTimestamp  1513170817456 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9787whuvh3bufzx5xm8z .
+}
+
+<https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig> {
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHT/EdDamdgV2Mtqg/N8H7Bc+zwJILV9ZJI2xXyFboHdegN1jgF4ZCxOYrDkHr505AIwBEkbtiI/muBDvAmot4lye+KnfiHZEylmA3Og82JD3ccn87oHyo56glBhCYDaKVnW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhNqR6Q6taN6WmAYlTzL8zrft8avQOyGzeihDyINuppG6eGXkABaDOLCsLhmGaQ/XuO+EemjK8sYgWM39AKlkKIfbSiXY34QcSb37pis7mAHkqqX0iKrQAPmvSbb/fBvXy5BaS8nBIv06LoyU/GbjqRSf4oEoWMOcE1OWYqHUvs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> .
+}
+
+<https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> {
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fd3jtdrkpb1x61pl2ix6 .
+    
+    event:fd3jtdrkpb1x61pl2ix6
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:ih9v6gyllshhvo5kxyv0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8mr0p8ua2srgw0zw69lc ;
+            msg:hasReceivedTimestamp     1513172392597 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:0uouhqi6aym8jad508kd ;
+            msg:isResponseTo             event:8mr0p8ua2srgw0zw69lc ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4j+rDkXxIN1TWTiX2FmPFQzLVWqfHqmmVmXfhOlT+WRlEu1IhiKwmtCcaOR1bD28CMGRu2E80fqL/sZyAo9dbJmLlXKWzleyNe8ELfgUqfpCGXfDlnePlDum255WD9rRdGg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJqyzUBUhStwyRnZXFDykPEVIBMBNtMij53h0S0Rgae1FaaC5bbngcWo3Im01f0xgZEPmB521cSAr0sXPYmOwcTxzhnZiZq+cC9Y6jnfubnHZxxYY964fw/OZ1lTEPW+z5KT7PDt2aIDzJM1n7xUyYDZE9/wzEdP6nO7t/6ytb0T" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig> {
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCBVurkxeedg4BOOrXm9NFSQAyZfz8YtNKWbq6QdzE4EqlUnjNGUY4gmOK+bav+ArICMEwVIwNn1iqo4xeG/AgvGg7APx53GjdVRT9xlEr9gGgYLNjFzlPUUBjgU7/LemJEHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RgI5acuaUt+lXrCKO8yEMr2+H20QhOkZSHVSCeHEG3bs1JjkgSUrqYVrJJy3oX7fqrVLa+ZGsm4NeVsCBeJobfAWavZHlykHdRdQMlRTqM14CoeE8h5+nlh8xDZhjc3xG4EfzoOjS2NTaQcx3BvZSn7yKX2AV2JSLTl9m2p+C9w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> {
+    event:5r6qvd7rennbi148vunk
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fk1a2jb7ortt8q14tcrb ;
+            msg:hasSentTimestamp  1513170866390 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5r6qvd7rennbi148vunk .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> {
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> {
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> {
+    event:xsbbah2dhkcg6d3h13gk
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0esqgu17b6xqppmgbty7 ;
+            msg:hasPreviousMessage    event:66nnn87elpe5995a5wjv ;
+            msg:hasReceivedTimestamp  1513170819637 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig> , <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xsbbah2dhkcg6d3h13gk .
+    
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCC6D307Lv5MzLutxg1KXUt+zR2Zwdrr9znEQqdMeBR7DVK6fsXypGeyeDJs2jOW4sCMQDLdydp0WInEodU0NRfYPX8hVB5j2cxSOyEUkHFi9tPMVa/PezteiikUTYLcC25DkM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ydoog51McxPJnLHQtQysJfmTPxn9t0sqIsCV3mcS5JcVt3h9euQ7MXfqjpJ55BrtwiyXzkbwsGftRi87A9WeREXhKdKRfZwAx4VeeHjxs8cI35ilfhEUYLK2EJ11BqhYGxl/a7Oq6/yzZTa31EqemFBLzEKQtllAWUAPw0Oy+94=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAFi/eyVUc/OGE3FUzVcjUs1guX7nBHOl6+Y8Y36/f4BVt+EU/m/RWnpG3d3bTfJpQIwcKCuoDCPI6WnnnfGPO3dpFl/KXJiOfKs5uunTQtjUY2MPx14jO6pfC5FOtrqKyaU" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "I/mRBA5Xn4voYymmrr8fknaGBWuacNDHWaLgaIwv6rd7P4XcjbkgVRmW2z6mMM7czSLAykoHdFtvMnm19vc4ADVPHDP5zPbOhFY4Eyc1eBzEmY/eM0ia23pv6Q8i8iKIEu4txknJxda1i0ESCft8zxyKDCd8TBUMhWrfiM+iPyE=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> {
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig> {
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDR1xb+ezOAzterooaxqminnZhxZ3ZjYwCSg4bL5EV7bHVizu3iTgKsm6iCa7mIdWAIwRkKyiq1Mk7tBAbc1TES1v8XaHFEk/p1VOEwOiskWC29sSUTOk30mMXlKkZYs36/W" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DxpG7VpU9zHMsUytfLtbLtoTkX4Rvo7gsi5pANfpiXNutiAr/7jlOeke3UaDHEZqYB4621NumM8IemdYjCbF/RjUtbPcv/rDKs252ShC3UA74bvbKFrsPiVd7klS+7csc5rEqd0pcPWXC878nNBIg8TGwdgf7d32Mikwj/jX2jk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+    
+    event:9787whuvh3bufzx5xm8z
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:1107469913331435500 , event:84bls7ssc3hfvt38vxr3 ;
+            msg:hasReceivedTimestamp  1513170817501 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> , <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig> , <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9787whuvh3bufzx5xm8z .
+    
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHT/EdDamdgV2Mtqg/N8H7Bc+zwJILV9ZJI2xXyFboHdegN1jgF4ZCxOYrDkHr505AIwBEkbtiI/muBDvAmot4lye+KnfiHZEylmA3Og82JD3ccn87oHyo56glBhCYDaKVnW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhNqR6Q6taN6WmAYlTzL8zrft8avQOyGzeihDyINuppG6eGXkABaDOLCsLhmGaQ/XuO+EemjK8sYgWM39AKlkKIfbSiXY34QcSb37pis7mAHkqqX0iKrQAPmvSbb/fBvXy5BaS8nBIv06LoyU/GbjqRSf4oEoWMOcE1OWYqHUvs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDnyteCF9KSTtbrsYFmRbZZ4ZNdnd1emM4ebceI6HeLNbsvUIn/fwsqR0c4GX0SshICMQCv744cBU9UEAX+NCbaYWGsBXQ2aMEi8w4SZBH066tSvoto5F0zMtBDg/RNW8Od/YM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKps/NCCOmxsm1SX9VlVmiTT2B1ZXMISJWueiRkERBLcwipaUlalOiyl3JIg4mt0hEzH3ARL/0AB3y8CVxZqj6dxouukL1POLUIgAEfu7EQcsA1hURMsefQMZM1jvHwcJY/pkiK9Bk7iDxdFsvexIZqDeD2IxO/IV6rpDr95/oaX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-mywf> .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig> {
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAJDEJld2ndIaCn6/1kRsp4kfm7HZT2fvH77JQ8s0zZUhQWyrBgXZRhiJrEBUIMZDwIxAMeCP4ugC6Et/yhH5xEdoiEoseTRJCw92Naa+b1yJptL8HGS6KyvC51/j0RbowFziw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "c0UEvfRWh/PcqHUGJZf8M8e0Oyoi9txmVMj5sRI0cnHfvY+ukgrlV5fTYIHMssQiyNQZKXomAMSgqlrllbY6hE0OAoBCsakCOZUvU6Dp0t996nSWJulqZbS0r4xCFn2LvVsUJ0hsv1M34w5dhkTjM67Xr+WYCHzqN3jsw2/kR5Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> {
+    event:4rit8itn4uyigyesq90s
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:p6x8qvs5m46mxw4jb7z5 ;
+            msg:hasReceivedTimestamp  1513170830179 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig> , <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4rit8itn4uyigyesq90s .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCtkFefE2I/jB6DpPOGarUrocUvk9wsq0eP5/sbYKnSul8I/fLoX9EI0nymhdwR20cCMQC0s09oW9Nxljq0VW/f+sHUjD7IXfa/8JCJ5WB67mzwikUUeXZyG2n1WUrefr/AN4U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Acv3A8Qod4xRE79i9TlRvAjNBNXrmZAmLgOIsvygmGmm9CkqJXsrAQZc8Dk6u49OkoJy25Rnb5CuVPc+HlhNkdIqLJHcMAZp9FurP/NU/gazz4tmlDIhovAiCwqhs+st5D9s5QuvQrOZSVQLohPI9AHz67Cmp/oi/ndwSB2OZqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCoqhvm2FD5Rqva7L71+Yp7neTxS3q20cnC6uDUvBDQGr3zyIUHhaI//qg2Yg8H7ugCMF+u/pBV+83p8mIAvN1y854tkyUcZDT3RuZ5hPbd344MBPqPT5Hv6YjlNdBDAuxoaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VWnF24UOUawtWVnzlAgCv5wRAMUrwFeauW2b2ws4/LA51c8s0QEN9157Cm5ueYFznh/ZLvse5tmKdklDej5i7T+DnRBWt5GqqEIdEmmSdfD5m5oiDg+lD5EPl+IzI2gzARU0odj6S6KpEO6hMQVdyOuG09zPYSpco7rDnUm4okI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig> {
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDf4Jiz6qEsxagnd32M27/KFDT4A8MrcpzmvLk9vJylevVEL/xRCPyIDpHVrN09m44CMBL8DlDPGzk/uINXaaOEFAujBOL/asEqNclcxcjfjF4XTH3MtRorUOv0iM2SS7N73Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Wj8ziPrZiyJHDhh+M6SeMCUQZulwT/3T3XFRkAUfaJIZdct90zT8XJmWFeX1TXO+M8EJtVGIWd8UbIUg+EiUllQdMp5qF2hlHGGke8FiSMMbeGEvozbp97W58+tTE8pDIHBJLO4qRvZg59Bu8uYRBIjWSh6WkhGaLKrv2DzUZ3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k> {
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+    
+    event:qi81r6ggzy26wznv94dq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zvx39rdagwj6o7nfiw1r ;
+            msg:hasSentTimestamp  1513171226453 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-1z7k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qi81r6ggzy26wznv94dq .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> {
+    event:u3op66771mcm3ibsrr31
+            won:hasFacet             won:OwnerFacet ;
+            won:hasMatchCounterpart  need:ekdwt2a60tesl77r13mu ;
+            won:hasMatchScore        "0.9"^^xsd:double ;
+            won:hasRemoteFacet       won:OwnerFacet .
+}
+
+<https://localhost/won/resource/connection/lhrkbkodc0y4rmc7z51y/events#data> {
+    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events>
+            a            won:EventContainer ;
+            rdfs:member  event:kaj9nimgw0lkcgmb1asf , event:h6c8epmrvb3gxqrvs81d , event:f3u4lc7l1czvps18lemf , event:ivr0xermk4aeb3yhohk4 , event:v5rvsrlg0x3ogdqyfuy4 , event:u02ulpncdj9l8ae8x2aq , event:cbcccoqqqbec6bxkl3y3 , event:i1frxy9ikewwjuyjcznt , event:59gtirhola4ydvddyo0k , event:xbhopokox5b4vz78e59w , event:tlyivx8nn93zw41ujn1o , event:csvglzqkcoddoreep5w0 , event:alif190jj9we7toczas8 , event:mmdq8395owv3xy9iyl5q , event:lur3g5en41crth556538 , event:i3k0giied2bgp0p44h7u , event:253k6pqq8gyttmmfxc7l , event:vj2yzrtlf700wixuxujw , event:t87usy00t0o9h4f0d1p3 , event:s9a226k3n70ihhaurhdp , event:4e2ws6ap0hp93iv0oyu2 , event:6fvg967tlh9rho8axvbs , event:xqsfn58cdatb7ryp8lzt , event:8c6o81ry6mxeetm2d2pf , event:ofx1afjv35cwpppp0wyg , event:cw64ogmt2lv6n4kdjdxh , event:v66scoiidw56iam8q86p , event:2uf9sj4itmz9fpas7suo , event:wlv9kjrh93gfzetdojp4 , event:to3x48329wwbanylmar0 , event:pj2n6r9g6jt39rv99xh0 , event:mv0xoe06cxsxt08s7guf , event:6m7oi7hxwvoi2pmguo6d , event:2sbarcz1yu7cenpcghay , event:xu87g40eu8cx053lad08 , event:x7cjarywf0513459swe0 , event:iasuj1z9fva0svkfqb79 , event:8gvplnjrinoqay8ycrc2 , event:9uyongxoip0kz7t9tsa8 , event:1tr3o22co1907d6b6n7s , event:mthg8rh8r4grme5ph2eh , event:5s66o8cqv4rxv74xfepg , event:orj8iruy8pcer6zzxlra , event:zvx39rdagwj6o7nfiw1r , event:m8b6jvgclclzy48p7wqd , event:4y6xcnpgc0xk4relqfox , event:t6d7eq3cq6nq54a16k1w , event:izq6icbkftfbzm0clxeu , event:cgqt5h004iql2003me2n , event:152dum7y56zn95qyernf , event:9oa8ktxu7tqzll06rhw9 , event:rig33yoxaetjw059bzuw , event:0uouhqi6aym8jad508kd , event:ck5071fsyaned6upryxj , event:xsbbah2dhkcg6d3h13gk , event:s9zfgm2iika5vgvayt7h , event:8h7v5ml1aflqmoyem61a , event:0s55ww5ae82lf3j3gwaq , event:n5rqfwjqbcpdwqjjwpdw , event:eczqg8lp7xbukpzikd41 , event:5r6qvd7rennbi148vunk , event:fn87pwzr9g4a9v368h4m , event:csridlusp0h45v9gf9v6 , event:xpspyx3bpyev5v5p1vf6 , event:pi2jpw9a1q00d11kr9ez , event:joo1uifc1fc2k6fk5z8t , event:plmfevq4c12f8itbisjf , event:xp44teiwtooczc14npe2 , event:4xjx598ewu7579zpl64p , event:bxwevm9gzqconmzxji4u , event:gv6zk2yqk6o8bl574n36 , event:ggbuodgi1pykilp8znve , event:collk6egdkt2tey39h8z , event:93e94yjsmx9l4lg8lu1b , event:eia6yrvml8v995ueq65m , event:cvloufr7mmg0siwflisg , event:xkeovy4cf48spd5euwj1 , event:4ongmje7w2v03mp7ztex , event:m4nq3rl0m1br8bea2n72 , event:eue8ar55z7as596cu33m , event:273p25fz6re5tp6drfsd , event:66nnn87elpe5995a5wjv , event:uu3ciy3btq6tg90crr3b , event:d3jq9fgiu47gdhclj7h0 , event:ih9v6gyllshhvo5kxyv0 , event:sdt7yr7q7t9iw8wcuu3m , event:dhdnzy40wlrnxh7ymr2b , event:cqvzpvoqvtkylzdybhej .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig> {
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHjnW7jow/Z7aL1QDqTFMpP+uUJK8at6ss5OZuet6gmrixv01UBKjCGc1IcJi2QP3QIxAKLau2w3EYVaNhiwbBvszShChrvxT7r///J2xtTY/nogW4LhF9XYHuO+POgxhB4ajA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VyoehYH0+v21MhUknlbDkitBJGdeDF/s45ZAHERkECa5rhyIeX5JdqiSIECSPn5+cSAH8BkNxf4BI8gM9hCIDNQyEXWnhSLcOJFshwCaQcFVyEunib8w+gc0HCrLM63xSQpwcSqjfTT/OTnQVWpuSIx8Zs9Qa6cHgEpPK++pxjU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> {
+    event:yrizizmtaxehctdi1m1n
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eyrx1pzifelg0uwuz7pe ;
+            msg:hasReceivedTimestamp  1513170818228 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> , <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yrizizmtaxehctdi1m1n .
+    
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH1yqqC7WG23lSs7lfYHqQYbfZoyzWv8pzkkY7KSy56/AtWes84THcr7OVjTgFhWwAIxANcFPCOQuk5+gcfnhKsxV5/euIxAInNmqLhNLlDVPX8CgC5ewaKeicWGzuD5L1lKCg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKrtZAmszTea8/mPmW40rtOPdVCYdADMnlLMbfhdufAvhnsFfwmpD7sxyoJ3BFX10CelmVx+XCGfgyekenV+xitpxAWEv32JMY6V0YLySwq2qustxP04XCNbDXceXk7p3eRFoVubLoVs5JPs/aDJ7OKEKVHP4WRTFYbVvvixZ+9S" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8gf6> .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> {
+    event:u02ulpncdj9l8ae8x2aq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:guewg0q3l68ts1ud5u2h ;
+            msg:hasSentTimestamp  1513172264009 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u02ulpncdj9l8ae8x2aq .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> {
+    event:joo1uifc1fc2k6fk5z8t
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:jbr090p3fhvimrc65vis ;
+            msg:hasSentTimestamp  1513170819518 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:joo1uifc1fc2k6fk5z8t .
+    
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+}
+
+<https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig> {
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDu8Gc/sKjgG1IFj1EYn2U2ruwOs17PSjlxgfmBHGcPuieyEIfzxA+kJKyLCuaB6y4CMQDz/tcSb5hCsQHYCqx8Hddv3pqV+P/wALc2mcaLoU0VbwUV2gD3c7QHtTfnjMCKb18=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Je1aXzcwnCLWttG4jcpWK1Ab18FJsLtCKX8hqJhjlvKMuiuICUU0Q/zEnU4qPOZH933RbMXCgYvAgfz4oI0oXus6FRWxCqB4uiR1UnVzEmVnMdlGeDXvosJUmWiCb0j7qOa1afsmvXVv+IWLfuIUre9RxyxFLIfImnf4WsYVwDg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> .
+}
+
+<https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> {
+    event:xu87g40eu8cx053lad08
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:obhgk474mxybc4fobdub ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:rig33yoxaetjw059bzuw ;
+            msg:hasReceivedTimestamp     1513172392256 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:5693603251585579000 ;
+            msg:isResponseTo             event:rig33yoxaetjw059bzuw ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xu87g40eu8cx053lad08 .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDVdxsx8AMqDVkLxwHHXe2EYoQfGTBPY/v0e03jny8i4Ji/btvU7i8IJb7o5KqOqvkCMFcDtdofYkQmTCtm9v4C4PbDnUXPrg+2rgSFIMF8E0z9qFAi0I6HcK2hFif6WDBF9Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIuO1GUXQ+n2hND0rBXn+YcBU+teqinFMEfnpxVOryDDyFTvYOdyFrRLr1erJ2VAn5trfyMVKpwwUMBdo3guZbsZ0K8MejqJ2x0WjSXHPYAU/sNyXGFtnsvamakkABV4phNySgVeYd9dScP0xAzd7RdXed70M1/njJrrmI5DObej" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> {
+    event:m8b6jvgclclzy48p7wqd
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817724 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m8b6jvgclclzy48p7wqd .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCnsID0qvu46i7S4kE7ivXBYihYjaVPQt7m5/z65xpzOuVY3/zvuTykONy+sgYSRnoCMQDfEi9MOkCz48aE/gAj2SuyI7oa7oSV5S4G4qpHdWg18wk8WNydf1RzoDNL3PbXjyM=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AwA/ynkGKwkxX/wASKNrWxbMgGDl81rf14nSUIq9WgQOJxYMshKI6mfMschKonv31zVm30AI4DdOkl88kw97lw==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> {
+    event:0uouhqi6aym8jad508kd
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> {
+    event:s9a226k3n70ihhaurhdp
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172280941 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9a226k3n70ihhaurhdp .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAZv36c/hMNuKFQRqHi7olfOEK0YoIWyCS/81rW12ia+oWHICFTWtwp+TqUNBtrUsQIxAP8MEFJ4X3aqvkGbVldPiixoCuwLiPRtiJyShNoNWVPsI0fIzVzDo95192mLkrjmPQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBY9JWyOJyn1czcCRyXLWrla726vdsImsV2DjBK1jqQnHZvqmgvJTFCxPCmsqWYyrkxInFKFpaItjfvXSZWK//7" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> {
+    event:orj8iruy8pcer6zzxlra
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:o73qpj11bouvhv9pfmhx ;
+            msg:hasPreviousMessage    event:t87usy00t0o9h4f0d1p3 ;
+            msg:hasReceivedTimestamp  1513170818418 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s-sig> , <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:orj8iruy8pcer6zzxlra .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCq/UEt3SVh+dO9rhDLTfATgqXjmIyEeOzeBKtN5LUHusk+vFlQrG37XszBI/XU89oCMB4TqqFhs3Jf6V7HDmwHi6yrs/DoP0iFKSByargEF7yBHVVPv4WDIoWmkiTbR3AbCg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AIyD2cyKqc1wBTQfwBIlhvgrFzvLQDBM288k20GVQCQ6G7GAAQs3TVlQU++TOktTpkiQcR5xRSRFdjuD3ff7t3hrNazlLpCtG/H5lb6U/1hbKjIaDbsFrN4nwax9YY093V2IzgXTcn1FQCrS9UUSeF9aQJqGfbhl+FxrlaQ43kJJ" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> .
+    
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHTGw+8qqLFv0gG34cliPPDKseheKGzGBbEwdZIaoP74lyRKUoR4NGg2G7l0Nm1hAIxAOP37UK+mVzE8mYUTOrCJlbc7W0msIsz0lzqZAnkShAMmsTAVkf9Ba+YPYJVVd3bqw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JRMvZZd/sedPNFM42HIM2smPs8J9Y5qkbjT7ymSriQ/Espd4doT4E22uxx39RRnOMtFn2h4H8DicAmCBFizHPmVNHwCvRT9OtcPGMzH/XRJsfWaiICmSNOuwOUEiEGA2ro1IZzsAxrpInIZXeROH0HLophyUomju10CeXitwk7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> .
+}
+
+<https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> {
+    event:xqsfn58cdatb7ryp8lzt
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:2uf9sj4itmz9fpas7suo , event:8gvplnjrinoqay8ycrc2 ;
+            msg:hasReceivedTimestamp  1513171154033 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> , <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig> , <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xqsfn58cdatb7ryp8lzt .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvj13J9u1HocJCN/w81lIYFGNWyZJX/dfwoRkQLpfvzv2LKF7otZjJFOu5c1UMiwUCMAsXxui7cf5cSeb1oomocs6tfKRD8WmtRAnh9OrOuBzS7Lo8wG5B3mhL+k21rQ2N+Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTR7wRzkvfsriFv555SSYyIEHHrE5p7o5hg8Fo8Zx9GUHhuj9hTICRytZoHkX+0huhWWDeLS35FeRKNIahwwkXmV5nwUcbCyGQmbuYvVz2oz1YDpZ5LbSLPP3rGbvl9a6kAK/zpftZQ5v0hBRevTP4kGh/U3EsO5ADd24Ck0BkH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGo+08Xgqf5uyZxGpCKf9oCBd8jRm1yKRDRXeMwENg7ie1w3jgv6AiAuK/1g6JFXywIxAL+YftISq1QlqQr/yZNjLRExXa+BgWIfIGrbOKD2hH33Q1QfHLuGMpgX0oEgzZnEjQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALGkx5gB2jaxOK4WZw05ONiVUCA0spS4tv/y7Wx8VlqoslJFh0/rzrpESQqtMqC44E8XzxTOjSPG5iT55wLTkhgEuxjlqTN+2NHgp/9xJwj0dGPIPK936ufMiRymLE+BJaXBZXIhT90SSCt8mEKJsFvXL6qeYt20n3f+A07X3ibq" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-kmit> .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> {
+    event:sdt7yr7q7t9iw8wcuu3m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6149800720990867000 ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSentTimestamp  1513170797721 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:sdt7yr7q7t9iw8wcuu3m .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> {
+    event:8h7v5ml1aflqmoyem61a
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817636 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8h7v5ml1aflqmoyem61a .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDS2lnRcxWk4keWqWlX8RHQ0BTt3c1k/o6As0XSY2NztaS24r/AFzbZpxtLt5X5CucCMQCXzHRcnH5E0pJxqO1TRDLsvsKKuymdz+FQjb0xce5UAvWAMRReKz0xNBDoHy17DbQ=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUubCGkTGd2y8+GCNPbbEM8/+UerqGfN6RGo2WGk92LeLs6ELo+7IA+gB/WPAKhdLzOl4/USD/1LCd6Of9HyZg" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#content-7rw4> .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl> {
+    event:csvglzqkcoddoreep5w0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rjc2w35typgyljixk4qo ;
+            msg:hasSentTimestamp  1513170818495 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-6shl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csvglzqkcoddoreep5w0 .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> {
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+    
+    event:p6x8qvs5m46mxw4jb7z5
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:plmfevq4c12f8itbisjf ;
+            msg:hasSentTimestamp  1513170829846 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:p6x8qvs5m46mxw4jb7z5 .
+}
+
+<https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig> {
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHDVEddJe7NmoiYbu1p+JiMoEVtLRur/+Yu0sFLq5DUIrrWrtdLK6f+prO8pKIdnOAIwOTKM8iqIJl5RCRTU1empKnTMdVGqYNnugzvjxmcJYcHlB3kEcJZB01RpgP4jXIiF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "BCqG99LdFS9ele8EvqJAKMSeLJhmvMv8EYQE5Ni7NpgpIlHWsUe9/VO+cD6uuuHHSCaOvn2v7Qpx4yxY1MJGPmc3EMhoELJYWIHnHCJDLdEWPPPZmLMlOd0p8TsDM58KKsaFHjQ8y6LYBomosNL8tVb2wxHGagv6/mWpsyY7ph0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> .
+}
+
+<https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> {
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vuhyvj1n1x01t4jeddkq .
+    
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBHsVzk0iN445oPyFMjO4YrLujaO4utwthhSOruN/uzhzNRcd1wsw7mntJM9pCUCoCMFI5C0YEt9A/unTNjITIMj1Eh0OI++zgD8XkJLQTcLdKyQxHFYRm0NmRVcogmyA15Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALHVkRX/E8lVerdgh+TvBnCbKecI1GN3o8zyTyztkQWeM5iwxeTTTlqHanvi+A32SJ/7GOQgPIO8snBg7LnoiW1n+m9RTiS9UKu/vNue1cAGLH8mgNEvEwPAwPlcwK8UOpj36RZ+h9XYIMOtkl+jUQ0yUU3sWTlYOlaajOGNFV7R" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> .
+    
+    event:vuhyvj1n1x01t4jeddkq
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:kaj9nimgw0lkcgmb1asf ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:00zilsxex8tqjumh6fi8 ;
+            msg:hasReceivedTimestamp     1513173166315 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:h6c8epmrvb3gxqrvs81d ;
+            msg:isResponseTo             event:00zilsxex8tqjumh6fi8 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> {
+    event:0o2v37foaz8bog1diet9
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:yqq73ffvbhkpyq3x3lxp ;
+            msg:hasReceivedTimestamp  1513172263949 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> , <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0o2v37foaz8bog1diet9 .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDV77PAf9ssu3lxleSAQuZBLb3R7NWUH/elcIVzZIE+VJUiOzAy7dfrxWonPLFBKfUCMEw4+jfWtx3cbKJ+Np+HTrlrDDdMo/+YqvWUicU1HW0ktQx9w9a5B+44ZJhA2d1CZA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "S5Q/lUSCYab2QN7DDA8bWo6kCEjM8IRf2xAM3KDz4oFpPkhDmY+qZyb/QdlzajEQkNuMhRH9WdYxQhZBCLqglMyTULbaJedYQY+QgxLR5es5gpZxh2GsElRrJ/gHVSMBTLaW+gfKU5/5E27NY74E4grCciIuscwWAMRE1KSDWrk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> .
+}
+
+<https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig> {
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCBzp1cAZP2R1cbcA+652mwXk4lOWb0noZmHYLFYB2maq+8BUQzaX97MnZyDFdmjdgIwTjdph52OJLgePV/du4zmDS1riW0qJEZoOgk3bDb1wFH/17wD0NBcX3rmsl4zAJKB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK4rRGDfNdW3i+RZ5TwMnjsRW5+oWCcyQUMKY8CQBOrt7M+StvhcSfKBRZbS0FvOHNo3SMAKMeLaBgfSpySwD0MDu+ErpXCYkye36db6t00XK+t43cYjJzOGLCOkP9BlpcA22JNVP/rZ1tyo1UgV920Jhmjr44xn/d00EPDXffzM" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> .
+}
+
+<https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> {
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> {
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> {
+    event:2uf9sj4itmz9fpas7suo
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513171153765 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2uf9sj4itmz9fpas7suo .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDlJ8alK9WP4ufsqQh8RvipZ7EOuLOA4jPmHo0J4ezb0WdYWoZDzJEEux5sa/ui2gwCMC1J+CJz816CzdZysOmc5K3bMGsW1n8S2Ra7/VaXBWmjfTCJ0vG9NWlujzUDOsp9nw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AqS2mysRS1IdtBgqynREUiir00HptjHq3nc+/Uq7tQNsy04le+2wIl7VkJxMLAyFJpHk10D9u01x2sr9F7CncA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig> {
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSScApJPZ8R7ecbEmjmoEu+pxkflMao560sVd3mK2alK8CPTRNoLg/oJQUxa4lqt4CMQDl6yHyqxvxqh+t/13iDG2uWEvqvA8TgR1P2eJIAvxbxg7pVc1XQ0UMGnHml7Zk4uo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MlLaQmKaG9RTw6byp/UmeWfM40JbjgQaSFTd5NFvssErRCjo1yVuoLAXI1iruqGepB6lIGSRN1S0hsatgpmvcmWoXkzUevzbgiED6gNpCycenfAl118R4lamQ0Ku1SnaTx+1VWfWgnaahTRxeUkYlzUaNiciDCfsmg2OLikWzfU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> {
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> {
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCze+nEa8uP7u4a04t/WNyNL+VvV4zKK2teCkpVFLqjrf3rqnPRTzHMwhRHMOEcUDQCMQCfk6N6smkgkH2Gq102MEYINEu9VKoQdClaLdi16QtWSj/+zLlsFdG7er9oko4qY9k=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G6xKcSI2QMzwl48C493kxUnM2jWC1VW3+sEqHHVDiuM0CGwvWbZF7LFKaE6JvAMjtfEKc3DYvPIENSr+7TXk5bcpWe1MvxMlbpJf1GgTelp8KEMAvigwTYdqvMoYyGkluyZ79204ZiuNy1/SeYuJbWvNvg+ZJuZU+q3HHN40g5U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> .
+    
+    event:5l16wlgqmeu6z6rt90ca
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4ongmje7w2v03mp7ztex ;
+            msg:hasSentTimestamp  1513170830791 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5l16wlgqmeu6z6rt90ca .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+    
+    event:pha7cg4ilx4j23f8xo0l
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:238289506881087500 , event:z1emzo49olrm66x3ukkt ;
+            msg:hasReceivedTimestamp  1513170861247 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-08kt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> , <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p-sig> , <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pha7cg4ilx4j23f8xo0l .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCuvcWOxQN2mBUQaLRxsJ5TOyGMRkQtbiwPGIKzIFMsFPci17spJyFKKxRDWelhq8kCMAlGuvVsFORNb/0TffuZtSU4kGfZ1JmafuesYG28KvAl6sydOYPx0XqIdxvd5WoooQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dza8LDmsxsZD4jcuV1OBZi+CYtB5HvHMl0zDmPvgPPC/YulCTn42n0b+FWooo6TFUPiIqEsneu0/Sen8YBgXNvZZmAaiyrBlw/5a2oyX64lWmz+IkZvccI/QyTQ9aSylPPyL1ziUj7B68mecA8ttyOORTxM/2GsZBzk/cy9QYQE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> .
+    
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDz34ndLZblqDWzmN4IE0ahv/7VeImWvkBu6pk7SDkk5zLl2iQOE4Yu0aDvq4S31d4CMAIdswiC5QuD8U5s36cQF9nqg0nYrwluQc/eixpAu14IsDF8Pzq/DIDDxmQOISwoUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UhIQ0cDKkvvxNoq5BNt40MGAuljOdnbBzrXJzaYTQ+OiSLfI7muzlgg1lDfKZrSWnXNKyXA9YK8giQNR8CLvAgyknhXX+G8GK7VkEBqFAtKPyg2QPE5QTledobFugn3+N4B8JIP7f7hKa0LWEQ67s3FvE/wdfgwQvbBylfMppL8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig> {
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCZ9Mu9e3c3q0zVLHnTFS+4h+xQ9q4QDfDeu1sdAxAWl1NNNdQ9KisDKBtmXYiivLoCMQCyE15ceoMvLAWACEeQHL5IATn12jdRR1NMBGUx8ilvEnCJbHckFRU9BeRHxPnHobM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fdzV80NOcs/SSJHtD8oi8qgp4L3ZQCIehVau8zZwy4E0FPwJc158UWDXK9kNTIwzgaAgPUsgDgOTUW5rBYnlpHU6BRzy/3AWKJHElR/niJdH7VxQuB5jwES7c/F6BdfcCfyc+GH/RkP/qvRQA7bB3t00YUX4T+VnU5UsRyJtMAQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> .
+}
+
+<https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6l5bwv7tkxg2g0bosl1u .
+    
+    event:6l5bwv7tkxg2g0bosl1u
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xbhopokox5b4vz78e59w ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:l27gk9ia5beeuyjqfp7j ;
+            msg:hasReceivedTimestamp     1513170798458 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:gv6zk2yqk6o8bl574n36 ;
+            msg:isResponseTo             event:l27gk9ia5beeuyjqfp7j ;
+            msg:isResponseToMessageType  msg:OpenMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCBVurkxeedg4BOOrXm9NFSQAyZfz8YtNKWbq6QdzE4EqlUnjNGUY4gmOK+bav+ArICMEwVIwNn1iqo4xeG/AgvGg7APx53GjdVRT9xlEr9gGgYLNjFzlPUUBjgU7/LemJEHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RgI5acuaUt+lXrCKO8yEMr2+H20QhOkZSHVSCeHEG3bs1JjkgSUrqYVrJJy3oX7fqrVLa+ZGsm4NeVsCBeJobfAWavZHlykHdRdQMlRTqM14CoeE8h5+nlh8xDZhjc3xG4EfzoOjS2NTaQcx3BvZSn7yKX2AV2JSLTl9m2p+C9w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> .
+}
+
+<https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> {
+    event:beyjpryu04ao4on0z22u
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xqsfn58cdatb7ryp8lzt ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fits98gjdl4ybaudq5oj ;
+            msg:hasReceivedTimestamp     1513171153959 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:2uf9sj4itmz9fpas7suo ;
+            msg:isResponseTo             event:fits98gjdl4ybaudq5oj ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:beyjpryu04ao4on0z22u .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME6PUbGpR+88/oQwBXRk18e95b+xrq28z/UNp/4GpxPG3XsShzIIh6RK/AYv6DpiBwIxALSmb+2M0+RbNzRg09jvW8E3CsS6Sxp8Iu67CllaLoAA4lw0ZN03UcbfZHCUfUykWA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XcLVrPuTUW/lSNQHtRCZ/eTaMVjFKB2J0IPlkvpvURyDmYhInqV7qmuIzruckTqTnkEB+27Vq5HZWsq2sbnD/l3Ib0MOp5BsiM+pRy0DzESrBcXDGKTCHzQEYL+M2Vj+KyZG20d4YZPbC9KR/PtLTp9tcU/uwY8QbVHFdilAhcU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> {
+    event:uu3ciy3btq6tg90crr3b
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:qyg9hv3nohv4ykv8ryev ;
+            msg:hasPreviousMessage    event:n5rqfwjqbcpdwqjjwpdw ;
+            msg:hasReceivedTimestamp  1513170841991 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> , <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uu3ciy3btq6tg90crr3b .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF4dFbf5fOJmIfPsLXTr/EfkuFinogPj6z8Mxfd24lZ8LhPw9E9izMeh6/N8yax+gQIwSxo/wfNve/d/MEBKITOoEI/3XMO1wp/KftE6PPxhHOtgFNnGtmLFgP2EpxFEKP9/" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ILuPWX/yMTCM6qyWob9ws8umhOD5VluyqBCCTl/Y/gheY14CAgMJZvfIKxzW0P35Lr4f1DS1Uo+VNX4qoytpfXkbpTt+B3sWZUoTlIdRDF1nAM4TlMrbfWvXwyqf/B86aRsy+UzCnawS0/dxfL11a87Tx0Ey9YeW2XG6od0JWk0=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig> {
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFpDF1mYWD8hsoHDb5v8FiRwj0S8R84+myfMvroW9NG7WZP3J4Uq8Oo7ztiE2ETW6AIwaZU+/I2JMbidZbneEo0kjTxb2sM3wCjiFdP7Jmv6FbtSFXw4KokasNsW4cpFLCEw" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EyqBQx0oUFQxEvOyh8QjiXjwS4TM3FVB45C5vTBNlJHUI+fwdSV/pDYLjvsbRlq1VY5n0z9HhUKjVo2y58VlzYTUQcu5vtLPHz8uGdwRlYCBUz4f4zez0SYMtRcco1EUCd4l1ZIdbA/TZ9/8mZV/1e0aGwrE34oqJrolb4U7CWY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> {
+    event:h2lo8jybm27ouaa4wuqs
+            a                         msg:FromOwner ;
+            msg:hasReceivedTimestamp  1513170782659 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCVhsAY7hBLadu1CWFOu4afRRKrTYxjbOa+uQ31OD7eTUoEggVuksPbJHT04zYkicsCMEw3BFMumDIgvhFMCvK7nyc99PoEk9uDykKS7L2auJJYJPsp78yPD5j4XL4xkBmjBg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "SstIdyZUGtr5VqtVkIWuL3OMF2/dL34GwjscGyw+R3V4XlTZRKP0ggomWl/12nrpoe++P3eaYAFT+9Fb0auyUO7INcceZWRmiziQ4sb6GGflQl8ExrmvkSjMIFFobzDT370BPe0VME2mqwO1/yB78clzqPGTsiWGb3FRIR+SUWI=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h2lo8jybm27ouaa4wuqs .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> {
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+}
+
+<https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig> {
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCzVV6qy/HjxXrIWL9hs1+f/M/FPuSZtI4i+MhrYwE47CUSRkQMYbmynjgYkXxEUjAIxAIeZy9h1/tAtQ7q4pwo+/ZQaFhdTItJ9EmDiMboW+I6n9dvtA/R7rqIcBKsXQqPwtQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RVUfEg72U0ax0YXBiJKk/HV8qGYUOubZdp8FJoUajOkfgmO3tZz4Wo2axeQZFJ5Qh4/zebyAifBAM5VM3c7KxKJOAcwkNT8OHmCsSdQVyu0L47UFJ6i1EB2X6m1bZCCo/tNZ+wQEcvDcFkhcwwel2BDApSbeI7ugj79I84UDSdQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> {
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> {
+    event:8c6o81ry6mxeetm2d2pf
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasPreviousMessage    event:ofx1afjv35cwpppp0wyg ;
+            msg:hasReceivedTimestamp  1513170818806 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig> , <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8c6o81ry6mxeetm2d2pf .
+    
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD3Y4a6E2HjiNdeqmuVGUAG+ff5QyFv8kzV1IWNr3oVnr0AbrEPWwzU3QHZzOcCftwCMQDLqHtPRB9OrdYV6n2vgeGoAcPBqg3TXBl9kTRSbdC7pkDV5+yidHEnyyHnJhroob0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fDvAR88Emuh73Vpv3kuUyeJUgqsbQd0XhuQ+ysVkAUe5Rti/URLo2IeHRKwHYvfd/FRFIKhTpxs09BRTjWL6sXP3lGoSEND6tjTjn//tHFuhpszlkEVvIQ06T5Nh5J11bPgQ+cSR9Cw18NY+/GmgYvJHtlCcwoFokdPTEbGJj/Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGypuqyt94/PYVVaK+FiSdvTIuCPqu7hSy0ozpPbhMFU5VmUJayI6Q1Y3syEFWSkGgIxAIaKJBOM8cVFb8bF/c+NxaoIsFfxt0CzSi9v681Y6kb9VLMC1Tdo6hE5VvO4dtmm+g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "TI4AzNDNulLi/PdeCHG0fua1XfEE7k2ZUVbYDsUVCzal1MUm6SzCUNl2PjIjXq/I7HuSck9RWc1w1hS5MDpAOije9FeYgZ7tEw+XFuUuCgIv0vkGDzSp/yWZRIeu1ypoScwLqrYnfFyG8ly7BnOLOA+mvhngM6DGqTH8ia9FoTA=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#need> {
+    need:2615528351738345500
+            a             won:Need ;
+            won:hasFacet  won:OwnerFacet ;
+            won:hasFlag   won:UsedForTesting ;
+            won:is        [ dc:title  "Burritos" ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "7db388b31fe1d8cb937115552ad0ce6b7d024c52e369f53917f4d432089c3b6f2052cd941cf3b1824aa77d6e96a3875a" ;
+                                              woncrypt:ecc_qy         "c39dd3edb8065ddb1e45764e0914a7d6e6e38656b87be285c4b8f14eaa698c05fda664cfa425827e5e9aae5d637ba5d5"
+                                            ] ] .
+}
+
+<https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> {
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+}
+
+<https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> {
+    event:v5rvsrlg0x3ogdqyfuy4
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:i3k0giied2bgp0p44h7u ;
+            msg:hasReceivedTimestamp     1513171230641 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:i3k0giied2bgp0p44h7u ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:v5rvsrlg0x3ogdqyfuy4 .
+}
+
+<https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> {
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig> {
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC8rfzC1UxD2WrZenm5CVJfUP3ol7NowZWmXKfMHriGAcSYy2RT44iF/fMzN8mWkkgIxAJauw05Yvyrmx6sphnq6aOZfaV2qNdLoHVULPZ8SRCaxr7toyEYrkOaV43FhjuGo7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IeDXUfVl45MiAtq39VW2HNKe+oMy6hiyun0lewEvcMq8xJe4dFToUmHFkCAv5KQPU7xsvPtBg3gMaiIZEfMeDJNAcNF8/wgc8FfY8NRcdxkGMozlzgnX83mrQxWqfYWbO/CkFrKLi7lY/iFmj1EXfPl0xaOyDHUqzuFa4iC2H44=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> .
+}
+
+<https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> {
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:7kbdyf9ffr2q657gkgte .
+    
+    event:7kbdyf9ffr2q657gkgte
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eia6yrvml8v995ueq65m ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:9se5txpx8xf4olwlettr ;
+            msg:hasReceivedTimestamp     1513170818853 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:253k6pqq8gyttmmfxc7l ;
+            msg:isResponseTo             event:9se5txpx8xf4olwlettr ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC7PJ7D9z0Q0ccZZEuB2vHZ1rBRfNDpVeNmMbdqfLOPPGqdkIU5Qez/dJHJeCJRyeQIxAIOe/nWDQ5WxlmVw5+HDacLChnsjhrdg0jIye7G4uNQlLKT9cWm1BK6AQeiPLjDVew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bR96WPKD4wLl4hy2Sj5/vx4sic3VOjSs627ORzkgsATQ3aBnedmyoJI9DaC8ayTNHwigNdopWvBgAcjYqm+JBR7WlfxZX0BD/svSHs8fJZvFpMdocD74OJwVynjlSbab2imPv3bMEuBKpGF2QjRPefwrFN32XY1+0LXa5RZlE5o=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> .
+}
+
+<https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> {
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1> {
+    event:to3x48329wwbanylmar0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:wpcsl4dxaxpdxbxpfo3r ;
+            msg:hasSentTimestamp  1513170854756 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+    
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-13o1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:to3x48329wwbanylmar0 .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> {
+    event:eue8ar55z7as596cu33m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:n0k3zboeco26jrnxa7l5 ;
+            msg:hasSentTimestamp  1513170819854 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eue8ar55z7as596cu33m .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+}
+
+<https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig> {
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCC6D307Lv5MzLutxg1KXUt+zR2Zwdrr9znEQqdMeBR7DVK6fsXypGeyeDJs2jOW4sCMQDLdydp0WInEodU0NRfYPX8hVB5j2cxSOyEUkHFi9tPMVa/PezteiikUTYLcC25DkM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ydoog51McxPJnLHQtQysJfmTPxn9t0sqIsCV3mcS5JcVt3h9euQ7MXfqjpJ55BrtwiyXzkbwsGftRi87A9WeREXhKdKRfZwAx4VeeHjxs8cI35ilfhEUYLK2EJ11BqhYGxl/a7Oq6/yzZTa31EqemFBLzEKQtllAWUAPw0Oy+94=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> .
+}
+
+<https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+    
+    event:rjc2w35typgyljixk4qo
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:csvglzqkcoddoreep5w0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:r5hu2rq515sq6wzgdjov , event:yrizizmtaxehctdi1m1n ;
+            msg:hasReceivedTimestamp     1513170818401 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8h7v5ml1aflqmoyem61a ;
+            msg:isResponseTo             event:yrizizmtaxehctdi1m1n ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> , <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rjc2w35typgyljixk4qo .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> {
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+    
+    event:9se5txpx8xf4olwlettr
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:253k6pqq8gyttmmfxc7l ;
+            msg:hasSentTimestamp  1513170818350 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9se5txpx8xf4olwlettr .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> {
+    event:tlyivx8nn93zw41ujn1o
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818957 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:tlyivx8nn93zw41ujn1o .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEzChG+S2Bdc2nq0KFUxo1ERyqBwysNvBY+GMd4OiuF8HFrKOKlLgTtPYgLh84F6VAIxALRGin/zCSElySh8J5bDbdMEzTLE6ho8BH/ZPgblj8HmBzVg0ErsAZYCjJv2WfuwbA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCZMyF9ad/NBKsrrC6UVyElcIMcEwkAih7PkXdsbJunfl+Arcw7VhXrDHFh+zA0iK0COi9xaagmyNIpU6J3Zd1H" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig> {
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC7PJ7D9z0Q0ccZZEuB2vHZ1rBRfNDpVeNmMbdqfLOPPGqdkIU5Qez/dJHJeCJRyeQIxAIOe/nWDQ5WxlmVw5+HDacLChnsjhrdg0jIye7G4uNQlLKT9cWm1BK6AQeiPLjDVew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bR96WPKD4wLl4hy2Sj5/vx4sic3VOjSs627ORzkgsATQ3aBnedmyoJI9DaC8ayTNHwigNdopWvBgAcjYqm+JBR7WlfxZX0BD/svSHs8fJZvFpMdocD74OJwVynjlSbab2imPv3bMEuBKpGF2QjRPefwrFN32XY1+0LXa5RZlE5o=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> {
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+}
+
+<https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> {
+    event:pj2n6r9g6jt39rv99xh0
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasReceivedTimestamp     1513170854605 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:t6d7eq3cq6nq54a16k1w ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pj2n6r9g6jt39rv99xh0 .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig> {
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDVdxsx8AMqDVkLxwHHXe2EYoQfGTBPY/v0e03jny8i4Ji/btvU7i8IJb7o5KqOqvkCMFcDtdofYkQmTCtm9v4C4PbDnUXPrg+2rgSFIMF8E0z9qFAi0I6HcK2hFif6WDBF9Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIuO1GUXQ+n2hND0rBXn+YcBU+teqinFMEfnpxVOryDDyFTvYOdyFrRLr1erJ2VAn5trfyMVKpwwUMBdo3guZbsZ0K8MejqJ2x0WjSXHPYAU/sNyXGFtnsvamakkABV4phNySgVeYd9dScP0xAzd7RdXed70M1/njJrrmI5DObej" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> .
+}
+
+<https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> {
+    event:273p25fz6re5tp6drfsd
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4y6xcnpgc0xk4relqfox , event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasReceivedTimestamp     1513170819894 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:xsbbah2dhkcg6d3h13gk ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:273p25fz6re5tp6drfsd .
+    
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCKNGoZuX3Cdx/avuEcE54aYkii9K5pEXQK0QWqpK0vVvEqWQvEoFjWBs7SbQV9i/wIwYolGkZVW7A7p1NietYbLCRHcrQEihskE/862juaVTmSe9hhGqisqVNWBxdsTHFwz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJd9IddYTEuf1hfrGTpj5bPbTDamBREL1KktLjF+hYsTc9pWnpYz2u4dL8MA50FLQJVe02vgmseTrrNJOuqQCU5JvmgX+M27x3rDaKDBUYxHmCGBP0N4g+ylfz3kQAb+ziLRg1t82LfBHQX8esySwF7gPWg/EA8yy7Zl1OZJR41j" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> .
+}
+
+<https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> {
+    event:ggbuodgi1pykilp8znve
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:152dum7y56zn95qyernf ;
+            msg:hasReceivedTimestamp     1513170830072 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:152dum7y56zn95qyernf ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ggbuodgi1pykilp8znve .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx> {
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+    
+    event:f9zpvftok83vya1djrg9
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1tr3o22co1907d6b6n7s ;
+            msg:hasSentTimestamp  1513170866300 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-69dx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f9zpvftok83vya1djrg9 .
+}
+
+<https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig> {
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD3Y4a6E2HjiNdeqmuVGUAG+ff5QyFv8kzV1IWNr3oVnr0AbrEPWwzU3QHZzOcCftwCMQDLqHtPRB9OrdYV6n2vgeGoAcPBqg3TXBl9kTRSbdC7pkDV5+yidHEnyyHnJhroob0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fDvAR88Emuh73Vpv3kuUyeJUgqsbQd0XhuQ+ysVkAUe5Rti/URLo2IeHRKwHYvfd/FRFIKhTpxs09BRTjWL6sXP3lGoSEND6tjTjn//tHFuhpszlkEVvIQ06T5Nh5J11bPgQ+cSR9Cw18NY+/GmgYvJHtlCcwoFokdPTEbGJj/Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> {
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    event:rrmkri9cdrtvp1bkjcnl
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8c6o81ry6mxeetm2d2pf ;
+            msg:hasSentTimestamp  1513170819081 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rrmkri9cdrtvp1bkjcnl .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#content> {
+    event:4846251213444807000
+            won:hasTextMessage  "one" .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#data> {
+    event:5151909952739158000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5151909952739158000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513173165626" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5151909952739158000 .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCQAxrKvkz8ahkRV+l2kXYm96j0EKWjR9tcmW6JSbDJZEvCm0ru3Ml7BDxGM5BWQUwCMG1NPtER68ZG/vEPLk1HIm4ZIWtD4WCr03/CGP+/Y8njelREpPYb4h32VSnEswdQvA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCWXkh6V26WyDNU3YcanwYU0+7slq08Ha1JAkdCbnIN6eKCqFB9b9xx5okeVbGLr0A9H0TUe3DxZxzMnf3Dkkht" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#content> .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig> {
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAURI8MSE1aDOt6QXLwIhRRwXspKgKuPIes5snqWi7Y1TqTAhhqFqdHMUsDKyh07gwIwayN+L4mGhAsMx8l30SlvPJZWbFGp6+2vprfrKaf0NLe1+tHwlZPtMDnJy3c7aTcF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "b1DtmHcAiH/o2j+W0Mf82QGRujysJJx4ksmX2/Q96klinAwgDxGuwpG5knAWWMuYMA0xPNZoWc5FOaiWzhvA6dTeQuRBoYXGuNkFeF9EyOcIP6a4S3Rq5E8rUzsnOLWfvzrtHC9mr/1Na/XKa6MbsZ8RyezZMUNHgPXtnHnDIJw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> {
+    event:u3op66771mcm3ibsrr31
+            a                     msg:FromExternal ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> ;
+            msg:hasMessageType    msg:HintMessage ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNode     <http://localhost:8080/matcher> ;
+            msg:hasSentTimestamp  1513170783093 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u3op66771mcm3ibsrr31 .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCPhKlVpokAvnBg1yWJaGLcnwsOAMlMcSlx4qV25ApbgMR+FXqkdf6T0Iof2ubjOTgCMQD9R9tUbEYcpOo7kz+XxmglErHn7pTwSZWXoYBiEav5Uc7za+zZA+HP5zsBHoDIOo8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UXQ3QlriHRK51zq1Z4qPkrefEl9lV4TUhlxrOhe+6oMMZ/gA++drkw6LHXXw5NRXT9y8yvRbIOuvzHxaTDuLpGkI3ViOCcuLy0wWxQaRVqg5eXe2dyVFi+vXBoQnt4zQJ1ZL2d+jUv9lL+Vzt3IF+qaI2qOdTelxG3DZ186GJjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#content-4i2l> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> {
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    event:0esqgu17b6xqppmgbty7
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasSentTimestamp  1513170819894 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0esqgu17b6xqppmgbty7 .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig> {
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDyuk9Ys52EN24nuADsy+4rk5T0oN6jW+wRdNl+DhzrG7aRXyTlbYmzjb+ABB4az7sCMHQpDt/f/Fy9SD14VPHBx08Rah7ymbdvTAjKK8Wk1ZVbleFdp13bLSB8eWDpTSANYg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIqS1qpEjSNioyIptjfNOCVqKRPY2BVaNIa2xWM5eRKUUj1Y+7628nghA67v9zAglRSejaaUhTIZgYx4+qR934t+hsalPzGoOIkH3pmQpHZIVAYE3/w9gKnB8jRosVJ9RDbSy+X73MsuwTTpHr7b2iBPXOjaEmSAqNag/8aVupZc" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> .
+}
+
+<https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+    
+    event:8pk5umtsiiwch3wl0mda
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6928365067343411000 ;
+            msg:hasReceivedTimestamp     1513172274135 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6928365067343411000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8pk5umtsiiwch3wl0mda .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl> {
+    event:uu3ciy3btq6tg90crr3b
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170841933 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-vztl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uu3ciy3btq6tg90crr3b .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZQCIHn4dPNfpNMxcaCNSXB6WjdBkIDLockXJExIYVNcxaGM145hskettGrSOTGfQIwYsFod55NWTupLAvpL/HbTyCR+2bPfScxWcBhBgAZSZGKDR0gPtNkMNRC4KmyD4xi" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "FOTSsWG3Kzbmyk5AHkje+axhoAmUDtaqAQdaUJE8PHx9Dilpl02dDHk1uYwiocvcDkajmgNSPIUsVmSd0wcJOw==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#content-fswl> .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d> {
+    event:m4nq3rl0m1br8bea2n72
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170819305 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-wn6d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m4nq3rl0m1br8bea2n72 .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCpehbfjEpX6KpMO3dpQgnngpJpKft5ppiphDInvS1rP+H/fLrxgr/jqTZbfLqI8FQIxAIT75Wi3rkLLkPSZ4g8iXUxIS/fTGvMzfaiDUHRSeVxMmfcL1h1R83vrDivjL+vMJQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCU/j3zZo+jKJnhW2WzKD90qZ+HMLKv0MYwod8CWJxMny7RmXTbXmp1fe6nu+kfmUOpmWqIXdPy7DhBxAUF/vrz" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> .
+}
+
+<https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig> {
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgo/m+wYmUd6CTfd235wU5AJ/REsZo0sWaVkMEp9VlkqYwwCvN2h5DuHp2f9C3ry8CMCRbkLpAGnAcCMusluqPjBPaiknhZiwJBMaOJdxnRv/Bv/I5cK2Ft/pryO7H3GdmPg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTtN07Njly2C1WBmJfeblgc3XM8I7+/hlven2vbL9MehvhDRmkbjHUYDIwSvBqfGETL2qnQdmR9OYl9D1bXAF83CIos8vRHDpNUwbLzmyWKCjfq7PANK+fBfKf0AU5yiEDCYCIlKz+F5/yh6IAknwcZoC/CeNAKSg3kJnnX1/tH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#data> {
+    event:6928365067343411000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6928365067343411000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513172274028" .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6928365067343411000 .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDIqrhtjcBva7tL0tPzK9+M2gnANK57UR7UHqxphiKlWxtVWvAa7KrRh/4Dobje3MwIxALSe6+C1p0a2I50Pj1qwC7TEzFR2SFeT+6h0IkzYDe8gH6YMD/azwEiGulkURxRU9Q==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "OsrZG5MpBoC3NQNpuGZjkbvL2N7hqqs75JxXonfIq1aVz0KfwOqDk1y0zo4An0FHeeTMrgcg8yPMrIVxcHdz4A==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#content> .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig> {
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBy9LDe4v3QpM+qcxrIVJcJM+v8YXmWHhOdSe8pGn2xnjBoOBEAxJ8Ok/7AX2kv58QIwN/dg/aYd5hDfZiQ139gbY7i5qCYd9vVD0L9GMFTRQvi6CmUO59Gws7ag0sVki59f" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvONhdodKnvof2flAEqXkQGHAmXmp0lMRlWwHnGfk+mXgJR9E7ulLyl1/SCqCkqmNU5it0jhespD1x4llp03fLtAqQAYpWJSP/XYRxjAGdXbm6IBLN5ghUgoK/b4FXYt+7dOX1wB/Z5NqKSI2U3zhJxOmz203R7YA53rTfVSAC8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig> {
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD15h8xYe/QPsx68/qkSp4qO2w6/1wPWhzTshQuowE2KXL/mTxwC2u59iXVbB54DoAIxAPawN3dIsZsiqABhitwR8LPf9RK2romuhxgMNkLtRS/fE8zIn1mdlHyxxBUg3d0Nsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aFKX2oNxuURr5F6nG8hm90H2H4A9iXdKKkADgZuhbzRnblRpaQxXyhM1b7g5xFYqPXfw5RiaqdaY+tua0Dae2atRCx4oUKVvgwVCqa1J5DsIRQV+L48EO2cXCZiPV7eBvxWFpmG6vP3wtJoJFw1X5sBNc8McxW7Eaw9zmFGHPUs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5> {
+    event:3v08br9ub79spo7ol4v0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:9787whuvh3bufzx5xm8z ;
+            msg:hasReceivedTimestamp  1513170817961 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-bdw5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig> , <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:3v08br9ub79spo7ol4v0 .
+    
+    <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDu8Gc/sKjgG1IFj1EYn2U2ruwOs17PSjlxgfmBHGcPuieyEIfzxA+kJKyLCuaB6y4CMQDz/tcSb5hCsQHYCqx8Hddv3pqV+P/wALc2mcaLoU0VbwUV2gD3c7QHtTfnjMCKb18=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Je1aXzcwnCLWttG4jcpWK1Ab18FJsLtCKX8hqJhjlvKMuiuICUU0Q/zEnU4qPOZH933RbMXCgYvAgfz4oI0oXus6FRWxCqB4uiR1UnVzEmVnMdlGeDXvosJUmWiCb0j7qOa1afsmvXVv+IWLfuIUre9RxyxFLIfImnf4WsYVwDg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9787whuvh3bufzx5xm8z#envelope-hkc3> .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDNkG9CWsI1Uogugc/23EjKVlb5KIrsz1vdWQVYgq3iBfWQCgW2K2iID6nQKQKi05UCMDHm8owD7nFGbixybU/ZD13oNu05ydBpKm4xMgVN3Of6oovmjjToaNWIqhBbjmBCVA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIERsNHBCiRhH7J9zjCs5epJxSAZRHlzeTXdgeFFq68J4lFS1k8f16p8y5ur9kFYWP7YQazAstTglpUjSJC42Ubm79z6BkMwpz8idVnT8tNwRs2lWuDa0IZltaJwS2q9NlJaDC/tfSGoWtzzEp++GxpXfe3wiHrtOIztXg9cO2R8" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> .
+}
+
+<https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> {
+    event:cqvzpvoqvtkylzdybhej
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eubp8u958hoow90rt9dz ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:vj2yzrtlf700wixuxujw ;
+            msg:hasReceivedTimestamp     1513172274247 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:6928365067343411000 ;
+            msg:isResponseTo             event:vj2yzrtlf700wixuxujw ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCj8XzMChHxr1OUg+i9codjorEeEZd6NEjZV6coLw/RVhHXZxpT2zQNHQCmrDfnAEwCMQCj3ztIZuDm1BVd0a+xGJHmDaIsyoFKWHvhFBS/sH1iorGhvMQLVK25Yv8VEpRFIoI=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OQCMclJqUGtvO8kZAcP6j/tZc385dizMr6Hlefne2dP6j9KEJRRIelXbDsYwWUO7SU5rwrgzcn+S3W29JFH3LiSu8/TrpEPkAG3AMX3165zJyJpiy/Ea7ZX7fPHo9H8MDrK+GzVIvX0M0EB3tFBsUnPmK1yahgabhMylNVKIZuc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> .
+    
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cqvzpvoqvtkylzdybhej .
+}
+
+<https://localhost:8443/won/resource/event/353368844400623600#content> {
+    event:353368844400623600
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig> {
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGe8RBcsAmlEy3TqTv2dv2OkC6s/cax5wkdVt6Rg3N6JIR57q498qr6/EoESv+0nDAIxAPeHgbIehSLypHcCqRdvJhdQ7eGBaMBHL9vUdkBtyWhWF+wSNbqHzCcHd0gyCm+ZaQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MX5PvyqFdTjQDfNW8QjE8mPU2aM2dSEd83wn4KFM3JFluOzUfQ7clLmtJ3FrFKyVrmcaqCyU3MkOs5R406hqw00Vj2wn+FrjtgQwNkJ+/yHbTfrSkNi+Jb+p3DO2fzFLByYna6qzYcaSrWIk+IV5sPZmSuwvDP74MXvIbcC8a5M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> {
+    event:cgqt5h004iql2003me2n
+            won:hasTextMessage  "Please go on." .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig> {
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCKCBv2TfWVNnEdBNJDP2HnaZ0PMW7L5HNZw9Gmq6CAo9xFL2Bg94Hln8Z3FfWW/1gCMEUR9lzsypqSXorLjR7YOrxCwGJ+TrwijmTypB/OZci9nt4qJxbM71ULf1nCwgmW7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jh4PEReRBiKtSQDmjELuQf13HhqnYQNzCnPuH3OrSjZXEOhXxI9Yq9HBx71f0dHclvOV07maj08KdgsSFlNBir9z/P8Mx19nrME5XrpntImqHAi1qF9Asjb6q6R1qRej7pvC9shbYWfSrOZDv1f9ADqr/O3kv/wKuRVYUjFC6do=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> {
+    event:rig33yoxaetjw059bzuw
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5693603251585579000 ;
+            msg:hasSentTimestamp  1513172392139 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rig33yoxaetjw059bzuw .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig> {
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDG6bzcVyWp6gPmZNoEArnWHnqTUuQk5YPWOzrW/RKSV5jN69wnrrw5JO+1SEcBqTgCMQCW33ygoBCPZm8Mvch+zfj2FaSBhVR5n2mNuwWYvIowwkIsO2/a06uOdcvwwlfJzG8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FP1723BVOeZpLu+ZOeOsl0bDQGHwycSHQa9cdvco/vdOIeBZzu1tIg+FIZRH5UqEOo2huYjHPXcWpJhQzHUbGEYSdymuttq299kanZdze+02sQ63vvM8sCs4MDqwTVoBy3cfOGzlXY74qvsuZ0x68XnoEWba9+A7la6xaLXnjB8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> .
+}
+
+<https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig> {
+    <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC7M5OdrUd53lIitnywJXohxT2HIa2cUtjM9Ff7i9kcHmRjU3JJoV30nniKIfPmHFsCMEsk74RAYg+LlL2vHmZxJzGsQQ+GhnhySy6O8xU7dI/GO34gDhwLFcH+U3PHZkDWfA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YsZP7L8khHhwtpozr8pM7tHONg7AMhpxd0PVbP2n4kpKkdq4UGqHExLU+akvLGErmneYgKCcG7HStRH4OVhVasSsN0iYmP7AmKJ2beNdlKc70mDDUA6dh9d0y45KTipjKxRZtfp/tUAcpar1D5tpwzCQGG8g7fpA2oikVNBHSB0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pj2n6r9g6jt39rv99xh0#envelope-nqke> .
+}
+
+<https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> {
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ivr0xermk4aeb3yhohk4 .
+    
+    event:ivr0xermk4aeb3yhohk4
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zpvc6zv244tfxddbhi6a ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:collk6egdkt2tey39h8z ;
+            msg:hasReceivedTimestamp     1513173165946 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:5151909952739158000 ;
+            msg:isResponseTo             event:collk6egdkt2tey39h8z ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC8rfzC1UxD2WrZenm5CVJfUP3ol7NowZWmXKfMHriGAcSYy2RT44iF/fMzN8mWkkgIxAJauw05Yvyrmx6sphnq6aOZfaV2qNdLoHVULPZ8SRCaxr7toyEYrkOaV43FhjuGo7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IeDXUfVl45MiAtq39VW2HNKe+oMy6hiyun0lewEvcMq8xJe4dFToUmHFkCAv5KQPU7xsvPtBg3gMaiIZEfMeDJNAcNF8/wgc8FfY8NRcdxkGMozlzgnX83mrQxWqfYWbO/CkFrKLi7lY/iFmj1EXfPl0xaOyDHUqzuFa4iC2H44=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> .
+}
+
+<https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig> {
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDrRHFNN7Mrr9Fxl8NG7H+m4c+xLjSMWGjzuz3HuTXKbablrhTB2t6hfjMT9g2pmvUCMQCH/3cK8O1svZehcINsK4rCvrwYPwfXS0Ndk9B6wHmTy1tsikceEFOk1Ve9aSI7vvA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aDewJVLuaMq36SHgnEVkyxDgvMIYbjcEc0nYbTCxzXoigscEIiNEzFBD+nx+JCFfp7XM6XG3Eqx50KsVJwAMkx4JXBIAZV1gCJqGliP1gYRRrVL9ZDfb2H4SYiz1+WxfjcPFJdmO9uSET9Q1eLaR0zZEgI28CLVnYeKgIj6RvUE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> .
+}
+
+<https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> {
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:yqq73ffvbhkpyq3x3lxp .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME35MheS2EarKRP3mQxGF8egj2rBSEwbuiOy3gnSuN7rM1JlzNSCEYONcxO0vYfWsAIwffHlktaF9Ha/U9qyj5POD8XCvaOJ/jtD7wPS+8Sq2Em7upn03egGjTmoArboJKms" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MQ5/EG7giY3bbGN8WrdVv3dqkjH6Jbw5vTsrmhye+Pn4g2lIVFf62IE7mYoFkx9JsMz44qc9QD20xn287dYrNNlkYYYp712APfJyMXPZz8L8GfbVo6Az//HgqDXQG+ypOBNLyQf3wyjHVoBLqJPKad6+Up6idIzYe2hUkNvQu78=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> .
+    
+    event:yqq73ffvbhkpyq3x3lxp
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0s55ww5ae82lf3j3gwaq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:c6ldwevakufr94hrcn97 ;
+            msg:hasReceivedTimestamp     1513171230845 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:i3k0giied2bgp0p44h7u ;
+            msg:isResponseTo             event:c6ldwevakufr94hrcn97 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#data> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6834006177130613000 .
+    
+    event:6834006177130613000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6834006177130613000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513171118697" .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHWptiDnbeFfpm0XFbU4U7FtMipP2DT0AMELJW0vn6wZcQYcqNZ4BSl75kMJnuLSwgIwbYcpqBOYXCeYAKCGxTyr+T0vf+TjLs0IMPNc4WF0xs5wGTA2ie3HJ+9YzHDR8qnE" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUOWQ8sXqnLXVf5APBLDIBor2HTcrmGONf5YfFmBq3JGyxiLb4RBSGWnbin28/LxtrAJuCXDTEL6ggI575O6Ix" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#content> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u> {
+    event:8c6o81ry6mxeetm2d2pf
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818518 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-le6u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8c6o81ry6mxeetm2d2pf .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD445DsCi6vJBK9oR0cSgoRYxOuxMahCXGQfwHh//pMJtJT4oLo/Mg3P/K0AAHCvH8CMQCyhbKD0k/093ANCTa/QEa8EuFgMFXqcw8zJXeQ1pDnFfwxSeEGNLcuJnhlMjzpBBc=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCFEGU+nhG9r9g2KQjFxGGzcxv1MsFv/R6bIiSIerwA+Wa8Iv//kazVRKGu26/bFcwzdIxZ/teK8Swuwkh9seQ3" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#content-wt5p> .
+}
+
+<https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> {
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+}
+
+<https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig> {
+    <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC4PWuDXnXY+qXvLPqrMQtYCekmKdJz5uVZrvsk1lqFq8lsiXXPWWXq6GLZVBhCKXAIxAIXMJzJ1A5BVF4enW8ec1AtoyJHg/hvPlK4AAUfnFeD9JTpCyLB/4CWmqY920zPhuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ETDkPzHhApStkceRMDX0EDe3DlQPW4W+8S75CSEixjY574tRv0eEb42LeyFDAq/jJaaznhUSDQ148CeSSd/U6wZrxkdPlJSjVQFm4yIgJdVluQTl02BAzumGJXSYHskwFLeXX/e4qB/Ev1TRvhrAiZH5I/WfKIsdKMVNaQ3PuVs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eyrx1pzifelg0uwuz7pe#envelope-24ee> .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o> {
+    event:kaj9nimgw0lkcgmb1asf
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:h6c8epmrvb3gxqrvs81d , event:f3u4lc7l1czvps18lemf ;
+            msg:hasReceivedTimestamp  1513173166373 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu-sig> , <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> , <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kaj9nimgw0lkcgmb1asf .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFZdBEa9BXvziatf48ebrukmJRBeZrAcp4N6tXAZPaoQAJhhzT0+dl+nXvZZovTIMwIwNXw4XPAVL/Vwxuu+iS1AGCKTitAyKiObfPr1xRDVhH0Uo+VbFixAFpejItMGX7oJ" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NTP6/pS/OIhohMc/qRBJQJTDm5jgV9k0DhtvfaqvMItowd4jdFtXPAehOlGi0p4VMv/co/uPpbK7tsGdV3DdHMjgK5QgxIGkuJSE5Zx9XOXdKIkJjDdKSLE9r5s80IDwJ++G/sHk6ffYaMceJ+IRIDjeG0ZemmzukfJdAM7m61E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDrRHFNN7Mrr9Fxl8NG7H+m4c+xLjSMWGjzuz3HuTXKbablrhTB2t6hfjMT9g2pmvUCMQCH/3cK8O1svZehcINsK4rCvrwYPwfXS0Ndk9B6wHmTy1tsikceEFOk1Ve9aSI7vvA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aDewJVLuaMq36SHgnEVkyxDgvMIYbjcEc0nYbTCxzXoigscEIiNEzFBD+nx+JCFfp7XM6XG3Eqx50KsVJwAMkx4JXBIAZV1gCJqGliP1gYRRrVL9ZDfb2H4SYiz1+WxfjcPFJdmO9uSET9Q1eLaR0zZEgI28CLVnYeKgIj6RvUE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> .
+}
+
+<https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s> {
+    event:orj8iruy8pcer6zzxlra
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818092 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-5t0s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:orj8iruy8pcer6zzxlra .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCMK7RuNV5+k47WMCvyyUxl98M3EEgGNAt6Rnqz3gZMK4SSY7qR2+dmG41lFDRRB50CMQC//R5cq1nBnxvl4VG1X4NBrxyf9tl8hk8XwN8ScKU2UnXpMLctikRK/ltes1cyhw4=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "D2M1sOkfbZZPkyRedB46cx07uTU0YMOLZp0ADViovC/bQs3Bj7NpKqIhLEswlKmteKDVCkRC7nO2mSVnryVDAA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#content-wi31> .
+}
+
+<https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i> {
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    event:o73qpj11bouvhv9pfmhx
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:orj8iruy8pcer6zzxlra ;
+            msg:hasSentTimestamp  1513170818700 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-cb1i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:o73qpj11bouvhv9pfmhx .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3> {
+    event:1tr3o22co1907d6b6n7s
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170866250 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-kzd3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1tr3o22co1907d6b6n7s .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAYnEfhK33rkMfzhBytn+lHarJWFuyB4qQ6R/YhwjcdhRueRAKsQUYl4Pu1+osqiGgIxAODtffYKrrFMuMZpWt8p5F0AAXis+UJbWtA/S65Q0Brc8mAR38DKb6GCUmC8SfrFCA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "A0t86E+OGat3RoZZhwy54ztHvtPwdTbcIGgVxFdrMN5cOhksn07KlCwwsYgna74/pvCn94cim8hb4YHRJ9cAxA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#content-nrkb> .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> {
+    event:j0oj37oa9ry8lzmm26ul
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4kx7gixf60v34gg65z8x ;
+            msg:hasReceivedTimestamp  1513170820071 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> , <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:j0oj37oa9ry8lzmm26ul .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBs2TL0vpH5kgu6PrQf1J6RfZqrhQu6xtrXCBbenSwt15LB7arcNd5PVr73WLxjwBwIxAP9lv9Z9WMsYQVEi6X79D/1MiGUtb0X2BQRg/Zy/0jLLPxpRK2kFqHqF608GNy5dKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJnls0vbJlaZ2SZAarw+ImPLYf1XiKqE5LCo6w5EdKpBlfm2ySRB+RzXOmGC0LzlhqCexxO8y6S5+8GnfcRqX5rCP8VogYUpyTySqt1wsyWeNiyEw/ZbtzZzoRC2bqLKDzVjo30htRdhF1QD9uOpERaq5buoSmETNJXrYDB7CRI3" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> .
+}
+
+<https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> {
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> {
+    event:0s55ww5ae82lf3j3gwaq
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:yqq73ffvbhkpyq3x3lxp ;
+            msg:hasSentTimestamp  1513171230879 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0s55ww5ae82lf3j3gwaq .
+    
+    <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAmW5vBO8d65hNPY+ctkCE/iDYdCYvbSn9znxnZAppqOm1PTFEaXPT6VTDdVr+Vc6QIwbBvBKVlLjDGbKhUGO5rHl939BI1dhGaIl+fSEcYOFyP32sf1ssQxjUZaUisMsrrr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "G5NmIjYV3wM+gyO3f014BpEjTv2HvAZPfqW34n6V1AdWtPzYyMyFdjXqugbkAwLENrrI+NJm6gKupsKymODlTkzq0+YGxzXMHnqTe0dv1A+WBLed5edtjCh+Lzh4SPXdv4Ll7lVjT8KQXAM5y7cu+V0rdfcPuxhbHD4sk4gDeLc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yqq73ffvbhkpyq3x3lxp#envelope-g6mf> .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> {
+    event:6149800720990867000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:sdt7yr7q7t9iw8wcuu3m ;
+            msg:hasPreviousMessage    event:u3op66771mcm3ibsrr31 ;
+            msg:hasReceivedTimestamp  1513170797698 ;
+            msg:hasSender             conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6149800720990867000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#data-sig> , <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6149800720990867000 .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA43eDMmZAjCwD+FvVgefs7Sy0xp08URBsbHq4r0sTvTbZkbDgNWqZ3ihVu0I5+iygIxAMoDwJZt8wUKvp0f0CzshgZZHiXKQVTUrxBEkMYtRzOhScGAQhqqDwOf5S46IuZvKA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "eJ89fIHdYfoIM8kw5sQ+QZD42/KZkE7PEWNs7shS8jiRvDQSATwbBIIPsyUeKArMuJ9m1IRw5kk0YGGYWvCgAq0erHu0+G9cmXZMu/1XdwXVYiwAf070Xh1d8PxikrAFHNaMckOaF0rqnshPJkntlXA3cRB8uaysa4vnOpOzzuM=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#data> .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDC+4nu9BC8IHVTrzaE7dPftFZQqziXbQsxSLMl9opMz9pzBqDUc7U/61dv7oRnoacCMQD/+vbj4G0V32zIb8elUOzFX1RKgSNT/KAaoxCl24MaJj/uaQtB2KHlEnUIH+LAwM8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvO3Mns1yXliZdv702yhaf75l6OPgFiUcbXMMZAntFgmNkKGFeL3DJb+i70ZOLt3f0COtaceXu3WKiYV2rkDnin6Mn2INUKVT/PvXXnVMFzbrz7eN9FXt3kLKj6Vgih5lE5YNpR+QQc0Evu13AR2/54isfIf6UfVIod4scEQn7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> .
+}
+
+<https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> {
+    event:xkeovy4cf48spd5euwj1
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9787whuvh3bufzx5xm8z ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:hasReceivedTimestamp     1513170817429 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:1107469913331435500 ;
+            msg:isResponseTo             event:4e2ws6ap0hp93iv0oyu2 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDaNCV6mOz1hMPBjIwgaK9m7SQ+X5CoMrWQver12d1LLJNDkqi+mxsIQoX7wMIOakICMQDiq2tU3CUAS1RR+Dnjw8SeBlrijUzmrFDligXf4F4e+c4GbEVqX7R+y6zvgnWacZg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FpgaMyJZj+TbzTw5Tzx9QqtHZnB4MZT4JOrsmWnKMcWN7Klz9oEVxsE5LfnpelVKksjYeza5sMqX8hP4gjAJOaUXSmeoJFjh6D3n4DQdYt4wgaU7U5aq1PZ++P4zcjuyV5T89ZrnAi0A78vP1edPe3IkveABG0KfnbO9gqgUDTI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> .
+    
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xkeovy4cf48spd5euwj1 .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> {
+    event:dhdnzy40wlrnxh7ymr2b
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:i1frxy9ikewwjuyjcznt , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp  1513170820580 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDG6bzcVyWp6gPmZNoEArnWHnqTUuQk5YPWOzrW/RKSV5jN69wnrrw5JO+1SEcBqTgCMQCW33ygoBCPZm8Mvch+zfj2FaSBhVR5n2mNuwWYvIowwkIsO2/a06uOdcvwwlfJzG8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FP1723BVOeZpLu+ZOeOsl0bDQGHwycSHQa9cdvco/vdOIeBZzu1tIg+FIZRH5UqEOo2huYjHPXcWpJhQzHUbGEYSdymuttq299kanZdze+02sQ63vvM8sCs4MDqwTVoBy3cfOGzlXY74qvsuZ0x68XnoEWba9+A7la6xaLXnjB8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> , <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p-sig> , <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:dhdnzy40wlrnxh7ymr2b .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDnma5hS7CN+AkrNpGNJfzlU592E1+0JChbJ+2wTlmWsKh85umQ7iE6CxHbR0tykfUCMQDdvmqJudAWOmXBbEBchSdEEWQNFrv7ULAciI0tifFJ1C1guzXK/ZIKNE8FLDmqr/U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FmCWu/7YK8JPCaKf1pHD5Ir2x3stZzUpPsd1t2QaPctrWWbRmA7AC3pXBIJd4v15a36zcWSVBaYbWzUpP50UUoroRqJFRcwLH1lgGtI2UmyOI+TpR5QUAj06YkrMBKoqkSJpl5tEBmc5bL+mElhU633mHAnkaqI2nkdfDF40fv4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> {
+    event:cbcccoqqqbec6bxkl3y3
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:3v08br9ub79spo7ol4v0 ;
+            msg:hasPreviousMessage    event:xkeovy4cf48spd5euwj1 ;
+            msg:hasReceivedTimestamp  1513170817676 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> , <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cbcccoqqqbec6bxkl3y3 .
+    
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDqyb+JuxvjGHc1T0WaKKpDU4Oej68/mGGt2AItm079FNYejuYNFO+HyF+uqIfPCVICMD0BUROi6w5+grv0+JqAuWzyU6/9iYevHZE4H0/4bsxXW0JW8KP3KkqI5Z3ftKaZ0w==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "eJZL/IDDYZjGc6WnmttuOxOxxhnWuiQJPPzmyrq5Vb8QEb6N2/7y7OTx1WMGdcn27QgNnbjn2MXnCHUEaLqnh3/5kf+E9QmUYSQm0TO3hMkda3vPLAHHdS7b5rC3LFtjjkakvErxcVwIjRu2mul7+sEsvXtoxC4wxfa6gpix7jw=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> .
+}
+
+<https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig> {
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCpkOb7e5AdXuk0dkdTvq5EEHbHPFQek+jqslE7ieVGVDK+OWhopzXqsOzVmAjLFJsCMQCP5spWOSsU35tGeXf+5NECMMe9H+shg2ppQe2oRvz1K4FYY+EawU2xrxZ47g9ghgs=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FApA2qocNuxYIXsIvWpkyVGUtz8xrSsE4BKgqzaNZpaDjoD23J7UAkNayg7fq41hPdopEPKHaRlcDIQk05w1ZR4jUpHcdj5aMaYKON9hX2OQ2+Y5l81XPmWkcmwJdph5CBdDaKl7dwhDcej/wafhee6jP8nY6raPXFIoKMrxgjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> {
+    event:lur3g5en41crth556538
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5iw37ggk8ccrcxxf8f8c ;
+            msg:hasSentTimestamp  1513170831123 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDFcF9dhwqFxyfmGS4/xP5bTdczsq7XKFNMi9IzM+EdA3zTBchhKNfwEEWv3zIp9PgIwEYWjn3ZZw+ye87uRsYHllyKJ98/vyaDpyjOJ5y48i2zIT33iqmFNgyLmcUK/+z5c" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "J50AHjLEwZrU+ngnODP26h28Yg9r2/lyypBPaiPj6QKLk3gmR3idU5wiOVw0Z/j469eChrk+lcxJ9Ena+phdjvhgp8BK5YRstd/an46vXcm6HMa5Svt+1DrtNwOcu/XqDzF0D/8h8iWfs5Q56elxWs4IfIbDg1DjJAH6sbYGtrA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:lur3g5en41crth556538 .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> {
+    event:qyg9hv3nohv4ykv8ryev
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:d5whye2xxe5kofpdojs8 ;
+            msg:hasReceivedTimestamp  1513170842081 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig> , <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qyg9hv3nohv4ykv8ryev .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSScApJPZ8R7ecbEmjmoEu+pxkflMao560sVd3mK2alK8CPTRNoLg/oJQUxa4lqt4CMQDl6yHyqxvxqh+t/13iDG2uWEvqvA8TgR1P2eJIAvxbxg7pVc1XQ0UMGnHml7Zk4uo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MlLaQmKaG9RTw6byp/UmeWfM40JbjgQaSFTd5NFvssErRCjo1yVuoLAXI1iruqGepB6lIGSRN1S0hsatgpmvcmWoXkzUevzbgiED6gNpCycenfAl118R4lamQ0Ku1SnaTx+1VWfWgnaahTRxeUkYlzUaNiciDCfsmg2OLikWzfU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-cxka> .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBlZjY/dtzOlPi5MdwNN093c8Lc/SHWyYxEtBdN85M4X/q0AOKFRsekcX5G1PPR41gIwdyHP0HZStd6DyRDcUitTk6P0WrYtRTMpRgDo4rEdJldeYgz6j4DoN8+IZi/Ir/g6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJvDQw6CO36riB5SG0Xw+LQAWVp+4ml3RMeE6fwWCuYdwFxGa0SWte74iah6QM3JTZCFzaBKGDHqq9hri4wm0EnoscWKI6kN7ZspdwMHijF2wFDjM/ddDv9Q3xlM9Rz8AmYWkJwFRjLeBq+eOQLZvqnvtRwA7DXM+KLtzxbweZj9" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> .
+}
+
+<https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku> {
+    event:4ongmje7w2v03mp7ztex
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5l16wlgqmeu6z6rt90ca ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:csridlusp0h45v9gf9v6 ;
+            msg:hasReceivedTimestamp     1513170830767 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:4055709708568209400 ;
+            msg:isResponseTo             event:csridlusp0h45v9gf9v6 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4ongmje7w2v03mp7ztex#envelope-ccku>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4ongmje7w2v03mp7ztex .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGNnDwc5YYL933nHtnxFVA8NxJPmQNfPjt8hUwvgsMvaLDx46ML4wY+pYH1ucJ9fCgIxAOilrXvu3vvKLsYDyD7SPEhFHW8/l7l56Q5P265Eq+y5WcpiYj1ZxjhQsPblPwyEdg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dGtyMN8bioDT+K5C1IRYeFks7KsJA4SHKzwPBikY20jzMfMPPit21cM9mBMjS30atk1s+RRjOjImLb8pqLB09JU9eb/j6U51PDhprQ7o3tTK2gNFuOqoZcxZda59EYQxnqHmravRFM13SrCgCz7WGYn+24ctpbypUCRspP26RL4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> .
+}
+
+<https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> {
+    event:6m7oi7hxwvoi2pmguo6d
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0uouhqi6aym8jad508kd ;
+            msg:hasReceivedTimestamp     1513172392503 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:0uouhqi6aym8jad508kd ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6m7oi7hxwvoi2pmguo6d .
+}
+
+<https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig> {
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDAYu+iwuVxn+iNMkc4L0fs+on/mVIZCFOji+O+vCzNXzj5lfoN6kNNBVOh30sox+4CMCj1NZS7eWslazm6cTDzC6dIZoTA/HbDmsoHhjrScMjszSKg2YWK2l+XmVSY+z6Q3Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TXmnN+JgFn7q4Fiqaup2b5+b0EJi5ml25hgsrE8Fgp11XS7srsuTx1SmoMWMfNT+XZcslr6jelRBzHNvw+ruNv63jvMRsHhCQwz4wTpVumclOxK3XYUnXv231zSCiaSP1BhVZZlLxeVMWwVuXWiOK2b8nIp8sTsXpoJ7efixUCc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> {
+    event:x7cjarywf0513459swe0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:cvloufr7mmg0siwflisg , event:uu3ciy3btq6tg90crr3b ;
+            msg:hasReceivedTimestamp  1513170842174 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDgo/m+wYmUd6CTfd235wU5AJ/REsZo0sWaVkMEp9VlkqYwwCvN2h5DuHp2f9C3ry8CMCRbkLpAGnAcCMusluqPjBPaiknhZiwJBMaOJdxnRv/Bv/I5cK2Ft/pryO7H3GdmPg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKTtN07Njly2C1WBmJfeblgc3XM8I7+/hlven2vbL9MehvhDRmkbjHUYDIwSvBqfGETL2qnQdmR9OYl9D1bXAF83CIos8vRHDpNUwbLzmyWKCjfq7PANK+fBfKf0AU5yiEDCYCIlKz+F5/yh6IAknwcZoC/CeNAKSg3kJnnX1/tH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> , <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f-sig> , <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:x7cjarywf0513459swe0 .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCvtSL//SlDGw/SSFiTHLK4QBUCohHmHPQxczSwFRpDd8tFyvvSCoEfgGydEErd4VwCMQCDGAwBUQYZfMy3zzWLvhDTWUmMeVihx2Kid8iG56zqjmEpPg8SL9zwHmyM6JCpHv0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PuTE0m9yoe7oa58iU7N68MFKRHRxy5pDuaPjhVFvNFjW8OoiZ6Lbwvjw3HeQekdqeLYm0IPwYE6gZwXfcTV2FNmFFUur+k2V/6VQyj8AP9R59zO3LbfuQl52fTj8vuycNnDun08bg4oD1YOSztjHyXbDDq69GC+E0zahf3bZxdY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> .
+}
+
+<https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig> {
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCXu+JCNySc3oh50OlxXAlsAhd2Spt8tI+7F+rZqKZjyKQJejXsFPNNjDwm8C0lG20CMGmv90AfghtrGZWJskhlMhhKDc92BeUg22NxyivMaJfqhHttOEK61XbGcV2KBqIhog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IjtO0ZaLQudoF6JL1+nY//2rbP+PCotIdSeL/rfJSYfAD1HS6zj50ceZ+j1ntDAcNk4CjMWpEp+ymwRIMP49CwrVheoxeAzzW3PqV9dUcSdzCdnaFwDp/+xwwLsStK8eK74GxUXOy6xsvxg0eeY/5qkqX4SBB3few+5ifwkZvso=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig> {
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCONDSxagGTZTEjj9rSbkkoWfOXNPIW1sdqd9aKJnl+KGcj25TmDij/2MvXgpWdPywIxAJlmcegDVi4tT+Jxu+jYm6gYvDfThqxQwUjZtT87sykFSr0NN1vsgbODrJAjiRGYIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kcc/Wqu7WW8J6gi8yhPkceVRBLT4vc2FZfQFIAIFdUO11gbGBWMdmY+53c6IfNntSdSxEHLMsWCrz/GwB04LAt7dS53eMFM0B9RoQEgS5p418U4IMVlcsERYCvISlkBGNfO/bI+sVQ/aIqaAVI2Alc2eOeZBr3j6ist+vkCnsrw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> {
+    event:5r6qvd7rennbi148vunk
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:iasuj1z9fva0svkfqb79 , event:1tr3o22co1907d6b6n7s ;
+            msg:hasReceivedTimestamp  1513170866423 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig> , <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> , <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5r6qvd7rennbi148vunk .
+    
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCBzp1cAZP2R1cbcA+652mwXk4lOWb0noZmHYLFYB2maq+8BUQzaX97MnZyDFdmjdgIwTjdph52OJLgePV/du4zmDS1riW0qJEZoOgk3bDb1wFH/17wD0NBcX3rmsl4zAJKB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK4rRGDfNdW3i+RZ5TwMnjsRW5+oWCcyQUMKY8CQBOrt7M+StvhcSfKBRZbS0FvOHNo3SMAKMeLaBgfSpySwD0MDu+ErpXCYkye36db6t00XK+t43cYjJzOGLCOkP9BlpcA22JNVP/rZ1tyo1UgV920Jhmjr44xn/d00EPDXffzM" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCrZswKls6aL/j5zsSCfhmh9QRjsK1CG4Ux2wXc80SG5HtsGyKRIoRdkDF/s1SeUFoCMFiafK+GGHmu9z/6pqGISCe6977nqbkuUMGuws38YyrfgiuBLZfdeEYOAN96ShRyVQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e9e5V2sdF96q7wSSHitm3xRk+lrmr3NH3OFWx9yBPVA4qGLjKKc9D7dl2dIvMXipsCMxd/mryscAe+eD0tszzrOxD3VY1EOTw9J39iobqBM0ncQ7nhRdGRc9Wq+ov3KL20hNW0C4tY+Un6WrGQ0VD4P23F3sf/cO3v2HH0DNFWE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-ak33> .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig> {
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5jl7uZw9ydMiunpmr4V6hPpZIE3ITtsFx958idfjajz8G+XW4MCYKOXez6fRG2+MCMQCI5D0NqeZIPT0a7aBZ2uqdGiv7WZ9Di+i6I7/OOErO7VsY0hPUSO8JxHKXwxZTSM0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MnW1zKO26p9UC5w2C+/gI65yqrKlUipUyVaGrI1+iV7m4chqma5tTT3cWCwSbbUXv4pwvZdHVKc+nQ7E01xTrTMJgYP+syJLOwUDOaNq5m3HgrYnto1TixrsCqMNDLZux7cFojSVOvWmqK1JXuzX2SGujQazKWj4/6dzeuNFRf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#data> {
+    event:5693603251585579000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5693603251585579000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513172392027" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5693603251585579000 .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4kT6piFh5ceXRL5F9yNB0YbuKL1tKXV1S45+0roXuvmyN+i2sWtYe1LK7jgNdBjECMAnQh8vQBg3FntQaEPfbA1nphu8eAhN/VGfo3s13z1kq/nkuOj8xm6QLMnx1RuT2aA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCPVk1s06jP3dBBjhEWN+uyI/MzhPxlTgXK8/mmfruFE6EZOpeGVcEmkKydyQkY2ZCShug6/M92ISdo50dJNGw7" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#content> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#content-9icc> {
+    event:m8b6jvgclclzy48p7wqd
+            won:hasTextMessage  "    'hint':        create a new need and send hint to it" .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr> {
+    event:qyg9hv3nohv4ykv8ryev
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:uu3ciy3btq6tg90crr3b ;
+            msg:hasSentTimestamp  1513170842016 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-d4wr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qyg9hv3nohv4ykv8ryev .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> {
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+}
+
+<https://localhost/won/resource/connection/lhrkbkodc0y4rmc7z51y#data> {
+    conn:lhrkbkodc0y4rmc7z51y
+            a                        won:Connection ;
+            <http://purl.org/dc/terms/modified>
+                    "2017-12-13T13:13:18.261Z"^^xsd:dateTime ;
+            won:belongsToNeed        need:ekdwt2a60tesl77r13mu ;
+            won:hasConnectionState   won:Connected ;
+            won:hasEventContainer    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events> ;
+            won:hasFacet             won:OwnerFacet ;
+            won:hasRemoteConnection  conn:b4vtw60q5p3ro3yfjybs ;
+            won:hasRemoteNeed        need:2615528351738345500 ;
+            won:hasWonNode           <https://localhost:8443/won/resource> .
+    
+    <https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y/events>
+            a            won:EventContainer ;
+            rdfs:member  event:kaj9nimgw0lkcgmb1asf .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#data> {
+    <https://localhost:8443/won/resource/event/238289506881087500#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:238289506881087500 .
+    
+    event:238289506881087500
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/238289506881087500#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170860967" .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMEXMpuV13LSw+vhQyFssnj3izlgi6ep6rVKS99hPT0+GSXSxcOruw8AENRbxWzRSawIxALDoNFBcKsBcxDv0fIoPmKmnDX15YMkxsHWPhCuWfMg8tR/JU/BjBSRyu5Im12q60g==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCT7Pm3XVPMHSKrpAp2Ph53zH5mNrhmO2gIHkN7OI/VcRYW9T31CB2jq5ZGoCvPCiu19+LN0jj5EE0gg0jmJqn3" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#content> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> {
+    event:tlyivx8nn93zw41ujn1o
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4kx7gixf60v34gg65z8x ;
+            msg:hasPreviousMessage    event:bxwevm9gzqconmzxji4u ;
+            msg:hasReceivedTimestamp  1513170819134 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:tlyivx8nn93zw41ujn1o .
+    
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGGOm0c3hHknNaKBAv0zxIguzu8eQqvLMx7dNDe0zSy/s4Uf7TcCWv19Emcn9/t3eQIwJtxpIHkqR/Ii0DjNeTrITbWqGyEBTFpbq6Hrlfr3WtUqHPVquK8wtQtzIx7Xu0E/" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RndohTRpkC6s6vDZ5dm0xCJBcZgV8ArF69EYgiCOBnIOO51iekDiMawPF0AES5kJeFL+mZElzH4lwis/PnbAbmsgLwEsm2rQeBCVczD8EpCKjRvqxO/qqjvv7NghG78ZODutp55kAI+k5vy9WS/bDCdOoUIql6P+aAafXTONZ9k=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCNn5OF84hSKR1M5+QMmsCrD5nsLLfv1QUGuf9Qp/KaAXqVZFqbjJPQBoGUyOmtSv0CME1FB3NvrjmUkztVaFT9mIc0APa6AptNXMEEGHgu/NnwJt0Axn8y5mUS4ovHs7fssQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJlbJyNYa7is+vlEstuyD+i5BFl95ImdgqejmYYED7f+LS9qm7jAh1TxudJZroWJi3dlIe7Y3BNKvyxuO/5xzzFLMGbfiiiw6GbqHczNDXHJKcot5RhvMFUvIjMXi2a/LJFnqJQNmzuNGzLvGTI6cy+m3nh/3eKIURIDlYX7xYbB" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-lhx6> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> {
+    event:h2lo8jybm27ouaa4wuqs
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> ;
+            msg:hasMessageType    msg:CreateMessage ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170782150 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h2lo8jybm27ouaa4wuqs .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFCXxJ8Aryjno98JuNKS8NjnGUvyI1GMCWiXNupDzsFEW6CNmW5nRkQjmPvLp+3/ewIwD+3BsKHIF7U6X/W98Ae+Byf2yveq3Vwdn4mw6o8lLnPZuGwlUF4Y5FkD0yCiUw3l" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALIdqjgaAkyUcCBsvFuzlu4yHFaiVeI3AxuHigLdQGsLt9W9DKREYG7p/LKF2+Vnc+MdPRM8Q+aiNz4yIgzuvnZLcyu0j6ga1r2tiiMJLjuh5V5BMZ7JgjfPSw10N/UrI8D5VLH5jvH7AwR1BTXHNRZ2E/EcbNNZf1pzJ+/2MTut" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> .
+}
+
+<https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig> {
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8hJnbfiu4bd4ahyykFzDFaJbAJFuHhaU28V62PnTFWgU/+XkupuU9QRcXQ6xpgeAIxALLgmxezekB1EZ6IKblpQhBek/XMGHu/f0xePNoFujsQ8kHs0jtDngXN/9hG1aTu0Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MDOlDmMYJEQQjXNfyUr1vswV1FajVFgBSDGq5LzjRQyzfajr44IbNGiNiPWuDcFTUTKcD9l5Eg76on3viBxwdYroIj13RXj5UmTUvxuPQ8LiVdeShj5byJwmCqVKIaG1znwssf/GLUYQHUmnOZA8GiFjO0RRyL+qaXzWvtfOr2A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> .
+}
+
+<https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#sysinfo> {
+    need:ekdwt2a60tesl77r13mu
+            a                      won:Need ;
+            <http://purl.org/dc/terms/created>
+                    "2017-12-13T13:13:02.665Z"^^xsd:dateTime ;
+            <http://purl.org/dc/terms/modified>
+                    "2017-12-13T13:13:02.669Z"^^xsd:dateTime ;
+            won:hasConnections     <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu/connections> ;
+            won:hasEventContainer  <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#events> ;
+            won:hasWonNode         <https://localhost:8443/won/resource> ;
+            won:isInState          won:Active .
+    
+    <https://localhost:8443/won/resource/need/ekdwt2a60tesl77r13mu#events>
+            a            won:EventContainer ;
+            rdfs:member  event:5cdkigzbdsxk44iw2kai , event:h2lo8jybm27ouaa4wuqs .
+}
+
+<https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y> {
+    event:ofx1afjv35cwpppp0wyg
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:ck5071fsyaned6upryxj , event:eczqg8lp7xbukpzikd41 ;
+            msg:hasReceivedTimestamp     1513170818746 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:eczqg8lp7xbukpzikd41 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQClAjshUZ0bRIsA4MLnSIeCSIKnyz3LQfuy064CYYIVc1BRB1KIj6ZwqA/F4jxKTekCMQDWMV47lfLGzthNmOR5L2664akDvrymeQXPXlI5PX6MqkafMCAG2+1twjt79ilGxrM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "a1I4RG56IZ0HyXJ5bAiCmKAvAKjJCD2n+BJYyOrexFekGlxTL5ve7W1LnOhHU4Bgs9CxM05U2Yyq+r4/QAyCbKQBIa/f5IPKwDIEqECaQnwZbXZy1gPp6ipOwB648yBVE1oMPAMz2j/4ht2yNZujCdOClZzuM7Ic/YxzmuMOa9Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/ofx1afjv35cwpppp0wyg#envelope-df3y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ofx1afjv35cwpppp0wyg .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#data> {
+    event:6149800720990867000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/6149800720990867000#content> ;
+            msg:hasMessageType    msg:ConnectMessage ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170797623" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6149800720990867000 .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDpWngPYUOoTIRzPSCDIRYw7XVL0tHO1EwfFRK7dkpkA5gwLsxFc3Pu8CPX+iRQxLwIxAPhs3h/yiv05AD58V3MkHhidjfwt9UCFMb5N0sKNeioJGcKpB8z+XZTqlq23+3QrhA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALMbzxssxu00LuwJ8o2HWnqftHOW6cbcbwNUuT6Oro62Pc6k1dh3X+HXMqOOmwxcgf/Moo1mHTJyNWt4KOEu1lKt0INBkFslijzRUdkh7rEnZvivUNvyXWUMaYzOoaGIpp+AsuCAxggSXH5YQ9+NgQqIZZBSVqYRhBXmLhdWuwij" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#content> .
+}
+
+<https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> {
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> {
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+}
+
+<https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1> {
+    event:rig33yoxaetjw059bzuw
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xp44teiwtooczc14npe2 ;
+            msg:hasReceivedTimestamp  1513172392235 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-hjk1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig> , <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rig33yoxaetjw059bzuw .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF0DQEL7Y6ywH7J86m9iCpaFzzGZMaOTrr3QEP9tYY8+8kNhz6d8cadeFPkrBcv0GwIxALYAOxJGzgzRJfQAPlEGseGQ4x6s8PA+LvNR4X4PRCOVVH7/OgwwEPZpZvdWwggWqg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJk12DIF8BEWSe3NI6LZcq0e7kn5Nr97GglfNbFz1rpAuQzs6dhOaBoQv/SV/CF6Bn/yX2bpIW+3lvH+kvR7Fr5gsTFMopkuausbHAVUArtGgXtGqEmfpdlD3E5tb+/2030uHb24MRNCJiG1aFDcIMU+qJUs7RWVLbwzpTMW3u9d" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> .
+    
+    <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME624OmZ/FEY4fVmSysULKZv7UF2tPv0julpk802t18Cmj5eQE2sYLwddLCNdsm5jgIwB3dCBw0HN6cOfhuUhbh/0ePZeD8ldqT8f9TygTfRKnPNShn59CyjyQ63I3z4Xl/G" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bFHeLGQHjvkGb0MENt6ztrtgUZnVVGNnTI29qWrtr1vkncVLt5ODozo5leNGnw3ksN8eQbr75uxvOG0Z3lfb2bSfO5+G4oYD/sX3zGQkNNtYjLhqT3sfxt+laClpFSs0deyza4sK52YcyXNP6kTn3pSHXCD4Ex5AtxSld8I03N4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rig33yoxaetjw059bzuw#envelope-ia7o> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu> {
+    event:cbcccoqqqbec6bxkl3y3
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817596 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-rmsu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cbcccoqqqbec6bxkl3y3 .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCF/hbvuhAlpZgyjBojjTjgXOZbygRAUrc5cpxlUknl+EyVTGDYi4ojz4CKLYDedpwIxAMMaASa3Wb2Hdolj+prcpMwywUzvx7VB6ZTJfijxoMzY2sHqtZH3IC7yN8pzSiavyA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBX1AVUlzqW+eW5b5nKkTjx7UR4BbPW3c7KHpDZnkSDjDLwrUD1nAuweJMbMdgiVaz5SMC0EqKGpuwJjkQnGhh9" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#content-3j4j> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+    
+    event:8ksy3mzfwa3n937tm3vc
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6834006177130613000 , event:d0muf1vbp6zai6jtnp7w ;
+            msg:hasReceivedTimestamp  1513171119069 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> , <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig> , <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8ksy3mzfwa3n937tm3vc .
+    
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDC3N+xh3W+jdNlpXWQFIyMpFAwOCiwmYF9FTDk+/x7R/wRExl0LHcS4L1wpdbNLkwIxAIjEZMM93CfITMqHTOxp4czNtE7YJ9FClCYPq1J3z/skmNBfn7zIJ/gaXnQmTbWTJw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dizt0KyQXdbm30eEGd6SE4UQ1YRO2154dXa/pUYI6ELRRsNQx7sueMtzcjji/RaZjHmb1b4WJdKc0WiTnO7CUpJHC83EqTvJUU6kZbn6IlDR2BEMUZzDXvQyWf97K7woiLonqodIIJEjwmtG1wMsatXNzXK06jnWw1jcQFnNPN0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF7DLztRcCmLvXZxhvUBXDlvuAwdzzydqhf0/3GyUy1jv0iRC5ULzS5c2uX/3WDT1QIxALxm8FV9FDm9BEhqv5py3ynvwRyZnA4LzvcvDJoifRHVCT8JBrtcqSmw/lJh1BBCfw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WCheSd7dCcoXlR3eepBNlMGLCFcSS4TGKJyrwdQ9A+x+pUulYkZUVEOgKnMvGHGY0mDBmM6K1SqkCkSfEBfA4joikWQdpdxshc4Sn5i00Zh8WezXmbhOrdW7uiDsTyJKKbHTfJlDD3WwM0FshYpo/mf7OiCAZQhXw710tgTbMhg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> .
+}
+
+<https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> {
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+    
+    event:0esqgu17b6xqppmgbty7
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:up8o74u1kna29g9phj23 ;
+            msg:hasReceivedTimestamp  1513170820404 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> , <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0esqgu17b6xqppmgbty7 .
+    
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDQg5E9atFosQbXDS/s4WZTBkkiRbeoLd7fqQuUuXJwKNwFUTQVC3Nud1pR540kTxUCMCH1aStQszWDJO0ysvhUJp3WyBw+xxD+FLTrU7IV3+HvOjmsPfx3dfMwmuFWtGj/Vw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Qej6eiW8ljLs4wAs/OiYRo71mH8ZMGlOFFaCYWXj0wsyZN23ViwZP/44coSgcirWJ7Yv95NODM7JpAI/ltcdCibZUK0ga0J4+93MrYE0u4DzE6dww6a5Y+qPVJYxolIXk/H5eQTTqVwM/HrphT2HYxQuuc3NWqtfRG1Rop/7nnE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-ds9x> .
+}
+
+<https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig> {
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCfb9b4/o0eflVtkvJNb2cHEbjJzB+18MenHM3Ma0uzpry9yd4TOWN34UxvgGhCQQ0CMB8fJljugWsUoztFIsYOszwRP/QUOQKQpZNU7QU7V4r0Am1JgIs7vJV8DIWhR9/uaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKb+p4XkNP1ACG5REa7tjbaPwbQ1b05ehepKt1DcGi7nM0Fp+SShOCPUqflEvTThmyZjZEB3g8jUK8ZCC17nVOPUG4BKxao+CfaDllZA0US3vl/QZt3G51YVA6KmiAE+DSG+26DWqO/qDV+gZlubodICXkNp18yEcIwBweT2r4Yy" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig> {
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCBXQAY9JCzR1KytintdoJQqCCijMN4fZh/scIuz+PU1Yo68ES0h/94Wo2DYHGfEVECMQC+YpU2wvl6TAscmFS04k+gOJemoI0/mwztgZPUNfvLmfkjRYorH+DNP15m+Am212w=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nxifj77s222vVKuupybo3fNtjRETwgJdrubPviAO2r6fBRgFSFDZempT2GNWXNKSRFmT+YMMxPs+p/Rcq/CDZ1mZaioBBYlZELSyqOJlj0QxSzIDZnVb64/+bAQYOvJCt7dgtUn5BYW7fHvyYxIcwFSLvmxnqlFbxne8MT8dkTk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> .
+}
+
+<https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> {
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+}
+
+<https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> {
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch> {
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+    
+    event:8ksy3mzfwa3n937tm3vc
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xpspyx3bpyev5v5p1vf6 ;
+            msg:hasSentTimestamp  1513171118998 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-a0ch>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8ksy3mzfwa3n937tm3vc .
+}
+
+<https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig> {
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA6xk9W0Nm7Q8n7VHBKI+Ffkrgs+R230cvNb2jldpbDuohwXmcEWD24TJc4T6JdlJgIxAP9vYMZbAV2k53k7Mdz+mY+NMy0np7t44P+SBI78Nb5Xt6I1lOP/hkxRfEcpElRSuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "djVOPPlodqPPEVgtuLU1iuOD6Mzo0/fsuipwuW3KTz79Vq48wnNPY4KWBkt/p1w9sOyeV2gsCNmbvtRdeN/UYZ3Sohb1gRmDcLzZyLuya/kKsX9aHr4KJyFXUdOmo+GGfJYkjwxMiS33UCQRRO6z2CyTk3/qdE9+dHr0yqIYhBA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> .
+}
+
+<https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> {
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+    
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:uonv0x93cu72oy531390 .
+    
+    event:uonv0x93cu72oy531390
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8863100035920837000 ;
+            msg:hasReceivedTimestamp     1513170841716 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8863100035920837000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p> {
+    event:i1frxy9ikewwjuyjcznt
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:tlyivx8nn93zw41ujn1o , event:eue8ar55z7as596cu33m ;
+            msg:hasReceivedTimestamp  1513170820493 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-af9p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig> , <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i1frxy9ikewwjuyjcznt .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0/xurl/bcm62GLYTMgHO9GJHr0GM3eT66vmp3CE+cRqaGylTxbd9WnyhErYKh/7wIxAPFxaBXKC1CMbFKX0vDGKRlFj8HbCvEJPYv36/y55GUwrW5qVQp5fizvulmNgEfilQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8ScmSRWdh8pqVwh+r3Pk7imDbcNJXLFJ18Jj4DMDEAVMwMma+MKQhdSLlEyDdHl7u17bZaO9MkdFYV418E1BbBOafVwuxHGcFK2FEO0PVDoDOb2DjDLt9Vi00P7fEh/w+t4acnUJXSAWjhRrhpLLFtjSxa4mmB9aHmvcKJGO8s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMF37Z3gVis9mUx/5S3OzCCTUKaYpBCQWL+T6mLE7ixgmSCCRoU0DwHC5qqRKDOZJawIwAbJ5aOVdpohOG1PcAkCi/Zo7TszNHMtfFHfqcnU2dQjixFGRnhfy8wFtxAEhnmZW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJwZQomlVyjpYAWnJ4GP32lx3pgwjczAQsd7aVSTL3muqWYb93xfgDKNj9076dNfTHG34TDgYol2kc61Hp4HIz4fAI0O9i5tUYgpsOT3cqqL1y582/Wff19Hzz2u9mWj9tkhUQn+0gSvxVdauQLETpHJ8DvasoYZECKDNDC0vrzO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+}
+
+<https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig> {
+    <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBHsVzk0iN445oPyFMjO4YrLujaO4utwthhSOruN/uzhzNRcd1wsw7mntJM9pCUCoCMFI5C0YEt9A/unTNjITIMj1Eh0OI++zgD8XkJLQTcLdKyQxHFYRm0NmRVcogmyA15Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ALHVkRX/E8lVerdgh+TvBnCbKecI1GN3o8zyTyztkQWeM5iwxeTTTlqHanvi+A32SJ/7GOQgPIO8snBg7LnoiW1n+m9RTiS9UKu/vNue1cAGLH8mgNEvEwPAwPlcwK8UOpj36RZ+h9XYIMOtkl+jUQ0yUU3sWTlYOlaajOGNFV7R" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/00zilsxex8tqjumh6fi8#envelope-gey9> .
+}
+
+<https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+}
+
+<https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig> {
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDMbYqBfil85PHaYQ1FQPPvFNuij3MG4UuUJpvsoYUy8O2dRFqkuBs1wIZ7eB47PKgCMAy/U4zDeH8X/U5Ibkb3lKQdhgQhM2k0j2ZHo/4xPCPyfgzbESik570jTPvLzYu18Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ctlHieV7uS9TlmRKmEwrpoACvef7iLjdemr9lRLQINiwxb18jKO3OseL/DD8kOXhtRWSC6yGH/Lr0xoa/dQUGDSbnvlW7aRyAQHYF8NQmUBbn7VnbPSgOHdYG98egkSA2vev9vphSuW7rHAlYCxgCbCApT5qIjM/RmdDx57J+Xs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> .
+}
+
+<https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig> {
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME13EwWl+3unTJ4OvDSR4tdJvf3ApYwf+bkYMhgB0uT3vlii+wc0ryUcWx1OnNI85QIwW76YwTCXbGMLpzjZqko5zswG4YXxNg9Js7qRJO2iUFgYJZVyLeQVeLRgYySdEC3Q" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "flusXaqyQbNDFTPPYD6uspuQqa1LZFSGLK2dnAWz/JJD8pvhLCPSYAYoi2y+Un/YeSRz6sNIjbvn7u4A4wcW7yF9Po0QZty/xzX803jGoXS9kkiQ6SPOe9IVj5yAeld5b5+OfHREyDSSA0+dCMv8ObQt48rnGTN7Zu6cQQZ+5Ek=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> {
+    event:collk6egdkt2tey39h8z
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5151909952739158000 ;
+            msg:hasSentTimestamp  1513173165842 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:collk6egdkt2tey39h8z .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu> {
+    event:kaj9nimgw0lkcgmb1asf
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:vuhyvj1n1x01t4jeddkq ;
+            msg:hasSentTimestamp  1513173166337 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-t5uu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kaj9nimgw0lkcgmb1asf .
+    
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAyOw+ekYDcfg4r0O8Z5sWEfgQ+qSw579eBWtO4R6t9gbr/GTBpbJN9N8SJyn0S1oQIwbmbEyAzsKZ2ID47+MjsuxUITfz8OBD0OFSgH4gTHc7CStJY3C0Xxi2r/BcRYx7aG" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Tz6sLpAjgMJqp+zCSpmaUFuG8DFhIz1l3XRkYD7h/mrplkQJVevyOVvQZrQQIPcj2BXtYuHERurq2kSKBmtVfMtp5wEigCp1Pzj9ZP36kk0Q0xVhTayUTQ6uMHfC3Xkg8svYl1EfUga/3X8Cf1H8Xs07qFW0WqBHGRCAPeHdkjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> .
+}
+
+<https://localhost:8443/won/resource/event/4055709708568209400#content> {
+    event:4055709708568209400
+            won:hasTextMessage  "two" .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> {
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig> {
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME35MheS2EarKRP3mQxGF8egj2rBSEwbuiOy3gnSuN7rM1JlzNSCEYONcxO0vYfWsAIwffHlktaF9Ha/U9qyj5POD8XCvaOJ/jtD7wPS+8Sq2Em7upn03egGjTmoArboJKms" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MQ5/EG7giY3bbGN8WrdVv3dqkjH6Jbw5vTsrmhye+Pn4g2lIVFf62IE7mYoFkx9JsMz44qc9QD20xn287dYrNNlkYYYp712APfJyMXPZz8L8GfbVo6Az//HgqDXQG+ypOBNLyQf3wyjHVoBLqJPKad6+Up6idIzYe2hUkNvQu78=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> .
+}
+
+<https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> {
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> {
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> , <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8950tg6pjze6lr52pq3y .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+    
+    event:8950tg6pjze6lr52pq3y
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:o73qpj11bouvhv9pfmhx ;
+            msg:hasReceivedTimestamp  1513170819096 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC8o0Hjeh9ecoNCW5XLtiEBQbrRCF44lke8zWnSHMuH/cAsuf2M+MicjBNlMDmbdxwCMHpBKge8dazpmAv2tFv4lPPifZcrhVLYKICxLrjnZxA/M77pp5FTpivVyRVyHyLcjQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Rr6gPmaT59AOAc6821EUWSw2b1hjh2ALv1uUXvdtmFHhrPvJmkuJyUxuSSH8OUcM9JpOZY0/r1w+85tVQLJI4VQ6xscU8V7pLnCeGx1w0def6DtjeLDW36/Y2aXDePS9Z5GR881EtpH+9tjwRaw6D5X2UVC09uYkso0dSL1pElk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> {
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> , <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zquh20fy530jymcv4c7v .
+    
+    event:zquh20fy530jymcv4c7v
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:nop2f4uemehxb73r1r6a ;
+            msg:hasReceivedTimestamp  1513170854693 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGWgSkrKRiOuh3C24gr7VSUArNd8vjLQKIeY43533dY8Omc5SHSzgHodLq6594aMtAIwbSkDvCwHYlON9Jur4hLBJgdjGuIF9rtzB9l5zolia6YRHTcEzP+RAbJMw7kCazRC" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI21b36EZ08kpcBtt+0oJIEwdEoPeYX449cypwX8y+ZEHrmsgqJt7thZTQbMt68NCgRiIkznaNRZ+IQf60Qm+Bma057G1VqKL86LYjhj7l9oPf7fFr8tq44Pc5Q3iYcXfXbFIZ95OARpzja5ytnlD6Sto3ya7Y6H1EVHhJoVp9VZ" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> .
+}
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> {
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5946672495584215000#envelope> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#envelope-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5946672495584215000 .
+    
+    event:5946672495584215000
+            a                         msg:FromOwner ;
+            msg:hasReceivedTimestamp  1513170781692 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEK62x8CHo2KNQQXdYyKJF3ccwPoZTkgYIyhyM99q+/p4XzIcnsk64r53wwF+wK8VQIwfChs09aB23WRhKp5qJbDxVzFwFCI5y0jTxXC0OwITZfZUz8zPnNuVa8BxFW3TNJt" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "PcO+QYO+Zam9qNraDy3Pay2+vOUjdM1lIZe3LrSJBNL5w4R0f7UoZzeFo9MgWV5xxDzZP8Bs6/TC+WT99EM7xkqEarDiNdcSaoFWJAZGJ6u53gj6Clx5aTZs6U1GQgCFuMjUFaJVaPGUkAhX+tANIwpC1YLTSobPjCK9UkQncCk=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> {
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+}
+
+<https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig> {
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlJJUwj6rVz5MAYseOY1b6315LTg4MVSYYsYOsSopsFb/fH+nEGmtrM2N02uBWfiYCMQCEePhqHStLwyluUKeNwa+VX+sPhXo5lvblTvnUFKENVHRdRtKHNlocYFocpLruNoM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKpWpWhPq3JF3pYVVgesevrqAR9a4p+eUE3Q/Zz+fcOKwO+g1kOiVjJRpTLjnB00c8bdNNpUD1yQ2X21T7+iUaOdUQ9+SaHnvgVRPLLrzoBtBZbWW6pyaO3237ha2vmxqMdlkC2+UpWRuYkthQlUIgZg5Mwql9N7ttg7vh6ej8yA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b> {
+    event:csridlusp0h45v9gf9v6
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4055709708568209400 ;
+            msg:hasSentTimestamp  1513170830692 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-2q0b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:csridlusp0h45v9gf9v6 .
+    
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+}
+
+<https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig> {
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDC3N+xh3W+jdNlpXWQFIyMpFAwOCiwmYF9FTDk+/x7R/wRExl0LHcS4L1wpdbNLkwIxAIjEZMM93CfITMqHTOxp4czNtE7YJ9FClCYPq1J3z/skmNBfn7zIJ/gaXnQmTbWTJw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dizt0KyQXdbm30eEGd6SE4UQ1YRO2154dXa/pUYI6ELRRsNQx7sueMtzcjji/RaZjHmb1b4WJdKc0WiTnO7CUpJHC83EqTvJUU6kZbn6IlDR2BEMUZzDXvQyWf97K7woiLonqodIIJEjwmtG1wMsatXNzXK06jnWw1jcQFnNPN0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> .
+}
+
+<https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> {
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> {
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+    
+    event:gi8wvgu0xrwk42ccs4qo
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:wlv9kjrh93gfzetdojp4 ;
+            msg:hasSentTimestamp  1513170797893 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gi8wvgu0xrwk42ccs4qo .
+}
+
+<https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> {
+    event:2sbarcz1yu7cenpcghay
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:lur3g5en41crth556538 ;
+            msg:hasReceivedTimestamp  1513170841770 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig> , <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2sbarcz1yu7cenpcghay .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCqxhC3517LBpbtOcLhszKeyH9ew5sTZh++ScjSzOHLPI82Pyc8YC+66XbT4mgkHaAIxAPdvDR4aClT7FPnMUK/FIKrrSi8pH4Wbcn5JgJHcFB/clPGw6SEQDsLD84kXw5PQIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HqdIh6BzCNaM4CQRLxv8Ad1C5CYQq2fr4YuinR+brNGgT/mhpNCsRyqRgBUWQudZx7tNRqdzcS7HLXjWeuArqXyqoBCxBdNw5l/IhvQev/DHRoB6hLb0/LCgYnXoG+0dmvlPhWVQ+5IEGwS8yYFaNVgmOxFwSAYNtn/kfJYqxa8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDU+1XZKyCLiNWRjI0dnbANbLQK+CcbkDPTVgjlOI6aLUGSMigvvxmi6naeQ8KrNwsCMDa7+w7kgqBqTFzr5D6QiwEB8QzD/lYBiW/NgFcKr06KG5+ApzznOAqYh9cQu0pOww==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "N0m+rZLYdstgaD93DOvsVrMAAmX/e7IZ2FRNA+EH722lBIMw8OKlhDbKWfoVS4wz2M70NRIoqaa2kKNJHK/YabZaoxc8OS1TtL7Jqw7mOcZWreBCCrNNEL9nnlOj3I9yL4p5BeeMeEWWnhM5KnHkRFGu06/0L9RnpL9XdS61ExE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-6kud> .
+}
+
+<https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> {
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+}
+
+<https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> {
+    event:4kx7gixf60v34gg65z8x
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:n0k3zboeco26jrnxa7l5 ;
+            msg:hasReceivedTimestamp  1513170819805 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> , <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4kx7gixf60v34gg65z8x .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCkZVANrNwPYph3E0i2Z6X+58WwyaIJnb+WWvnBFfz5mySeZO//rMl7lZ6ibLgpFrwIxAMTLpWrUw4dwDbYm99ypBe8lSc1mjOLTm5e+HONsjGzkrMFTqgYXdvJ7JpywSG5aiw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKW9jF1AT+TJt1o0o0ermAVzXYGIrye9XnOkvUuvC4Cc4/lbgWxbrYRpCukHwHqXZTsB+VwkG22f4CTiaJKZNu2ts9Ljo6azpCI/bbW+TJWvCSpfpYw8Mz/3623+0h7NsMKhao4peEqUznRjy09seZv6DJj4xYRPauOsCMQAJk14" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-hi1t> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig> {
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDl/hkfSe2IwapaBDzFRoEhZxrP2P9YiY8FgbkWqMWkdIAH/a3Wgvbwb24hYx4FynQIxAKP1xxubuFoR9g1b8Xh8kJv3O7/KYozptOVpnNp9iReJA29oOpvaHR9FhaFCLmgWNA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YAkN2j98/s4Fn+0Fy/PxrHUyKfFw9WSxxd4naB3aRJLYAYUg4+FMAZlJs5oZW2l7vUxGx0RF3VzaH9Hr4X7xLIrcCvi2/+b4itdM4OYgXCKtbyFVzLBrRKfxpdITVNQVRAX0zSOVF3yuOLMBORgePpYb50hHU7i2F4hjq8iwScI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> .
+}
+
+<https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig> {
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH9NsQdN66hMeZ0vk7KT5AnpnohOiS/CB1VnayXxRmxZk77r4a5nomPv4N2iothsEQIxANXYWW1m3iF0BLTa7L3WTsYmkO9tppaIzP7UKVzD2HJI1u/ShW2aFCSrdq9OlD95eQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "X20g3kkDFS9eYgwvoZeOAQD7XF8M9sOWpdHWw0sFEhTNzstHvT4ObDA/Pm4XzGFfuDGmzyrpy2cnLFHqL2G6HapR13nnzzBhuwo90vxf9FwvWD6GcXfD06hI8v/ovCEYkGMqTH/oUGnLK59CGz1Qn+7/qGi//l4v6XLOeorK9rE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> .
+}
+
+<https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+    
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:saegwhiwygztg1mpf4xh .
+    
+    event:saegwhiwygztg1mpf4xh
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4846251213444807000 ;
+            msg:hasReceivedTimestamp     1513170829703 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:4846251213444807000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#data> {
+    event:4846251213444807000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/4846251213444807000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170829592" .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4846251213444807000 .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD1XcORU5GxAYutm3D+iOT9nVXbpbeqlSyRB5xlCcMNWBx3pChw1qDOk+NatkxDygUCMQCaGN57aFG9KTWnR/0ZW3DNacwfmKZ3Xcs0PEP3TwCdeK9+8mXhrQ1i9Bd1c5rZTzw=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "CARaNKFJR4joQ+2zDV0VmnwGXZJZzqtWHHFEVQIl659kn+b/jPdbMEEtGAYmwpaOAaRF7xoG1b5PIhuCoC6qgA==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#content> .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> {
+    event:fdxtdqeonqc6mk01crog
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5l16wlgqmeu6z6rt90ca ;
+            msg:hasReceivedTimestamp  1513170831045 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig> , <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fdxtdqeonqc6mk01crog .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHjnW7jow/Z7aL1QDqTFMpP+uUJK8at6ss5OZuet6gmrixv01UBKjCGc1IcJi2QP3QIxAKLau2w3EYVaNhiwbBvszShChrvxT7r///J2xtTY/nogW4LhF9XYHuO+POgxhB4ajA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VyoehYH0+v21MhUknlbDkitBJGdeDF/s45ZAHERkECa5rhyIeX5JdqiSIECSPn5+cSAH8BkNxf4BI8gM9hCIDNQyEXWnhSLcOJFshwCaQcFVyEunib8w+gc0HCrLM63xSQpwcSqjfTT/OTnQVWpuSIx8Zs9Qa6cHgEpPK++pxjU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGCm/09vZEkM4lcNJx+gKm+2Xp6JsebEXr7r8QgeagdTyqm/ijVL6mGgxqG+zV3zFAIxAP9gzNawedUebvkzFjG9dFg5/HT5zfwG+kAZJXejgPAEMr7FcADEHTa3QfbqHLRZ6Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIg6Z6UZE0s2a5I/XlbHdwGWcGeJchlDkWnQIVc2HpNZYcV550t3wHkqij25WSnOJS4MiF3AVR8FmSQFg0yy1GFawoRy7734zeFkA/g2oIYnkSlYtMyzoxc7PDAJPYAUE+DYlgFvU5dE9m0hu6Ml07QzbrxSBzlCi4Dtqv2dV5Qh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> {
+    event:alif190jj9we7toczas8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1d5xlvosu9j6umgi8r47 ;
+            msg:hasSentTimestamp  1513170830228 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCRpoVQIqjJBtF44akGQN2ISQ8WfI4ceoiUC7w1GUAVUUIDdk7Zh0vARmKBNjjbMRUCMQD24LVq/deeFI8dpmbsta4mcVZjlbZGUFvk+axbDo6qvCOIzCwBi4nxg0ysR1rK/HQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GAF9+rmEHzT5ds10xCy5cid+h7NnoINyLDnr2M9qU/s9bLwkx7a+RyB81s2H8zkqgG3uBTvFW3HG/amkyAD3scLobgSbrS3FT2byGjAAc+cwwD08rgRkVxJVSAmmTxus9RUfNG9h59RyTvqsff4nkCuU6wdeEjfQPupo/Tf05g8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:alif190jj9we7toczas8 .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> {
+    event:0s55ww5ae82lf3j3gwaq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:v5rvsrlg0x3ogdqyfuy4 , event:i3k0giied2bgp0p44h7u ;
+            msg:hasReceivedTimestamp  1513171230940 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> , <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig> , <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0s55ww5ae82lf3j3gwaq .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH9NsQdN66hMeZ0vk7KT5AnpnohOiS/CB1VnayXxRmxZk77r4a5nomPv4N2iothsEQIxANXYWW1m3iF0BLTa7L3WTsYmkO9tppaIzP7UKVzD2HJI1u/ShW2aFCSrdq9OlD95eQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "X20g3kkDFS9eYgwvoZeOAQD7XF8M9sOWpdHWw0sFEhTNzstHvT4ObDA/Pm4XzGFfuDGmzyrpy2cnLFHqL2G6HapR13nnzzBhuwo90vxf9FwvWD6GcXfD06hI8v/ovCEYkGMqTH/oUGnLK59CGz1Qn+7/qGi//l4v6XLOeorK9rE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v5rvsrlg0x3ogdqyfuy4#envelope-x1nn> .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME4zXkSquRnyZGv4WcTZhygFz2y452UP/ifRrvo1RNoeT9OV30kp0VC4o56P8uTjpgIxAKofPRkD1Mc8TKUBra3rPqc6V8syC3FjVGGv3rKMTcukETLdkkHd2mf83OxtHmDhpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "GJiojYvJ4MDhMdNmW+xa8K0iV6xCqzBsG4okgSyk5w/SBlyiK81FTHCq+IemlgNWe0UFmTjmYCT5vOLYMgtY79ja+j08xoxt4hkZAP0VfngdipGssZpGVnrm2vEz4kDtw9ny2ti6xe7WedxaocMAPFI21hGzWHC4tYTQ70UXs2M=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-fe83> .
+}
+
+<https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> {
+    event:wpcsl4dxaxpdxbxpfo3r
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:to3x48329wwbanylmar0 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:zquh20fy530jymcv4c7v ;
+            msg:hasReceivedTimestamp     1513170854716 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:t6d7eq3cq6nq54a16k1w ;
+            msg:isResponseTo             event:zquh20fy530jymcv4c7v ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:wpcsl4dxaxpdxbxpfo3r .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDUP/fs+55TXUZubu+45hQ+ta04XzP7sDbwb8ECqWcI8OrsYCadNZ2mdHGuO1n0F/ICMCW87yDqhImKEtP8txkLCdVI8/lkBI3wJ3t1gRSNXC89HTEqo2vvZG377rFgmZnzrQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UkfJOncQPcw65kiy88cWFeApVgVHAnfZfQsjR8MowmZBIKcYUB08bpAaM9t3sQrdqZ0O+3KMYCgDdbxyUIKBeP37e18X7BepkZg70SsiHllnMNXELkRWrIlu3C+VzMRrufK7sMk94N3GSJ/oV0vv+7mpq4yxDc6fSgn5kAevy+A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> .
+}
+
+<https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> {
+    event:izq6icbkftfbzm0clxeu
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasReceivedTimestamp     1513170798286 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:gv6zk2yqk6o8bl574n36 ;
+            msg:isResponseToMessageType  msg:OpenMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:izq6icbkftfbzm0clxeu .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> {
+    event:eczqg8lp7xbukpzikd41
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170818470 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eczqg8lp7xbukpzikd41 .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDETQTI4v/b5O62feqQgEyd9wB2tFPfKQ4mGFXq+ur/i5phWiW70pw4BpWgJOhCi+wCMGcsW+IaxMxaBdU38lCsbJPEGFZlBiCVqVCF/ILeQVpGGsp59/oD9VlGRDHLF05e9g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "JyBD6LNYgu8RSOFAfZSgtETg81Y3qQEmD9WaF8U8Wkblw7zJsKi5eFE9nIaF9kKcH8UU2gX9W1uFM/yWfkxMJg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> {
+    event:fn87pwzr9g4a9v368h4m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:353368844400623600 ;
+            msg:hasSentTimestamp  1513171226328 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fn87pwzr9g4a9v368h4m .
+    
+    <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMH3AdFcD5cLFJpzxGVOABznXRD34pPYBaai0ph9Kpa6R7ki5bZRF1XoUmHbpBEMK+QIwPya5idNpBYYAePgV1irrlJAlRqqO/2Bk27Q+KvxBLJqKNXnyArwhwcFvF+e5Hk95" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TtMrzn6eUbGsdm5XSA8gIsYt/lazgBiLnR9Gq1bTml6Mu5qXNle+3ayFHf//RqR2T4OxDxfvKoiuufsohQUYZXD5UAVEtPU5dgCZGiTSn+dePbfpkGBPH7k+PMrQ3hz7EHYh1oHiLdlnHB60MVvvk4+/MnMpyUd3rHrIVSUD4Ho=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/353368844400623600#envelope-xzxy> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#content-xewr> {
+    need:ekdwt2a60tesl77r13mu
+            a             won:Need ;
+            won:hasFacet  won:OwnerFacet ;
+            won:is        _:b0 , _:b1 , _:b2 , _:b3 ;
+            won:seeks     _:b0 , _:b1 , _:b2 , _:b3 ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] ;
+            cert:key      [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                              woncrypt:ecc_algorithm  "EC" ;
+                                              woncrypt:ecc_curveId    "secp384r1" ;
+                                              woncrypt:ecc_qx         "9c0061a6eedba513964807c7ca22240f921b821b1d68f626c4e41857226c3e303422c6e82e15359d9e7f426f73ed5bfd" ;
+                                              woncrypt:ecc_qy         "4c5b1853cd18af57937c88598c80aa7d7e8a9e7ffddc0c4dc999f0c88805347e5b5ab9b1829ff463e6fd751c6186a69f"
+                                            ] ] .
+    
+    _:b0    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b1    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b2    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+    
+    _:b3    dc:description  "This is a need automatically created by the DebugBot." ;
+            dc:title        "Debugging with initial hint: Burritos" .
+}
+
+<https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f> {
+    event:cvloufr7mmg0siwflisg
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:uu3ciy3btq6tg90crr3b ;
+            msg:hasReceivedTimestamp     1513170842016 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:uu3ciy3btq6tg90crr3b ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+    
+    <https://localhost:8443/won/resource/event/cvloufr7mmg0siwflisg#envelope-1l1f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cvloufr7mmg0siwflisg .
+}
+
+<https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut> {
+    event:xsbbah2dhkcg6d3h13gk
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170819569 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-imut>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xsbbah2dhkcg6d3h13gk .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC6L2e8HVt8wOr0lgvlozUAghNAC3Z2C3R5JcOhIhzHGRhT7X0+pjTfcCitXpovnc8CMDc2WkWe9j/zaxT1n6c8h+6D8a4FVn6whYSJyConWSf3BGoOOzeBnOChgjp8dgowaA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "BF9GL63mQJd1MXHqDgmIN1m0bvKVCdnAUiDYMSrCdwlWDNF4SfwYKdLq1b6ZC4XsQz71ZPPsLptZl33nTCHYUg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#content-ci4b> .
+}
+
+<https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt> {
+    event:dhdnzy40wlrnxh7ymr2b
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:up8o74u1kna29g9phj23 ;
+            msg:hasSentTimestamp  1513170820434 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-0qzt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:dhdnzy40wlrnxh7ymr2b .
+    
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBNQ1eYs28R4JcpyRm6fDx5ujJMNt14iL2xiKfLwRsYlk9zdhxBCreTSDxqPq1RT/AIxAIixg1HPyLYmjQkWXppX22ClPN8UOP9rm7KjgSv0yBbVJCXbSgbaFMHkvEdZdE3vuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eSHdII+JsxfOBEks8/BqH39e4q7wk8lhMAmjEL70MsVf2ZcITamYIdj3PLy5H80bDtiK4Q7PfuhP9+YHx7RCbAMxBgTEqOibibCFtAinQEMVMmHftPAlq0ZuRBn6UCU0t+ORwQStZB9MrpOUqA/6yq2n3zZZGW3WHv5SiK79cus=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg> {
+    event:l27gk9ia5beeuyjqfp7j
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:gi8wvgu0xrwk42ccs4qo ;
+            msg:hasReceivedTimestamp  1513170798408 ;
+            msg:hasReceiver           conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-pbqg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig> , <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l27gk9ia5beeuyjqfp7j .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHgabnaxK8IZ9ikFDriWlf959XOzloKYuSCoJCdtZktH4PEFkBZnRrX90zOV5UFs2gIxANBLmS5yXSwLnvatq/MytzaXaz0PYeqpJ26YbR0LLURNFVQ3MrMK4OCGPiJ95dnDMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eG9Ad4ZqtP+ud3nWrJ/Id3P9iQGA7our5i9VvfuqOHpSJOzNwJldplrtxhzqaUp0njmw6G2MVUHYqIQp1CdyBJwKI/VaiSzsAigTId0q8u1BrdiEvnnwZ+QNt27ImYhFEdSZ7U2yPNpXDH2O7s/8RBHbCAdsIOLzZxUDsSijaEY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFOpEhDXHQlQQrLrKC8kisavjQl/HY83X+ABj8ViPD97D/f4ljkAT2t/ayfDFSd6DAIxAJIulYV8llPSx/CHKRtjFehKoXDB6rGACAlPhCR4ugd60Lfazc3eyD5l/N6lLfiwHQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NPN7qjNnc+0mljKwTAQ1h3WRGTRL8AjjMkgWO4IQ4WDWHxRHFJlqK5+VuCVS5oq187os27WjDdxFHYAyuenzKA0IcXcvomHN7lWw6rtTJH5zU/A5vxt4PaYPfb/nRka5hT0t62TsCAkD5mLtPfsSR7PsIvNNzzynXK1Jy/tnHzM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> .
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le> {
+    event:c6ldwevakufr94hrcn97
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:qi81r6ggzy26wznv94dq ;
+            msg:hasReceivedTimestamp  1513171230809 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-v1le>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig> , <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:c6ldwevakufr94hrcn97 .
+    
+    <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8hJnbfiu4bd4ahyykFzDFaJbAJFuHhaU28V62PnTFWgU/+XkupuU9QRcXQ6xpgeAIxALLgmxezekB1EZ6IKblpQhBek/XMGHu/f0xePNoFujsQ8kHs0jtDngXN/9hG1aTu0Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MDOlDmMYJEQQjXNfyUr1vswV1FajVFgBSDGq5LzjRQyzfajr44IbNGiNiPWuDcFTUTKcD9l5Eg76on3viBxwdYroIj13RXj5UmTUvxuPQ8LiVdeShj5byJwmCqVKIaG1znwssf/GLUYQHUmnOZA8GiFjO0RRyL+qaXzWvtfOr2A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qi81r6ggzy26wznv94dq#envelope-tn1q> .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDvhbVMOQ1Ig1IxHqTfkirWvWfxGrW/jnwZzGxJwe9OGv3PUYP0DHgx4ANR1qXIoIcCMDZI0yGgOf86hAxxc5W2su8Iq6vRzzjoW7qO2tmyWn3Alkw8SrbBVKn5oKmZCfvCdA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DMi+xYFaYErTz935OwLrUqPLJfRmggVmjbn6qn6s/alM/Vv00T5p6CiLRhkkFsoiU0IvigIVdu4BWMkQhET7zP6h1yKF5Ojf66KMHEfPVNfyxnCFaTLP8D2vtkhnNAWRzRiFTQQrjA5oqhcZZxqTK53/WmIPZhkOt0UKoFMKHs4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> .
+}
+
+<https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb> {
+    event:4rit8itn4uyigyesq90s
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:152dum7y56zn95qyernf ;
+            msg:hasSentTimestamp  1513170830072 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-vdpb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4rit8itn4uyigyesq90s .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg> {
+    event:zquh20fy530jymcv4c7v
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:t6d7eq3cq6nq54a16k1w ;
+            msg:hasSentTimestamp  1513170854605 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDMnXh22VWVmnnVIoTUyjck5dqvsNA+9f6VoNEi/j+8J7e60yaqRF1fWiqfYwXSOmAIxAKRqe4HSGOrD/8oyLbDkJBQ780+8IBAIxbjKBTE+lhoE5hMmW7QMDiT3Kz3T8pubeQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IKwQuyFZImHdzNdGyrt8xi5i3pwHh6cTqTELvgo0BXcWQYaqZEBdgMZ912RhAla+09Fx+e8iF6IIT/bC/uDQHcbLemNZ/cJGtRFCibyYpanXgb9XEwj9EObfZx3S/6nVyIw/0/hVh0us3RNCVq46NZIXoh7FIxlDSL/BQMjW+Sg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> .
+    
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-updg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zquh20fy530jymcv4c7v .
+}
+
+<https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359> {
+    event:x7cjarywf0513459swe0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:nop2f4uemehxb73r1r6a ;
+            msg:hasSentTimestamp  1513170842138 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-6359>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:x7cjarywf0513459swe0 .
+    
+    <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1dkP6QxvRbFd224Zs401MsgKEuqFhnjZg/cHKrrRVTZKhixndjYwDKwALxw1kjSYCMA7d4w+OTo4OWRN/NZuSoUvroCEy1RgaxPwAUlz68h5ioDWfSVqfwgmYDSjemE2DTg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8COi16QVJOquHwG8fB98tBXmw6Rv+Ay12kBqSUs0loMVQrx/c0fcpcPjjyb/QbA6Z4HyMuHB+hNgfuf4pfwZMx8QkSjIcGftqWrRoCF4vRAo5zfj/TQNT/2jDWHjsPgcxQjGH2tuaY9ZiPh0IhQZktFF4wKFckhJ2EQ9wkxYeE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nop2f4uemehxb73r1r6a#envelope-f3qm> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1> {
+    event:mmdq8395owv3xy9iyl5q
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5r6qvd7rennbi148vunk ;
+            msg:hasReceivedTimestamp  1513171118942 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-ylc1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig> , <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mmdq8395owv3xy9iyl5q .
+    
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzFIl4PjdbXYSlD31IrBKQKz6oX5EX0e6NSETXe+NH5SeMZr9HxAfsNPsPf+7BA/ECMQCwUYpJh+5P8VhXoSOuiyFbYUCFS1k8R6gbXVQYvqRTSbG3wWzUVdepkvDGu27og1g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PRF6LjrxSZDoat13nv6Y7NFRoD6H/jvtlfiSrc58fq7CLn3f0MtjH2JtCG6vSGzcXHvJYkvMJKN2LZdHsekkAexWhjmpS+g5Uk5C5r+zWEUbHugv9+EGHlEganamOeo0qgiRTQMFDQS/Qt461zboPint8stjXSQLtlvRnWWMfIY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDp62BWtRF/XSfdNCtz/PUIjVyoE9wOGyFbzZBQHobaEEb9OHPIvK06t0k2VJk5vh4CMAX2Sv0jNjas+T6XhLh18XyxebDaHb9/sd6TSbnGeYWdFyNEkDg5PGjr9Iz7AC6Zfg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PdM/2GWODjO8m3QMMwOaA4zHv7sqjJSoJ77jQSIKHwC6fEpoaHt87Xv4j7VthUb3CNFqGzJ5YGD6RarrFaj6kmzUSwpt//Tig56DxCGYSrXIYQhMQ0/PaC07PKBgO1sg5DNnWKDpn3Di/VHoX0zBmM4vz0il40T5IaLOsEqSIRM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> .
+}
+
+<https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk> {
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+    
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+    
+    <https://localhost:8443/won/resource/event/up8o74u1kna29g9phj23#envelope-eibk>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> , <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:up8o74u1kna29g9phj23 .
+    
+    event:up8o74u1kna29g9phj23
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:dhdnzy40wlrnxh7ymr2b ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:j0oj37oa9ry8lzmm26ul , event:obimbxem9rgy4jw669vf ;
+            msg:hasReceivedTimestamp     1513170820361 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:m4nq3rl0m1br8bea2n72 ;
+            msg:isResponseTo             event:j0oj37oa9ry8lzmm26ul ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3> {
+    event:f3u4lc7l1czvps18lemf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:h6c8epmrvb3gxqrvs81d ;
+            msg:hasReceivedTimestamp     1513173166250 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:h6c8epmrvb3gxqrvs81d ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHp4C1RSljSdiBfO3R9tVa2DRTO4RFk2KD5aF8nkhTT7KSoeuninMa2C0WD8ArVIHQIwb6UF6IeN8nQ1qC975VwyQfWp2Z1Cc4gUItiUQBSBUE0iQzirEkyqD+NCgFva0rZT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "P6eJk6beaxNH3kOGRXPclyFphiVukXZGuX45FObU0sfebZ6p+taTjF6vK0KtAfIp+B8hb15oM7hk78riSTzwNiAlsW5q7MUuQ2RVx1BvtOhNOqrd1oZH5pUqAusFnn+teJ59doCIfZMwXyVTClNmUTGZX2vf20DtdNugr40juyM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> .
+    
+    <https://localhost:8443/won/resource/event/f3u4lc7l1czvps18lemf#envelope-jhz3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:f3u4lc7l1czvps18lemf .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> {
+    event:gv6zk2yqk6o8bl574n36
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:l27gk9ia5beeuyjqfp7j ;
+            msg:hasPreviousMessage    event:wlv9kjrh93gfzetdojp4 ;
+            msg:hasReceivedTimestamp  1513170798255 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> , <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gv6zk2yqk6o8bl574n36 .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFokQYOMW3QfdcccXmewxBg2SmvU7gDVqSb4qrv8GA/lM14jXn7yr4Xg23P/vMJ9nAIxAIIM8YLDsgQ+DcgCWGsaOBM15XQmKHX5sHvIolCzj4YjjAcQ7zdHzZ+SBEiquVwV1g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "FiWB68RkVnW++oJwqvTYH8SgokQs+LFiR69MfVtquD/1F/xVLKxfEDK415cBAqf4Gi2aMvEc3SKzM5PfBlpsFptWIyHFQudBSxD5gKaM0hB17KOjhmkfDhNiWHdN0Yw5AF2A1X9qEbBuvv1y6yFtZcO+7TbJ2k5LaT21T9SwW10=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> .
+}
+
+<https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig> {
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXRJYG0ftvSXFMxiOr69/P66KnIv+WcuIt+DWtD7xW7TuTSxe6JGnReuZLuQlmURICMQC1SEOZ00JWARGgxDU6QV5S6iAClzKI4yITVECbU0VTy4PsCkDKx1oxeyehxuoV4dQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VoOyZrxwoqwhIjWwhAx0R885hWG7pYIgPfgtywGWQmN7Fom2vfScNTWH+VnPpaFE+qrQVPHlP6/6ggNyLhsO0WiquMFWqhEebzgo0dOBZyIdGSjPgtFYudNUanngr3rEnZDVBgBh89aM4whZ8QZ9X9xj4HzU9ResMzH9NnwF43U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> .
+}
+
+<https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg> {
+    event:j0oj37oa9ry8lzmm26ul
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasSentTimestamp  1513170819786 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-72mg>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:j0oj37oa9ry8lzmm26ul .
+}
+
+<https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i> {
+    event:sdt7yr7q7t9iw8wcuu3m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:h2lo8jybm27ouaa4wuqs ;
+            msg:hasReceivedTimestamp  1513170797829 ;
+            msg:hasReceiver           conn:lhrkbkodc0y4rmc7z51y ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-907i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> , <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:sdt7yr7q7t9iw8wcuu3m .
+    
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+    
+    <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMQD985B/e7+8s0S0DsTSmbZJ/CRvTQeArp4jDasIR6UaqnPW1nFAutVAoOo73+mMATICL2aCglPgWcgDH9CcDmw5QhiKcNYWpmTamZ/pXuIngTi1ao29XBfGLIK9sJWxppiN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "T9pYKrAhEd6XyRFR4jaK0E96GEiZGfDYs1XL99FDiWK8622vYjviLUoB/A/k35D97tkaGToid0K6jHFxr8ysKDaw/97ibjv2P4lVX21tLmlQuovxqdb8R4Iiuw8R7KC/Mjutr8PS3xNYPyZYRhYbH2hoKKBLWlabbCHX8+IeU54=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/sdt7yr7q7t9iw8wcuu3m#envelope-cpdg> .
+}
+
+<https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> {
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> {
+    event:eczqg8lp7xbukpzikd41
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:8950tg6pjze6lr52pq3y ;
+            msg:hasPreviousMessage    event:9uyongxoip0kz7t9tsa8 ;
+            msg:hasReceivedTimestamp  1513170818537 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eczqg8lp7xbukpzikd41 .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5jl7uZw9ydMiunpmr4V6hPpZIE3ITtsFx958idfjajz8G+XW4MCYKOXez6fRG2+MCMQCI5D0NqeZIPT0a7aBZ2uqdGiv7WZ9Di+i6I7/OOErO7VsY0hPUSO8JxHKXwxZTSM0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "MnW1zKO26p9UC5w2C+/gI65yqrKlUipUyVaGrI1+iV7m4chqma5tTT3cWCwSbbUXv4pwvZdHVKc+nQ7E01xTrTMJgYP+syJLOwUDOaNq5m3HgrYnto1TixrsCqMNDLZux7cFojSVOvWmqK1JXuzX2SGujQazKWj4/6dzeuNFRf0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzbAQ2BL1n33UuO7acDwtFqTGsERVzhBEJriPEwtuhkshf62BZu4THik6AGkMwt+UCMQD7Fnp2eC7FsmVeYqiePiv14x2xce/zZgRysTL6F94hmkLshiV6Ffe343JXMjcARXw=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AKJs0LL+AXlGVVL+88ZeKmY2UEgj/ztv+GhedA1qhrXkzIN7Ev8xt8ir22bBY86sctFCiiRjuO5Xlx2syxyIN9ExrxpuBMOBourDabW8wg1kiwYvmAGMiIBo0trlai6HY7XI5DulyrHIQVp5FikbcQvzW2bM8esu7aGBsYGPziUO" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-i98i> .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> {
+    event:h6c8epmrvb3gxqrvs81d
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513173166148 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h6c8epmrvb3gxqrvs81d .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBPLWbiBlL3DHML6S4bOqD97AS7FvqQT8KCVSN3aRj7QML9LgaohStEHXJM1EPCzmwIwb3sTsIIPAGc9hsBaOEtWpUiDN0SJ5fsADQtgwMHezPgIvSE7vCkpDqSaKHZ+42Oj" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NDEWSk8nJzdGCc/U4AuEr61ph7SIFQCMpTQW8LCNsZtKWmdno43bbN+I1nh7A9Wtx68qlpiJhzhrYUSit3rYtg==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#data> {
+    event:1107469913331435500
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/1107469913331435500#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170817192" .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1107469913331435500 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDvWZ9GrBCYmRLDPcf3Zy9ctWbfMLlqB7joijR++XeOKbeJeMOEaaDK8QRltm/0cKgIxALi0Ot4jzL6K+oIPc7qb3SwWcoYPG46sebFqG4MONu5RJMs70g/wIn3SmCun+ERSsw==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCBOuadhn1OsP77rGImWi7xBXcZ4HQgEFNRbBN5T9vCNY5F6dqL970JrEfp+YjgfadY58LtZYn48eT7blzDJZhF" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#content> .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> {
+    event:gv6zk2yqk6o8bl574n36
+            won:hasTextMessage  "Greetings! \nI am the DebugBot. I can simulate multiple other users so you can test things. I understand a few commands. \nTo see which ones, type \n\n'usage'\n\n (without the quotes)." .
+}
+
+<https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4> {
+    event:9uyongxoip0kz7t9tsa8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:cbcccoqqqbec6bxkl3y3 , event:orj8iruy8pcer6zzxlra ;
+            msg:hasReceivedTimestamp  1513170818418 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-hbb4>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd-sig> , <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9uyongxoip0kz7t9tsa8 .
+    
+    <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCeMxqqHKx+Ml7JIz7mKjWcedcLsozemK/bBVrl2p4lw/lgaecozWPNzKVC5yAtEuwCMBwRAUNbLLArWZAQ/EGF/LMIDcHmdOvhlILsKG/AZQpR2Tm+Kum3bp/gkEk/oE0Aig==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJDLony/RWbq7EfC6MKodZ8cGYQwM1AdR+11P3KpljObngoGYvOXteIJ12f1KEXLRlZY2hiixSDXJXzoBYJwLdQy+KjZhWkRv4NkeDNW7cf5ZopLu7EJqNp2BvJEz6qIybWe13J4emEgy+G2NKN5jpZYPW29MivOEx45YM4/WXge" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9uyongxoip0kz7t9tsa8#envelope-n7rd> .
+    
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> {
+    event:nepohymog91pfkznq0ry
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eubp8u958hoow90rt9dz ;
+            msg:hasReceivedTimestamp  1513172281087 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig> , <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nepohymog91pfkznq0ry .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBy9LDe4v3QpM+qcxrIVJcJM+v8YXmWHhOdSe8pGn2xnjBoOBEAxJ8Ok/7AX2kv58QIwN/dg/aYd5hDfZiQ139gbY7i5qCYd9vVD0L9GMFTRQvi6CmUO59Gws7ag0sVki59f" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvONhdodKnvof2flAEqXkQGHAmXmp0lMRlWwHnGfk+mXgJR9E7ulLyl1/SCqCkqmNU5it0jhespD1x4llp03fLtAqQAYpWJSP/XYRxjAGdXbm6IBLN5ghUgoK/b4FXYt+7dOX1wB/Z5NqKSI2U3zhJxOmz203R7YA53rTfVSAC8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAFq603EC4EU6uFiucGDGC4Kz6z45W6jwEYPnVUG+cXO7fuitU4V1ZX/QMcjgf5tFwIwRnJo4nOWOGEYegI9Mn3SudCj+fgsni1oX/cK46lpX5wP7kEQLALOizV5jtjNF5jB" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CyXqkmnutKS5HJ2R5hP3CazGJR9hNdyWCUIubajcHbi3qb5Azp3856OhMjkCATsbzo3NteJFdc1PECjEADNIwnnH76f+O9zp4h1S6JBE8ze+bTac3dpy/J2U539/YkG6DkuJ29Pc5dJCfY4vs8m94JEGDIxkHMY77w5TAuvJnYw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> .
+}
+
+<https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3> {
+    event:0uouhqi6aym8jad508kd
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172392390 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-bit3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0uouhqi6aym8jad508kd .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZp0fH74r41wO0vmvM2ND70yepMU8oz1snJq8eu2vldB397rPT7GllTNzemyQuyngIxAJgjMxQupDqsrA0/hOsAkHLl40/EmSjy/zfZSHNWFT1kpiOMpxzHD0fBnFRCIHgIlg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBPyB9ExNzcRs5FE3X1HURk7IrrTzAFrh4ONFbU+mwa6HvrBFW9yEr0og/m4+l2+uh+u2Qz6tvHZbr0NsYj94bV" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#content-6ot3> .
+}
+
+<https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> {
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+    
+    event:at9ld2d9yv5dmfmzbxjc
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6149800720990867000 ;
+            msg:hasReceivedTimestamp     1513170797721 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6149800720990867000 ;
+            msg:isResponseToMessageType  msg:ConnectMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:at9ld2d9yv5dmfmzbxjc .
+}
+
+<https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> {
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig> {
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8qI64moKP/D/+XBh+1XDqUAooItSmLoEk/xt7WEH9/zGnX76uGoG6TQ1gbEC2+nQIxAKZGQk3n6IvpdbH4DAugjamtOcgKDDQtGHOuaqhcNnMUtW/3z38CJr1jExlpT44cLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIIUS+7qXLkSoWnELV0FBeAUb8G6KYdsblySs1Z9IQKdQOiKkwbz786HZdTq0+bl3OG4qqXB54TWjT8wmjMkkXLJDkbgxNyZrY0pzVjkGs2VhBe3khTGq2JABzOhDDu5bFKnoYRrYaJPhbA9AMdSrcfYl2dGq6R+pIvRIdi8bKfe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> .
+}
+
+<https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+    
+    event:elqliyw383sgw1gbtxcf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4055709708568209400 ;
+            msg:hasReceivedTimestamp     1513170830692 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:4055709708568209400 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:elqliyw383sgw1gbtxcf .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> {
+    event:93e94yjsmx9l4lg8lu1b
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rd1ryd06xejacyss9qy5 ;
+            msg:hasSentTimestamp  1513170820601 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:93e94yjsmx9l4lg8lu1b .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> {
+    event:u02ulpncdj9l8ae8x2aq
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:9oa8ktxu7tqzll06rhw9 , event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasReceivedTimestamp  1513172264092 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> , <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig> , <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u02ulpncdj9l8ae8x2aq .
+    
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBuXv823DJnc0Gy/hyx37tadJtAcEMhnJZVt/pNvhd6zFqT0eF+nWMRtXyrWyUoSwgIwOtYJWYw585IWoWy63tL9+QqIQKthFe0mry2n5kdV73A5ytfDOX213DGz95WGGbPO" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKijqTKR104eXXLrK+ZKsQZU6H1W858mHLkxcm5YdXq0JGqty8hJ0rmy74/j+VUTaDbj5O84D8+hNPFQibObM6emitgNZSgHBBsBqYxdAaisjX8CjekBZxnOwrLMFYan9qVlDSKJdovOqGezO8d2w3jv4u9YeukUi64EYFCxR3/q" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGiDM+RMI0Wdo4q7L9YivAzmnQYWCzxFl9D00cu6uFQUjG1Xv4BJyYK7qkjSpa2CYgIwffRwmUquzxPpz0q/0KYtSmd7BrlNte/zUzWzGiawwAEM+wYf3G0FSvRq+8OeHvck" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FUok+M6VVb8rhkOuJAzjHphvnNEgKgUqV8SQIqJTGUPUVFByOmgFp0KVyfE+c8Aw7aLZcSX+JPLBBNqNQHI5nfjujOxmipWdWDh1HRgfxnSiGdVnVHiUAfulKuFDkfE//9sCHbL+ue7em+kEbKCJjYwOm5HhfxKfWfeK8ICTaL0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-eo99> .
+}
+
+<https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88> {
+    event:9oa8ktxu7tqzll06rhw9
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasReceivedTimestamp     1513172263229 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:d3jq9fgiu47gdhclj7h0 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/9oa8ktxu7tqzll06rhw9#envelope-vy88>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9oa8ktxu7tqzll06rhw9 .
+}
+
+<https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69> {
+    event:1d5xlvosu9j6umgi8r47
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:alif190jj9we7toczas8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:4rit8itn4uyigyesq90s ;
+            msg:hasReceivedTimestamp     1513170830202 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:152dum7y56zn95qyernf ;
+            msg:isResponseTo             event:4rit8itn4uyigyesq90s ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/1d5xlvosu9j6umgi8r47#envelope-nd69>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:1d5xlvosu9j6umgi8r47 .
+    
+    <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFpDF1mYWD8hsoHDb5v8FiRwj0S8R84+myfMvroW9NG7WZP3J4Uq8Oo7ztiE2ETW6AIwaZU+/I2JMbidZbneEo0kjTxb2sM3wCjiFdP7Jmv6FbtSFXw4KokasNsW4cpFLCEw" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EyqBQx0oUFQxEvOyh8QjiXjwS4TM3FVB45C5vTBNlJHUI+fwdSV/pDYLjvsbRlq1VY5n0z9HhUKjVo2y58VlzYTUQcu5vtLPHz8uGdwRlYCBUz4f4zez0SYMtRcco1EUCd4l1ZIdbA/TZ9/8mZV/1e0aGwrE34oqJrolb4U7CWY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4rit8itn4uyigyesq90s#envelope-e0zs> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig> {
+    <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFF7nVswC+C/CDHpgtMK9S/nJZB1SIkFahY9q0e4t30WW++BN96UCzE9vNtUvStw6QIwCK9UiNA8QXHuoHgl4nAQH+R/4MjsvBjSGvuWAahWD/NcsEojg44JRwrhYQ8Hp9XL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HDQDX2RpYG0zz95Kc/OgkQJ0/DnfVqRsKdpen/mtATuI/JcMa8mLtJUw6DAvTTueta821mTZIHyrbhywTWVRJ9jJk/ccuYGbTwYDbBtBYrBTj5jI5lnWpKrstjCyUGwgJXlbA00PQF6o4yIqsDXwCCA8ckflhxTh6C+E1+amYyk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#envelope-vkdg> .
+}
+
+<https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig> {
+    <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC5MQPvfy1x5k+OvV2xOi9t0g8RUlM/eyeY6jr7p9dyt5+cyP9Ldy+UEVquCMHWUOMCMB/gyfb4C8vyD2HAa/ZRs487vk/Dbh3quHgx8fDU21htaIFoyHU50Jgo8AQjgLd93w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Uexg5eLuuTMWEWLquFb48wGaVDbBK8b2hF03TV6zJeGaLub9f4QxuiOdLgHeOEymmsyD7SHAPTGZvjV6A7dYz9tnv1mlKr3l4Htno/iidmzucvXcNhjwyHG0Vold2yayG4K8u64VWf4CpxLlJ+GXI6UCg4a2HIT5S/PV5Zus1GE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/to3x48329wwbanylmar0#envelope-521g> .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig> {
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDaNCV6mOz1hMPBjIwgaK9m7SQ+X5CoMrWQver12d1LLJNDkqi+mxsIQoX7wMIOakICMQDiq2tU3CUAS1RR+Dnjw8SeBlrijUzmrFDligXf4F4e+c4GbEVqX7R+y6zvgnWacZg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FpgaMyJZj+TbzTw5Tzx9QqtHZnB4MZT4JOrsmWnKMcWN7Klz9oEVxsE5LfnpelVKksjYeza5sMqX8hP4gjAJOaUXSmeoJFjh6D3n4DQdYt4wgaU7U5aq1PZ++P4zcjuyV5T89ZrnAi0A78vP1edPe3IkveABG0KfnbO9gqgUDTI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-wtkv> .
+}
+
+<https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37> {
+    event:lur3g5en41crth556538
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:mv0xoe06cxsxt08s7guf , event:cgqt5h004iql2003me2n ;
+            msg:hasReceivedTimestamp  1513170831170 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-vr37>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> , <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig> , <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:lur3g5en41crth556538 .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCXu+JCNySc3oh50OlxXAlsAhd2Spt8tI+7F+rZqKZjyKQJejXsFPNNjDwm8C0lG20CMGmv90AfghtrGZWJskhlMhhKDc92BeUg22NxyivMaJfqhHttOEK61XbGcV2KBqIhog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IjtO0ZaLQudoF6JL1+nY//2rbP+PCotIdSeL/rfJSYfAD1HS6zj50ceZ+j1ntDAcNk4CjMWpEp+ymwRIMP49CwrVheoxeAzzW3PqV9dUcSdzCdnaFwDp/+xwwLsStK8eK74GxUXOy6xsvxg0eeY/5qkqX4SBB3few+5ifwkZvso=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> .
+    
+    <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHO2bKj118CBgzgnHPqlUu6JXhyDNe2+bYKinVRk43vhQWSzfvUi94wCRKqF81UPcCMFjdG/ZmPj8mo2RG7r3atUcHiXg0qI8N/BRKxj/C/td73y3ZnrTcGxEfLfj55poOHA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VTrT6b/9XG4/gostK5/U5nmNWuvLxzirkwoDlu4QkGeC2kQwzpYjuii2hUAfcdG03yD0V+3v00jz5NPiiPpBymBKDrFQqSE5RKjC5pEvje7V7EEPqoSTjHs+dxMD2v9JDWHn/CWCNq3z/WPyFlDGrtt1N+leDA7/Vb8dz1bn2E4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/lur3g5en41crth556538#envelope-9o4q> .
+}
+
+<https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q> {
+    event:iasuj1z9fva0svkfqb79
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:1tr3o22co1907d6b6n7s ;
+            msg:hasReceivedTimestamp     1513170866299 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:1tr3o22co1907d6b6n7s ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/iasuj1z9fva0svkfqb79#envelope-ui1q>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:iasuj1z9fva0svkfqb79 .
+    
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> {
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+}
+
+<https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> {
+    event:k175l3od8wq1w0s2uy9e
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4xjx598ewu7579zpl64p ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:r5hu2rq515sq6wzgdjov , event:rjc2w35typgyljixk4qo ;
+            msg:hasReceivedTimestamp     1513170818539 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:m8b6jvgclclzy48p7wqd ;
+            msg:isResponseTo             event:r5hu2rq515sq6wzgdjov ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> , <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:k175l3od8wq1w0s2uy9e .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+    
+    <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDteYS/XMLsvPAb+ffY5JxqKS2at9nQmjpiR0iWRsb7k3lX8Tj/Y5VJEh0OC2MsB6cCMDnSTKZEcOL8MLQybEX2jcMTrdUzja1DHeRjxaKoafw8MHVUA4hqYXFRYTN9chGjbw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "HYC4z8LDcwIwop/SwQxjmnN4jk10wnqwcg7u5Yo9tBlEjAn3vyrqJFRUaSfn5v1rRG7rlbSOw87jKZiHhcta05PN2VTiZX/Und9Yu5bQmM0kdFHurq7dmEX2goSxeyL20xK3tVF0yz1IhaC6pFx1HYTHQYadtqhAyUZ92ejkC/w=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rjc2w35typgyljixk4qo#envelope-cxb6> .
+}
+
+<https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> {
+    event:n5rqfwjqbcpdwqjjwpdw
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:d5whye2xxe5kofpdojs8 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:2sbarcz1yu7cenpcghay ;
+            msg:hasReceivedTimestamp     1513170841799 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8863100035920837000 ;
+            msg:isResponseTo             event:2sbarcz1yu7cenpcghay ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:n5rqfwjqbcpdwqjjwpdw .
+    
+    <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDyuk9Ys52EN24nuADsy+4rk5T0oN6jW+wRdNl+DhzrG7aRXyTlbYmzjb+ABB4az7sCMHQpDt/f/Fy9SD14VPHBx08Rah7ymbdvTAjKK8Wk1ZVbleFdp13bLSB8eWDpTSANYg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIqS1qpEjSNioyIptjfNOCVqKRPY2BVaNIa2xWM5eRKUUj1Y+7628nghA67v9zAglRSejaaUhTIZgYx4+qR934t+hsalPzGoOIkH3pmQpHZIVAYE3/w9gKnB8jRosVJ9RDbSy+X73MsuwTTpHr7b2iBPXOjaEmSAqNag/8aVupZc" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2sbarcz1yu7cenpcghay#envelope-u42l> .
+}
+
+<https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig> {
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDmUzvYHlnqFhsNhN9yyn+ACcibzuWF90B2IB0Ss3l1lMclmKqZG/mPbYAQhdjq6GwCMEJMC0sdfXllbc11OzyV04BR7bJRGjQdhIDZnqFlBvgd6CQvtxqn2cpoKqjUfbR1nQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Y3/E/xdFsD4nOnjRLgSS9fOotoomwZe1+AhyQKOhq0TLsgci00CR6apNZwVKH4Y//Q/7SUUxLwEnEQj0QTNo7VIFwtqh1xpUlXRycTLgWXttqIYwoGZmqFq9cfI8BQDQrWcqinZ9dE/bqW1chLYBxfOQIR4TYpzfhxpamfa9rUU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl> {
+    event:zpvc6zv244tfxddbhi6a
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5151909952739158000 , event:htpqlj3ablwc32xmfh9r ;
+            msg:hasReceivedTimestamp  1513173166031 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-pppl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig> , <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0-sig> , <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zpvc6zv244tfxddbhi6a .
+    
+    <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME13EwWl+3unTJ4OvDSR4tdJvf3ApYwf+bkYMhgB0uT3vlii+wc0ryUcWx1OnNI85QIwW76YwTCXbGMLpzjZqko5zswG4YXxNg9Js7qRJO2iUFgYJZVyLeQVeLRgYySdEC3Q" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "flusXaqyQbNDFTPPYD6uspuQqa1LZFSGLK2dnAWz/JJD8pvhLCPSYAYoi2y+Un/YeSRz6sNIjbvn7u4A4wcW7yF9Po0QZty/xzX803jGoXS9kkiQ6SPOe9IVj5yAeld5b5+OfHREyDSSA0+dCMv8ObQt48rnGTN7Zu6cQQZ+5Ek=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/htpqlj3ablwc32xmfh9r#envelope-d8ck> .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDU4+jevCEOWc8voQQ8h2nV/Pn4KEDIkNnZIM51tllzHQpijS2qVgqJlxDFiSK8MkACMQCQ6xjJVlvjJ8AmR2OkCOw+yaTrBm5GoVS4ED/UHj6Ccmnv5W7w4RxAa0B+M7NJu3I=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "btzcc4RL5rZYlyeqR+V8TVf20+JX/WBLhUvUz0vdl/rvGZvwbIcvFmN3br9I4KtBNo+I6sIxpoFhNRp9ylrPV5KUdqUkis8itS1a8Yr5+YauN5I2Vz2j+olOko6NiDJ11sCwJtrOxTfdboewzpALPIJHuB3xPw4su1M9fWTbGtE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> .
+    
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> , <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:r5hu2rq515sq6wzgdjov .
+    
+    event:r5hu2rq515sq6wzgdjov
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:yrizizmtaxehctdi1m1n ;
+            msg:hasReceivedTimestamp  1513170818340 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFotN5JxE4mPq2QPE5Bf34Y5hpxBkL2HfQtpbb/6UOuZBq/TaxwypQmgty4hmuMa/wIwLuMmn5gohro68KafelelWss14HmLLnZS7tfzN7+isAjYdfH0darmX8KGiiDM5CeA" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "YONfOPQ/b4aX1DZZ8n2QxL+c8n5BhtwOfqUTi0/N2+yfTgc5tUKOrF0K0/hY9w1wZn3AnAajGRiJOKzOoqFYdZw9fFH8D/VR9Mq0gJMD7ZxbvEKtXX/jjuINXPIMVpXZJtUd/BxZUp+UqC68NxevmjV8saNdMV+JuCl3D8kf3WU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> .
+}
+
+<https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> {
+    event:pi2jpw9a1q00d11kr9ez
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:eczqg8lp7xbukpzikd41 , event:273p25fz6re5tp6drfsd ;
+            msg:hasReceivedTimestamp  1513170819939 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig> , <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> , <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pi2jpw9a1q00d11kr9ez .
+    
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMA11jGjU5LwcuOW1pdtMWAUHBVeW8Mj6tYN1j0eRWA5MtkXVFdn//7awdr18/zt5bAIwVs6RikAKg8uct0inNm0R/Ryir3Z0yrXO+5nJdn9mLADtuXhG+Uf4saCgT3qlAPuz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYrzqWsP3oknOJwdB1xDEdIeammtUVGiyhQHxEiaQIgTVM7rxDJppG98oxPevBIcaCyMPS1CgnXGP5JhgN5HnSJRKveG2oWzkHlpB+te8i5nTWGWPO1XCJe9PSmOcOEz+JJg0hpS6W8pEwHmc+zlApVoXdK0IgKbonSIEwiXFjx" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCSdoT+ujH2W+HDFJApoyJAzYmi+ZJL+emt1Ry5l99/HHv0sI8FPwc7f4jkksTltLACMHfWEeJNwe05o3IX9/deGxQTzeALz/KUnNXr5r5RLnjvpPie0gZf3/5dhA8rfjGthg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKvqWhwTCfU3z2/KKn+RE1SKV4MdAHGCWm3LiZphtT649dkMwM90w/uqGWHh1KSClOZgtildtzk/1rQx1r9fgWpLi/99mznV0UJfGaQOv1xvrkDHiMYgjWeOlGNFkoBsxSLuqf7mK6eg65+t/82ch1rVdp/c8I/GeggLjSB6twqe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-xvip> .
+}
+
+<https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig> {
+    <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCzFIl4PjdbXYSlD31IrBKQKz6oX5EX0e6NSETXe+NH5SeMZr9HxAfsNPsPf+7BA/ECMQCwUYpJh+5P8VhXoSOuiyFbYUCFS1k8R6gbXVQYvqRTSbG3wWzUVdepkvDGu27og1g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PRF6LjrxSZDoat13nv6Y7NFRoD6H/jvtlfiSrc58fq7CLn3f0MtjH2JtCG6vSGzcXHvJYkvMJKN2LZdHsekkAexWhjmpS+g5Uk5C5r+zWEUbHugv9+EGHlEganamOeo0qgiRTQMFDQS/Qt461zboPint8stjXSQLtlvRnWWMfIY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5r6qvd7rennbi148vunk#envelope-il48> .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> {
+    event:ih9v6gyllshhvo5kxyv0
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6m7oi7hxwvoi2pmguo6d , event:0uouhqi6aym8jad508kd ;
+            msg:hasReceivedTimestamp  1513172392668 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD3ksE9fVD9HN8BvojwS6iW7puqIJ6/ajml9OvRPOz8ipbtRxpFtSWdKU6oL2kzVq0CMFzW6CyHSMWljfkQO8K2ZD7Sn+sjRmjFMarUu77Dg1y5EAlUaVJERZiE3cA+qf16sA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZGNMWbF4vHIietqLLdf2z1bCMFdwCZIXiV6vVHxZjyfTFJvfqyBemr81W/gA97uAab/oK9mGUvqAxi98RTvwP6kDgCRzK34m8BEArdoEMUlpkY92pi0icoSLv/nrxOB9WcSY7cpfBF35cPTzXYP1680n1FaQrUklC0DErUD02kY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz> .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0uouhqi6aym8jad508kd#envelope-7xqz-sig> , <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig> , <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ih9v6gyllshhvo5kxyv0 .
+    
+    <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCzVV6qy/HjxXrIWL9hs1+f/M/FPuSZtI4i+MhrYwE47CUSRkQMYbmynjgYkXxEUjAIxAIeZy9h1/tAtQ7q4pwo+/ZQaFhdTItJ9EmDiMboW+I6n9dvtA/R7rqIcBKsXQqPwtQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RVUfEg72U0ax0YXBiJKk/HV8qGYUOubZdp8FJoUajOkfgmO3tZz4Wo2axeQZFJ5Qh4/zebyAifBAM5VM3c7KxKJOAcwkNT8OHmCsSdQVyu0L47UFJ6i1EB2X6m1bZCCo/tNZ+wQEcvDcFkhcwwel2BDApSbeI7ugj79I84UDSdQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6m7oi7hxwvoi2pmguo6d#envelope-cmd0> .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCuXHsCdWa/QaVXxEhJBvtYqrihS18odQb8uSDMFY3jCI8WV+gNBJNNDbjbpFsP5g8CMQDgQLhoSISkx5xlw8fHi3Zml3/efYzoxPRiIxgw9OJFP+/LDtVdrSShrLJ5drutYp8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DqKjOpr50a/vT7PPguFuE+qW/PBgx7V0MKwt2FGLGh+r7nN9GLM1zNudnthkqXblz3GAAxqdnREZWeiZrfabwUKjRi3X31j81+d63JCA7LZcj0+g64u4U0Zfq36kWvRvdrNOe+kM5OEFwOjrYbb7IgqTpPCYn4nxnui3fbBtoms=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> {
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+}
+
+<https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig> {
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDz34ndLZblqDWzmN4IE0ahv/7VeImWvkBu6pk7SDkk5zLl2iQOE4Yu0aDvq4S31d4CMAIdswiC5QuD8U5s36cQF9nqg0nYrwluQc/eixpAu14IsDF8Pzq/DIDDxmQOISwoUw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UhIQ0cDKkvvxNoq5BNt40MGAuljOdnbBzrXJzaYTQ+OiSLfI7muzlgg1lDfKZrSWnXNKyXA9YK8giQNR8CLvAgyknhXX+G8GK7VkEBqFAtKPyg2QPE5QTledobFugn3+N4B8JIP7f7hKa0LWEQ67s3FvE/wdfgwQvbBylfMppL8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> .
+}
+
+<https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig> {
+    <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCG+VNiKA4S0uVRH8WlJIEmLexRHRX5PQ9nP4zNw2jvSXA7/5ZvMh9hSq1sOmQOBNwIxAIABDOVT3EbMjsXeqlyEgYFXl/iDmZWHyy4bSQMJj2JgvkKyAokZoxX64r4S9XcggQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ZOkmpJI43GASvxA65flR5o5niMxaPUld0mFv+RbcxJdwWbjr4VDEOGb5m+IXWCOlLJrvHlQAY9PI4jk61mbRodUI5GaJB8+I6NLw+vCYvvoaKZkijuzfgAVxvsQzo+zP7RYizptH4Y9GbtMfH/EVTPXUpEha1bo9aOZ/KUJjAG4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qyg9hv3nohv4ykv8ryev#envelope-nif3> .
+}
+
+<https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd> {
+    event:l27gk9ia5beeuyjqfp7j
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasSentTimestamp  1513170798286 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/l27gk9ia5beeuyjqfp7j#envelope-jlgd>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l27gk9ia5beeuyjqfp7j .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> {
+    event:5s66o8cqv4rxv74xfepg
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4846251213444807000 ;
+            msg:hasSentTimestamp  1513170829703 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5s66o8cqv4rxv74xfepg .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8> {
+    <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCLaBHK4/gAh7FYYaKwFJdJbiX1fZo9z/vNMYZlqxEeJlfvASR6urO7wbaGkAW0TEACMQC+7oYLoJhk27coLks7eDaJUQqKlAQMZoOMOJO7sY0VZOEbj33Up5go0X6L/8vNzPo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VlJLqsx2Uv1Gdf50pzdmvGd51soxvt7eccQXiYbH6T3fv0bw7A8XAYOCh1HbnDQHpCNzodoueAOR09bMu55Lj3uCiFBKc6IENhFTIlp/mTcfiV8NyvGkQVDlcqJS9hVhHHh9Kb0+fYv0zK8h3+4MQDrU1ez17jLZuQqIbi/vLH4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> .
+    
+    event:obhgk474mxybc4fobdub
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xu87g40eu8cx053lad08 ;
+            msg:hasSentTimestamp  1513172392286 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-siv8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xu87g40eu8cx053lad08#envelope-ew53-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obhgk474mxybc4fobdub .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig> {
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDfw6RjfKej9g1wFhJ8wBcji6sphRoMY1Mc7zwkwNF7ec9BD6NbTVIkCkD+5W+LYKgCMB4hU46IbbjtcY+IyF3kRzYUjGkQQ3bi0mW4Y2+IEdbcoeKch0a2Z6pgPcj6qAB1AQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJobL4DX8RH6eABJo63zGPi91YYRaFecb0c+lt57cx+KPiF4n4mm0yhNBxeHXVP8VTtGpG5wDFfKk76Dq0XuQSDBQNZO1FgwvlO90M3J3lL0wcpUHYbFV3JT43jJddImygDLIubBJATjggqhMJgGHOvKkPUrvVl2ydxvbLMaOhd4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-s6oo> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> {
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig> , <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fits98gjdl4ybaudq5oj .
+    
+    event:fits98gjdl4ybaudq5oj
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8ksy3mzfwa3n937tm3vc ;
+            msg:hasReceivedTimestamp  1513171153939 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCHuBl4tO52A/cRsD650rSlYaBC+ZLjSbLKeOzaUGI9T3zPQIKyTLaJeHYAXWnj7VAIxAKomPeIcHR1V7C3p/yn8/1gX1T0aLL/rdEqsrzG/WhWoREEshrsOL4CLF+PWdYLqjw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKdr2MpvDM3mISPrzUZV70qaFuJxDW9k7zFCqbWefZUy1wY14OAlAwnyHpWl4pK7a02jzZPo8EDVLE6Xz8ojdEOCKdruBiFpdla0y3dxUD3Npkh82jsQhX/Qu/XK9/wg6aAZm57DqW6DnviPknWZP+9pz8FOY9uD2cQe5i8LucA4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> .
+    
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDbZM6sVlcW32kDrUEe0VW4fzvUzT5jFZkFmefSxMIoRAr+UWBHyeqdEwyxI9BphTECMQCnMwL1kWfHr66liiutcer0axqoDHQXCPV0DbO1K2UrOLUxLXm7OpEiutCi7rWJYSM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "QSM0k2Wd44jsvKVlw1YCfV5HqCaLiFv/+z3Qa+HdN+nkZIy1A1M55hWq6MGuPX/UwUyYjhApG3n/jajsjcBSgBqaxtVmDBeZbbai1cwacrVaCAMqwMfhGu5Cde+dQURgOcsuz5Ltyus3Z8lTWEoaXKHzxVZGxjAaMkBX4o6WvX8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-wu3h> .
+}
+
+<https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> {
+    event:s9zfgm2iika5vgvayt7h
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:pha7cg4ilx4j23f8xo0l ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6fvg967tlh9rho8axvbs ;
+            msg:hasReceivedTimestamp     1513170861144 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:238289506881087500 ;
+            msg:isResponseTo             event:6fvg967tlh9rho8axvbs ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvJUwX5io7kRVCpCg0ACH7aHcLJaDpV6xgWnuM8L/J9HJ4L1G0zcb2cOPThKHdjaECMDGsIUf/dAuTnYgKxDJXunm5OaPW/RxtK/UkoeR9LjdH1NZx29k0dK3FX1ucOxQhSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VqBi30b6cD/Tkabv3jR/WYmM2nv0zuxQtPaNP9kPQok1RA3zkXsvsV5jyylmK4h+r+oTW6uDitde/XJy5+lQQZe0AxB8FNXRiR3szQLsg3GnwCM/G3cGQPAgq4bd60+c0/0nztI789MoS72tSiCL9/suHukcvjwyuujrGP54BHU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9zfgm2iika5vgvayt7h .
+}
+
+<https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> {
+    event:4y6xcnpgc0xk4relqfox
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:joo1uifc1fc2k6fk5z8t , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp     1513170819785 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:m4nq3rl0m1br8bea2n72 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCZ9Mu9e3c3q0zVLHnTFS+4h+xQ9q4QDfDeu1sdAxAWl1NNNdQ9KisDKBtmXYiivLoCMQCyE15ceoMvLAWACEeQHL5IATn12jdRR1NMBGUx8ilvEnCJbHckFRU9BeRHxPnHobM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fdzV80NOcs/SSJHtD8oi8qgp4L3ZQCIehVau8zZwy4E0FPwJc158UWDXK9kNTIwzgaAgPUsgDgOTUW5rBYnlpHU6BRzy/3AWKJHElR/niJdH7VxQuB5jwES7c/F6BdfcCfyc+GH/RkP/qvRQA7bB3t00YUX4T+VnU5UsRyJtMAQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr-sig> , <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4y6xcnpgc0xk4relqfox .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> {
+    event:s9a226k3n70ihhaurhdp
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:nepohymog91pfkznq0ry ;
+            msg:hasPreviousMessage    event:cqvzpvoqvtkylzdybhej ;
+            msg:hasReceivedTimestamp  1513172280980 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> , <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:s9a226k3n70ihhaurhdp .
+    
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDhVjFPfjP1km9KBjY38135O3pJexoUjhco9kXhd7j+wqRIfKIOf9mybc+W7EKhJdECMH7q9BGKHmlvxNln5/FAB1aLl6wYFdk/GCfKlFMx5JnvZeB6f/wIYfeV90CuBsHOdw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AJ+Ozvenfm0egS/moNWMp/PVS5IsNX/BrVql5Z251EgtoGxX7K5d96soRNO55JgSS0UIgCQvgNt1i3yDkLcobIViCSZUye1Q7kQ3l1Rx9PmUsJxz+FVD2XnKiKw06ndCXh9E2m5ypOu1FdHaZNNsXhWgUBdo1nFu2oVwVOr4dh16" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-lh6r> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> {
+    event:d3jq9fgiu47gdhclj7h0
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513172263114 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d3jq9fgiu47gdhclj7h0 .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFE7f+uvuuoRHvEsbHQUjJkzQaHH77SaXWCQQiR2KbGaRqQqifMGRGVaJZLquNrovAIxAKSlku367h1DB3ANA5Pbmx3mbrUoqYz4LfxzgOtzxG0dWPKZc7SDSGxGEYe+3VCe4A==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCUNJaixYwyrmDN3xT6gpMsU3LQUlAbM0uAOoPGLHbw9Sb49ikYyd2CiRaj+qF6Fu+4zbTq5Csn6TowAkxZztrj" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> .
+}
+
+<https://localhost:8443/won/resource/event/6149800720990867000#content> {
+    event:6149800720990867000
+            won:hasFacet        won:OwnerFacet ;
+            won:hasRemoteFacet  won:OwnerFacet ;
+            won:hasTextMessage  "Hello, debugbot!" .
+}
+
+<https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#content-e1n7> {
+    event:m4nq3rl0m1br8bea2n72
+            won:hasTextMessage  "    'validate':    download the connection data and validate it" .
+}
+
+<https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig> {
+    <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAyOw+ekYDcfg4r0O8Z5sWEfgQ+qSw579eBWtO4R6t9gbr/GTBpbJN9N8SJyn0S1oQIwbmbEyAzsKZ2ID47+MjsuxUITfz8OBD0OFSgH4gTHc7CStJY3C0Xxi2r/BcRYx7aG" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Tz6sLpAjgMJqp+zCSpmaUFuG8DFhIz1l3XRkYD7h/mrplkQJVevyOVvQZrQQIPcj2BXtYuHERurq2kSKBmtVfMtp5wEigCp1Pzj9ZP36kk0Q0xVhTayUTQ6uMHfC3Xkg8svYl1EfUga/3X8Cf1H8Xs07qFW0WqBHGRCAPeHdkjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vuhyvj1n1x01t4jeddkq#envelope-pk6y> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> {
+    event:8mr0p8ua2srgw0zw69lc
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:obhgk474mxybc4fobdub ;
+            msg:hasReceivedTimestamp  1513172392573 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig> , <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8mr0p8ua2srgw0zw69lc .
+    
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDofotudXy7gQL7BNCKdKwmSS5KI+QX61jqaEpMqQMGgk627/jEY6G/G6yGAw8/GYMCMB6S2X1Nmdudwux1SM2YgwY9ZG53NW3Uao83fNoz+bkEaJgJvUkTIYEzj1mJXqMvsQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkUlJaz0b1w22WpXI2eb/G+wDJA97AD9hHhlaeQuqBdgosuyj5xz08VrIJAFI1hflhCXb/2Bf01aiz96lgVU1ouXRY6LMCeNrleoqGSXsNlNFBSKbMU5Z70Fly61hDJ+/gNU4L9D52ge8ADvjyaFaW+RF+0AaFI6//pB76PloeX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> .
+    
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCATfMa5FjphJsfba/tJSZX8wTniY3JuBWSzdn3ZbLTiUgyTGbQCSqcE/Nrn8OUfCQCMGE7UsOVIAKElLNp7FLtVxdXXqFR50EzaYDWaQJpUYEGJ8QhDlHatv9lz+jeVOb+yg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dLjzUBcmwvJmTRjHU0jopMjA2uyc6zwzqNWPjOPh6bwoEM0CGBsLo/VDpCIx9SQ+9ucd0hYNy8kWEPiYJCAZLyXyzokBr45AVNDRtOKAE3iv9xvepctyG7EQaFP2jm54aJRJxkMMmI82JDsYKRhvu0CrXjkYQaGl2ajKXESxI/I=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-klso> .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> {
+    event:eue8ar55z7as596cu33m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:8c6o81ry6mxeetm2d2pf , event:pi2jpw9a1q00d11kr9ez ;
+            msg:hasReceivedTimestamp  1513170820219 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> , <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig> , <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eue8ar55z7as596cu33m .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCxiytXBuh5w3NE7kdsAUsVjzJGK+tF2KgU5+AEyO3DTzGigsBoen0nQUM1l/n09XQIxAOnJ3IidktXW2rZHoBql+fazmmhrqXnDffE9Us5ux/rL+izk9q94Z/T8BcUHiKSzmQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bm/4QvtUDDVrZLPsj72ecL/AEWekrp27ZkOyAwdYk8gvcmIXDSgFqqiLc1HuR8NQSEM1ZNP8xPFKSC2uWiOFiscTul+6HVBmISweVHKVWabTBFcp+7uMkhxBRM1E+djcfk8KJ3RAKYCQcNF2lpa+rrtKGR9uKwe/gmDFxZqe9gg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/pi2jpw9a1q00d11kr9ez#envelope-flqa> .
+    
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvtn4dj/B24YDX5L5WZhNiZ1xGafjJbe4ZKg8VKfoiMtK5T8Wtq8YD/6D06CibIF0CMH8aV5E8b1a0y1oqx12gUpQsuyzna50NYMvu2e33Dr3eoJCaANpfCSiEdpgz1hSTsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SonIgV9p9wtlgZYTYQcGl9CkM4DFLvSd2huqeWYHvRaTjf/6EMIM78oRRH04ORVK/fqK/VerTWBC3tPDKyxhxjHZfzlyj+FsPRL1tWs0LYyIkPSdEaSuRJ3LwdJYsytyLq0zJ3l0puWf4k4VgXOEsl1rKcTgFS7yB0uDlGooQIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-h4dx> .
+}
+
+<https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> {
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:l8d77tygvfnfycfu5201 .
+    
+    event:l8d77tygvfnfycfu5201
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:xp44teiwtooczc14npe2 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:nepohymog91pfkznq0ry ;
+            msg:hasReceivedTimestamp     1513172281105 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:s9a226k3n70ihhaurhdp ;
+            msg:isResponseTo             event:nepohymog91pfkznq0ry ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD15h8xYe/QPsx68/qkSp4qO2w6/1wPWhzTshQuowE2KXL/mTxwC2u59iXVbB54DoAIxAPawN3dIsZsiqABhitwR8LPf9RK2romuhxgMNkLtRS/fE8zIn1mdlHyxxBUg3d0Nsg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aFKX2oNxuURr5F6nG8hm90H2H4A9iXdKKkADgZuhbzRnblRpaQxXyhM1b7g5xFYqPXfw5RiaqdaY+tua0Dae2atRCx4oUKVvgwVCqa1J5DsIRQV+L48EO2cXCZiPV7eBvxWFpmG6vP3wtJoJFw1X5sBNc8McxW7Eaw9zmFGHPUs=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-nud6> .
+}
+
+<https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> {
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+}
+
+<https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1-sig> {
+    <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDcZnu4Ah+XglCwi+0reTqdOVei6RvJy4KoEAGAj88SMj2LYRgbBPCaYbxK3qm6kuICMQD1Xt/AQdt1SKM5sbPmc6GOxIJgBSfctClukYXp7rRB6Cl3wapKljH3uKrMR5bWAbc=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "JD6mXv4FFd53Gwev8+dWCcuVQUzOdLWvmisb1J1o7fZhsxC27WYduY491AdmcnB0cdq19Y8/nsM6cKDgeIABEKgyIxgyVWGuH7KKkfz4AWjVGxT50ImfhQ5vadP/r/rhtUYxlQEesYH/JWIODxB4zjv/wzfrhzj9OYD12vp/SQA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5cdkigzbdsxk44iw2kai#envelope-t5s1> .
+}
+
+<https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> {
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+}
+
+<https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig> {
+    <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDkAsWJNhJ4vgEXszJAYhawhUpCxKy6T0L6aej2zf1VNWfTY2UiUs6MiRkuSgXhaD8CMQCKSK4jrDUFeUU3clg3gOHiunLiSnyqhQIzrcczi61R3T3W/WokLNqfo0V6pm/6P8E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJm5X4PgCEbGpl0P+o4wU7nS7eyQaESRJUvMonGOhwiN/bwawK4q8BCV7nBgvddCs2XDsbp5jhXNZYf6Fe3giBH4THN4l1dFsadUUD0vEMzDm6dqZQ0tjYeafNADDL2473Yy565WPi2RDb9ZY0GEDP9HYndAcNox1QUtqoY3gSUO" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0esqgu17b6xqppmgbty7#envelope-n4vl> .
+}
+
+<https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig> {
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA4I2mYY9MxqVkhL7VnxgSOAg8JvOsBmH8KT2u3fHVkCzQYnCMElXWrtLDUzg5INdAIxAJCLEkR6Q23dLZwQgK3wBUeHkISwAlOAURLkDQSNo8YlnDTBzyIax637/ti4lxj88g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dy5XCmNEQdZT5t3oLfs48R0qrkleA2+3gLggoLL8FjsDhWBOnjHC6Rf8fVv7vKv6Lzpl8TGzazk+Ypj8+fwukAnH/MNa0lgBMpU0cJi1nFcPWJtCr5XmYfHn0WR99YbRKlyQ3PJ5++M0E9VcBVdMQEoLRNaBjOzE3+t9BBgzuT8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> .
+}
+
+<https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> {
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig> , <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:obimbxem9rgy4jw669vf .
+    
+    event:obimbxem9rgy4jw669vf
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:i1frxy9ikewwjuyjcznt ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:j0oj37oa9ry8lzmm26ul , event:4kx7gixf60v34gg65z8x ;
+            msg:hasReceivedTimestamp     1513170820250 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:tlyivx8nn93zw41ujn1o ;
+            msg:isResponseTo             event:4kx7gixf60v34gg65z8x ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQD1d+vgK2PWHqXG/OdaHa5LYEnI/M4oL5vKe54UP4OyXQRLJYEBjzwsV8fbHBKH09MCMDj+t0eyUCRwIEDsc1uQwYhmkX7fXCZ8YFb/YPqM53ax/ib0ArX3wmCO0y2AE1Xy4g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkP6gGoKU1byo8NOg1IAJTQen/dfcfDR9g5RrT1zktkf0BiNm9GIjzZlIN+2mSEU7bZMDaop8ePpCmzesz0+rIXHFAKF9uGgO39QOt6RjcS6Em1+VJCSoa7ic8px0h97wj+VHbkOzwWMI/2ChA2MtpBVspi9ytZ6wDs4kRtrSL0" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4kx7gixf60v34gg65z8x#envelope-yyow> .
+    
+    <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHS/nWjUYvfrJlFQHMqMJH6rqB89+QMb6QfdTWzb7P0Haz1+/kC3wAgTiSr/9ZOxMgIwEGJsCs17PgQbWwugac/baSD8Kb++Ga3VGzgpICcy5B8dCzs6B39BfbXUwKbwfba3" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K4dhMcqrITUHqTpohP4erNwGJfYmSxhVs55T7yvxDvQQEMTVEeQp+OPvekVW9opusUBFsuTK7MDJDLIsTQgwbqv7q8qfvfvQkLUFSBI8Br5OQlBJMw5QwodnKhu5Er4737+C2oQURqjGqASBFPIshF32OvbWP+Mg9iPE43Zbaj8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/j0oj37oa9ry8lzmm26ul#envelope-m93v> .
+}
+
+<https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy> {
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+    
+    <https://localhost:8443/won/resource/event/kv6651s4ochvsbafubzm#envelope-8zvy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:kv6651s4ochvsbafubzm .
+    
+    event:kv6651s4ochvsbafubzm
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5693603251585579000 ;
+            msg:hasReceivedTimestamp     1513172392139 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5693603251585579000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> {
+    event:fk1a2jb7ortt8q14tcrb
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5r6qvd7rennbi148vunk ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:f9zpvftok83vya1djrg9 ;
+            msg:hasReceivedTimestamp     1513170866368 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:1tr3o22co1907d6b6n7s ;
+            msg:isResponseTo             event:f9zpvftok83vya1djrg9 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fk1a2jb7ortt8q14tcrb .
+    
+    <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCfb9b4/o0eflVtkvJNb2cHEbjJzB+18MenHM3Ma0uzpry9yd4TOWN34UxvgGhCQQ0CMB8fJljugWsUoztFIsYOszwRP/QUOQKQpZNU7QU7V4r0Am1JgIs7vJV8DIWhR9/uaw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKb+p4XkNP1ACG5REa7tjbaPwbQ1b05ehepKt1DcGi7nM0Fp+SShOCPUqflEvTThmyZjZEB3g8jUK8ZCC17nVOPUG4BKxao+CfaDllZA0US3vl/QZt3G51YVA6KmiAE+DSG+26DWqO/qDV+gZlubodICXkNp18yEcIwBweT2r4Yy" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/f9zpvftok83vya1djrg9#envelope-u69z> .
+}
+
+<https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig> {
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhL7kBxvJoqFUG/n2cDN5cQTWIlMtrVoCoPaRxIrOZKKzikjUtlmeTz69tW6rLHrcCMQDUWszGUPxBe+QtahXtaohx26J2IyCYc3Wuisc4qd4bPY3R5mt3l6zghBCQ1n7AaFg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OP5Qzir4GiMtWLFgYEjQ2w2WZW7II57qSGm6NiaKOUpAII3r1ouEUoizjiaQ/M+Hl8iCYjhI3exsuWpZ33s4sNiU31u+7++kGs0uq1VWDxH0V2PI7mnvrs4lkT/aBu8maWbyBKrUqnfoYpu4+OCVsDj0wkCcnnRnMiU55OPCDeA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#content-yko1> {
+    event:tlyivx8nn93zw41ujn1o
+            won:hasTextMessage  "    'send N':      send N messages, one per second. N must be an integer between 1 and 9" .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+    
+    event:p6x8qvs5m46mxw4jb7z5
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4846251213444807000 , event:saegwhiwygztg1mpf4xh ;
+            msg:hasReceivedTimestamp  1513170829891 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> , <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig> , <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:p6x8qvs5m46mxw4jb7z5 .
+    
+    <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDBXqkcO99XGnV+YwaJ1ktvwST2X0u8mjorTyzgemi6jHvs8KfOg88N59La+eixSXgCMEiKSr4QwXjOrBopK6jL08VDbe/IkTMra3HxZMPcpFyUBszqTDKWpE8q12Xukpsung==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaqMTIy9jfUs2aJIvLranFeghQreF4PVVO+HmRC9x4KJPDjGwxNc53t2SHnx1TNgK5g7sLpYg8dSvF1wkmTRO5sltpYPMwriQZ++e9cHY5zxMqH3SYsA544nyIp4dIbOshMngRrgh//iAMoQ3SdiAgfWWdetYUzlPDB7jv9D67x" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/saegwhiwygztg1mpf4xh#envelope-oh63> .
+    
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC4TrUBe7yhKk81J0ZHVTyL2uK/oOAR+e5mz/atdTcA9a2diQyRnMbOAl0v7w5bubkCMQCYsYVBSbr4Ls9gqllIPJuXguklIm8aS8wLdjH6m1pq2vbHooeI79E8GtH/TKVtM94=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nj7I2g36BP67Wydg0TCtQXeDzEce4CnH4PYUWAxFXnjC1rmB8/p17Oy7fgDl8mpqieZGK2mhC3sovuqLTwZyoR5vzG7PHhWDsOzkV10es19ws0eSL7p9qio9/I5lo36Xs51vLjj595MnWo+lFpWknTKBgIXb15OsOdmVZHslFPI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-tqqp> .
+}
+
+<https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig> {
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQClAjshUZ0bRIsA4MLnSIeCSIKnyz3LQfuy064CYYIVc1BRB1KIj6ZwqA/F4jxKTekCMQDWMV47lfLGzthNmOR5L2664akDvrymeQXPXlI5PX6MqkafMCAG2+1twjt79ilGxrM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "a1I4RG56IZ0HyXJ5bAiCmKAvAKjJCD2n+BJYyOrexFekGlxTL5ve7W1LnOhHU4Bgs9CxM05U2Yyq+r4/QAyCbKQBIa/f5IPKwDIEqECaQnwZbXZy1gPp6ipOwB648yBVE1oMPAMz2j/4ht2yNZujCdOClZzuM7Ic/YxzmuMOa9Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> .
+}
+
+<https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k> {
+    event:i1frxy9ikewwjuyjcznt
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:obimbxem9rgy4jw669vf ;
+            msg:hasSentTimestamp  1513170820356 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i1frxy9ikewwjuyjcznt#envelope-3a8k>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i1frxy9ikewwjuyjcznt .
+    
+    <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDXx5qds6ZTCs58dr8mlBfQjbY09pfcE/esswqE3lgO+zOqazT4pVECTi9FMvHgB3gIxAK1yeJsHM3KRd9tsQjnrvshhOZDNrnclFf/FO0qXY+uzri9oYH4yEMQuQOlIzb9jsw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IASXX5P4rM+AFJClLXKf/za4R0956D0v41SLz4x+PHMLsLaih2E73RoBSqmOqtJIm5H83bWJkfoahr1DJhM3VLDBbQibRKRXlTXkIrq71j8PO84dstbB73TO2aid9/DYJi0i4kLfZQ7qgZbofcPJgzgHoVSzup3p+4QQty0jrOU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obimbxem9rgy4jw669vf#envelope-hqbl> .
+}
+
+<https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig> {
+    <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMA11jGjU5LwcuOW1pdtMWAUHBVeW8Mj6tYN1j0eRWA5MtkXVFdn//7awdr18/zt5bAIwVs6RikAKg8uct0inNm0R/Ryir3Z0yrXO+5nJdn9mLADtuXhG+Uf4saCgT3qlAPuz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJYrzqWsP3oknOJwdB1xDEdIeammtUVGiyhQHxEiaQIgTVM7rxDJppG98oxPevBIcaCyMPS1CgnXGP5JhgN5HnSJRKveG2oWzkHlpB+te8i5nTWGWPO1XCJe9PSmOcOEz+JJg0hpS6W8pEwHmc+zlApVoXdK0IgKbonSIEwiXFjx" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/273p25fz6re5tp6drfsd#envelope-vg7i> .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq> {
+    event:eia6yrvml8v995ueq65m
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:7kbdyf9ffr2q657gkgte ;
+            msg:hasSentTimestamp  1513170819041 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-wzrq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eia6yrvml8v995ueq65m .
+    
+    <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDv4lhG51UM2yMHFgQF9L3X1RcaMv1GWMa7xNvOMiSUozScaCIbWupcXjQMMST7+gMCMQDzKGJf/VZx8uazq+00g7l8UzQU5XI86/BR17TbnprixEngn9ElgBTq76cViSXFwgU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "WE9Zgf/s1hYkm+6SgKCqhWAGRgEzqzqiNphqoUcSpttoQ8c+V7wrctVqAMdfn0uTW5EJ4k/s2NsfzQIbeExjwqfOEpdZ02qsFIOpPbfUlaTuQDr912YpCc/lcKdexOH0pW5S7n8k5VtJc3ZKC9CCCUf2Ddv1InYS6KzFWFAiMyo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/7kbdyf9ffr2q657gkgte#envelope-3fej> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> {
+    event:u3op66771mcm3ibsrr31
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:5946672495584215000 ;
+            msg:hasReceivedTimestamp  1513170783148 ;
+            msg:hasReceiver           conn:b4vtw60q5p3ro3yfjybs ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth-sig> , <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:u3op66771mcm3ibsrr31 .
+    
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDYCgdlasSZIHsMLaov1YMvPZu+76MVfqzGEwkaV8f02BAPQEm1dd0SFrTqRLwgK1UCMQDaqBb9id6PsSflGcZjWdh02so5JJ8zozB36DQGreCxwpy05uVga2SN37Hj+2CXKDE=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Hvar/V/WJcYQrbWIqEXf5J5unb7/rBCQi+rPGyG3hebmf9+bPDexcSmrY4cBYuV1sG47W4LCKYO/UU/LYHai5BeKimCerepWpCsHpyUWscBphyXe+xSeWvnw6jqPobT9q6hu3KEFx1BBGvudTguQ6r3vTjeAWM77uhR9QpBUTAE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-kzth> .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+}
+
+<https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o-sig> {
+    <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDUs5usweForoenC6byhbFepj3D/iAJAYLhWF3xO2SW2IATNZWFqeOhbnvLokI7JekCMQD1JanKazkUE5gMmNbAB21GcEd2foNLXddJTccHzISK5W34ZMVU2zeVqaFjYoUXhvM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FS1OEAtteK4qAAa5KV3c5KGTdq1XVw963+nLGc5/UWUhWCkRmhG+fTSwT1Ia8G4nEu/NQFssNUYAB//Lwj6uonyeB+GAlR//CmZDJeWff2Uo7A4f+qNOcltmQhKFOlU1Q7gmwdxCHptOPEXo/Ucrs0sy7HSdrxER9mwpErSNzBI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/kaj9nimgw0lkcgmb1asf#envelope-ei1o> .
+}
+
+<https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig> {
+    <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDC+4nu9BC8IHVTrzaE7dPftFZQqziXbQsxSLMl9opMz9pzBqDUc7U/61dv7oRnoacCMQD/+vbj4G0V32zIb8elUOzFX1RKgSNT/KAaoxCl24MaJj/uaQtB2KHlEnUIH+LAwM8=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UvO3Mns1yXliZdv702yhaf75l6OPgFiUcbXMMZAntFgmNkKGFeL3DJb+i70ZOLt3f0COtaceXu3WKiYV2rkDnin6Mn2INUKVT/PvXXnVMFzbrz7eN9FXt3kLKj6Vgih5lE5YNpR+QQc0Evu13AR2/54isfIf6UfVIod4scEQn7A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u3op66771mcm3ibsrr31#envelope-jnqx> .
+}
+
+<https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8> {
+    event:bxwevm9gzqconmzxji4u
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:8c6o81ry6mxeetm2d2pf , event:4xjx598ewu7579zpl64p ;
+            msg:hasReceivedTimestamp     1513170819081 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:8c6o81ry6mxeetm2d2pf ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCf/fdInjdyz1iYLMe7IjMIj0I0s28J9dRIznTow4yPWLMDgAQ1RItVQcNyA4XaGI0CMC7uTiR0R4WG0FZUODUc53CuEZHZDjeN1MXGSVcKtQIcbuzgL/UrsCqoCgKXuwQO+g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aMOZu+pH38S59z1B3bJ6iKvqNphXrUttOzx1TLcbdyaPisvTFn6AlJucTPh25IxSnaHBgIxldTKGM2edcP5O9amOtJroF1HnYBcidn0lT4vMnaEenrP//S4/OATNXQwCktQYvjlwSFj7AmNLo3312oM5TrlVEnKcewtp40iggNQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> .
+    
+    <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQClFXhmfQ4BA6wmBwbDpBUFN2d3G/zp7/f6/C4btbFRnCcTFRPb8XB27X199pxc8uYCMEUw0ZMOqS2X3nU8Nt4G4JS/tcLmLYgKZlj6hyK0rOL6lMAMdBqsM+g4bZvAO6Mt9A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI7UUDWJlrZauuwCbAbzua1hp03MFSn3IBhX5Y1cFN+EeQo2a7F5gSCbFNozmdkSrtYjE1Zbp7UbeoxTE6seWjN6XbSZXmq4YZA6FyF1iOR+W3ajVutW3Eq80ej6AtRZ6g9fuWt9y7pl68mD9dz7LoFaQNeFVuKdqSQkSGK1gYQj" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px> .
+    
+    <https://localhost:8443/won/resource/event/bxwevm9gzqconmzxji4u#envelope-nyo8>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig> , <https://localhost:8443/won/resource/event/8c6o81ry6mxeetm2d2pf#envelope-g9px-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:bxwevm9gzqconmzxji4u .
+}
+
+<https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig> {
+    <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCtkFefE2I/jB6DpPOGarUrocUvk9wsq0eP5/sbYKnSul8I/fLoX9EI0nymhdwR20cCMQC0s09oW9Nxljq0VW/f+sHUjD7IXfa/8JCJ5WB67mzwikUUeXZyG2n1WUrefr/AN4U=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Acv3A8Qod4xRE79i9TlRvAjNBNXrmZAmLgOIsvygmGmm9CkqJXsrAQZc8Dk6u49OkoJy25Rnb5CuVPc+HlhNkdIqLJHcMAZp9FurP/NU/gazz4tmlDIhovAiCwqhs+st5D9s5QuvQrOZSVQLohPI9AHz67Cmp/oi/ndwSB2OZqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/p6x8qvs5m46mxw4jb7z5#envelope-bdbz> .
+}
+
+<https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5> {
+    event:guewg0q3l68ts1ud5u2h
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:u02ulpncdj9l8ae8x2aq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:0o2v37foaz8bog1diet9 ;
+            msg:hasReceivedTimestamp     1513172263980 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:d3jq9fgiu47gdhclj7h0 ;
+            msg:isResponseTo             event:0o2v37foaz8bog1diet9 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/guewg0q3l68ts1ud5u2h#envelope-i8j5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:guewg0q3l68ts1ud5u2h .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMDR1xb+ezOAzterooaxqminnZhxZ3ZjYwCSg4bL5EV7bHVizu3iTgKsm6iCa7mIdWAIwRkKyiq1Mk7tBAbc1TES1v8XaHFEk/p1VOEwOiskWC29sSUTOk30mMXlKkZYs36/W" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DxpG7VpU9zHMsUytfLtbLtoTkX4Rvo7gsi5pANfpiXNutiAr/7jlOeke3UaDHEZqYB4621NumM8IemdYjCbF/RjUtbPcv/rDKs252ShC3UA74bvbKFrsPiVd7klS+7csc5rEqd0pcPWXC878nNBIg8TGwdgf7d32Mikwj/jX2jk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-qnr5> .
+}
+
+<https://localhost:8443/won/resource/event/238289506881087500#content> {
+    event:238289506881087500
+            won:hasTextMessage  "validate" .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb> {
+    event:t6d7eq3cq6nq54a16k1w
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:zquh20fy530jymcv4c7v ;
+            msg:hasPreviousMessage    event:x7cjarywf0513459swe0 ;
+            msg:hasReceivedTimestamp  1513170854581 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCONDSxagGTZTEjj9rSbkkoWfOXNPIW1sdqd9aKJnl+KGcj25TmDij/2MvXgpWdPywIxAJlmcegDVi4tT+Jxu+jYm6gYvDfThqxQwUjZtT87sykFSr0NN1vsgbODrJAjiRGYIA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kcc/Wqu7WW8J6gi8yhPkceVRBLT4vc2FZfQFIAIFdUO11gbGBWMdmY+53c6IfNntSdSxEHLMsWCrz/GwB04LAt7dS53eMFM0B9RoQEgS5p418U4IMVlcsERYCvISlkBGNfO/bI+sVQ/aIqaAVI2Alc2eOeZBr3j6ist+vkCnsrw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann> .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-d3sb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/x7cjarywf0513459swe0#envelope-9ann-sig> , <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t6d7eq3cq6nq54a16k1w .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAtGq9Gy/I9eAgMSkqKWT8FA1B5cmN3W7XxRpiBS/Quwx4QIohYdUVy9CiBBgjUGkgIxAOUakCQa5nLvKqot8M4Y7Jpli3yYp8ZENbOhM2SLQ5i38M9+m/gcm7OBQ47ApEzUkg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NxdIu/DqqRvVtYUgYyqi1msDWkUJPjIWXs7w4K2tub33wXjYvS/SppMCpg6Y+gZOxFjqKYD2zmVZ6WItsXMrhJHoo0edRkt8CemDzwBSAcz2k4isunhy6FnvLLvADJy9nc6SPbC9Xo3Q1tzQXZfjVVXTdOcKh5oq6lEXJ3+v7bk=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> .
+}
+
+<https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig> {
+    <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCHuBl4tO52A/cRsD650rSlYaBC+ZLjSbLKeOzaUGI9T3zPQIKyTLaJeHYAXWnj7VAIxAKomPeIcHR1V7C3p/yn8/1gX1T0aLL/rdEqsrzG/WhWoREEshrsOL4CLF+PWdYLqjw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKdr2MpvDM3mISPrzUZV70qaFuJxDW9k7zFCqbWefZUy1wY14OAlAwnyHpWl4pK7a02jzZPo8EDVLE6Xz8ojdEOCKdruBiFpdla0y3dxUD3Npkh82jsQhX/Qu/XK9/wg6aAZm57DqW6DnviPknWZP+9pz8FOY9uD2cQe5i8LucA4" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8ksy3mzfwa3n937tm3vc#envelope-ihvy> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#data> {
+    event:8863100035920837000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/8863100035920837000#content> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed   need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  "1513170841624" .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#data>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8863100035920837000#content-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8863100035920837000 .
+    
+    <https://localhost:8443/won/resource/event/8863100035920837000#content-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC1SDThUTgri/GJGdlV5Cp+KxU6yvAsl6KsLqJXI2MHHcuWHsbsnwXtEar+rl7b4/YCMQDVKYzOD65kHBfCzFWyjKLj64PzeyBcHhZ7IfDzpAwdw1aPXsKlJGyHKen+iePk0v0=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "RsycxbSmRChDTN8xfCTOI23rtey7Lz44Zmc15K2F4pzs8vZmzTkrdbRDnvx3TlZuZR/+a8Sg1v2GRy1pu5Tnrw==" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8863100035920837000#content> .
+}
+
+<https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig> {
+    <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC/ipBtZpVoIOL2B6Y+PBT9OfHO0rfxoFhzlwpwOkPLtlaWddt+VNsNRHWgyed46UgIxAMZuCiV3oHRfJ2ktl3e3oyVHfllDDI8pUHBzE8y79qQIkqRpzm1pe2sU4uGX0DyefQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIYFypjdMw3ulsfsSbkSWJZbkyHPK8gT+7Hj9kBXcibEaI2xFPjjmaBcXpQPOpdXx/v184OtSV/3XFVDNlvaLw4faqVNqdSlFDz5QhDxw/pRKNYoF9de4fa2uhm4D8sJqlgCRMFCZVXY7MoS6tGPU7ArEkMIW0Cnoqa/OoYASEpf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6l5bwv7tkxg2g0bosl1u#envelope-fdi3> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> {
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> {
+    event:d3jq9fgiu47gdhclj7h0
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:0o2v37foaz8bog1diet9 ;
+            msg:hasPreviousMessage    event:0s55ww5ae82lf3j3gwaq ;
+            msg:hasReceivedTimestamp  1513172263200 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig> , <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d3jq9fgiu47gdhclj7h0 .
+    
+    <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXRJYG0ftvSXFMxiOr69/P66KnIv+WcuIt+DWtD7xW7TuTSxe6JGnReuZLuQlmURICMQC1SEOZ00JWARGgxDU6QV5S6iAClzKI4yITVECbU0VTy4PsCkDKx1oxeyehxuoV4dQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VoOyZrxwoqwhIjWwhAx0R885hWG7pYIgPfgtywGWQmN7Fom2vfScNTWH+VnPpaFE+qrQVPHlP6/6ggNyLhsO0WiquMFWqhEebzgo0dOBZyIdGSjPgtFYudNUanngr3rEnZDVBgBh89aM4whZ8QZ9X9xj4HzU9ResMzH9NnwF43U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/0s55ww5ae82lf3j3gwaq#envelope-0kjy> .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGjIKnIbUDCBDKZdQmOhNV2c5iq0hpVmowjeGvvZ2lnXCrTMxLLCRSmyombPKz6n6gIwFjtP17S9ABBLHNpzeWu5VrewI1H3DrqkLylxU+EUV7M2frxvdraAWxElczxmc7ma" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "NIDT06nuw03uDm1k9CeTGJxv3BFeo8zKDrPpvWBKcwRkXgoKwLJgTSyy7UsvVti2+BSCKSlHrYwVHq5dsROfmND0aCCMq7c8ZkzCM8YWfzw+HOvEVQmzMcXd95s1vnykGjcf2cosnSQWbtPUjZF7KnFT6MoupZglk6fUrg9iF1A=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-of32> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> {
+    event:m8b6jvgclclzy48p7wqd
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:r5hu2rq515sq6wzgdjov ;
+            msg:hasPreviousMessage    event:8h7v5ml1aflqmoyem61a ;
+            msg:hasReceivedTimestamp  1513170817902 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> , <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:m8b6jvgclclzy48p7wqd .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+    
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC9Qs1OFC7hT/dglINmUKi6N5OJtlOptzY1K/UxKmdHBd912QqBeCzC1RRQc9GaoAsCMA4YMBuvTjPA67yfF0Yj5igMGiWWrBXkwjcztvsqpY/bH+TZicgt9ZYZX6eYpTpTjw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "Fs1yj/CFc28ztpE/9zMhiLH1TzvfvJRO43TzZIweuvb/sJdYHCwfkytjQMuDmh0pkEqqH433QsZCZMdQnI0nttJ+/HuI6mS5PJO2IR4rAxFCyab/gwYYiQ6EELTxSLDJPxWQg7CoEzZ0PLPn8yLN2zsSmk3G3xNDM9Wyl0/eyRQ=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-8uc1> .
+}
+
+<https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig> {
+    <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHJAMapAYr0rNTZyYy94/DHaPCH6vROiWz/Oahrqu07OcHU5lc+yRPuBqmhhc6gTcgIwC0LUP+k+cwvQhUTfSsPm3U8+4Wg4mTvJHTdEq1q6MON8gd7XiLOUYh2oUjzBvrbv" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eHMnbyBPIhvtqusyuAzMLq/TAMfBqTJThOvHC3LMMaXOb3huXFGXE83swICWIhfUdTqunnjKC+o5indlQKmYWl/Vk0ag0Hxdt1ZPJYpUZu4j6qLiQ6G5t0OZjHznf0+tGUJk7kGFFtV5QN2UD9Y8rWNPXcE8UvNQaGQ3Qa9tmWA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wlv9kjrh93gfzetdojp4#envelope-kms2> .
+}
+
+<https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> {
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> {
+    event:4846251213444807000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:5s66o8cqv4rxv74xfepg ;
+            msg:hasPreviousMessage    event:rd1ryd06xejacyss9qy5 ;
+            msg:hasReceivedTimestamp  1513170829679 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/4846251213444807000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4846251213444807000#data-sig> , <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4846251213444807000 .
+    
+    <https://localhost:8443/won/resource/event/4846251213444807000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFCtJwx67CDyzhrZAEaw8/ZaxmMV3OyQiywtLMZvISlw3q2jS1MoUfbjkRvFNaNxNAIwe5zwq9rIoPKsxHYYNzWvs3dXhrFh2UqAb6Sl/pU8DDuKneEgLs5w+VgPzHBKDDxD" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "akHfnW8zEDf9fdAioX2i58sjU+GYPPkiVOfxdKk7QCoB971iT5xdLz/pHXQwEI+dz4aOjXb5osxy4IZk3zVJaEsbVls7KHNN2cXWZRoHzMFsZNa5CxUjjTWZ9yFKobLLaziLlliuRBDrI6WN7lknzTvDfEmGdANkGV0+GweO4Wg=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#data> .
+    
+    <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDDXFpU7zLaJCGyqXwn4UCjJBWQ5Kky+wBEf29Aa2M6a1hC1WNzbGHiZ28+dtU2zj8CMBaMScF/wF2a8mYE93kB3uMD7iQcBUl86MsOPk0JB63Sz/6nQbno3g9BwUiCnDrEWg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Oy+CgIlZWQETxG507pi9BhQXTjv8wbmvtF3o7H92mo7zRPhhvGdRohXx5oPGVO+f8TsxUnMa+1766GGqOfW0QXP0lLhXTysjrafLb6DMy57mkVYfGqkQ0PfA8kM/G2CJSEth78qC7bluhRgycVgDg1YPqucedCiDrF1e/Sdrwc8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rd1ryd06xejacyss9qy5#envelope-ruck> .
+}
+
+<https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> {
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+}
+
+<https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4> {
+    event:66nnn87elpe5995a5wjv
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:tlyivx8nn93zw41ujn1o , event:m4nq3rl0m1br8bea2n72 ;
+            msg:hasReceivedTimestamp     1513170819555 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:tlyivx8nn93zw41ujn1o ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGZSQMmQ3LjP1Qj5MqcJsclP0OFejCxZsj5NOFHYujTch6WM5iFgZ8o3bv/cdM4j7wIxAPI1doM5SzXBEoCxolVwKTFDvmSl4DjyYIS+Itg1mZBsg2ZhlkvXQkA/84FTFgUB2g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbKgswEv9jm4DQD5IcOoXlL5eZmR+0/LnmcOZCF+XO+zUns/vs+0qGJqZY0PNCxjTfZsj6yhMc3bxO5dQInXE5APqu9CT15xyQAy51koNBQ6kR/W5pcR/OdN63z82An1iCCl/OhwdQe2eRpK2iGFFjQ8pjERNGG+qzeV3Ck20QE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz> .
+    
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+    
+    <https://localhost:8443/won/resource/event/66nnn87elpe5995a5wjv#envelope-e7y4>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m4nq3rl0m1br8bea2n72#envelope-xmkz-sig> , <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:66nnn87elpe5995a5wjv .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x> {
+    event:h6c8epmrvb3gxqrvs81d
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:00zilsxex8tqjumh6fi8 ;
+            msg:hasPreviousMessage    event:ivr0xermk4aeb3yhohk4 ;
+            msg:hasReceivedTimestamp  1513173166229 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xz7x>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6-sig> , <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:h6c8epmrvb3gxqrvs81d .
+    
+    <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDfsOCh04rbw3/fB3x0ouVwKcr6qqU5DWZbYMF5BebZn9phecIzTJTgzLmTk34V1UICMQDiDrlXHXKmmwmx6TZCbfpduj1AaxEbxiqNQHb+//RLDaxwQxfoMXvy0jXM6cH1cMg=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "dlaR30ByFzpxD1F/d7c5Pv1Ieem8i5sRljgxCWxN/YwsWCFOxaJ7wNdJ4hmcuYGdVcNgiP95QmWsvDJ2BODPnJIQ0zDX7pijSRkKCCvrChDIj+v4lsomnDa4xjZ9mPoxNzWZ59pvmsI2l96o16Ysy5ZsH7RcFCGyBaCgEAPTjYA=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#envelope-xjo6> .
+    
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+}
+
+<https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1> {
+    event:8gvplnjrinoqay8ycrc2
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:2uf9sj4itmz9fpas7suo ;
+            msg:hasReceivedTimestamp     1513171153830 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:2uf9sj4itmz9fpas7suo ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCyzuZYfD+zjDoaScLo7rbqvu+ZXdLGf+UnN5947CB+rXQjuw8dHEE9AJyPNhjw/QQCMQDsywohHSC0UujhjWSKl3aHEp4E0zF5cBWuGpwnWGA0qw9BQ2IwWLv6yBIzTfOeqxM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKFHhum1QKzgZBYKRExRjeLZBqX5l9W/kgy3cTiEfIC7LX0mg3p9eQbxwEkeLxBn2bvCjV6EOmCqn0XwG3LBe9hf8+qkWb51l1BSB8E65VW+r09oLRqqQU29JJ39zNAX7NYq3rgJJiVpjGX3pf2jwxYm9sqY4RBEQt+isRQOK12U" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> .
+    
+    <https://localhost:8443/won/resource/event/8gvplnjrinoqay8ycrc2#envelope-8eq1>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8gvplnjrinoqay8ycrc2 .
+}
+
+<https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig> {
+    <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDmjl9AY6pbq2C/8sQMSFIsWV3MVDZQYD7goKYKGL4t1aT8GIhCVRtl/ntRdTmuIJsCMQD9/CSmj5RXzqCIgENqaB1/iYL7zVpltQFlkCepuK1UnLLXCLZUoJdSr5FXofBIzN0=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "E+jWMjmUNdTGMbDubZ+R1SNOSdhPp8Nv3LMxZEAUNzR5GSEgsw/Ng9nWpudHpzb+CpOBhmuPHTdKPBbmhVnh739jmTxyCzzC4yzfO3WBONondQlmoSLyz1DYveT0topDoDpxr7bJQVHAP7YYbs47kLcEWCFNJkV9LMgHpkjbn2U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eia6yrvml8v995ueq65m#envelope-le64> .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> {
+    event:253k6pqq8gyttmmfxc7l
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:9se5txpx8xf4olwlettr ;
+            msg:hasPreviousMessage    event:59gtirhola4ydvddyo0k ;
+            msg:hasReceivedTimestamp  1513170818034 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig> , <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:253k6pqq8gyttmmfxc7l .
+    
+    <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA6xk9W0Nm7Q8n7VHBKI+Ffkrgs+R230cvNb2jldpbDuohwXmcEWD24TJc4T6JdlJgIxAP9vYMZbAV2k53k7Mdz+mY+NMy0np7t44P+SBI78Nb5Xt6I1lOP/hkxRfEcpElRSuA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "djVOPPlodqPPEVgtuLU1iuOD6Mzo0/fsuipwuW3KTz79Vq48wnNPY4KWBkt/p1w9sOyeV2gsCNmbvtRdeN/UYZ3Sohb1gRmDcLzZyLuya/kKsX9aHr4KJyFXUdOmo+GGfJYkjwxMiS33UCQRRO6z2CyTk3/qdE9+dHr0yqIYhBA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/59gtirhola4ydvddyo0k#envelope-4ysx> .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBaVX/GtkSPDECfDSre03q1yLJMnZe860Fc+IuSE3VX3T8hX+FvuWD6hCS8ELyd0uQIxAJB6TrvOCjdNgzT7q+z8WplSqwBmn4D+Z378mCRDI9FOFcjAZq006f1N319lJzZJ9g==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AK37HTEODeZyGhL0eitn9Zho4UfFGG1XdKEasi8X6syg3d+rGVIE+4iBGaqncQe2rYDbRgKex31G1lGBEy0ksywrLUGg0UxQwmH+aBl6Osp4G7pzniVsY343UqpgSHgeygapxWRuiynss4/6Am0vm4HTC3Br7unCZp7FXfI1TMzj" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> .
+}
+
+<https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01> {
+    event:4e2ws6ap0hp93iv0oyu2
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:1107469913331435500 ;
+            msg:hasSentTimestamp  1513170817336 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/4e2ws6ap0hp93iv0oyu2#envelope-ze01>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:4e2ws6ap0hp93iv0oyu2 .
+    
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> {
+    event:xbhopokox5b4vz78e59w
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:izq6icbkftfbzm0clxeu , event:gv6zk2yqk6o8bl574n36 ;
+            msg:hasReceivedTimestamp  1513170798588 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig> , <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> , <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xbhopokox5b4vz78e59w .
+    
+    <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDhL7kBxvJoqFUG/n2cDN5cQTWIlMtrVoCoPaRxIrOZKKzikjUtlmeTz69tW6rLHrcCMQDUWszGUPxBe+QtahXtaohx26J2IyCYc3Wuisc4qd4bPY3R5mt3l6zghBCQ1n7AaFg=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OP5Qzir4GiMtWLFgYEjQ2w2WZW7II57qSGm6NiaKOUpAII3r1ouEUoizjiaQ/M+Hl8iCYjhI3exsuWpZ33s4sNiU31u+7++kGs0uq1VWDxH0V2PI7mnvrs4lkT/aBu8maWbyBKrUqnfoYpu4+OCVsDj0wkCcnnRnMiU55OPCDeA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/izq6icbkftfbzm0clxeu#envelope-v0uk> .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+    
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCpyW1KNsG2XvRyfQrEZqa9oNGk5eO1boTvEE0raZNapmu9LC8ClT/bGLBaSFkpn+AIxAL42Ave30nZXVRn71OrkTORDwZzXXiFXkY+KDbx06wXZoeUs/MPfWo5fq3EAlFN6qQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AICr3ADiXnr6z7Dlnj8PAlKh7FPT2Hb/ySeQ73ZCjlWKp11r26C+rAUgrKRT08nTBU0SiDwRGKXI57IjA9aWkgAxr50kKDBOrFTzuCL5+ByEHPY4dVZZxU4ymp4bpkkqfz/4DI+lBeXVb2Udm9uq1braHdjfTPuHpG/WgAuMjNjV" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-oqlr> .
+}
+
+<https://localhost:8443/won/resource/event/h6c8epmrvb3gxqrvs81d#content-42xs> {
+    event:h6c8epmrvb3gxqrvs81d
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig> {
+    <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEvWR/fHCOdGj/uM5AChtdhVB006Hq0TpUIqkazxmdzzhGqEonoxPJWBwx5thvc/gAIwLjD7QXA9jnarEQ6zdtH/aa/BfBaBkE3/GtC38UtFyylcywQ239p/rMGf9Caos9X7" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "L7ZDsU+JNUesAdJuZXheut2HyOwcDSJlEYCiPwF3sbNJsaZRaxGBXQQzUziJNb+8tUw/ADfUVt1hT1egjBF1T3PqDMeTJrvo3SjW3k+b81deyIEV4ffjS0TyAMVAQC5EFz5JeIgZ3I3Qf8iT/Es5VOnnQBTJCUTp0tAcBHoqxNg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/mthg8rh8r4grme5ph2eh#envelope-belo> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> {
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHQM8Ofx4GN/RfIMbIIyG5AOlEDEp1gx54McaTdNic1mqEzUbgvXxqzm5Z+4MWHKBgIwEXlkuJYpmc2gOpPILYwC4EY2T++/TFWs03yqjZPsg7/ZJvJ0E8hWryEmjAVCpdBL" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NrBsiOimmcylijq/VzzZN3UNOxWczjYDuoJ6YoqQVJq6sxcMbGhV1dWy7tGJA0YjpmM0vjEaIPWrcYBcDrQuGQc/8WPcSnVw7JVjmuygI/EIT8cr+ilS2ZaVpdKvYEzQRZf7YEXUlo9Lsh2UkoxkOU54oO9vdnX3JtkqKFXySUg=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> .
+    
+    event:rrmkri9cdrtvp1bkjcnl
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:jbr090p3fhvimrc65vis ;
+            msg:hasReceivedTimestamp  1513170819400 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:rrmkri9cdrtvp1bkjcnl .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDAzmCOec+6ssyiuQdedN8KjJicgXlwz+dff+ZZ+VSg4PW9rHr/rxu8YuQJqBedIj8CMQC1+6HknafQNMhhuimJsvm38qH4jpevvwFAIBTPw0mozvDA1QYQM5Tz64Spd+pfl3g=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NeTl3UL90+SdUaJceBRW8okcZ6jhQYDGgdcE3X1RcwAkz8nztDencdyACYKdxyBbWUT93kZDUGe5PE5DzHQe0gtNS2JfVCq/9ntnQxVXH6zv9YX2YZ4zct8tOEC6sd/S0INEhY7CvazST2xqdXk258IHVHuPICqHzEkBIuqaQa0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-g0ij> .
+}
+
+<https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig> {
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDsoACeLxf/+IE5gGN5+M8+xdafOXT23XABQv7HN8M9jxmP5HRBnZsD4NYZIPfhdM4CMQCLxNWA8XtkrWqgEfrmS8oiGc57Qxc90xnWcjfqbRwD5htWyf3VysSyaOM5MGdb1lU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbasWeY7409EneTPZB5PGTrRZ87optqYqAJ8K6sxrVaDVI/veZNZXQppInCsGHXnUKsv9b23DKyDd0KFFYFj2YUuNKNz7kwAzIxnKDFI3sBHg8W820U1WqQXudbw3k7gXsE8cFYa9UkgqTJP1yfOit7kAKQ7b07dE3S0FFAaY3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> .
+}
+
+<https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu> {
+    event:mv0xoe06cxsxt08s7guf
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:cgqt5h004iql2003me2n ;
+            msg:hasReceivedTimestamp     1513170830961 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:cgqt5h004iql2003me2n ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    <https://localhost:8443/won/resource/event/mv0xoe06cxsxt08s7guf#envelope-x6mu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mv0xoe06cxsxt08s7guf .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig> {
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCj8XzMChHxr1OUg+i9codjorEeEZd6NEjZV6coLw/RVhHXZxpT2zQNHQCmrDfnAEwCMQCj3ztIZuDm1BVd0a+xGJHmDaIsyoFKWHvhFBS/sH1iorGhvMQLVK25Yv8VEpRFIoI=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "OQCMclJqUGtvO8kZAcP6j/tZc385dizMr6Hlefne2dP6j9KEJRRIelXbDsYwWUO7SU5rwrgzcn+S3W29JFH3LiSu8/TrpEPkAG3AMX3165zJyJpiy/Ea7ZX7fPHo9H8MDrK+GzVIvX0M0EB3tFBsUnPmK1yahgabhMylNVKIZuc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig> {
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC/F/NI/VX6ASFjJdeDRH7jIQdMlB9h9vRhLpDxk6B6SZS5GbR21Jmi0FkeLEI2ddACMDRCYOUb+G+m3xYGgSnX7fdy7no747rU0fv06q1EA4lumW0xmIicFp5/UUR4CF5jKQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FeYE3UT6mrctO35PUk5kNdyjMgkPcgIMGahGbwUFhSuhXAuQ7VAsnkkoR6cZrzjrwsB1X08GsGcqhDb7S6JLDvQcu+iy2x9hn92M9kI85P3Gil04V1qFzcNYR0/VL9LG56gbWrTRlQppMn6i1aGcKT6KyHuPk/yXp05+HWkhUAk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> {
+    event:152dum7y56zn95qyernf
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170829995 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:152dum7y56zn95qyernf .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBOnKYKfOVB/cbSmWfIsVk5ReDs+K+W1BA2zWsYyzWdG0Rwz9MQPE2smPmAjQnc5uAIwJGG7428m810arTDwaiPdhpZsPeV3GENizs/ecPWkyYuedUh6WqjZObHJi1/dM430" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrBVwCc+0SugMjMe1MtCrTjGMUeRjykYniSY2yRXY0ZKzESrmg6KR4pmbSysyzGw7TtvnekSRZhqz04gafbvlECd" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> .
+}
+
+<https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig> {
+    <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDSdXKxn2RchP4xrCWyLeayYTKVwVnV1HkzIsd0SiECJtGwpR2KxulgqwcXJmxIwWgCMGx1arfYmMjcUYonVQg81x0nlCLJV7h0Dn2bt8O+vUMfPqTw8VT4t93wZSmcZugcDg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKgtovAu1Mz6cHi8kGtsitdaetXC7zLrzOcAYAtCWrqbilRQdx1Yq0PMrXgHnz+anofp6Y+2VPLdxXq3HCdChOID3hCxVUKlVM0uSi43HrL9ecfDi5gJ0Ib5H3aEKYAyQopbxfRYdnpOW/N4fhrh2BDARHDoo3ww61eE5j0lWF6n" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/tlyivx8nn93zw41ujn1o#envelope-u4sl> .
+}
+
+<https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d> {
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC2SHabHPSdzzZCzuf0t29H0+E924wZgop/TwU9xs8TEn2e4aCKKaH92hEQyTJwsyECMQCiGK8t2XZs1Krq6a7LRUoKnjxvkv6phBZAE3yY7QEIC+VRxSZkCxuBValqco7/l6E=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ex9C1O0gcR/onChUoY4VNnks88Sr8PMvNbsOKQiqGaKIO2gmV/bwHRWSZVbGrs0eWsCebmkwHhRHtrOt/cwvhA33YDRIZV9iVlTqrlGuQNDZP1SylTuQdo88A7Xg+BybXWCoQj1Ywfuuu3HjYFbdfTmncUTpRodTfKrqw+SDEk8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> .
+    
+    event:fdxtdqeonqc6mk01crog
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cgqt5h004iql2003me2n ;
+            msg:hasSentTimestamp  1513170830961 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-t64d>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-73df-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fdxtdqeonqc6mk01crog .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#content> {
+    event:6834006177130613000
+            won:hasTextMessage  "validate" ;
+            mod:retracts event:8863100035920837000 .
+}
+
+<https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y> {
+    event:5iw37ggk8ccrcxxf8f8c
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:lur3g5en41crth556538 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fdxtdqeonqc6mk01crog ;
+            msg:hasReceivedTimestamp     1513170831085 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:cgqt5h004iql2003me2n ;
+            msg:isResponseTo             event:fdxtdqeonqc6mk01crog ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5iw37ggk8ccrcxxf8f8c#envelope-aj2y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5iw37ggk8ccrcxxf8f8c .
+    
+    <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCKCBv2TfWVNnEdBNJDP2HnaZ0PMW7L5HNZw9Gmq6CAo9xFL2Bg94Hln8Z3FfWW/1gCMEUR9lzsypqSXorLjR7YOrxCwGJ+TrwijmTypB/OZci9nt4qJxbM71ULf1nCwgmW7g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Jh4PEReRBiKtSQDmjELuQf13HhqnYQNzCnPuH3OrSjZXEOhXxI9Yq9HBx71f0dHclvOV07maj08KdgsSFlNBir9z/P8Mx19nrME5XrpntImqHAi1qF9Asjb6q6R1qRej7pvC9shbYWfSrOZDv1f9ADqr/O3kv/wKuRVYUjFC6do=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fdxtdqeonqc6mk01crog#envelope-tbl3> .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#content-u0zd> {
+    event:2uf9sj4itmz9fpas7suo
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig> {
+    <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEZu1xW/5P9mo82xJEBHM1TWxCTw7GIp1uwRlg4/Vt6rg5trZirrsJWzZdBoVRCLmgIwBGBnQQkFD4Y15co1lqV1+KhWf1ZpK7j8mTtVwn/PBGAZEALi7pfD091aQnZAUZkn" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIy+T8J7/o5ATgD94rearSfd16+Ne1MwcM8mXK6RigcjoD+vl9BdbN8dkPwr7eK9kr2TVJtJDgSBoK7AK6OuOWzQvhDlSzqZINmaeZVHUwqj2rKV/vwGJdbIqYqolOfdrqLd1bZ4kJr/p3PBneFdlPqzA8BkO0UzYNt3IZ8XAbEe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uonv0x93cu72oy531390#envelope-gk4x> .
+}
+
+<https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig> {
+    <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCu35A9dEWCwOZ9sWonLL3N1uPP7XCqIuQX6MJqnqgrzXzZqnowWGsOeaMiXDU5yrwCMDquASAPHeYrdD8KW2mHDV5PFsREEtqN2Y3feWrZXadclkgCL/6yPklYftptXTCE+A==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XiEm8ijjyj76Bm5i7gq503utA2NAxAyo6nR8iJZkIjVz2vQ75dtRHSKfm8movvrKddDdeSkRQEaJ+JvCO1DmilnG7qNzbfBB1j9rClTHeErpZvcEJZYZHFsINBcyAfavXGnusE/Mljr5IBznPG8gGlXv1WjxNK9h5U7TChYisZQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/wpcsl4dxaxpdxbxpfo3r#envelope-dh2h> .
+}
+
+<https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> {
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+}
+
+<https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2> {
+    event:8950tg6pjze6lr52pq3y
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eczqg8lp7xbukpzikd41 ;
+            msg:hasSentTimestamp  1513170818740 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCME+3NyuHMjfzR8ibEAysUg8pQyRYqVuoJ15oohfkDr8iinjDGdUNGAWXXSCVEvUf/wIwWrF8CKtjb++4Dj4sJ9/ea7X4iqzs0MxECJW+fMaBcprLJ+nk3BU5yTn3v7bfQxht" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eEiYLRNLiVOCjTzytc6t8LPhsMA1Ia80xObgp2b3ZonLKiD9F5LfwSccvzS0HEBTGxAy2eoZj1hh9/XLGzE92ZxmdhGcc1BxyyDWA3aAEzOEsPKgrW4U7UhvK9D3R7lJGxaLC8LKIlD5LyWqVpld9MO5pAXDO8EO+2sDBMNN0pY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-pkd2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#envelope-cd9k-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8950tg6pjze6lr52pq3y .
+}
+
+<https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig> {
+    <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0/xurl/bcm62GLYTMgHO9GJHr0GM3eT66vmp3CE+cRqaGylTxbd9WnyhErYKh/7wIxAPFxaBXKC1CMbFKX0vDGKRlFj8HbCvEJPYv36/y55GUwrW5qVQp5fizvulmNgEfilQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I8ScmSRWdh8pqVwh+r3Pk7imDbcNJXLFJ18Jj4DMDEAVMwMma+MKQhdSLlEyDdHl7u17bZaO9MkdFYV418E1BbBOafVwuxHGcFK2FEO0PVDoDOb2DjDLt9Vi00P7fEh/w+t4acnUJXSAWjhRrhpLLFtjSxa4mmB9aHmvcKJGO8s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eue8ar55z7as596cu33m#envelope-3nip> .
+}
+
+<https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig> {
+    <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD2EfKVsS4PSlEqSB+/gjEiRmdCKO5s7WDv/eAbfiaDutf2XB9FOqWPMRLn9OaC0IYCMQDYF3W4pZ8zyng2pjF/1MUHYpxAeNCFBR2z9dB9Vy0YwYd7/CSHx9lKK1p7fK2K3AM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "DdTwy8dZPDZTlZWA5NMwp3LViu06y+ocwZ5yhXihMFQ1J0TPqsakf+ol+m7HOENv+xfT1fuwe3D2a9ejfee52VLPRtWTcONC8cLkXAKE330uDgX8MX+H7YYH3EPyjcbscFVY2APMIy7rMzPxRwclRk2J9sDXeC+bXI6NhozZSnI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ilkgs5gp030i06fb97j2#envelope-zvpz> .
+}
+
+<https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb> {
+    event:zvx39rdagwj6o7nfiw1r
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:qi81r6ggzy26wznv94dq ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:fn87pwzr9g4a9v368h4m ;
+            msg:hasReceivedTimestamp     1513171226426 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:353368844400623600 ;
+            msg:isResponseTo             event:fn87pwzr9g4a9v368h4m ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/zvx39rdagwj6o7nfiw1r#envelope-ylfb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zvx39rdagwj6o7nfiw1r .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDf4Jiz6qEsxagnd32M27/KFDT4A8MrcpzmvLk9vJylevVEL/xRCPyIDpHVrN09m44CMBL8DlDPGzk/uINXaaOEFAujBOL/asEqNclcxcjfjF4XTH3MtRorUOv0iM2SS7N73Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Wj8ziPrZiyJHDhh+M6SeMCUQZulwT/3T3XFRkAUfaJIZdct90zT8XJmWFeX1TXO+M8EJtVGIWd8UbIUg+EiUllQdMp5qF2hlHGGke8FiSMMbeGEvozbp97W58+tTE8pDIHBJLO4qRvZg59Bu8uYRBIjWSh6WkhGaLKrv2DzUZ3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> {
+    event:i3k0giied2bgp0p44h7u
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj> {
+    event:c6ldwevakufr94hrcn97
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:i3k0giied2bgp0p44h7u ;
+            msg:hasSentTimestamp  1513171230641 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDlnMFHi1yHQWURwmgatMhc0rctb+tCDfISGX1DfTni2x9vRbI6+S9GSBv1hlnXWXAIxAO0mar2urnnX27aagu55pFwqiIPuylmPGBfQCBXRXLbTMEUFFkXaYw7Zhd3tFRwsUQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CRpv20jDVjr3DxnzsObIMYRf4iEP7ihordlgQPGxANN6jOfHndbyf0RMGXduxD9Mp+GBRWwE9CSe5uIZTOhjx/vGbl5FyhOsyn7RgAQerfrpfpLp/aIS5EwmWBamHmagJnmI0bqak3QRb0e//DkK+dMmYhAQ3iJm5JEyGi+1WQI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> .
+    
+    <https://localhost:8443/won/resource/event/c6ldwevakufr94hrcn97#envelope-q0nj>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-edpk-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:c6ldwevakufr94hrcn97 .
+}
+
+<https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig> {
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME5OBo/oLUcxTC1uP26j4He2vb+W5XANy+mDPS0F9btVzUibk6eojj3qAK7kTBwu4AIxAKAHUS0FJGtZfyV5/A5tEmDUCWAg5Q5pJZ5OOwkISpVgxyz91D+Utm5bISGX93XeYQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XCSe1I+OCINMSa1ce+cdA15F2KD3hNam5XW5gD1OGjA05K1cOtRsplN48SoTEit+zV/g4+5UeWj40FmEif/u0s6IeM922i2LhaOwgh4ZBPaot6UASQW35L5h+d0GT9QfzDaFBC3dm9qplcDRrN9vnFgldw3TNYbCuhLGU8BnkIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> .
+}
+
+<https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi> {
+    event:alif190jj9we7toczas8
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:152dum7y56zn95qyernf , event:ggbuodgi1pykilp8znve ;
+            msg:hasReceivedTimestamp  1513170830265 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-q6bi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig> , <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig> , <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:alif190jj9we7toczas8 .
+    
+    <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDX5Gvhbn/4eqif270CyZ92VUF72HMPRH4nzJjR/0S3YJ6vpVMJaBAP8HA17FpOkJACMBJVIkW2/XVbP3BzDA9KJzd9x6hLSMIEieYqQZWtbbzgQme8aZ/ymxskMJcw9wdEog==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK0bVFozUzO5otj38hi+R4s8pIBDzD8jrzbOxet9iD6wR1LQPjI5Zf/z5d3Xix27tMUadjGAfR0fv56v33HxLf+OV7behKNrupdUdqQyRk7QokfPM/8uYzIC2UYR7cECZajbYDWsQYgZMRH7y4PqYq1g3zh0ufckqMmlADswXW+u" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ggbuodgi1pykilp8znve#envelope-9pro> .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMC0mRMkc3qzRI3IuPWuHoYKIXBlVRBY/lnTQEVDngo38gj9jNG/9UjxmSnYe83m/eAIxAK1j98jPfWEFd7pvAL4DU9b9/q0myrF4ZFxfLcIlR5uMav2NAggebH5YSgEuZAusyQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I2QAcIcb8k5jr2a41dPrmhIRH+gnj3avrt74UZOLtwNRei2wNuyO7ICeVgyopnV88IoeRqBqLXK9Gv6ABcvkAdYcrun04dR6ovXHDyLW1W04eG64BfZdAci200mFxVks96F6eyH9fu1CkTP1eLZr1zjwU7/fLo1ae1qe6ll5vD8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> .
+    
+    <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlQS7FI+OrA9G6wWGcyBKhOwYSDbOB1WVVDgRZ63TXp+iwytziBrf4Bj+PPSLj/lQCMQDQ1nDN/LyykB9bfndfUKAH2hgXXYngRTVs53tANB0olGcCDnBKzD8vTMOCi191VNo=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UluOM+LB0yMl5C/C55LKx+/dvCiQmfaq1FapfUeOAaXp0chQENwLWp29L7hZ95TzUNW7VIUnqhwI5DTWmLQXm+X7m0wHBNRee8EFM6OlDDMFGxMTU3fmHCNm4JZ+Gs7hsZAJ8yJXGUYlivHPAyUpgHT/0MmAPVjymT3K7Dxh8k8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/alif190jj9we7toczas8#envelope-gizc> .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#content-19tl> {
+    event:152dum7y56zn95qyernf
+            won:hasTextMessage  "I'm not sure I understand you fully." .
+} 
+
+<https://localhost:8443/won/resource/event/5946672495584215000#envelope> {
+    event:5946672495584215000
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/5946672495584215000#need> ;
+            msg:hasMessageType    msg:CreateMessage ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed     need:2615528351738345500 ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170781491 .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#need-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5946672495584215000 .
+    
+    <https://localhost:8443/won/resource/event/5946672495584215000#need-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDa3BdYxIPv4W98aouZ+UGvM9W44G+HCaINpDstu6t7nNArzMxa+iUWr4m4EP5KC04CMC/75bbMikGWIG4Ff0pE9OdWaXZRQd1sib3DGTAuFrZASO7NxjiZJS0LsBsMYzzZvQ==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "WTNx49tEAUN2Goqf5gd0xOoFC7x0IMNL0fPznqXgkXCYZzDF4hX8RxPXKFIuKcoWanZyW+Qr2SI/tBddp2dUXEKPIg5VqI0XntmIeO3z2Rk8vI9JV1gU99e3NcUAPU02IFO72yYByrI88VfWazhcBXQofouJPKAw4xHxZzOTn+k=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#need> .
+}
+
+<https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6834006177130613000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#data-sig> , <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6834006177130613000 .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMG2QlOJfI7d9PmdICU1aRQLkwcReC74fLXcaOS/rCOI6XSnXVSPBCi3rqE61s8ExagIxALjxXXPj79vi8PAAuHFz4Nm1l6Fpou/LRh8RN9nLW983tmGyI8tacL2Ce8umBR2VaA==" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "NvqzhZ+xbEj7gLS/NLJ6/hM1ee8wAsA0Xk+nGVs/tgajhEZyCNxhXjv+C3f0XA3Qpc+39PFi6/6Cvt2mQzFlMwKXbhm896P18cS3wtbkU92EgcpirxT85UPyEsgnJQboKIRt9yjKnn21RpY/drNI3YEzZJnIFdOoy8e+boRBb00=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#data> .
+    
+    event:6834006177130613000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:mmdq8395owv3xy9iyl5q ;
+            msg:hasPreviousMessage    event:fk1a2jb7ortt8q14tcrb ;
+            msg:hasReceivedTimestamp  1513171118815 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFVRDxdaBxD00KHFvR+cG0oEc+FaZScSsQsfl9dVRdlCLSK2Qq87s9mMUXkwfl70QQIxAI+hTpq55I5/bfDeMhKealJCfZJ7uH44fhe9wycRDzr41aNcf5NbVdsIO0/bXIk5Tw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK1viIMt6t8HbPIzqFLwIxz+t+ASCouZwl54IVFY+JT7e0YGHOOyqCvCznMRg2sQYhGAYYE6QdzK02JQCGko/1MQMx5J6agDU0nnMZvZRc9FsMCWFBCseT65bK+r/qWXnfmj6JQTX/fUGmDdIUe0If/cLxUPAGfm2kqtHOb/bI+I" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fk1a2jb7ortt8q14tcrb#envelope-e06j> .
+}
+
+<https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig> {
+    <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTWdBNDaRwngX0VfS+QwdSXRagenkv3OngMCuogbsxxtqX//wAq7B0i6Z5e35AjwwIxAMSQkzKnpGWn3bf/hwMsdK+hv7IAv7vqTxWZxJn+ENO+4GBt6Xjmh2bh/K+Ov/t27g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKyny/gk0D3vbJEkxmXVkxcClqdBqlEMO8U7t32aZjF3VOBQRBFY4PHK7sDEAz8u3oNaZYRbQYYu3SFOV287B/+CtO7tvSdN6cDwg2VlpXQfa8X3GM5saPweudEoN43DlqzRNKsDpbx+UWqp58wDhw753rJm0okgBfTSLm+oUIL5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5151909952739158000#envelope-u0vh> .
+}
+
+<https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0> {
+    event:zpvc6zv244tfxddbhi6a
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:ivr0xermk4aeb3yhohk4 ;
+            msg:hasSentTimestamp  1513173165971 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBqpywXtdSik6dEfNWW+m4ut20FaieTHHX/AyBPeWHmZo4G1FXBxNYD3WFfP7YE0GAIwUQo0uo3fKyEq4pGi1rEYTH4fA7OAJf/3SvqLMU6bUc9mPUpIz5z+rliOxsTyrFmI" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "fTouTpf4M+GvSO357XPpOaxPbLlJt8B3zwEjOwLMuACSrOe/ZxEz/XMR5Ql+TrDIJ/4vGFnEeps7iCSNNztmQBTnp2H64xXhGKz2yEi7V8kaKuG099SNuTvmkEME84XNB+xqGu2JxQxRnTht05ZI3Yv+czw6ROEM3gwF+QXOQmk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> .
+    
+    <https://localhost:8443/won/resource/event/zpvc6zv244tfxddbhi6a#envelope-inm0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ivr0xermk4aeb3yhohk4#envelope-4roa-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:zpvc6zv244tfxddbhi6a .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr> {
+    event:gv6zk2yqk6o8bl574n36
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> ;
+            msg:hasMessageType    msg:OpenMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170798149 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-wlcr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gv6zk2yqk6o8bl574n36 .
+    
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHLmgtATJOg5y9/mi0r6MhqJKDD+15+geT/EwulSNoj0RoeIXpdtcvcId+m7tp2nGQIwZJskHbS4DploT5N8uKopZYn+7nA5EWp1q6IKaQPh4pPbOd1G/kZs1Al3Cj0PNejg" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCROB64WWTuH/QrNr9odNCnCghI92UXN8sutfQM9UBdhjXYH1a5LzQLBxQCURX7CLKPEB/iKLfhAViJlvbpMP6v" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#content-paqe> .
+}
+
+<https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig> {
+    <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDofotudXy7gQL7BNCKdKwmSS5KI+QX61jqaEpMqQMGgk627/jEY6G/G6yGAw8/GYMCMB6S2X1Nmdudwux1SM2YgwY9ZG53NW3Uao83fNoz+bkEaJgJvUkTIYEzj1mJXqMvsQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIkUlJaz0b1w22WpXI2eb/G+wDJA97AD9hHhlaeQuqBdgosuyj5xz08VrIJAFI1hflhCXb/2Bf01aiz96lgVU1ouXRY6LMCeNrleoqGSXsNlNFBSKbMU5Z70Fly61hDJ+/gNU4L9D52ge8ADvjyaFaW+RF+0AaFI6//pB76PloeX" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/obhgk474mxybc4fobdub#envelope-q6t3> .
+}
+
+<https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig> {
+    <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME6PUbGpR+88/oQwBXRk18e95b+xrq28z/UNp/4GpxPG3XsShzIIh6RK/AYv6DpiBwIxALSmb+2M0+RbNzRg09jvW8E3CsS6Sxp8Iu67CllaLoAA4lw0ZN03UcbfZHCUfUykWA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XcLVrPuTUW/lSNQHtRCZ/eTaMVjFKB2J0IPlkvpvURyDmYhInqV7qmuIzruckTqTnkEB+27Vq5HZWsq2sbnD/l3Ib0MOp5BsiM+pRy0DzESrBcXDGKTCHzQEYL+M2Vj+KyZG20d4YZPbC9KR/PtLTp9tcU/uwY8QbVHFdilAhcU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fits98gjdl4ybaudq5oj#envelope-fuam> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> {
+    event:5693603251585579000
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:rig33yoxaetjw059bzuw ;
+            msg:hasPreviousMessage    event:l8d77tygvfnfycfu5201 ;
+            msg:hasReceivedTimestamp  1513172392116 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5693603251585579000#data> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5693603251585579000#data-sig> , <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5693603251585579000 .
+    
+    <https://localhost:8443/won/resource/event/5693603251585579000#data-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCKKn5VjPnHEF20zyDY28FSr1aci71l/dV0vFfxSUE9QcZB5cFXgB4c18aI6cA/9zYCMQCPM/AroctQwY7AGxmmXf2f3qXmW93inrgqLLjEZvFvzpVXLqYXLVNKM1oPCtVAUDk=" ;
+            sig:hasVerificationCertificate  need:2615528351738345500 ;
+            msg:hasHash                     "Sg9TJ/GIO0kAFNnD473qStQPI70e5HwM0efS1MU9yqsRjTdHPgIlojw/orXkTbPdLph1+FBGqiPWNcrk5DsNEf3ZtOjFfl085lNZYco2+K3Dwig2ni+g/m5fmt85F4n9hdJOdrzQqo48llHRAa2zrFabi7XMpyQC38w6OJS+5fU=" ;
+            msg:hasPublicKeyFingerprint     "oIPdw5Ttz8M/Snl52+TZ3xyX1eun10Dof+2IkKf4i1c=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#data> .
+    
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+}
+
+<https://localhost:8443/won/resource/event/1107469913331435500#content> {
+    event:1107469913331435500
+            won:hasTextMessage  "usage" ;
+            agr:proposes event:6149800720990867000 .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig> {
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF0DQEL7Y6ywH7J86m9iCpaFzzGZMaOTrr3QEP9tYY8+8kNhz6d8cadeFPkrBcv0GwIxALYAOxJGzgzRJfQAPlEGseGQ4x6s8PA+LvNR4X4PRCOVVH7/OgwwEPZpZvdWwggWqg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJk12DIF8BEWSe3NI6LZcq0e7kn5Nr97GglfNbFz1rpAuQzs6dhOaBoQv/SV/CF6Bn/yX2bpIW+3lvH+kvR7Fr5gsTFMopkuausbHAVUArtGgXtGqEmfpdlD3E5tb+/2030uHb24MRNCJiG1aFDcIMU+qJUs7RWVLbwzpTMW3u9d" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig> {
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHgabnaxK8IZ9ikFDriWlf959XOzloKYuSCoJCdtZktH4PEFkBZnRrX90zOV5UFs2gIxANBLmS5yXSwLnvatq/MytzaXaz0PYeqpJ26YbR0LLURNFVQ3MrMK4OCGPiJ95dnDMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "eG9Ad4ZqtP+ud3nWrJ/Id3P9iQGA7our5i9VvfuqOHpSJOzNwJldplrtxhzqaUp0njmw6G2MVUHYqIQp1CdyBJwKI/VaiSzsAigTId0q8u1BrdiEvnnwZ+QNt27ImYhFEdSZ7U2yPNpXDH2O7s/8RBHbCAdsIOLzZxUDsSijaEY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> .
+}
+
+<https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy> {
+    event:t87usy00t0o9h4f0d1p3
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:253k6pqq8gyttmmfxc7l ;
+            msg:hasReceivedTimestamp     1513170818350 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:253k6pqq8gyttmmfxc7l ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t87usy00t0o9h4f0d1p3#envelope-lfhy>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t87usy00t0o9h4f0d1p3 .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC8Fmvp1QQCZwn2Dwtjcenb5tf0h/dhYAe9roc0gmD0F/e9LHlQN9W8ntD9R3TjwrYCMQD9lQlttKWnQ2ENVdBWEsM298lPeo8mnxVUHDncPpcob3iF5TNCNPG0ULZa2mP5BVQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "ESRIityDllbOboeQ2NiqaumRk31B9QIthEE0O9plB/CGpEcnyJK2O746pz6RzDyMEMjqBNId5SAeqhIw7Lr6jSsb8Txaw5L8ZXYPZUPK8ot55z4xqGntQCbUUxy/6HDoQ76vtT9yP8L081qkTqrZ9r584DTsya15hYA+SjxX/Ss=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-5hpz> .
+}
+
+<https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf> {
+    event:jbr090p3fhvimrc65vis
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:joo1uifc1fc2k6fk5z8t ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:o73qpj11bouvhv9pfmhx , event:8950tg6pjze6lr52pq3y ;
+            msg:hasReceivedTimestamp     1513170819289 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:orj8iruy8pcer6zzxlra ;
+            msg:isResponseTo             event:o73qpj11bouvhv9pfmhx ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/jbr090p3fhvimrc65vis#envelope-akxf>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig> , <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:jbr090p3fhvimrc65vis .
+    
+    <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBglgo8mkSNupDXrJ8ZAhBBp9upr3dA9+sj9vyYJMjqdEf0TJfAOwhzdwzox1ik8pwIwNrVWYrE7m+E8fEiSX0bcnt5GW0XWG9idRE/J7ULhW8PVkGdC52jV5hdoZ24/efv6" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UjKuHV4IjR5uYuKClP0g2+8/Ox9BKZjC5aj9GHqxYEysm5W76OBq15q9mwG4uxNfnj0NYMzcyJcWL8+n761sMa5EIAhzI5U+pHWzfAbZKeJEnWGanwoCdqd1A9Taf0fvrmo/PXPIisrvFaMuTOv7H7t+lYtq2xCTerFY/GztKhw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8950tg6pjze6lr52pq3y#envelope-7hiu> .
+    
+    <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFWL/YmG+EUiIA03zdKRC4ss53juNPHzFqKBi6kPYkbNB/Gbur0pMK2FX41a2yNk0AIwN6eCjYtnQ4ZVtgxU4uN9yYksY2rsbty2IxFwrCo+XMzlAwG0w/agvoAMhNOslzHW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKU86NSVuVDEiz22JT2t6CtTV86SUwixnHzCP/vrP4UxrKJj7QaAcl8q1hbLnYZPOqBMcEbPHxN7Bc2pSITVjflJ6UDKDTZGD0CLYHuJVvDHSbl5XsKYwy8fUg/o4/Q3otkrFp/fOwmRWP01RWJF8lSl3b3+urH9TyR+A9m0tlCh" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/o73qpj11bouvhv9pfmhx#envelope-8x4e> .
+}
+
+<https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv> {
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+    
+    event:nepohymog91pfkznq0ry
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:s9a226k3n70ihhaurhdp ;
+            msg:hasSentTimestamp  1513172280997 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/nepohymog91pfkznq0ry#envelope-h9xv>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:nepohymog91pfkznq0ry .
+}
+
+<https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr> {
+    event:joo1uifc1fc2k6fk5z8t
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:orj8iruy8pcer6zzxlra , event:xsbbah2dhkcg6d3h13gk ;
+            msg:hasReceivedTimestamp  1513170819741 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-3izr>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:joo1uifc1fc2k6fk5z8t .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGwqbLwpW7h75OYqpkzBF8x5ZpGgQZgXiwdFwqFkSJUCw9bdGJEWzsuRcrYDrCN+TwIxANOmlsaYfMcyE+GHDnN79OtKmq6srnbsLUH+hIMxsr/GJaL0mA4FPH7wZITyEfXwiA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKOoq+82kojUy70xoxylQPopd92JDIYD+uSJTMAJi0WyMk6i9/t5mJ2W2W0oby24UTyCwZr7BxWjg/jAzefMmTmwXG7BwPUtZMDR1stMOPfuV0hqMI3AbpUpwVi2x2aqnQ/0C4Q5s35LWA0NDwujSbrsJuPcPcqN7moSg2Oy6wx5" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/joo1uifc1fc2k6fk5z8t#envelope-7c7u> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65> {
+    event:6fvg967tlh9rho8axvbs
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:238289506881087500 ;
+            msg:hasSentTimestamp  1513170861073 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-dn65>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:6fvg967tlh9rho8axvbs .
+    
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+}
+
+<https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig> {
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAOTPDudfs/Cd5V/GrJEzC4k7/tneEqMWICWCsYNoG6pLGMunN0lQpG2O/GR88My2AIxAK/2gj1ajnyF2AZDdpNzMGUo6764doB6paez0/mNrdg42mEs0p42NIQvsYs8/E+FLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SNTUm15xP6UsR6YuP9szbZaRL7GYAdoVO8tddnSOBmBxcmYWYjHmm66JogzxHyUO9jKr8sUqUWC0BgcDjrRPmexWIHbaG48eivqUULmWhT9QWpFiOFiGdG+wdaOmoOa6JCBFWRtdfCSuUUIUWnm0hGzWyumaEjZDZn8MAYfmFqY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> .
+}
+
+<https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af> {
+    <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCDvMn44lUgDYkJDxb/rt+Pj/EpScTjUe1GyHnMJ8qjcWZoN5gGAjL5OccmxtJOCugIxAJYFofT6zqF7w4C3If9TcA7UfGrYp4jF4HPg7LdKwiKPSxsADzXMbiZOnfu9RUXtTA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UPTUuHXDLVBo5qNy9NLUQeDdx2k83qWKsi+v4Mx37bcto0G+7JjKkX6ClQroH/TvmfP6RAzXMKgcucN6tqqpdH9WFBoVP73EKt4+b3HwjcgjH/kcHdPBcTsVdqQMxikVZq3FOTqO4YoJMEFjzBw3M33JBtd6d96UHOSLqkXRsOM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89> .
+    
+    event:5l16wlgqmeu6z6rt90ca
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:4055709708568209400 , event:elqliyw383sgw1gbtxcf ;
+            msg:hasReceivedTimestamp  1513170830843 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-c8af>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/4055709708568209400#envelope-ky89-sig> , <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig> , <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5l16wlgqmeu6z6rt90ca .
+    
+    <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCME5OBo/oLUcxTC1uP26j4He2vb+W5XANy+mDPS0F9btVzUibk6eojj3qAK7kTBwu4AIxAKAHUS0FJGtZfyV5/A5tEmDUCWAg5Q5pJZ5OOwkISpVgxyz91D+Utm5bISGX93XeYQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XCSe1I+OCINMSa1ce+cdA15F2KD3hNam5XW5gD1OGjA05K1cOtRsplN48SoTEit+zV/g4+5UeWj40FmEif/u0s6IeM922i2LhaOwgh4ZBPaot6UASQW35L5h+d0GT9QfzDaFBC3dm9qplcDRrN9vnFgldw3TNYbCuhLGU8BnkIM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/elqliyw383sgw1gbtxcf#envelope-xl4f> .
+    
+    <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEUEs4gdCcTLtvr1c1xl45DO2+gi+ezG14jdILaeyPHEbNTm0NNr5D9X9wcqZ+mBMgIwetxyxLDfnU28y8oP8nqeCmOA0FaTphco/v/CA4caZSPjbwOUNCyRVRg8nhHiV9VU" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PlW9+75I67XyYLqU8RST58olXJJOtTORGan06sjFCy1ELEuUtHA12NboMtFnk9CmsglWF2xQgeNWevNm3ChAXthcUeCzHNfgzjk4iF6DzLyN0jtn8XRJNzIwpuKxOZaY6pWQy8VQ37E0JVILyuH7B9PGLNbwfXT3+jabdKHHY2Q=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5l16wlgqmeu6z6rt90ca#envelope-mlwi> .
+}
+
+<https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig> {
+    <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDO4qwrEcSbdA0YGAOp+JrxXz35mFo3MiEWPsq2KkvP3+Hindm1ccK3tV00eorOvwICMHq4vQePQGugwsRhaYVNpwtakVSiopR6LNk0W7HdfiR4pUIFP+i/8JySA1cjb4vVMA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LXv05PYNB/4cAk1+QvjMTXz/WlxmzVDWwBfil/hbWTQBOJDyuuyX8KoDFw4yvQ8gSu49wGH/OJca30EVg0nH1zH6/zHjVTQdMyFOzAOZwtl3MepzFreVD/gSMsMYnf+fx+87SSq8lxojD5aQt6AIOwLCTtUovc1hHld+7l9+P6U=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gv6zk2yqk6o8bl574n36#envelope-ytn5> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc> {
+    event:t6d7eq3cq6nq54a16k1w
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170854547 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#envelope-2vbc>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:t6d7eq3cq6nq54a16k1w .
+    
+    <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMD2O6TSLlLr39EtVJ4/MOsZU7ENZwE7P3rIDsWElT8w2SrpWVUOIhwyab+E+rYPiVQIxAIq2sGyn9IHCo2sn3odNmOuClxoGH0c0dwOx2rJKuNKOEEA2lORukf1rRUNZlNdJ0w==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCAKIo9JS7Wq8xGWO1SXKm2vk6N/oDJXFTfV5k8JCisX+zbeEQQarPbEYlE8AhPtXJKMF2HmnVCoijT+CmkjAEd" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> .
+}
+
+<https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#content-490k> {
+    event:d3jq9fgiu47gdhclj7h0
+            won:hasTextMessage  "Ok, you've been absent for a while now. I will stop bugging you. If you want me to resume doing that, say 'chatty on'. For more information, say 'usage'" .
+}
+
+<https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> {
+    event:plmfevq4c12f8itbisjf
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:p6x8qvs5m46mxw4jb7z5 ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5s66o8cqv4rxv74xfepg ;
+            msg:hasReceivedTimestamp     1513170829815 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:4846251213444807000 ;
+            msg:isResponseTo             event:5s66o8cqv4rxv74xfepg ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAURI8MSE1aDOt6QXLwIhRRwXspKgKuPIes5snqWi7Y1TqTAhhqFqdHMUsDKyh07gwIwayN+L4mGhAsMx8l30SlvPJZWbFGp6+2vprfrKaf0NLe1+tHwlZPtMDnJy3c7aTcF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "b1DtmHcAiH/o2j+W0Mf82QGRujysJJx4ksmX2/Q96klinAwgDxGuwpG5knAWWMuYMA0xPNZoWc5FOaiWzhvA6dTeQuRBoYXGuNkFeF9EyOcIP6a4S3Rq5E8rUzsnOLWfvzrtHC9mr/1Na/XKa6MbsZ8RyezZMUNHgPXtnHnDIJw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> .
+    
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:plmfevq4c12f8itbisjf .
+}
+
+<https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb> {
+    event:ih9v6gyllshhvo5kxyv0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fd3jtdrkpb1x61pl2ix6 ;
+            msg:hasSentTimestamp  1513172392622 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-k7jb>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ih9v6gyllshhvo5kxyv0 .
+    
+    <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBr7tJFb7Jf2JC/M/NuoqLj8JlizAzmDUXwbuf6qtA7tD6h4UtVQ7L0lt6mjWqkpKQIwdGz2buc0sTE5SjmupRCSEktGRIoWJgTAPTztZEFKPGp6vWNYXbkJjgcwJEOU+NOo" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IGRXIMmXC6TgE4T4NytLokTwFXhkudLNSG8JU2sjgD8e3KN9UNtuV5vSQW+7QoNJvfzvAtr6o0OHanQYsdMSMHffG2jfxhbCDGcJ9NgAeUnYaotKwMZGoRY4YIBNVj3sUzz8gf1YIYR9eRPaCGxaNR4rUZR41gxI8KwYHbDWsfc=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fd3jtdrkpb1x61pl2ix6#envelope-87zr> .
+}
+
+<https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp> {
+    <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHL+zjNRbdUUayYr47LAyEIwPuZonsLh80abCjhq8wz1oerhj7hdvgnPwoRNFW2i6AIxANTZdhOMMRfiuH8i3O8smwQ+Vl0O4xhGhMfZ2hQ86xY47aT1B/GIYbIvtLB+aXTKLQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "NvPWE5DWyyk0wPsUNaVb5NC2b9ZUfTvZKK2w2jD7F9eRJ0I+uOO+E+kSUMMCvUA+cywthGWjGBxZfujDzVUzyK5RQjzFNgwGBYROgOlYW9dTYgN6f1f/NgfhNfynTkvybWXnNd6+KXzRjoZAPJnD0fgkpkkDBAdl4WKjwpauyjk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd> .
+    
+    <https://localhost:8443/won/resource/event/84bls7ssc3hfvt38vxr3#envelope-vbbp>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/1107469913331435500#envelope-f9hd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:84bls7ssc3hfvt38vxr3 .
+    
+    event:84bls7ssc3hfvt38vxr3
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:1107469913331435500 ;
+            msg:hasReceivedTimestamp     1513170817336 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:1107469913331435500 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+}
+
+<https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p> {
+    event:pha7cg4ilx4j23f8xo0l
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:s9zfgm2iika5vgvayt7h ;
+            msg:hasSentTimestamp  1513170861163 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGQeib1oxU+/nDQru2GHY2ZitHvD+JP3/bQsOwRDB515t3DsgJOMloNiKrA7NUPe1gIxAIZ7xxgZOb6rCuk4Xff1xaEbUS69DzvvyXW5GHZHBQtyWWe73VKCSA3teRKbtxDuBg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJVFiCPC1RHlSDJGcjP19N+lG5stuxn5HY83NiSiMvyPP1F0WM8Pty3lOGlZL8wsHVCqPtCPepWdjzwjFK9n7I595s4uMwcP1MXczwlgrpy9esZW+kRM9GVkd0kz74NuKr1qr5IYizo3v0YlYG+fol05fnAZ+k/GRjSjbqlICpSL" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> .
+    
+    <https://localhost:8443/won/resource/event/pha7cg4ilx4j23f8xo0l#envelope-n86p>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9zfgm2iika5vgvayt7h#envelope-ij4g-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:pha7cg4ilx4j23f8xo0l .
+}
+
+<https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip> {
+    event:gi8wvgu0xrwk42ccs4qo
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6149800720990867000 , event:at9ld2d9yv5dmfmzbxjc ;
+            msg:hasReceivedTimestamp  1513170797993 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMFnyNDZI8bB83+8LG2CCqEzbHhAnWlSF3eBChqQdHZZKwrGScuhJFu4SmcmtdLNJrQIxALpKey6Tieyrihk4Z5M7UTLAdYaXTV+5ZQGbMRlLWFspglC+eSMqIreKNmK77A9Mtg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "cGLud9CbOYmmcdTnbXBg8zTJyMruh3Fqf5/GCXku0WSXcokiGenVrhRrvY31Sm/0QNXsTuzBJpqvNln4iPoqkzSG94rrQMpF242bKiiDxt31hOSrIvp1FhiXHm4zeIQP2l8JfeTeMw9OLoIahIUfQhl0GJRY09BBVsANBadAkLk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x> .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-ibip>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6149800720990867000#envelope-bx9x-sig> , <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f-sig> , <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:gi8wvgu0xrwk42ccs4qo .
+    
+    <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDeQT4PpBFqCuzWCiA9uRbwBcoLC4U0dmYghhH4lBNDouUbnUZpFQJd2bgYPM0YHM0CMQCMPwis8TeG9KXgU9XMxS21uteATTNsRzkNJyMuaPzMLRoKzO2Qs0UYtVmzKQ73MsQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "TAzAosbG5+RqHAEoDPonQ6ZHEaV1WRkVMeNNEX0xOAiIGRbchUQno0UtbnBRLzH+6XTPP2W+XkDLvoBdKS9jDdSzHlnJPb6++1wcPYHUPOoCsQRjoJQR80tRvs1ix7g91e98ffGhFkGbToRGlpvsA2eYELxbPPl4V7/1X8k6JsM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/gi8wvgu0xrwk42ccs4qo#envelope-xk2f> .
+    
+    <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMA4I2mYY9MxqVkhL7VnxgSOAg8JvOsBmH8KT2u3fHVkCzQYnCMElXWrtLDUzg5INdAIxAJCLEkR6Q23dLZwQgK3wBUeHkISwAlOAURLkDQSNo8YlnDTBzyIax637/ti4lxj88g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Dy5XCmNEQdZT5t3oLfs48R0qrkleA2+3gLggoLL8FjsDhWBOnjHC6Rf8fVv7vKv6Lzpl8TGzazk+Ypj8+fwukAnH/MNa0lgBMpU0cJi1nFcPWJtCr5XmYfHn0WR99YbRKlyQ3PJ5++M0E9VcBVdMQEoLRNaBjOzE3+t9BBgzuT8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/at9ld2d9yv5dmfmzbxjc#envelope-532q> .
+}
+
+<https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt> {
+    event:ck5071fsyaned6upryxj
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:csvglzqkcoddoreep5w0 , event:orj8iruy8pcer6zzxlra ;
+            msg:hasReceivedTimestamp     1513170818699 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed            need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:orj8iruy8pcer6zzxlra ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCjpbmTX0lr9wP1/Zo1hHS+Fl2u4fjPUdH/yE6sdRKji5EwwaEaO39DEFn+V0yQ934CMQCOra6yGFaUiNov9TBtqCpdrA0PlqS2+TbLk9vgR1Y2i3tJOqV9DHOpnMvqtBoD8xA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKl3BcYNqGF5zjaCI+WVJb+Emvtms4hbI2EQfrVj9yjhtVc2XU10xXgX21+l6IrgaMAWjQBxJFDeVFxKNDtExNCHMCpn3LYpCBOW7Ho0NxYYSVSXbiRK3+eA9bbX5ds2h8jMFa7E1Tj/EGZub3wHG3wQG3zV2Ztt2PziTkcY6pev" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d> .
+    
+    <https://localhost:8443/won/resource/event/ck5071fsyaned6upryxj#envelope-gldt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/orj8iruy8pcer6zzxlra#envelope-7s6d-sig> , <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:ck5071fsyaned6upryxj .
+    
+    <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHDVEddJe7NmoiYbu1p+JiMoEVtLRur/+Yu0sFLq5DUIrrWrtdLK6f+prO8pKIdnOAIwOTKM8iqIJl5RCRTU1empKnTMdVGqYNnugzvjxmcJYcHlB3kEcJZB01RpgP4jXIiF" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "BCqG99LdFS9ele8EvqJAKMSeLJhmvMv8EYQE5Ni7NpgpIlHWsUe9/VO+cD6uuuHHSCaOvn2v7Qpx4yxY1MJGPmc3EMhoELJYWIHnHCJDLdEWPPPZmLMlOd0p8TsDM58KKsaFHjQ8y6LYBomosNL8tVb2wxHGagv6/mWpsyY7ph0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csvglzqkcoddoreep5w0#envelope-yjab> .
+}
+
+<https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#content-ooms> {
+    event:s9a226k3n70ihhaurhdp
+            won:hasTextMessage  "Ok, I'm going to validate the data in our connection. This may take a while." .
+}
+
+<https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c> {
+    event:fn87pwzr9g4a9v368h4m
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xqsfn58cdatb7ryp8lzt ;
+            msg:hasReceivedTimestamp  1513171226407 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCG2rGSj81rzhPOgphwNGDprwQDnYa6v4vmiURfxoK35k5Ot4iIRYisycowAEwstMYCMGvCf8cJt5uzYi3QBJ3kFGsyeYm6n2AdS+M2AeGOzXl1s6cmJIZBvWi0Nj+wC+yekA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Ts/IRXsq00oSzXho352YoQkBH5CBw+mNTmD9is1ypvznH9qrw6ZQyWW5eSMKXkxHHwlqkiyG1bcjr5gvV3I15RnHcCh9JkpBH9snd3F90zHdKqh7PfwLa9MSm219Pgbgxs4la/biGYsFhDeZtb/fiRrwP3kNRaFF8sz9lP0SA48=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql> .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-vx1c>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xqsfn58cdatb7ryp8lzt#envelope-caql-sig> , <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:fn87pwzr9g4a9v368h4m .
+    
+    <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMFUCK6FBLgmf8MmgQJlwTfPJXAEp/JJ5V4r10vU0kc7eBVlaQfGyAyN1M4HAOAjHHgIwT02b49DKEfNDfw/81QEMQYd/HAnsuWdnzgtWngutgz/8cmBBq2i9pOaBW+SEODGj" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "K0nhark3Hrpoub3bRUcf7h408RBYkK04XuJBChVB18w4CpqHMOPTV/OCqU4fZ3lz9BodLOEGRqQ09J1SAcZnJkbiUHIuXOqQA4ZCQ6cvpmIZwSQZexhbCr9vmwaXiugqWwnEtxOl8+LyK4PmKul5nm/wqJIZcanR6mrCgKAopME=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/fn87pwzr9g4a9v368h4m#envelope-hrkx> .
+}
+
+<https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig> {
+    <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvJUwX5io7kRVCpCg0ACH7aHcLJaDpV6xgWnuM8L/J9HJ4L1G0zcb2cOPThKHdjaECMDGsIUf/dAuTnYgKxDJXunm5OaPW/RxtK/UkoeR9LjdH1NZx29k0dK3FX1ucOxQhSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VqBi30b6cD/Tkabv3jR/WYmM2nv0zuxQtPaNP9kPQok1RA3zkXsvsV5jyylmK4h+r+oTW6uDitde/XJy5+lQQZe0AxB8FNXRiR3szQLsg3GnwCM/G3cGQPAgq4bd60+c0/0nztI789MoS72tSiCL9/suHukcvjwyuujrGP54BHU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6fvg967tlh9rho8axvbs#envelope-rt5a> .
+}
+
+<https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw> {
+    event:0o2v37foaz8bog1diet9
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:d3jq9fgiu47gdhclj7h0 ;
+            msg:hasSentTimestamp  1513172263230 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCTDcHSqFtVW48pgWzGFvF11K669zn1D0C4840qBUe8edUlaX9S+yh55JN3Em7NhLwIxAJvP0dy9L9W6jyN7YOmS/7abtIH7EWSIg+E7AuRU6FIIR+Eh6e3K782FztURJDOUBA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "chotLyZESYqXR5Xbrs4rrVv+CkKkvfqGblm9FVDawFIHTy91tPgzmL9fJ6E6M01niKXJw0JH2gwpV3sFfAXSweIhboOSNJoRCk4FPQr7fWdwJwkOB7DavU/RpmWO/hCkFJwW6n9pUafTwB+zuQdSc3ElbfGTX4YkCpc2KSeZflE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> .
+    
+    <https://localhost:8443/won/resource/event/0o2v37foaz8bog1diet9#envelope-87iw>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/d3jq9fgiu47gdhclj7h0#envelope-pfc6-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:0o2v37foaz8bog1diet9 .
+}
+
+<https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig> {
+    <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMCKNGoZuX3Cdx/avuEcE54aYkii9K5pEXQK0QWqpK0vVvEqWQvEoFjWBs7SbQV9i/wIwYolGkZVW7A7p1NietYbLCRHcrQEihskE/862juaVTmSe9hhGqisqVNWBxdsTHFwz" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJd9IddYTEuf1hfrGTpj5bPbTDamBREL1KktLjF+hYsTc9pWnpYz2u4dL8MA50FLQJVe02vgmseTrrNJOuqQCU5JvmgX+M27x3rDaKDBUYxHmCGBP0N4g+ylfz3kQAb+ziLRg1t82LfBHQX8esySwF7gPWg/EA8yy7Zl1OZJR41j" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4y6xcnpgc0xk4relqfox#envelope-7ypi> .
+}
+
+<https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s> {
+    event:xp44teiwtooczc14npe2
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:s9a226k3n70ihhaurhdp , event:cw64ogmt2lv6n4kdjdxh ;
+            msg:hasReceivedTimestamp  1513172281150 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQD+pgU0KcvZU5haXgJP0vPN8ABSF5dbTtUqDRZryj4UgIBm2+20arCT8B8Pv3e3iJoCMQCy7lHFtRUap6GlYkPxiTEJghh1BKcg7TGsVJwG7y39y5VqEEgsvxW6+JIGRSHCV+M=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJO+EIpLsVgCPdJRSRb3+yFHtvJClYDEcA7bkFGerLNyBTOfK869VooFtodMwa7ssZGktottWz72JobouCx8YSbyWTuAWtj6FugvNRVhb274fbXYPtzuxVyi5RsimWVPi/ScyDHLq0rO7n/+TKEUkrTeviY+JO/eouQwGKPeLqM1" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3> .
+    
+    <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCpkOb7e5AdXuk0dkdTvq5EEHbHPFQek+jqslE7ieVGVDK+OWhopzXqsOzVmAjLFJsCMQCP5spWOSsU35tGeXf+5NECMMe9H+shg2ppQe2oRvz1K4FYY+EawU2xrxZ47g9ghgs=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "FApA2qocNuxYIXsIvWpkyVGUtz8xrSsE4BKgqzaNZpaDjoD23J7UAkNayg7fq41hPdopEPKHaRlcDIQk05w1ZR4jUpHcdj5aMaYKON9hX2OQ2+Y5l81XPmWkcmwJdph5CBdDaKl7dwhDcej/wafhee6jP8nY6raPXFIoKMrxgjQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn> .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-6e2s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/s9a226k3n70ihhaurhdp#envelope-yra3-sig> , <https://localhost:8443/won/resource/event/cw64ogmt2lv6n4kdjdxh#envelope-8ecn-sig> , <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:xp44teiwtooczc14npe2 .
+    
+    <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHIx7i7d12TqyqQxJOgTP3GOqwsKzyDJNQ2GBZ1LPAkT0X9xkjTWywrqCNuT+o+f0CMB116fNtAT1XTy/RImn1ShbeSfsdIAGua71m80LKnTk/4mv4TMHOkWoQmhPbVgO0Rw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bkVBm69HspJbFkk+BkV8Y4k8t6FSh2K6KjPskLkj7xl1B2KFmVOo5SKjXdZhr7RNv/2iDR3l3JpEFAg99jF5M8KDpyhdMRlj8GavJ3ybG7RG9fudrv4+fapmW3y6H/mpgjouVZTVfDDwxTJScBRNAybAjrvXYUldI6OfyIQtwzY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xp44teiwtooczc14npe2#envelope-ljoc> .
+}
+
+<https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig> {
+    <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCf/fdInjdyz1iYLMe7IjMIj0I0s28J9dRIznTow4yPWLMDgAQ1RItVQcNyA4XaGI0CMC7uTiR0R4WG0FZUODUc53CuEZHZDjeN1MXGSVcKtQIcbuzgL/UrsCqoCgKXuwQO+g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "aMOZu+pH38S59z1B3bJ6iKvqNphXrUttOzx1TLcbdyaPisvTFn6AlJucTPh25IxSnaHBgIxldTKGM2edcP5O9amOtJroF1HnYBcidn0lT4vMnaEenrP//S4/OATNXQwCktQYvjlwSFj7AmNLo3312oM5TrlVEnKcewtp40iggNQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4xjx598ewu7579zpl64p#envelope-se3z> .
+}
+
+<https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup> {
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+    
+    event:9se5txpx8xf4olwlettr
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:k175l3od8wq1w0s2uy9e ;
+            msg:hasReceivedTimestamp  1513170818593 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-3oup>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> , <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:9se5txpx8xf4olwlettr .
+    
+    <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDKYZO/gMNajY53bT9TTYkQA9LSmNHW9EmTbDTLT/QEBdrcSBOWMnJgBCCFcRJI4jMCMDTvCOYCjx4TrpfNFBPTFhHd3qkU86i8CqUlCGDH77fLUaZqzLVMpOuvqzE7RXZh4Q==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3sDKWQHYrBUqNvokc5PGD4Sxk7++1qfoEZqwNr8pOQuo2joAFo7oewiKUOt8+5RareGDHysWiWZCOYQBts5CwREyn6LXfxANFp1B/CRnea/lie2GRnct+jVv14RKLrckzaFe5l/k50jQOreyZDrE4pakYCOi2Ph1lH2jDS/+CY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/9se5txpx8xf4olwlettr#envelope-qgi7> .
+}
+
+<https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig> {
+    <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCE6+fv3kekPziO6ycHrssyEPEmVd3+oedrFW0bzWh05yKvDWVgTawfoW168fvCVj8CMHB35gY1CVGJGhMaDqsC4Ij3v+se7tRt86ZbNfRsv6ZQ/pAq0b4Qp0P7I39JyT+k8g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "e3lUhvyoQ1vICrN7gzkfdE4ambRm2eLkGGMC5N3tEXO1GEgLl6Qu5cEaolyp+5DBjamJB2NyaF687kwMhJez51KQQucfYUTcLWlHSoTkX6DX0FcW7ZgJucNoRdOkp9mcaheChQBrrFpRNwt/PuKJa4nKnzYPz0WoFzzFHuQ29p0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xbhopokox5b4vz78e59w#envelope-c4tf> .
+}
+
+<https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig> {
+    <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMBgqKyPnzzAwSOrEWdRQg6Sie/qAIkk4RoWRG91ZNs3ZaufTv+MKJwYQABvm+3z7XwIwBLKmbvFJYVVOg7lL9/P++F6Y9vV6f1KKYvAdWgTIlZc9CmKAenHwRPcjInJg/vHN" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "IkoFOioyKj1dJ0gWaM6qBVMO+6kp0qzYm4xYEoTELcB+T+YNUN0/qjRj5qeU0wm6n19CwYXsLjkH1B72qWkDpi8O1HyYuHp9nyXBDX7t+zPmO1W9CYQenLQCQB+wFhjUpCHiJt1Acjc7e9JntFdHzP8rkr9spFB4WlUK4j7+xxo=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/uu3ciy3btq6tg90crr3b#envelope-cl9j> .
+}
+
+<https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig> {
+    <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMDv87GZxGT9wI0KPGFKMsAXfYQ143yb9uZu/jVI/Ca7ue0cM/4MMtL5fO2/EO0BjMQIxAL3qWGffDtAABCKqDBpHbwoQlpI9EAmnwaMgsAMWUZsStfbXtV+WzWbq7iuKMfperw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "bfgvE4UOg/GIl3ISB6im7o1fm8CoXP0j/hmf6KdMcGUbHreJMviSC2QaThHvW0fBvs8bWEgKrGODsPd2kubJUnZ44pwtVwFT6Cz2It/EZ9qP0nEj1T1kuui54nEA3xvPeMx8OfJ13z8R47tTi7bv6Lpo2WQIAYQWm4EcsGA/HE8=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/4846251213444807000#envelope-tsng> .
+}
+
+<https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig> {
+    <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCIHYJRc+B6nZ+hUiwDZq/Q2Fp8CPHoH5rQFelPF75d10S5XXGQXxkAmWPKzO4D4ucCMFOPqkRH7cUPp9lDchF+UP9kxoVBKiTG543RR8YfH0tjOXifKyViHGgWrEuLfEx/bg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AI1eBedRsRLIMYU9bgETGQaRtxLOgb9SPDTnF/EqEbBoHDTujfjJSTrm5Hl6oGsS4VaFRaSSc5hWeAmC+lUSdiv0c5VPGDIzvYxyr23oprVQOOO5bRH6X9d+K+5Jj0aUsnOyVZhPN3mkGlq0x/OuFi7Vlwuv/N1iXKsIp04x39TH" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/l8d77tygvfnfycfu5201#envelope-ab06> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig> {
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCVhsAY7hBLadu1CWFOu4afRRKrTYxjbOa+uQ31OD7eTUoEggVuksPbJHT04zYkicsCMEw3BFMumDIgvhFMCvK7nyc99PoEk9uDykKS7L2auJJYJPsp78yPD5j4XL4xkBmjBg==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "SstIdyZUGtr5VqtVkIWuL3OMF2/dL34GwjscGyw+R3V4XlTZRKP0ggomWl/12nrpoe++P3eaYAFT+9Fb0auyUO7INcceZWRmiziQ4sb6GGflQl8ExrmvkSjMIFFobzDT370BPe0VME2mqwO1/yB78clzqPGTsiWGb3FRIR+SUWI=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-pm69> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig> {
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMBHe8v4g3/N32haNsMx+nQ3Or7NVbBTiGihBdHuSeX/9pRaSAlhhP1YFUviTMH7XrwIxALfvIg59u75UaxFD0L2wc2GGIfm6sD8VOVLikkQJBO77+N4Sti/yQewY9jwJc8tKpg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "D9NwDcnYkB0K46TWVa0vYNJ5/pIwcF8uCAuhDztUpV5rXDNEWz+HyntdysghgtPcRXaAz29wnBoC98wrXa02bMPnGg7BsUBnXKZX4NFg4TLBBSpU8jECI2drvdQvuq5nX6YxOUENAInTDKAEohiu49k8YLogubHY09UpENjmbcY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> .
+}
+
+<https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b> {
+    event:5s66o8cqv4rxv74xfepg
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:93e94yjsmx9l4lg8lu1b ;
+            msg:hasReceivedTimestamp  1513170829788 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-3o7b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig> , <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:5s66o8cqv4rxv74xfepg .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMH8qI64moKP/D/+XBh+1XDqUAooItSmLoEk/xt7WEH9/zGnX76uGoG6TQ1gbEC2+nQIxAKZGQk3n6IvpdbH4DAugjamtOcgKDDQtGHOuaqhcNnMUtW/3z38CJr1jExlpT44cLA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIIUS+7qXLkSoWnELV0FBeAUb8G6KYdsblySs1Z9IQKdQOiKkwbz786HZdTq0+bl3OG4qqXB54TWjT8wmjMkkXLJDkbgxNyZrY0pzVjkGs2VhBe3khTGq2JABzOhDDu5bFKnoYRrYaJPhbA9AMdSrcfYl2dGq6R+pIvRIdi8bKfe" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> .
+    
+    <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDZTkDgRaF835Oj6UwKOD/ygmD8e4HAxQQwpeLz/jnDc3bWMFGJPg7+m9b+/ICRSbACMDg9WzhntoN3QOFzxb2NpLOgPZw4SuWYnY1UbchtO6up378IyVkcX2Jb5L7if3xIQQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SaS7Juk/DlCPIs/CVazI1urUK5Bln0+qpYMqTnAVvfCdojEkSCgptbjbx+ok154wj3b5AKv5xrHqK59P1Rjr1dXOxVNHwu3h9d+1S128AcgyFoFvxtYK6aqIsfQfdFqOi57vGM0JYu3PQXp8hiSJbsgn7++gXOBheIke6ai0OhU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5s66o8cqv4rxv74xfepg#envelope-y4li> .
+}
+
+<https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig> {
+    <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDzS/bk96GJchKO1m7DnKdhfm2CL4zvRK7ZiaccbWPsE1EXhW8sa39WXOOC/hWOAx8CMCXKOLK0rk5ld8tlTsb9tlcMJCKDQGdWKBdQi+BBoOIqq9ol/wE2Ym/ZpPB5VXW0Vg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RKHyiXCMt4iH7VuKUjn2wxIM2u3mcI8bYo75myWM66x/22tpGT8BUJyOJG3QdeV+7IxZpX3GoWN3CbqPqzk4aYYjfnxB63nvKLaz6akXsBn8P4c3LcFe3l6r/+PHwfJSJD3W7XuXquVlssnM+4ZDZBKyZdfdJb4zj1t2OcbZ+gI=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5693603251585579000#envelope-euv2> .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> {
+    <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGH+PfbrouCmehIdgRXo4yunvWwzhPtuohLCmpYTsOBbyW9uM9aWkTsWGaAcmemS9QIxAITEuF4D+mvQU+FR8q4uHsF6iUR+iDOpvd/2owK9vvoe531JkyzyvW2PAR27N8V2Pg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKXeJziUssUYB3zf/yp8yil19ecdCaToDeZjjVumuVUAB/rHArTg3cSIEIqh31c3ilAPv8cy00Iwl4KhDFHm/bwakDlNd9VAmi0roKPPJzjSLgj2+d2DWCOz15U5LFIJRpdNlyvY5DrDykhFjDn/y8Dfn4ubZLVbh+EtY7qVmpQf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> .
+    
+    event:eubp8u958hoow90rt9dz
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cqvzpvoqvtkylzdybhej ;
+            msg:hasSentTimestamp  1513172274273 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cqvzpvoqvtkylzdybhej#envelope-x6p3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eubp8u958hoow90rt9dz .
+}
+
+<https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq> {
+    event:152dum7y56zn95qyernf
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:4rit8itn4uyigyesq90s ;
+            msg:hasPreviousMessage    event:plmfevq4c12f8itbisjf ;
+            msg:hasReceivedTimestamp  1513170830048 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-6uuq>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig> , <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:152dum7y56zn95qyernf .
+    
+    <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDHK/LL60brZNHJs4NuDuK45dYsAbBN0G5Ltv1Mtnt/h13j2+kYyPuI63Q+pN8wzg4CMDI2P7Dnk6jl+rBi7zcF9YEwZ5IMh3OIUok0iUWw3KcrdTYw2w3xPe4BIuHjVcJ1Qg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "VJvGP2sqpOvyAm4HMKp+HWB2tlKhUpBsUXUJ/jEB2G5mTL/kd0GB0yRk8VtY9KieJVP4n433CJcxse8IbfH6dLdVFEnHCbvT08am6nGHyrxvb8OaIXNawizvdkHIegcSw/5eXMpStx2KVU6DjLBXz9I+vaDmdSwIL+ARMlcV1+c=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/plmfevq4c12f8itbisjf#envelope-015z> .
+    
+    <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCvfSPUG9//xVIon8GFe4AsWPaOM/i/MtawDdiFs8J26W2cmkahhmBlVU1+1AS/9pECMGdsE/jBM8Pwt0WYhq61JK8wP8wOKwmf+Ry4jJsAE7ABP+Qk3u0nrKdiH2QHu9cTmw==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AKSu7kDaVNwTO76WzYes7L/X1hV6XCnD8JqYvNwdG7uC3b5EYsEmuLPEuOoNx6NDHpX/DDeN2rewpJ5izSCtCKBpa/CWDYRzyv5xNZ6TF2HeYIfxZMXTQi3AmcZsJbkNhSvSDZw3ZSOKJQPZnlk+IjzBxUu7wLcIi/yqCHA6I/cz" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/152dum7y56zn95qyernf#envelope-2648> .
+}
+
+<https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s> {
+    <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHKN6e7lYKZBpTFhP4RNuz4rrQid5geA0hoRna9vGW6w74Xo7D+gV+sk6GgOJzBwegIwGu+L8AYaGvMQrbFaBFncrE/l1xIbNeEngVoESrXVOzyUd4Hkj2bwNLGH1d7lHsHT" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "CI9ZUmggmSeCNb8MJLLx8KIlFfqz10cdxu4eQvlwjbMOtWIOXbiGBCH1QfKlJVWdraz7oKeMffX1UMETuEel0gTP9rGDyzAURpNQoruBN/UczsrGWfzJ4SyxSK4/UQjcG/GKsmOl91F+CjLHpWRKqCQVUWtJthQ+KHy9pj9TRGA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> .
+    
+    event:r5hu2rq515sq6wzgdjov
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:m8b6jvgclclzy48p7wqd ;
+            msg:hasSentTimestamp  1513170818019 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/r5hu2rq515sq6wzgdjov#envelope-ii1s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/m8b6jvgclclzy48p7wqd#envelope-u35f-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:r5hu2rq515sq6wzgdjov .
+}
+
+<https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6> {
+    <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAlEwKD5FAMaKyUwm7W6LHLLRdEG7SLizy+ev40Dmkux8pqjs88S1qc0eHJ30c0k4QIwX27IDuGaxk21COf+81YXznH55gV5AhF3xQ9VaN0/yP3hdYphke9/8mCzOIK/KsRr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "SZFt+I+SbyhZTAv92sY3LxoA3cA3yxs4AKvLtzmwDx1tj1r/Xx+AjD9bkjQRc3Wb7sA+YLQF6MpEHdqRDlCcR1pX+7nVYs6yvdPq2RGV7pbZIwlN9aCg7/AsGS7nFXWqhxURl4v2ecX2N663aO3aIgFTQBLLu7xEKugbbpsRQQw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq> .
+    
+    <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEAiz2f9ajxin8AOua0owcQBeSQVzG/AfI1+a5tIm6t3ZPtmK6MoWFAnHESOEWVUxwIwEmkyGXont/hM/s/MWOqMcEKs3nZ3XOb/3zBcjGnqKGCkJdti8vrEeHhAwlFTHIdb" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Kp873YDlEeX3AoV1fjtNoe747auudnnAavdPJ6kLIKxUZ3Mf+3PVlS0PLF5fXS5zJUceoMbKe9G5yShz5o6L/3I1CNoTi0+R0Sh+Mxy3hlIj2ZyPYKDiQL0rOI67nUdnvqYPh4bQ0bBgBvBgaZhy8GqQkNRDtgh1jST35onShvw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay> .
+    
+    event:n0k3zboeco26jrnxa7l5
+            a                            msg:FromSystem ;
+            msg:hasCorrespondingRemoteMessage
+                    event:eue8ar55z7as596cu33m ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:49hcv8na1594ijbpx3hp , event:rrmkri9cdrtvp1bkjcnl ;
+            msg:hasReceivedTimestamp     1513170819716 ;
+            msg:hasReceiver              conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasReceiverNeed          need:ekdwt2a60tesl77r13mu ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isRemoteResponseTo       event:8c6o81ry6mxeetm2d2pf ;
+            msg:isResponseTo             event:rrmkri9cdrtvp1bkjcnl ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n0k3zboeco26jrnxa7l5#envelope-jak6>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/49hcv8na1594ijbpx3hp#envelope-swnq-sig> , <https://localhost:8443/won/resource/event/rrmkri9cdrtvp1bkjcnl#envelope-uqay-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:n0k3zboeco26jrnxa7l5 .
+}
+
+<https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu> {
+    event:253k6pqq8gyttmmfxc7l
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170817841 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#envelope-bxuu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:253k6pqq8gyttmmfxc7l .
+    
+    <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCju3pOuc5FYy92BIFY2oHUlq0NNCrL6bCOgExhY14piu9y7a+n9v9rOerRsCq+NQ8CMB/FTZevtHRqRn0L/viEM3RFIo/QmruTaH7rpFX0zua2HIOertiztyPuwFFijgSyOQ==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCF3jrMIqN9xNks9z4cBE05d5sVgBAlLgMAlRW12JwpcGR+N5BIBcyPfFn71SXhyWr9mtVM+IWKwsepLEr5BdzS" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/253k6pqq8gyttmmfxc7l#content-ydre> .
+}
+
+<https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig> {
+    <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDUP/fs+55TXUZubu+45hQ+ta04XzP7sDbwb8ECqWcI8OrsYCadNZ2mdHGuO1n0F/ICMCW87yDqhImKEtP8txkLCdVI8/lkBI3wJ3t1gRSNXC89HTEqo2vvZG377rFgmZnzrQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "UkfJOncQPcw65kiy88cWFeApVgVHAnfZfQsjR8MowmZBIKcYUB08bpAaM9t3sQrdqZ0O+3KMYCgDdbxyUIKBeP37e18X7BepkZg70SsiHllnMNXELkRWrIlu3C+VzMRrufK7sMk94N3GSJ/oV0vv+7mpq4yxDc6fSgn5kAevy+A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/zquh20fy530jymcv4c7v#envelope-ux2p> .
+}
+
+<https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i> {
+    event:mmdq8395owv3xy9iyl5q
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6834006177130613000 ;
+            msg:hasSentTimestamp  1513171118837 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/mmdq8395owv3xy9iyl5q#envelope-eg0i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:mmdq8395owv3xy9iyl5q .
+    
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+}
+
+<https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w> {
+    event:collk6egdkt2tey39h8z
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:ih9v6gyllshhvo5kxyv0 ;
+            msg:hasReceivedTimestamp  1513173165910 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-2l7w>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig> , <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:collk6egdkt2tey39h8z .
+    
+    <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCBXQAY9JCzR1KytintdoJQqCCijMN4fZh/scIuz+PU1Yo68ES0h/94Wo2DYHGfEVECMQC+YpU2wvl6TAscmFS04k+gOJemoI0/mwztgZPUNfvLmfkjRYorH+DNP15m+Am212w=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Nxifj77s222vVKuupybo3fNtjRETwgJdrubPviAO2r6fBRgFSFDZempT2GNWXNKSRFmT+YMMxPs+p/Rcq/CDZ1mZaioBBYlZELSyqOJlj0QxSzIDZnVb64/+bAQYOvJCt7dgtUn5BYW7fHvyYxIcwFSLvmxnqlFbxne8MT8dkTk=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/ih9v6gyllshhvo5kxyv0#envelope-jkiz> .
+    
+    <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDCGC+fxSUaQjjIuQSVVIigcnCWzEKPveJ9NUSdywX/FT3BMZnMyhYSvdkmhbpTEVICMQCbh2INMmp1jvWD1ynEXIzsqWUQSSOReOq3k2g5P6Ocw4iq5tY9sDrz/DegDrV4aFc=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AK+J1W60ORQU0cHT/gegRIlK9tSB1RF7VNTddUPUI0Rv6vG7oVO13Mr/9Vv/a7gNVYpla9j2oXKnb0oPDuxBNtVW9YbhzZwcML+5NJnTCJWbeDLjAIfYEU70BMhGK3CQPXlhjdvs2uNHNaRK8eZ2qX0T1q5mgyx6vqL9dmPGuWGo" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/collk6egdkt2tey39h8z#envelope-cujb> .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt> {
+    event:vj2yzrtlf700wixuxujw
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:u02ulpncdj9l8ae8x2aq ;
+            msg:hasReceivedTimestamp  1513172274227 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-n1zt>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig> , <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vj2yzrtlf700wixuxujw .
+    
+    <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDsoACeLxf/+IE5gGN5+M8+xdafOXT23XABQv7HN8M9jxmP5HRBnZsD4NYZIPfhdM4CMQCLxNWA8XtkrWqgEfrmS8oiGc57Qxc90xnWcjfqbRwD5htWyf3VysSyaOM5MGdb1lU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "PbasWeY7409EneTPZB5PGTrRZ87optqYqAJ8K6sxrVaDVI/veZNZXQppInCsGHXnUKsv9b23DKyDd0KFFYFj2YUuNKNz7kwAzIxnKDFI3sBHg8W820U1WqQXudbw3k7gXsE8cFYa9UkgqTJP1yfOit7kAKQ7b07dE3S0FFAaY3s=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/u02ulpncdj9l8ae8x2aq#envelope-t2ru> .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMG3cgv3q5U/BNS/byfl0v5KNgRhpy+NIElWSV5KmTXuyIAnNqgKNMe8VN1u1YybNXgIwCxz6tc4aHvt6naHxzxLbvO+C+04n8RNsVNBqTaXr7FGLowqnIhYqfUMydQ29GOYr" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "M2xYxjfxT54CXeLx9x4QCilSOfEbGJF6DIYX5Kq6e4VHf4vX56SORqKnym+728poaqxzv6rd0qV8S2LsQNYCYI+Z7R9CvdYM+hia6dJUNDDE84qhxzBsBXbILV/uJpe43o01tXF1OeV+CEykmjvIRasig2lfrUb9rMEREdZXqj0=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> .
+}
+
+<https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5> {
+    event:8h7v5ml1aflqmoyem61a
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:yrizizmtaxehctdi1m1n ;
+            msg:hasPreviousMessage    event:v66scoiidw56iam8q86p ;
+            msg:hasReceivedTimestamp  1513170817880 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-2hv5>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig> , <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:8h7v5ml1aflqmoyem61a .
+    
+    <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDmUzvYHlnqFhsNhN9yyn+ACcibzuWF90B2IB0Ss3l1lMclmKqZG/mPbYAQhdjq6GwCMEJMC0sdfXllbc11OzyV04BR7bJRGjQdhIDZnqFlBvgd6CQvtxqn2cpoKqjUfbR1nQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Y3/E/xdFsD4nOnjRLgSS9fOotoomwZe1+AhyQKOhq0TLsgci00CR6apNZwVKH4Y//Q/7SUUxLwEnEQj0QTNo7VIFwtqh1xpUlXRycTLgWXttqIYwoGZmqFq9cfI8BQDQrWcqinZ9dE/bqW1chLYBxfOQIR4TYpzfhxpamfa9rUU=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/v66scoiidw56iam8q86p#envelope-v2bd> .
+    
+    <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDTcDA03QT1luSmHUw8uU2jo+vqHbMxCxB5LRT03w6xLUlIaBLI+qfnHYpHXRdmbxUCMCvfpe9jTMRIlBmKyb1agBotI/xe+iqvzBWCOno3hqPyTKdPDBSTjW7uzymyFhGZTA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "AINzmExGAuItVY4iWWX3ka/npoT4mGt4I7PUbuawXKnz0IZOuGTHwkqoFrG2CCFb37sn0BTzblmN2Dpyl/LglekbqhzW0/lnedushkiLv88rsJ3cIpo5pHe81/qQy0l5+UBKIWL0Bb3WD3UVMSc3Q8no+okXcQ5oAN5J3tsSALFT" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8h7v5ml1aflqmoyem61a#envelope-wbv3> .
+}
+
+<https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig> {
+    <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAxuHJyKH6yb0AjzITBNr+WXaKzSWQgiH6EL7gl85MSPLDV+MV5176lNkjqhj+RuawIxAPclRjOd+9tfP6Hi8sLUSfZe9yMKHYDpq0CfT93tl7xB5wcQOB7aAZFXdnJKfRsQSw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJtjnTh+5b0TnAkSk52R/y9T3vwzypfGqx7zZplrz1fb2NDF5QfvFu6vkWxuZkN03bzs6MWbuxrYW65nm0T62vgcdYW3oHXu9JWdKK/C2NNYuK/cPVn39YplFH9Wr0Ua4Y2q2VvyZUxy8o1c0c7HJh9HMVZIyO9Hg33eP4isfjqP" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/yrizizmtaxehctdi1m1n#envelope-8kkr> .
+}
+
+<https://localhost:8443/won/resource/event/8863100035920837000#content> {
+    event:8863100035920837000
+            won:hasTextMessage  "validate" ;
+            agr:proposesToCancel event:1107469913331435500 .
+}
+
+<https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig> {
+    <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDXHZeVv8i+pCh2OALHybQiCzxo6GJZFjfK1S1bD3fK8jucrOtHesC10lzZ6RGmK94CMQDr4LrEVKGMtUEc7Op+XwQHfAdPsiOiKBWGtg3/kXd9utxPzKYJzaXVSloYyLOmSiA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RMthaMI/n9dlF/JbALNsauVSOVQhoDOJYaPLBeCI+stktXq6FPG/U8cApdcrqLR2lvElCr0Nzky6FHFC6WomMZZTcgoiEYK38zJG6ErG7AzTtgX/Jaz6nKHprBm/TTwFEm67CGfE3n6/SFFuPePbzYX+VNP87bbjijOsMBsA7iA=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xkeovy4cf48spd5euwj1#envelope-0x2u> .
+}
+
+<https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s> {
+    event:i3k0giied2bgp0p44h7u
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513171228916 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#envelope-m92s>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:i3k0giied2bgp0p44h7u .
+    
+    <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDSRCvUFmUuUw0S2we23jtPDgtMhNOB8DWHhjz0YLnEzj9/X4WF5WHAu4HhccF/PfoCMQDbLXNse4PXwdoeM586V1kqTqL2wR4okNB19i2CZAbnp+eqUZyhHnWKE1QPo/34YRo=" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "EPmfsABiUChbH+MZ+Tyg2eLP5+CMe+9bimftudbsYu2v97a8hGfz2RxISy2cnfuN6NFfmjDLgvj9T6Ru1A/LPA==" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/i3k0giied2bgp0p44h7u#content-73q8> .
+}
+
+<https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig> {
+    <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC4j+rDkXxIN1TWTiX2FmPFQzLVWqfHqmmVmXfhOlT+WRlEu1IhiKwmtCcaOR1bD28CMGRu2E80fqL/sZyAo9dbJmLlXKWzleyNe8ELfgUqfpCGXfDlnePlDum255WD9rRdGg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJqyzUBUhStwyRnZXFDykPEVIBMBNtMij53h0S0Rgae1FaaC5bbngcWo3Im01f0xgZEPmB521cSAr0sXPYmOwcTxzhnZiZq+cC9Y6jnfubnHZxxYY964fw/OZ1lTEPW+z5KT7PDt2aIDzJM1n7xUyYDZE9/wzEdP6nO7t/6ytb0T" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8mr0p8ua2srgw0zw69lc#envelope-iyaf> .
+}
+
+<https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig> {
+    <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHYxrBjJ552Zeuv7mn4RAChwo3MyPRMTEqFcPtZYd7sw5jvzahd+M1EZJgfwbX+GUAIxAIFseYpEMJfGbpcK2E1gli5yD+GI2IYPDhuHe8NPW6c+cI+euYsI2fW0zsmWVx0XnA==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIlXQjXHzAIWgPrUKe3iPk+lkGuLEXpGTkwq+MNqTEo+1eZzQV9/edoDylIEWi4lnlqyQZY9D58Wv325vYHjj4gy4u3kfq83+taPiSB7GfwW+8UVUvIQZcYHQoHCAsP4SygP8YNbLrjyGbfHHulvrNOa/3/Fj16Y/IOYb3rRgkgb" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/k175l3od8wq1w0s2uy9e#envelope-vxhb> .
+}
+
+<https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig> {
+    <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMHdvB6D0bnXC0nnVc41YCqvjgkc1MsLilJn6+biG2LkJ6tMbjVJet42R1h520OhqQAIxAKnH7R7ATvW1zV837e44hsQE/uAa1/6HmfmaOmnqHBhr3SCuOoHnjeVIDXF3/F+svQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "LhRY5CbEvEehwp/JIX4JOMKF1jRlB0sQaCMvWp26X8u7B8Ycgo51Rj8jM5YollMaXiKLTqgZ98j1QhBL86mZaGGpItmYaxnMX76+o3/vLtw6OTwOo3vmMcvx1HOizEgkC+8r5f+G5p+qjNEGMYwSKYrwa289efOJjwMbak2WULY=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/h2lo8jybm27ouaa4wuqs#envelope-j18d> .
+}
+
+<https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u> {
+    event:93e94yjsmx9l4lg8lu1b
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:xsbbah2dhkcg6d3h13gk , event:dhdnzy40wlrnxh7ymr2b ;
+            msg:hasReceivedTimestamp  1513170820733 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMGZHmDktDtnu6ZvYEeT9AdWc2UG1oZ9fGIKCOKqGoUAKJfpAUxp3kW2vEjyPYZBf0QIwN7d7JyxkhcBweslGCs6ICrBL0Z0C5d0gVo9Os/sXq9YM/13n2XO2yx+1Y2iYS+zs" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "B22EITMj++SLnFn6FwwjXoDYUIO6icnNkV58lZpERO6NHRAQxFtTD182toK4TK3sNApWEI2r5LeoBNwGmIJB+kinQXqduZ+jZ8mSOcwC+v4U/c9JVUuvR4mNK0xkn5nK6hzOsP37o0kHXOECHYPO+pcDZTGSkQ7FnO/4SiQ4ldQ=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-4r6u>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xsbbah2dhkcg6d3h13gk#envelope-kz6e-sig> , <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig> , <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:93e94yjsmx9l4lg8lu1b .
+    
+    <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMAJDEJld2ndIaCn6/1kRsp4kfm7HZT2fvH77JQ8s0zZUhQWyrBgXZRhiJrEBUIMZDwIxAMeCP4ugC6Et/yhH5xEdoiEoseTRJCw92Naa+b1yJptL8HGS6KyvC51/j0RbowFziw==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "c0UEvfRWh/PcqHUGJZf8M8e0Oyoi9txmVMj5sRI0cnHfvY+ukgrlV5fTYIHMssQiyNQZKXomAMSgqlrllbY6hE0OAoBCsakCOZUvU6Dp0t996nSWJulqZbS0r4xCFn2LvVsUJ0hsv1M34w5dhkTjM67Xr+WYCHzqN3jsw2/kR5Y=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/dhdnzy40wlrnxh7ymr2b#envelope-je2p> .
+    
+    <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMATMRieaehOcM8oVH/Sle07y55YWY7NKR1wQsRdj5XgEq5vu2AfEuhHzxsGcwVf8TwIwZajvTLPulEPB5McofGo6pVW7z8jDt0aEoLjeD3vMQ0pHKUD70yTK3G7Ekqr3gN0n" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "RBs4Wxn4zVx4N3kF5F3vpSkbabHW4pegoL2pD+UPLNeXX/dfzVmdLCGV1wG/oqu9lDStFoE/LrsB/pmq9/rVzKF+gVw9mUKUgxjm7RMkAby5qZNfEiOR2zM/uxEzysxnsCKz8uDkeTYbejTbzQeUg7A4ZK6kJRKGf9fiNbotf08=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/93e94yjsmx9l4lg8lu1b#envelope-7zk5> .
+}
+
+<https://localhost:8443/won/resource/event/t6d7eq3cq6nq54a16k1w#content-wx7j> {
+    event:t6d7eq3cq6nq54a16k1w
+            won:hasTextMessage  "Connection https://localhost:8443/won/resource/connection/lhrkbkodc0y4rmc7z51y is valid: true (downloaded 266 rdf graphs)  " .
+}
+
+<https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0> {
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+    
+    event:eubp8u958hoow90rt9dz
+            a                         msg:FromExternal ;
+            msg:hasPreviousMessage    event:6928365067343411000 , event:8pk5umtsiiwch3wl0mda ;
+            msg:hasReceivedTimestamp  1513172274307 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-apn0>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> , <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju-sig> , <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:eubp8u958hoow90rt9dz .
+    
+    <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDEPR9SsPgvGZynkN63mOr6hsc6bJrqXjutlcM10zXq74ip2DRwtJT6BrFGkx13sgMCMQD8Pdrc6hEKXX3v5okbLALEWoE6ggulF/LaI21XYWqSv5uug3jAN4BpzKuh+tibNqE=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EgnlV48KjV4va4x0JumtL4gy+FJ/E6bq0k3Ltdvb7+6I+4BM3FXerELXTUnlXb3z6pSdKkv3Yowj0e32DhWQSUAqqNf1lFZZjWtmdCLwR0/7N7Z1xZ8Sl3rjdaHiPoLfL7aKgLqpUQaxhsBsjOOMAT9TsqEDaAn+Defq5hGzc3A=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/eubp8u958hoow90rt9dz#envelope-yhju> .
+    
+    <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDlJJUwj6rVz5MAYseOY1b6315LTg4MVSYYsYOsSopsFb/fH+nEGmtrM2N02uBWfiYCMQCEePhqHStLwyluUKeNwa+VX+sPhXo5lvblTvnUFKENVHRdRtKHNlocYFocpLruNoM=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AKpWpWhPq3JF3pYVVgesevrqAR9a4p+eUE3Q/Zz+fcOKwO+g1kOiVjJRpTLjnB00c8bdNNpUD1yQ2X21T7+iUaOdUQ9+SaHnvgVRPLLrzoBtBZbWW6pyaO3237ha2vmxqMdlkC2+UpWRuYkthQlUIgZg5Mwql9N7ttg7vh6ej8yA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/8pk5umtsiiwch3wl0mda#envelope-3nfd> .
+}
+
+<https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t> {
+    event:cgqt5h004iql2003me2n
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> ;
+            msg:hasMessageType    msg:ConnectionMessage ;
+            msg:hasReceiver       conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed   need:2615528351738345500 ;
+            msg:hasReceiverNode   <https://localhost:8443/won/resource> ;
+            msg:hasSender         conn:lhrkbkodc0y4rmc7z51y ;
+            msg:hasSenderNeed     need:ekdwt2a60tesl77r13mu ;
+            msg:hasSenderNode     <https://localhost:8443/won/resource> ;
+            msg:hasSentTimestamp  1513170830888 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#envelope-m88t>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:cgqt5h004iql2003me2n .
+    
+    <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCRdsvIvZ4uX+n/6GKA1FA073rtuWogzDuEy63vcwDXW9tu6DU6Z2ihc9mQZf8gDSwIxAMYtjEYHPqGpYsfF1N+9iTbovSevmcsUrJapZDW1iiAtzFHJrNQgiE58t6KK6ybFSA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "ALNs2UTDIodwFyAkA57/S4xpXn6pTLvNmZqzm2oMxTdmypt/0/Y4eQ4AdVjOQetMTxvAiQ6J/tIRzEMWFTU0qrCGzNrFfexGiz0TLmOGU9Hv4+o4BbECK7cdgxcYVIlh1YgYo0CO5RBFWoEf98ko6bfTEvFLy8CjQzp0wCK/ESl1" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cgqt5h004iql2003me2n#content-lqq7> .
+}
+
+<https://localhost:8443/won/resource/event/eczqg8lp7xbukpzikd41#content-xg7t> {
+    event:eczqg8lp7xbukpzikd41
+            won:hasTextMessage  "    'deactivate':  deactivate remote need of the current connection" .
+}
+
+<https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y> {
+    event:2uf9sj4itmz9fpas7suo
+            a                         msg:FromOwner ;
+            msg:hasCorrespondingRemoteMessage
+                    event:fits98gjdl4ybaudq5oj ;
+            msg:hasPreviousMessage    event:xpspyx3bpyev5v5p1vf6 ;
+            msg:hasReceivedTimestamp  1513171153811 ;
+            msg:protocolVersion       "1.0" .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-sc0y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig> , <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:2uf9sj4itmz9fpas7suo .
+    
+    <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCLiF2Oo6yR66MbOsTWOoHmu9WSJLKN56cvo9JxLGqBkJyk6bccxc23weX5CSQKE3ACMEej4JfA96dgMpP50ynn0HQbNhiOU3gGjBjcr+CPhG5ZMJmDx+YUN3qEBgZs3D59Ew==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "I5Z5ICKCBQgOW26igPokbuW8tM01DjXPT0EUnfoEMWCNT7HnzNjp1DNQIEUPWNtvpcFNUzt9CPKOh2Cew4OGFRsnQPK8J98xhaEb558ZQPelLNq5+4rPuNJCYIU4VHiDd7GrvxPFJlLAOx0myQ5bcDAtky9gE7ZOAGyAzX/ZH6E=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/xpspyx3bpyev5v5p1vf6#envelope-9lws> .
+    
+    <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCHcLhnKBEhtW8uGCiNVUkVb1rTbX8Q3NCKlWI/K9+Vv7XhZB3LZH9RZjI17O+HFrgCMDGmjxPKFbFQAfbU2+3xc4YjJSeYe5Hr1LTIwBWofkxgIU5Vf7P3JZgrGIuE0PUhlA==" ;
+            sig:hasVerificationCertificate  need:ekdwt2a60tesl77r13mu ;
+            msg:hasHash                     "LHFtESfrJZ3IfdJ4sFf2wk6+PYJK9RoJ1JGDl262QmCvq5ep7JpfeUlnWN1scMZeIRR7YyZU+NBmFBPu3pa4/a/QgB5YlHpweIgW4gu9l9Oe0X36AhVMA+wFYMZmS83u6tUtU5tEupu2K0hBU2UH830Ng1ernS65RcULeG9URMU=" ;
+            msg:hasPublicKeyFingerprint     "CM2r4ZNKH5bf5dS0HEbJ6133FXCXF3jyg3+Z70mK7yk=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/2uf9sj4itmz9fpas7suo#envelope-zwgl> .
+}
+
+<https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig> {
+    <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMCtOBx0DJ1s+5p/+VElN4UcceRlXXPRA2GROyWzZMXjokq4vRFeqXnuzmgRCc1EAZwIxAMrj/lduyo0xwpma5gSJn/YGvvYDEGBAZXFIMmDIKn5OJBXqjxyruMmnWxgFQTb45w==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "H4o3btmIqMN6TfHc3fy+ob16nA0i+etSihGq6GhfKXJ/QOKm6Z5iEYbP6XiCcih/uUbYi/ZYUFumMOWw8Di6PBqYYon0JGgO7q2RrSYpXvQumfOjKKFq9pIpsIg3B5sjuUVzdi6cq/e49oiWzfEp2Wo57lh2ccIhvCWN+2fazmw=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/1tr3o22co1907d6b6n7s#envelope-sprf> .
+}
+
+<https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y> {
+    <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQCpItk4iDtkOziI2HJ2FGAgakwEmhxRqwmr8T3YSXszb8K/f/REwGAWWO9RdgmN5noCMCbk2NVW/W1V0uV4H/vkRSqVX7yWJClPM3ifR2y+WtdS6dZAkHYrD9EH++zvNjH5GQ==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "EVIqE5Sgm/fDi96LwB+qeQ8gU4IgCo6QiP4YmqvSiXb4V3+yxUKOQ1M711e7VyxOuu7yuhEX3WE5ktJnO7usPXzxTkTMr0vUo68ApDVJrPF62D2lPJMwgu5LF7XSqqmawBijrmJsNeoSTbIJVvGC9NK+TRnlb6RXmZwSmG+0eJM=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv> .
+    
+    event:z1emzo49olrm66x3ukkt
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:238289506881087500 ;
+            msg:hasReceivedTimestamp     1513170861073 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:238289506881087500 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/z1emzo49olrm66x3ukkt#envelope-027y>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/238289506881087500#envelope-otwv-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:z1emzo49olrm66x3ukkt .
+}
+
+<https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh> {
+    event:d5whye2xxe5kofpdojs8
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:n5rqfwjqbcpdwqjjwpdw ;
+            msg:hasSentTimestamp  1513170841832 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQC5EUJrCXtS85x9aAQBM7cnWIFI9JQRt0MeqXTZjSYX07kn3Do69jyn5ZqmNCaVB+gCMQDSIavZTB+ycpGvFs7IgXMAJ+W5hfEuahzkWiPD786EjakTIxjr1o5k+jHtesfqmnA=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "Iubf0kX+52CREWuoNMdu3IG7S1cNmPwXc/QfsvRBRz/znsEzoBXJJ08Tx88ryu2U6e3mlcysAyvKnG+gBlCRz4qwyGMb65i+ZgtBF/qhf2e25kd9vLyImhY+wEBaJVdePXGyT5zen6yJwF9F2oRCXhWhjD+J/SKhWK7n3SPyZko=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> .
+    
+    <https://localhost:8443/won/resource/event/d5whye2xxe5kofpdojs8#envelope-umhh>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/n5rqfwjqbcpdwqjjwpdw#envelope-p3vi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d5whye2xxe5kofpdojs8 .
+}
+
+<https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m> {
+    event:vj2yzrtlf700wixuxujw
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:6928365067343411000 ;
+            msg:hasSentTimestamp  1513172274135 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/vj2yzrtlf700wixuxujw#envelope-vl0m>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:vj2yzrtlf700wixuxujw .
+    
+    <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQCXZgDQXQOgiU/CIrrIe1Y9lidMn7wZQEdYOMyA2WXZpVk/ooJAeDfx5KHOeKPT+YgCMQDrGHS5+9EsjhvkQunZjvMyHKM+Y300gUNStEyeHXyPdZbcX2+LJpMuSC+tQPTJ/BQ=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIaMZ+IFYR6CzPTFZ+pa2ZNR5qTG3ooNQvK9TUiWrJxxbM0BeBiA0TQR48r+3bulR3u2HFylGynye/OciBeF5HasVeBSCy+dQH55BqRNjdYRPO6SljAL12VCu5N9IDMNkOzVJ1EaD5njipYRdXWGdpyVMBgZG+hWcnxxuKiRae8V" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6928365067343411000#envelope-9voe> .
+}
+
+<https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig> {
+    <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMGNnDwc5YYL933nHtnxFVA8NxJPmQNfPjt8hUwvgsMvaLDx46ML4wY+pYH1ucJ9fCgIxAOilrXvu3vvKLsYDyD7SPEhFHW8/l7l56Q5P265Eq+y5WcpiYj1ZxjhQsPblPwyEdg==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "dGtyMN8bioDT+K5C1IRYeFks7KsJA4SHKzwPBikY20jzMfMPPit21cM9mBMjS30atk1s+RRjOjImLb8pqLB09JU9eb/j6U51PDhprQ7o3tTK2gNFuOqoZcxZda59EYQxnqHmravRFM13SrCgCz7WGYn+24ctpbypUCRspP26RL4=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/csridlusp0h45v9gf9v6#envelope-4ny1> .
+}
+
+<https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b> {
+    <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQC+Uh2w91nO0PiQM1ZbPV3ivy2nUpOROl646v4bcZJW/XsZgR3K7BUl1l9S1aIeZDACMH8IPIUipk9MVmxNNxvEksoen9F/+G8jot4jYjPpMq3JzsujxVOJnHfZ35Ndnvd+Ow==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIVRclFXmsxfRFLl8+J6bHbeWMsunA2rbTESy7FSwCc3cJz486iKwuRxI3WyYW3ufVZOE6FYUWB2f8UAZpWOfb0AaaBkWoiwPy2d2GGMN9ILfRwQTKjfjinFAyi9GDHXhbydPIEFImzp+rHySpw3+6tKXtVD96DeitkbdIUaK3qA" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> .
+    
+    event:3v08br9ub79spo7ol4v0
+            a                     msg:FromExternal ;
+            msg:hasCorrespondingRemoteMessage
+                    event:cbcccoqqqbec6bxkl3y3 ;
+            msg:hasSentTimestamp  1513170817835 ;
+            msg:protocolVersion   "1.0" .
+    
+    <https://localhost:8443/won/resource/event/3v08br9ub79spo7ol4v0#envelope-yv8b>
+            a                      msg:EnvelopeGraph ;
+            msg:containsEnvelope   <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff> ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/cbcccoqqqbec6bxkl3y3#envelope-p1ff-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:3v08br9ub79spo7ol4v0 .
+}
+
+<https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig> {
+    <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGYCMQDPFhb34OB8k2mJw1ENpRFAjJpJQG7uD06okQcrZK6LlAd2hYoU1P4pYvOaaDzzrt8CMQDLyHns3EDXnZSwSd3dmyI5WmnpoPGmhyGLh6XK8XHZLu/dDvT1VbLunwZYq+PYeYU=" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIY/hoszevOdgHxM3akZjWGg9V1V60yySVEHuOh31BxokPNLZx3FVYfI+u3TkQ2Zr0o0ZQApULD7w9RdGDMX7BBnCIFUhXVDTJfEDItHN69STmLORhIugUJp6TTk3Q3vjhyMowtPST0yNdf5dm9bXgBuNPI9uo9tU/SITKIIRukR" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/beyjpryu04ao4on0z22u#envelope-8ltu> .
+}
+
+<https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i> {
+    <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMF6CT9l8JeDwAmlBIaI8msTFeArggS130y/2ZuGxX8QzwKgGgUjDQgPKhbO9uhhqvAIxAP58F5/jwVciExUF/5pP50ljQcDmWxr4SeN0w1XTt3YiGkC5qJgNPRH9C726x9xO1g==" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "XwQFl1nj/59tiAmZV60R7K+0PuEygmtEP9PlMOVvJ9aTnayKqnpMygT/3yChxtTLgVcbSVODbVZ4W27+RnOTqFoE06LHccSaE+PFWupC897bduMj/auR3HL4VLvFvlX5Epyo6mklUYfJ78kBu5lhSrUhC7MKC4OWZJyRtLwhMlE=" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi> .
+    
+    event:d0muf1vbp6zai6jtnp7w
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:6834006177130613000 ;
+            msg:hasReceivedTimestamp     1513171118837 ;
+            msg:hasReceiver              conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSender                conn:b4vtw60q5p3ro3yfjybs ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:6834006177130613000 ;
+            msg:isResponseToMessageType  msg:ConnectionMessage ;
+            msg:protocolVersion          "1.0" .
+    
+    <https://localhost:8443/won/resource/event/d0muf1vbp6zai6jtnp7w#envelope-xo0i>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/6834006177130613000#envelope-w3mi-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:d0muf1vbp6zai6jtnp7w .
+}
+
+
+<https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu-sig> {
+    <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMEav2d8Yjom5QcDq1kc1AOAdVN+XfDiOKPTRz+bLL7sc+FFPHri3X8PTHGnq3UxpmQIweUWTRIM7lY8lHX1dTKuEozXbBUC/2X5rRO5RZnfy/A+TrAQmJD1UKCHnz+9jFvzW" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AIukH4kDFailxHMWUQ2r5cLeeuLc7c6TSE+Ip4kVAOZYPv64d/rrLIq9JbwXTSioDSb5Ju2VOWJUJXOyWqooIdOQjO1/VHUOG0+uVJxUvYRayLtWZgSKlIqaTYX1hBnhcQgLR5Lsa1Pqx3Oi5l3nA2zHNG8UIPKWmR6ZN947IGz6" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu> .
+}
+
+<https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu> {
+    <https://localhost:8443/won/resource/event/qqhehmrwyd15rhzizczp#envelope-q5fu>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    event:qqhehmrwyd15rhzizczp .
+
+    <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMHwnER9mKIObNAS5AabD9LaVkZp0+oEv5YQ7m3IwvO8BurB4ZWEH8ubqB7P5eAavHAIwQbYEtNiZouwAh8RT4zPwLK/FWjbZavVeDMaGJoEpzHLc8q08VHQIlVYB2zvciIER" ;
+            sig:hasVerificationCertificate  <https://localhost:8443/won/resource> ;
+            msg:hasHash                     "AJJ8Qqi1Qt0/aVKYQlGeQmM9dzXVs//BADbonQsJGbbGp18abhuHQ0sjnwyKC+v9mPiQxOElUhzcuwxRhiR6nhwc0mb52wcTQfudQDAM66ztwOwup8Ibrt7RDl+4kJvdwlbhAyKpcm/mwzGXljnqY0k2QrsUD4fbaz5ZZhhijACf" ;
+            msg:hasPublicKeyFingerprint     "Sk7FwsKgm/SxPIjRVipweRj/6PYMlJlh9ubLMqz3myY=" ;
+            msg:hasSignedGraph              <https://localhost:8443/won/resource/event/5946672495584215000#envelope-ust8> .
+
+    event:qqhehmrwyd15rhzizczp
+            a                            msg:FromSystem ;
+            msg:hasMessageType           msg:SuccessResponse ;
+            msg:hasPreviousMessage       event:5946672495584215000 ;
+            msg:hasReceivedTimestamp     "1513170781771"^^xsd:long ;
+            msg:hasReceiverNeed          need:2615528351738345500 ;
+            msg:hasReceiverNode          <https://localhost:8443/won/resource> ;
+            msg:hasSenderNeed            need:2615528351738345500 ;
+            msg:hasSenderNode            <https://localhost:8443/won/resource> ;
+            msg:isResponseTo             event:5946672495584215000 ;
+            msg:isResponseToMessageType  msg:CreateMessage ;
+            msg:protocolVersion          "1.0" .
+}


### PR DESCRIPTION
Steps to verify:
`won.protocol.highlevel.GetProposalsTest.oneAgreementProposalToCancelRetractedBeforeAcceptTest() ` uses a conversation with a retract of a proposeToCancel. The expected output therefore is the previously made agreement.

you can edit the input file of that test and remove the retract statement, then the test should fail.

Do the same with the similarly named test for `reject`.

Fixes #1682 