### PR TITLE
Fix deactivate command execution

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -888,6 +888,11 @@ public class WonRdfUtils
       return URI.create(findOnePropertyFromResource(
         dataset, connectionURI, WON.HAS_WON_NODE).asResource().getURI());
     }
+    
+    public static URI getWonNodeURIFromNeed(Dataset dataset, final URI needURI) {
+        return URI.create(findOnePropertyFromResource(
+          dataset, needURI, WON.HAS_WON_NODE).asResource().getURI());
+      }
 
     public static URI getRemoteConnectionURIFromConnection(Dataset dataset, final URI connectionURI) {
       return URI.create(findOnePropertyFromResource(


### PR DESCRIPTION
Implementation had been an incomplete copy/paste production from the create command.

To check:
1. create need in debug mode
2. wait for connect
3. navigate to the conversation
4. enable RDF mode 
5. open the need resource URI in another browser window
6. in the conversation, type 'deactivate'
7.  observe that the connection is removed from your view.
8. reload the other browser window and check that the need's state has changed to `won:Inactive`

Fixes #725