### PR TITLE
fixes issue with firefox layout - changed flex to grid to ensure usin…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -3,13 +3,13 @@
 
 won-connection-header {
   color: black;
-  flex-grow: 1;
   //padding: 0.5rem;
 
   display: grid;
   grid-template-areas: "icon main";
   grid-template-columns: min-content 1fr;
   grid-column-gap: 0.5rem;
+  min-width: 0;
 
   .ch__icon {
     grid-area: icon;
@@ -35,15 +35,16 @@ won-connection-header {
 
   .ch__right {
     grid-area: main;
-
     display: grid;
     grid-template-areas: "topline" "subtitle";
+    min-width: 0;
 
     &__topline {
       grid-area: topline;
       display: grid;
       grid-template-areas: "title date";
       grid-template-columns: 1fr min-content;
+      min-width: 0;
 
       &__title {
         grid-area: title;
@@ -51,6 +52,7 @@ won-connection-header {
         text-overflow: ellipsis;
         overflow: hidden;
         font-weight: 400;
+        min-width: 0;
       }
 
       &__date {
@@ -59,6 +61,7 @@ won-connection-header {
         color: $won-subtitle-gray;
         white-space: nowrap;
         padding-left: 0.5rem;
+        min-width: 0;
       }
     }
 
@@ -68,6 +71,7 @@ won-connection-header {
       display: flex;
       flex-direction: row;
       font-size: $smallFontSize;
+      min-width: 0;
 
       &__group {
         display: flex;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
@@ -33,13 +33,9 @@ won-connections-overview {
       padding: 0.5rem;
 
       &__header {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-
-        won-post-header {
-          flex-grow: 1;
-        }
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        min-width: 0;
 
         won-connection-indicators {
           padding-left: 0.5rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
@@ -19,11 +19,12 @@ won-create-post {
   padding: $gridRowGap;
 
   .cp__header {
-    display:flex;
     grid-area: header;
+    display: grid;
+    grid-template-columns: auto 1fr;
     font-size: $normalFontSize;
     text-align: left;
-    width: 100%;
+    min-width: 0;
 
     &__title {
       color: $won-subtitle-gray;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
@@ -3,14 +3,15 @@
 
 won-post-header {
   color: black;
-  flex-grow: 1;
   //padding: 0.5rem;
 
   display: grid;
   grid-template-areas: "icon main";
   grid-template-columns: min-content 1fr;
+  grid-column-gap: 0.5rem;
+  min-width: 0;
 
-  @include square-image($postIconSize, 0 0.5rem 0 0);
+  @include square-image($postIconSize);
 
   won-square-image {
     grid-area: icon;
@@ -22,15 +23,16 @@ won-post-header {
 
   .ph__right {
     grid-area: main;
-
     display: grid;
     grid-template-areas: "topline" "subtitle";
+    min-width: 0;
 
     &__topline {
       grid-area: topline;
       display: grid;
       grid-template-areas: "title date";
       grid-template-columns: 1fr min-content;
+      min-width: 0;
 
       &__title {
         grid-area: title;
@@ -38,6 +40,7 @@ won-post-header {
         text-overflow: ellipsis;
         overflow: hidden;
         font-weight: 400;
+        min-width: 0;
       }
 
       &__date {
@@ -46,6 +49,7 @@ won-post-header {
         color: $won-subtitle-gray;
         white-space: nowrap;
         padding-left: 0.5rem;
+        min-width: 0;
       }
     }
 
@@ -55,6 +59,7 @@ won-post-header {
       display: flex;
       flex-direction: row;
       font-size: $smallFontSize;
+      min-width: 0;
 
       &__group {
         display: flex;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -26,11 +26,12 @@ won-post-info {
   }
 
   .post-info__header {
-    display:flex;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
     grid-area: header;
     font-size: $normalFontSize;
     text-align: left;
-    width: 100%;
+    min-width: 0;
 
     &__icon {
       @include fixed-square($postIconSize);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -53,11 +53,12 @@
     padding: $gridRowGap;
 
     .pm__header {
-      display:flex;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
       grid-area: header;
       font-size: $normalFontSize;
       text-align: left;
-      width: 100%;
+      min-width: 0;
 
       &__icon {
         @include fixed-square($postIconSize);


### PR DESCRIPTION
…g the whole available space even for short titles, and set min-width to zero so that even firefox will 
collapse the child elements

fixes #1704 

i changed the display property from flex to grid to ensure that the child elements use the whole available space, because, min-width: 0 is necessary so firefox collapses grid (or even flex) and not display the whole child element -> this is rather unituitive but well explained in this link https://bugzilla.mozilla.org/show_bug.cgi?id=1108514