### PR TITLE
Feat update mobile layout #1671

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -61,11 +61,11 @@ const serviceDependencies = ['$ngRedux', '$scope'/*'$routeParams' /*injections a
 function genComponentConf() {
     const template = `
         <div class="cp__header">
-            <a class="clickable"
+            <a class="cp__header__back clickable show-in-responsive"
                 ng-click="self.router__stateGoCurrent({showCreateView: undefined})">
                 <svg style="--local-primary:var(--won-primary-color);"
-                    class="cp__header__icon">
-                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
+                    class="cp__header__back__icon">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
             </a>
             <span class="cp__header__title" ng-if="self.isPost">Post</span>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -32,11 +32,11 @@ function genComponentConf() {
 
     let template = `
         <div class="post-info__header" ng-if="self.includeHeader">
-            <a class="clickable"
+            <a class="post-info__header__back clickable show-in-responsive"
                ng-click="self.router__stateGoCurrent({postUri : null})">
                 <svg style="--local-primary:var(--won-primary-color);"
-                     class="post-info__header__icon clickable">
-                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
+                     class="post-info__header__back__icon clickable">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
             </a>
             <won-post-header

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -61,11 +61,11 @@ const defaultAgreementData = deepFreeze({
 function genComponentConf() {
     let template = `
         <div class="pm__header">
-            <a class="clickable"
+            <a class="pm__header__back clickable show-in-responsive"
                ng-click="self.router__stateGoCurrent({connectionUri : undefined})">
                 <svg style="--local-primary:var(--won-primary-color);"
-                     class="pm__header__icon clickable">
-                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
+                     class="pm__header__back__icon clickable">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
             </a>
             <won-connection-header

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -34,11 +34,11 @@ const serviceDependencies = ['$ngRedux', '$scope', '$element'];
 function genComponentConf() {
     let template = `
         <div class="post-info__header" ng-if="self.includeHeader">
-            <a class="clickable"
+            <a class="post-info__header__back clickable show-in-responsive"
                ng-click="self.router__stateGoCurrent({connectionUri : undefined, sendAdHocRequest: undefined})">
                 <svg style="--local-primary:var(--won-primary-color);"
-                     class="post-info__header__icon clickable">
-                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
+                     class="post-info__header__back__icon clickable">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
             </a>
             <won-connection-header

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -16,6 +16,9 @@ import { actionCreators }  from '../actions/actions.js';
 import {
     connect2Redux,
 } from '../won-utils.js';
+import {
+    selectNeedByConnectionUri,
+} from '../selectors.js';
 
 import * as srefUtils from '../sref-utils.js';
 
@@ -44,14 +47,14 @@ function genTopnavConf() {
         </div>
 
 
-        <nav class="topnav">
+        <nav class="topnav" ng-class="{'hide-in-responsive': self.connectionOrPostDetailOpen}">
             <div class="topnav__inner">
                 <div class="topnav__inner__left">
                     <a href="{{ self.defaultRouteHRef(self.$state) }}"
                         class="topnav__button">
                             <img src="skin/{{self.themeName}}/images/logo.svg"
                                 class="topnav__button__icon">
-                            <span class="topnav__page-title topnav__button__caption">
+                            <span class="topnav__page-title topnav__button__caption hide-in-responsive">
                                 {{ self.appTitle }}
                             </span>
                     </a>
@@ -62,7 +65,7 @@ function genTopnavConf() {
 
                         <li ng-show="!self.loggedIn">
                             <a  ui-sref="{{ self.absSRef('signup') }}"
-                                class="topnav__signupbtn">
+                                class="topnav__signupbtn hide-in-responsive">
                                     Sign up
                             </a>
                         </li>
@@ -137,17 +140,26 @@ function genTopnavConf() {
 
             window.tnc4dbg = this;
 
-            const selectFromState = (state) => ({
-                themeName: getIn(state, ['config', 'theme', 'name']),
-                appTitle: getIn(state, ['config', 'theme', 'title']),
-                adminEmail: getIn(state, ['config', 'theme', 'adminEmail']),
-                WON: won.WON,
-                loggedIn: state.getIn(['user', 'loggedIn']),
-                email: state.getIn(['user','email']),
-                toastsArray: state.getIn(['toasts']).toArray(),
-                connectionHasBeenLost: state.getIn(['messages', 'lostConnection']), // name chosen to avoid name-clash with the action-creator
-                reconnecting: state.getIn(['messages', 'reconnecting']),
-            });
+            const selectFromState = (state) => {
+                const selectedPostUri = decodeURIComponent(getIn(state, ['router', 'currentParams', 'postUri']));
+                const selectedPost = selectedPostUri && state.getIn(["needs", selectedPostUri]);
+                const selectedConnectionUri = decodeURIComponent(getIn(state, ['router', 'currentParams', 'connectionUri']));
+                const need = selectedConnectionUri && selectNeedByConnectionUri(state, selectedConnectionUri);
+                const selectedConnection = need && need.getIn(["connections", selectedConnectionUri]);
+
+                return {
+                    themeName: getIn(state, ['config', 'theme', 'name']),
+                    appTitle: getIn(state, ['config', 'theme', 'title']),
+                    adminEmail: getIn(state, ['config', 'theme', 'adminEmail']),
+                    WON: won.WON,
+                    loggedIn: state.getIn(['user', 'loggedIn']),
+                    email: state.getIn(['user','email']),
+                    connectionOrPostDetailOpen: selectedConnection || selectedPost,
+                    toastsArray: state.getIn(['toasts']).toArray(),
+                    connectionHasBeenLost: state.getIn(['messages', 'lostConnection']), // name chosen to avoid name-clash with the action-creator
+                    reconnecting: state.getIn(['messages', 'reconnecting']),
+                };
+            };
 
             connect2Redux(selectFromState, actionCreators, [], this);
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections.scss
@@ -4,6 +4,7 @@
 @import 'flex-layout';
 
 @import 'connections-overview';
+@import 'responsiveness-utils';
 
 
 .connectionscontent {
@@ -15,12 +16,5 @@
   .oir__requests{
     flex-grow: 1;
     max-width: $maxContentWidth / 2;
-  }
-
-  @media (max-width: $responsivenessBreakPoint){
-    .post__contentside--empty.hide-in-responsive,
-    .oir__requests.hide-in-responsive {
-      display: none;
-    }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
@@ -6,6 +6,7 @@
 @import 'sizing-utils';
 @import 'textfield';
 @import 'create-isseeks';
+@import 'responsiveness-utils';
 
 won-create-post {
   display: grid;
@@ -24,6 +25,7 @@ won-create-post {
     font-size: $normalFontSize;
     text-align: left;
     width: 100%;
+    align-items: center;
 
     &__title {
       color: $won-subtitle-gray;
@@ -31,8 +33,8 @@ won-create-post {
       font-weight: 400;
     }
 
-    &__icon {
-      @include fixed-square($bigiconSize);
+    &__back__icon {
+      @include fixed-square($backIconSize);
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -1,6 +1,7 @@
 @import 'won-config';
 @import 'sizing-utils';
 @import 'animate';
+@import 'responsiveness-utils';
 
 won-send-request,
 won-post-info {
@@ -31,14 +32,10 @@ won-post-info {
     font-size: $normalFontSize;
     text-align: left;
     width: 100%;
+    align-items: center;
 
-    &__icon {
-      @include fixed-square($postIconSize);
-    }
-
-    &__icon__small {
-      @include fixed-square(1.5rem);
-      padding-left: 0.5rem;
+    &__back__icon {
+      @include fixed-square($backIconSize);
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -4,6 +4,7 @@
 @import 'connection-message';
 @import 'connection-agreement';
 @import 'animate';
+@import 'responsiveness-utils';
 
 .post__contentside {
   border-left: $thinGrayBorder;
@@ -58,14 +59,10 @@
       font-size: $normalFontSize;
       text-align: left;
       width: 100%;
+      align-items: center;
 
-      &__icon {
-        @include fixed-square($postIconSize);
-      }
-
-      &__icon__small {
-        @include fixed-square(1.5rem);
-        padding-left: 0.5rem;
+      &__back__icon {
+        @include fixed-square($backIconSize);
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_responsiveness-utils.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_responsiveness-utils.scss
@@ -1,13 +1,16 @@
-/// use to hide e.g. labels in responsive-mode. never(!) use this mixin
-/// to hide features (they still need to be accessible one way or another)
-@mixin hide-in-responsive {
-  @media (max-width: $responsivenessBreakPoint) {
-    display: none;
-  }
-}
 /// use to hide e.g. labels in responsive-mode. never(!) use this class
 /// to hide features (they still need to be accessible one way or another)
 .hide-in-responsive {
-  @include hide-in-responsive;
+  @media (max-width: $responsivenessBreakPoint) {
+    display: none !important;
+  }
+}
+
+/// use to hide e.g. labels when NOT IN responsive-mode. never(!) use this class
+/// to hide features (they still need to be accessible one way or another)
+.show-in-responsive {
+  @media (min-width: $responsivenessBreakPoint) {
+    display: none !important;
+  }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
@@ -84,12 +84,10 @@
 
   .topnav__page-title {
     font-weight: 700;
-    @include hide-in-responsive;
   }
 
   .topnav__signupbtn {
     @include won-button--filled(white, $won-secondary-color-lighter);
-    @include hide-in-responsive;
     @extend .topnav__button;
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -29,6 +29,7 @@ $toastIconSize: 2rem;
 $postIconSize: 2.5rem;
 $postIconSizeMobile: 1.5rem;
 $feedIconSize: 3rem;
+$backIconSize: 1.25rem;
 
 $bigFontSize: 2rem;
 $mediumFontSize: 1.5rem;


### PR DESCRIPTION
There have been some changes to remove some of the fixed elements in the mobile view to ensure having more space for the "important" parts.

-change close icon of the create-post, post-messages, post-info, and send-request to a smaller back arrow, and only show it within mobile view
-hide the topnav-header if a post or a conneciton is open (but do not hide the slide-in connection loss info, or toasts)

fixes #1671 

ps: responsiveness-utils.js is using !important now for the display attribute, usually i stay away from ever using it, but in this case it isn't as wrong since hide-in-responsive and show-in-responsive are utility classes that should overrule everything else even if the selector priority of a different display attribute would be higher