### PR TITLE
moved direct localstorage usage for private id into the respective js…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -14,6 +14,7 @@ import {
   parseCredentials,
   generatePrivateId,
 } from "../won-utils.js";
+import { clearPrivateId, savePrivateId } from "../won-localstorage.js";
 import { stateGoCurrent } from "./cstm-router-actions.js";
 import { resetParams, checkAccessToCurrentRoute } from "../configRouting.js";
 
@@ -244,7 +245,7 @@ export function accountLogin(credentials, options) {
       })
       .then(() => {
         if (credentials.privateId) {
-          localStorage.setItem("privateId", credentials.privateId);
+          savePrivateId(credentials.privateId);
         }
       });
   };
@@ -264,7 +265,7 @@ export function accountLogout(options) {
     ...options,
   };
 
-  localStorage.removeItem("privateId");
+  clearPrivateId();
 
   return (dispatch, getState) => {
     const state = getState();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -9,7 +9,7 @@ import { msStringToDate, getIn } from "../utils.js";
 import {
   isUriRead,
   markUriAsRead,
-  resetUrisRead,
+  clearReadUris,
 } from "../won-localstorage.js";
 
 const initialState = Immutable.fromJS({});

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -26,6 +26,10 @@ import {
   clone,
   prefixOfUri,
 } from "../utils.js";
+import {
+  clearPrivateId,
+  clearReadUris,
+} from "../won-localstorage.js";
 import jsonld from "jsonld";
 
 import N3 from "n3";
@@ -40,6 +44,9 @@ var won = {};
 
 won.debugmode = false; //if you set this to true, the created needs will get flagged as debug needs in order to get matches and requests from the debugbot
 won.showRdf = false; //if you set this to true, the RDF icons/links are visible
+
+won.clearPrivateId = clearPrivateId;
+won.clearReadUris = clearReadUris;
 
 won.WON = {};
 won.WON.baseUri = "http://purl.org/webofneeds/model#";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -2,11 +2,12 @@
  * Created by fsuda on 25.04.2018.
  */
 const READ_URIS = "wonReadUris";
+const PRIVATE_ID = "privateId";
 
 export function markUriAsRead(uri) {
   //TODO: BETTER IMPL
   if (!isUriRead(uri)) {
-    let readUrisString = window.localStorage.getItem(READ_URIS);
+    let readUrisString = localStorage.getItem(READ_URIS);
     if (!readUrisString) {
       readUrisString = JSON.stringify([uri]);
     } else {
@@ -15,18 +16,18 @@ export function markUriAsRead(uri) {
         readUriList.push(uri);
         readUrisString = JSON.stringify(readUriList);
       } catch (e) {
-        resetUrisRead();
+        clearReadUris();
         readUrisString = JSON.stringify([uri]);
       }
     }
 
-    window.localStorage.setItem(READ_URIS, readUrisString);
+    localStorage.setItem(READ_URIS, readUrisString);
   }
 }
 
 export function isUriRead(uri) {
   //TODO: BETTER IMPL
-  let readUrisString = window.localStorage.getItem(READ_URIS);
+  let readUrisString = localStorage.getItem(READ_URIS);
 
   if (readUrisString) {
     let readUriList = JSON.parse(readUrisString);
@@ -40,6 +41,14 @@ export function isUriRead(uri) {
   return false;
 }
 
-export function resetUrisRead() {
-  window.localStorage.removeItem(READ_URIS);
+export function clearReadUris() {
+  localStorage.removeItem(READ_URIS);
+}
+
+export function clearPrivateId() {
+  localStorage.removeItem("privateId");
+}
+
+export function savePrivateId(privateId) {
+  localStorage.setItem("privateId", privateId);
 }


### PR DESCRIPTION
… file, and expose the clear method for both the read uris and the privateId within the won object

similar to won.debugmode = true, it is now possible to call:
- won.clearPrivateId() -> to remove the privateId from the localstorage
- won.clearReadUris() -> to remove all the read uris from the localstorage
