### PR TITLE
Storing privateId in localStorage and writing it into the uri on connection

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -231,6 +231,11 @@ export function accountLogin(credentials, options) {
         .then(() => {
             _loginInProcessFor = undefined;
         })
+        .then(() => {
+            if(credentials.privateId) {
+                localStorage.setItem('privateId', credentials.privateId);
+            }
+        })
     }
 }
 
@@ -247,6 +252,9 @@ export function accountLogout(options) {
         doRedirects: true,
         ...options,
     };
+
+    localStorage.removeItem('privateId');
+
     return (dispatch, getState) => {
         const state = getState();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -42,8 +42,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
     * initial page-load-speed.
     * TODO fetch config data here as well
     */
-
-    const privateId = getParameterByName('privateId'); // as this is one of the first action-creators to be executed, we need to get the param directly from the url-bar instead of `state.getIn(['router','currentParams','privateId'])`
+    const privateId = getParameterByName('privateId') || localStorage.getItem('privateId'); // as this is one of the first action-creators to be executed, we need to get the param directly from the url-bar instead of `state.getIn(['router','currentParams','privateId'])`
     if(privateId) {
         /*
          * we don't have a valid session. however the url might contain `privateId`, which means
@@ -105,6 +104,8 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
             payload: { loginError: 'invalid privateId', credentials: { privateId }}
         });
         throw e;
+    }).then(() => {
+        dispatch(stateGoCurrent({privateId}));
     });
     //dispatch(actionCreators.login(email, password));
     //return; // the login action should fetch the required data, so we're done here.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -58,12 +58,6 @@ export const pageLoadAction = () => (dispatch, getState) => {
     checkLoginStatus()
     /* handle data, dispatch actions */
     .then(data => {
-        if(data.username.endsWith('@matchat.org')) {
-            // session-cookie is from privateId-session, but there's no privateId in the url-bar => logout to have consistent state again
-            return logout().then(() =>
-                loadingWhileSignedOut(dispatch, getState)
-            );
-        }
         return loadingWhileSignedIn(dispatch, getState, data.username)
     })
     .catch(error => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -296,13 +296,8 @@ function reactToPrivateIdChanges(fromPrivateId, toPrivateId, dispatch, getState)
         return Promise.resolve();
     }
 
-    if(fromPrivateId && !toPrivateId) {
-        //privateId was removed, log out
-        return accountLogout({doRedirects: false})(dispatch, getState);
-        //dispatch(actionCreators.logout());
-
     // v--- do any login-actions only when privateId is added after initialPageLoad. The latter should handle any necessary logins itself.
-    } else if (state.get('initialLoadFinished')) {
+    if (state.get('initialLoadFinished')) {
         if(fromPrivateId !== toPrivateId) { // privateId has changed or was added
             const credentials = {privateId: toPrivateId};
             const options = {doRedirects: false};


### PR DESCRIPTION
Fixes #1692 

Right now navigating to a uri without a privateId doesn't add it back, because the routing doesn't trigger.