### PR TITLE
fixes #1765 quick fix for \n in description (also a quick fix for \n …

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -26,7 +26,7 @@ function genComponentConf() {
             src="self.theirNeed.get('TODOtitleImgSrc')"
             uri="self.theirNeed.get('uri')"
             ng-click="self.router__stateGoCurrent({postUri: self.theirNeed.get('uri')})"
-            ng-show="!self.message.get('outgoingMessage')"><!-- TODO: MAKE THIS LINK WORK FOR SPECIFIC POST.JS/HTML usage too if the view will still exist then -->
+            ng-show="!self.message.get('outgoingMessage')">
         </won-square-image>
         <div class="won-cm__center"
                 ng-class="{'won-cm__center--nondisplayable': !self.text}"
@@ -42,8 +42,8 @@ function genComponentConf() {
                 	<span ng-show="self.message.get('isProposeToCancel')"><h3>ProposeToCancel</h3></span>
                 	<span ng-show="self.message.get('isRetractMessage')"><h3>Retract</h3></span>
                 	<span ng-show="self.message.get('isRejectMessage')"><h3>Reject</h3></span>
-                        {{ self.text? self.text : self.noTextPlaceholder }}
-                         <span class="won-cm__center__button" ng-if="self.isNormalMessage()">
+                        <span class="won-cm__center__bubble__text__message--prewrap">{{ self.text? self.text : self.noTextPlaceholder }}</span> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
+                        <span class="won-cm__center__button" ng-if="self.isNormalMessage()">
 	                        <svg class="won-cm__center__carret clickable"
 	                                ng-click="self.showDetail = !self.showDetail"
 	                                ng-if="self.allowProposals"
@@ -79,13 +79,11 @@ function genComponentConf() {
                         <div
                             class="won-cm__center__trig"
                             ng-show="self.contentGraphTrigPrefixes">
-<!-- no intendation here, so it renders correctly -->
-<code ng-show="!self.showTrigPrefixes">@prefix ...</code>
-<code ng-show="self.showTrigPrefixes">{{ self.contentGraphTrigPrefixes }}</code>
+                                <code class="won-cm__center__trig__prefixes--prewrap" ng-show="!self.showTrigPrefixes">@prefix ...</code> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
+                                <code class="won-cm__center__trig__prefixes--prewrap" ng-show="self.showTrigPrefixes">{{ self.contentGraphTrigPrefixes }}</code> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
                         </div>
                         <div class="won-cm__center__trig">
-<!-- no intendation here, so it renders correctly -->
-<code>{{ self.contentGraphTrig }}</code>
+                            <code class="won-cm__center__trig__contentgraph--prewrap">{{ self.contentGraphTrig }}</code> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
                         </div>
                     </div>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-info.js
@@ -31,10 +31,7 @@ function genComponentConf() {
                 ng-show="self.isPart.is.get('description')">
                 Description
             </h2>
-            <p class="post-info__details"
-                ng-show="self.isPart.is.get('description')">
-                {{ self.isPart.is.get('description')}}
-            </p>
+            <p class="post-info__details--prewrap" ng-show="self.isPart.is.get('description')">{{ self.isPart.is.get('description')}}</p> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
 
             <h2 class="post-info__heading"
                 ng-show="self.isPart.is.get('tags')">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-seeks-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-seeks-info.js
@@ -31,11 +31,7 @@ function genComponentConf() {
                 ng-show="self.seeksPart.seeks.get('description')">
                 Description
             </h2>
-            <p class="post-info__details"
-                ng-show="self.seeksPart.seeks.get('description')">
-                {{ self.seeksPart.seeks.get('description')}}
-            </p>
-
+            <p class="post-info__details--prewrap" ng-show="self.seeksPart.seeks.get('description')">{{ self.seeksPart.seeks.get('description')}}</p> <!-- no spaces or newlines within the code-tag, because it is preformatted -->
             <h2 class="post-info__heading"
                 ng-show="self.seeksPart.seeks.get('tags')">
                 Tags

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -65,6 +65,9 @@ won-connection-message {
         border: $thinDarkBorder;
         background: $won-light-gray;
       }
+      &__text__message--prewrap {
+        white-space: pre-wrap;
+      }
     }
     &.won-cm__center--nondisplayable {
       // hsla(57, 100%, 95%, 1);
@@ -81,7 +84,16 @@ won-connection-message {
     }
     &__trig {
       max-width: 100%;
-      white-space: pre-wrap;
+      &__prefixes {
+        display: inline-block;
+        padding-bottom: 1rem;
+        &--prewrap {
+          white-space: pre-wrap;
+        }
+      }
+      &__contentgraph--prewrap {
+        white-space: pre-wrap;
+      }
     }
     &__button {
       padding: 0.5rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -71,6 +71,12 @@ won-post-info {
     won-post-is-info,
     won-post-seeks-info {
       padding: 1rem 0;
+
+      .post-info__details {
+        &--prewrap {
+          white-space: pre-wrap;
+        }
+      }
     }
 
     won-need-map {


### PR DESCRIPTION
…in messages) -> we do not replace the \n with <br> but just preformat the output element

fixes #1765 

additionally allows us to display newlines within sent textmessages
refactors the prewrap style of the code element in order to remove the indentless lines in the template (prone for restyling errors) by moving the prewrap attribute into the specific code tags and not the parent element, thus creating an even neater look than before as we lose the unnecessary newlines at the start of the rdf content in a connection-message