### PR TITLE
Bumped n3 version to 1.0.0-beta.1

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -14,7 +14,7 @@
     "leaflet": "0.7.7",
     "loadcss": "0.0.2",
     "medium.js": "1.0.1",
-    "n3": "1.0.0-alpha",
+    "n3": "^1.0.0-beta.1",
     "ng-redux": "3.4.1",
     "rangy": "1.3.0",
     "reduce-reducers": "0.1.1",

--- a/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
+++ b/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
@@ -37,11 +37,7 @@ function config(env, argv): Configuration {
             minimizer: [
                 new UglifyJsPlugin({
                     parallel: true,
-                    sourceMap: true,
-                    uglifyOptions: {
-                        //Needed because of n3 issue https://github.com/rdfjs/N3.js/issues/135
-                        keep_fnames: true
-                    }
+                    sourceMap: true
                   }),
                 new OptimizeCSSAssetsPlugin()
             ]


### PR DESCRIPTION
Contains fixes for https://github.com/rdfjs/N3.js/issues/135 and https://github.com/rdfjs/N3.js/issues/136

This allows us to minify function names again, and makes it possible to use synchronous parsers in the future.