### PR TITLE
Refac  add tags picker component

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -6,14 +6,7 @@ import angular from "angular";
 import "ng-redux";
 import won from "../won-es6.js";
 import { postTitleCharacterLimit } from "config";
-import {
-  attach,
-  deepFreeze,
-  clone,
-  dispatchEvent,
-  mergeAsSet,
-  extractHashtags,
-} from "../utils.js";
+import { attach, deepFreeze, clone, dispatchEvent } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -151,9 +151,6 @@ function genComponentConf() {
             </won-location-picker>
 
             <!-- TAGS -->
-            <!-- TODO: move resetTags() to a new button -->
-            <!-- TODO: make tags individually deletable? -->
-            <!-- TODO: add # to tag text -->
             <won-tags-picker
                 ng-show="self.openDetail === 'tags'"
                 initial-tags="::self.draftObject.tags"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -20,6 +20,18 @@ const emptyDraft = deepFreeze({
   matchingContext: undefined,
 });
 
+// const availableDetails = {
+//   description: {},
+//   location : {
+//     detailName: "location",
+//     detailTitle: "Location",
+//     detailIcon: "ico36_location_circle",
+//     detailComponent: "won-location-picker",
+//   },
+//   tags: {},
+//   ttl: {},
+// };
+
 //TODO can't inject $scope with the angular2-router, preventing redux-cleanup
 const serviceDependencies = [
   "$ngRedux",
@@ -68,6 +80,7 @@ function genComponentConf() {
                         <span>Description</span>
                 </div>
 
+                
                 <!-- LOCATION PICKER -->
                 <div class="cis__detail__items__item location"
                     ng-click="self.toggleOpenDetail('location')"
@@ -209,8 +222,6 @@ function genComponentConf() {
       this.draftObject = clone(emptyDraft);
       this.details = new Set(); // remove all detail-cards
 
-      //this.resetTags();
-
       this.showDetail = false; // and close selector
     }
 
@@ -233,21 +244,13 @@ function genComponentConf() {
     }
 
     setDraft(updatedDraft) {
-      // if (
-      //   updatedDraft &&
-      //   updatedDraft.tags &&
-      //   updatedDraft.tags.length > 0 &&
-      //   !this.details.has("tags")
-      // ) {
-      //   this.details.add("tags");
-      // }
-      // TODO: tags get deleted if draft is changed, why???
-      // this.textAreaTags = updatedDraft.tags;
-      // delete updatedDraft.tags; // so they don't overwrite anything when `Object.assign`ing below
-      // this.updateTags();
-      // TODO: what does mergeTags do???
-      // updatedDraft.tags = this.mergeTags();
       Object.assign(this.draftObject, updatedDraft);
+      this.updateDraft();
+    }
+
+    updateTitle() {
+      const titleString = (this.titleInput() || {}).value || "";
+      this.draftObject.title = titleString;
       this.updateDraft();
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -166,7 +166,10 @@ function genComponentConf() {
                     ng-keyup="::self.updateTags()"
                  />
             </div>
+            <!-- won-tags-picker ng-show="self.openDetail === 'tags'">
+            </won-tags-picker -->
 
+            <!-- TTL -->
             <div class="cis__ttl" ng-if="self.openDetail === 'ttl'">
                 <div class="cis__addDetail__header ttl" ng-click="self.details.delete('ttl') && self.updateDraft()">
                     <svg class="cis__circleicon nonHover">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -101,6 +101,7 @@ function genComponentConf() {
                         <span>Tags</span>
                 </div>
 
+                <!-- TTL PICKER -->
                 <div class="cis__detail__items__item ttl"
                     ng-click="self.toggleOpenDetail('ttl')"
                     ng-class="{'picked' : self.openDetail === 'ttl'}">
@@ -137,37 +138,21 @@ function genComponentConf() {
             </div>
 
             <!-- LOCATION -->
-            <won-location-picker
-                ng-if="self.openDetail === 'location'"
+            <won-location-picker 
+                ng-show="self.openDetail === 'location'"
                 initial-location="::self.draftObject.location"
                 on-location-picked="::self.updateLocation(location)">
             </won-location-picker>
 
             <!-- TAGS -->
-             <div class="cis__tags" ng-if="self.openDetail === 'tags'">
-                <!-- TODO: remove title and move resetTags() to a new button -->
-                <!-- TODO: make tags individually deletable? -->
-                <!-- TODO: add # to tag text -->
-                <div class="cis__addDetail__header tags" ng-click="self.resetTags() && self.updateDraft()">
-                    <svg class="cis__circleicon nonHover">
-                        <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
-                    </svg>
-                    <svg class="cis__circleicon hover">
-                        <use xlink:href="#ico36_close_circle" href="#ico36_close_circle"></use>
-                    </svg>
-                    <span class="nonHover">Tags</span>
-                    <span class="hover">Remove Tags</span>
-                </div>
-                <div class="cis__taglist">
-                    <span class="cis__taglist__tag" ng-repeat="tag in self.draftObject.tags">#{{tag}}</span>
-                </div>
-                <input class="cis__tags__input"
-                    placeholder="e.g. #couch #free" type="text"
-                    ng-keyup="::self.updateTags()"
-                 />
-            </div>
-            <!-- won-tags-picker ng-show="self.openDetail === 'tags'">
-            </won-tags-picker -->
+            <!-- TODO: move resetTags() to a new button -->
+            <!-- TODO: make tags individually deletable? -->
+            <!-- TODO: add # to tag text -->
+            <won-tags-picker
+                ng-show="self.openDetail === 'tags'"
+                initial-tags="::self.draftObject.tags"
+                on-tags-updated="::self.updateTags(tags)">
+            </won-tags-picker>
 
             <!-- TTL -->
             <div class="cis__ttl" ng-if="self.openDetail === 'ttl'">
@@ -299,6 +284,9 @@ function genComponentConf() {
       if (tagsInputString && !this.details.has("tags")) {
         this.details.add("tags");
       }
+
+      // TODO: add updated tags to draft
+      this.updateDraft();
     }
 
     updateTTLBuffered() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -145,14 +145,14 @@ function genComponentConf() {
 
             <!-- LOCATION -->
             <won-location-picker 
-                ng-show="self.openDetail === 'location'"
+                ng-if="self.openDetail === 'location'"
                 initial-location="::self.draftObject.location"
                 on-location-picked="::self.updateLocation(location)">
             </won-location-picker>
 
             <!-- TAGS -->
             <won-tags-picker
-                ng-show="self.openDetail === 'tags'"
+                ng-if="self.openDetail === 'tags'"
                 initial-tags="::self.draftObject.tags"
                 on-tags-updated="::self.updateTags(tags)">
             </won-tags-picker>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -216,17 +216,17 @@ function genComponentConf() {
       this.draftObject = clone(emptyDraft);
       this.details = new Set(); // remove all detail-cards
 
-      this.resetTags();
+      //this.resetTags();
 
       this.showDetail = false; // and close selector
     }
 
     updateDraft() {
-      if (!this.details.has("tags")) {
-        this.draftObject.tags = undefined;
-      }
       if (!this.details.has("location")) {
         this.draftObject.location = undefined;
+      }
+      if (!this.details.has("tags")) {
+        this.draftObject.tags = [];
       }
       if (!this.details.has("ttl")) {
         this.draftObject.ttl = undefined;
@@ -240,52 +240,21 @@ function genComponentConf() {
     }
 
     setDraft(updatedDraft) {
-      if (
-        updatedDraft &&
-        updatedDraft.tags &&
-        updatedDraft.tags.length > 0 &&
-        !this.details.has("tags")
-      ) {
-        this.details.add("tags");
-      }
-
-      this.textAreaTags = updatedDraft.tags;
-      delete updatedDraft.tags; // so they don't overwrite anything when `Object.assign`ing below
-      this.updateTags();
-
+      // if (
+      //   updatedDraft &&
+      //   updatedDraft.tags &&
+      //   updatedDraft.tags.length > 0 &&
+      //   !this.details.has("tags")
+      // ) {
+      //   this.details.add("tags");
+      // }
+      // TODO: tags get deleted if draft is changed, why???
+      // this.textAreaTags = updatedDraft.tags;
+      // delete updatedDraft.tags; // so they don't overwrite anything when `Object.assign`ing below
+      // this.updateTags();
+      // TODO: what does mergeTags do???
       // updatedDraft.tags = this.mergeTags();
       Object.assign(this.draftObject, updatedDraft);
-      this.updateDraft();
-    }
-
-    resetTags() {
-      this.tagsString = "";
-      this.textAreaTags = "";
-      this.draftObject.tags = [];
-
-      this.details.delete("tags"); // remove card
-    }
-
-    updateTitle() {
-      const titleString = (this.titleInput() || {}).value || "";
-
-      this.draftObject.title = titleString;
-      this.updateDraft();
-    }
-
-    updateTags() {
-      // TODO: do something with text that does not start with #
-      const tagsInputString = (this.tagsInput() || {}).value;
-      this.draftObject.tags = mergeAsSet(
-        this.textAreaTags || [],
-        extractHashtags(tagsInputString)
-      );
-
-      if (tagsInputString && !this.details.has("tags")) {
-        this.details.add("tags");
-      }
-
-      // TODO: add updated tags to draft
       this.updateDraft();
     }
 
@@ -328,14 +297,28 @@ function genComponentConf() {
     }
 
     updateLocation(location) {
-      if (!location && this.details.has("location")) {
-        this.details.delete("location");
-        this.draftObject.location = undefined;
-      } else if (location) {
+      if (location) {
         if (!this.details.has("location")) {
           this.details.add("location");
         }
         this.draftObject.location = location;
+      } else if (this.details.has("location")) {
+        this.details.delete("location");
+        this.draftObject.location = undefined;
+      }
+
+      this.updateDraft();
+    }
+
+    updateTags(tags) {
+      if (tags && tags.length > 0) {
+        if (!this.details.has("tags")) {
+          this.details.add("tags");
+        }
+        this.draftObject.tags = tags;
+      } else if (this.details.has("tags")) {
+        this.details.delete("tags");
+        this.draftObject.tags = [];
       }
 
       this.updateDraft();
@@ -393,15 +376,6 @@ function genComponentConf() {
         );
       }
       return this._descriptionInput;
-    }
-    tagsInputNg() {
-      return angular.element(this.tagsInput());
-    }
-    tagsInput() {
-      if (!this._tagsInput) {
-        this._tagsInput = this.$element[0].querySelector(".cis__tags__input");
-      }
-      return this._tagsInput;
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -8,6 +8,7 @@ import "ng-redux";
 import labelledHrModule from "./labelled-hr.js";
 import imageDropzoneModule from "./image-dropzone.js";
 import locationPickerModule from "./location-picker.js";
+import tagsPickerModule from "./tags-picker.js";
 import createIsseeksModule from "./create-isseeks.js";
 import { postTitleCharacterLimit } from "config";
 import {
@@ -349,6 +350,7 @@ angular
     labelledHrModule,
     imageDropzoneModule,
     locationPickerModule,
+    tagsPickerModule,
     createIsseeksModule,
     ngAnimate,
   ])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-info.js
@@ -39,7 +39,7 @@ function genComponentConf() {
             </h2>
             <div class="post-info__details post-info__tags"
                 ng-show="self.isPart.is.get('tags')">
-                    <span class="post-info__tags__tag" ng-repeat="tag in self.isPart.is.get('tags').toJS()">{{tag}}</span>
+                    <span class="post-info__tags__tag" ng-repeat="tag in self.isPart.is.get('tags').toJS()">#{{tag}}</span>
             </div>
 
             <h2 class="post-info__heading"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-seeks-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-seeks-info.js
@@ -38,7 +38,7 @@ function genComponentConf() {
             </h2>
             <div class="post-info__details post-info__tags"
                 ng-show="self.seeksPart.seeks.get('tags')">
-                    <span class="post-info__tags__tag" ng-repeat="tag in self.seeksPart.seeks.get('tags').toJS()">{{tag}}</span>
+                    <span class="post-info__tags__tag" ng-repeat="tag in self.seeksPart.seeks.get('tags').toJS()">#{{tag}}</span>
             </div>
 
             <h2 class="post-info__heading"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -12,7 +12,22 @@ import {
 const serviceDependencies = ['$scope', '$element', '$sce'];
 function genComponentConf() {
     let template = `
-        <input type="text" id="tp__textbox" placeholder="#"/>
+        <div class="cis__addDetail__header tags" ng-click="self.resetTags() && self.updateDraft()">
+            <svg class="cis__circleicon">
+                <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
+            </svg>
+        </div>
+        <div class="cis__taglist">
+            <span class="cis__taglist__tag" ng-repeat="tag in self.tags">#{{tag}}</span>
+        </div>
+        <input class="tp__input"
+            placeholder="e.g. #couch #free" type="text"
+            ng-keyup="::self.updateTags()"
+        />
+
+
+
+        <input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/>
             `;
 
     class Controller {
@@ -39,9 +54,9 @@ function genComponentConf() {
         }
 
         
-        textfieldNg() { return this.domCache.ng('#tp__textbox'); }
+        textfieldNg() { return this.domCache.ng('.tp__input'); }
 
-        textfield() { return this.domCache.dom('#tp__textbox'); }
+        textfield() { return this.domCache.dom('.tp__input'); }
     }
     Controller.$inject = serviceDependencies;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -50,6 +50,7 @@ function genComponentConf() {
         this.initialTags.forEach(function(tag) {
           _tagsForTextfield += "#" + tag + " ";
         });
+        this.showResetButton = true;
       }
       this.textfield().value = _tagsForTextfield.trim();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,5 +1,5 @@
 import angular from "angular";
-import { attach, extractHashtags } from "../utils.js";
+import { attach, delay, extractHashtags } from "../utils.js";
 import { DomCache } from "../cstm-ng-utils.js";
 
 const serviceDependencies = ["$scope", "$element", "$sce"];
@@ -39,6 +39,21 @@ function genComponentConf() {
 
       this.addedTags = this.initialTags;
       this.showResetButton = false;
+
+      delay(0).then(() => this.showInitialTags());
+    }
+
+    showInitialTags() {
+      this.addedTags = this.initialTags;
+      let _tagsForTextfield = "";
+      if (this.initialTags) {
+        this.initialTags.forEach(function(tag) {
+          _tagsForTextfield += "#" + tag + " ";
+        });
+      }
+      this.textfield().value = _tagsForTextfield.trim();
+
+      this.$scope.$apply();
     }
 
     updateTags() {
@@ -57,7 +72,7 @@ function genComponentConf() {
     resetTags() {
       this.addedTags = undefined;
       this.textfield().value = "";
-      this.onTagsUpdated({ tags: this.addedTags });
+      this.onTagsUpdated({ tags: undefined });
       this.showResetButton = false;
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -23,6 +23,8 @@ function genComponentConf() {
       </div>
 
       <!-- LIST OF ADDED TAGS -->
+      <!-- TODO: make tags individually deletable -->
+      <!-- TODO: add # to tag text -->
       <div class="tp__taglist">
         <span class="tp__taglist__tag" ng-repeat="tag in self.addedTags">#{{tag}}</span>
       </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,34 +1,31 @@
 import angular from "angular";
-import {
-  attach,
-  //delay,
-  extractHashtags,
-  mergeAsSet,
-} from "../utils.js";
-import {
-  //doneTypingBufferNg,
-  DomCache,
-} from "../cstm-ng-utils.js";
+import { attach, extractHashtags } from "../utils.js";
+import { DomCache } from "../cstm-ng-utils.js";
 
 const serviceDependencies = ["$scope", "$element", "$sce"];
 function genComponentConf() {
   let template = `
-    <div class="cis__addDetail__header tags" ng-click="self.resetTags()">
-      <svg class="cis__circleicon">
-        <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
-      </svg>
-      Remove All Tags
+      <!-- TAGS INPUT -->
+      <div class="tp__input">
+        <input 
+          class="tp__input__inner"
+          type="text"
+          placeholder="e.g. #couch #free"
+          ng-keyup="::self.updateTags()"
+          ng-class="{'tp__input__inner--withreset' : self.showResetButton}"
+        />
+        <svg class="tp__input__icon clickable" 
+          style="--local-primary:var(--won-primary-color);"
+          ng-if="self.showResetButton"
+          ng-click="self.resetTags()">
+          <use xlink:href="#ico36_close" href="#ico36_close"></use>
+        </svg>
       </div>
+
+      <!-- LIST OF ADDED TAGS -->
       <div class="tp__taglist">
         <span class="tp__taglist__tag" ng-repeat="tag in self.addedTags">#{{tag}}</span>
       </div>
-      <input class="tp__input"
-        placeholder="e.g. #couch #free" type="text"
-        ng-keyup="::self.doneTyping()"
-      />
-
-      <!-- ng-keyup="::self.updateTags()" -->
-      <!-- input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/ -->
     `;
 
   class Controller {
@@ -38,54 +35,36 @@ function genComponentConf() {
 
       window.tp4dbg = this;
 
-      this.addedTags = this.initialTags || [];
-      console.log("initial tags: ", this.addedTags);
-
-      // doneTypingBufferNg(
-      //     e => this.doneTyping(e),
-      //     this.textfieldNg(), 1000
-      // );
+      this.addedTags = this.initialTags;
+      this.showResetButton = false;
     }
 
-    doneTyping() {
+    updateTags() {
       // TODO: do something with text that does not start with #
       const text = this.textfield().value;
 
-      if (!text || text.trim().length === 0) {
-        // do stuff
-      } else if (text.endsWith(" ")) {
-        this.addedTags = mergeAsSet(this.addedTags, extractHashtags(text));
+      if (text && text.trim().length > 0) {
+        this.addedTags = extractHashtags(text);
         this.onTagsUpdated({ tags: this.addedTags });
-        // do stuff
-        // if last character was a space, add tag
-        // if (text.endsWith(" ")) {
-        //   this.addTag(text.trim());
-        // }
+        this.showResetButton = true;
+      } else {
+        this.resetTags();
       }
-      console.log("TAGLIST: ", this.addedTags);
     }
 
-    // addTag(tag) {
-    //   // TODO: check for duplicates
-    //   this.addedTags.push(tag);
-    //   console.log("TAGLIST: ", this.addedTags);
-    //   //this.onTagsUpdated({tags: this.addedTags});
-    // }
-
     resetTags() {
-      this.addedTags = [];
+      this.addedTags = undefined;
       this.textfield().value = "";
-      console.log("TAGLIST: ", this.addedTags);
       this.onTagsUpdated({ tags: this.addedTags });
-      //this.onTagsUpdated({tags: this.addedTags});
+      this.showResetButton = false;
     }
 
     textfieldNg() {
-      return this.domCache.ng(".tp__input");
+      return this.domCache.ng(".tp__input__inner");
     }
 
     textfield() {
-      return this.domCache.dom(".tp__input");
+      return this.domCache.dom(".tp__input__inner");
     }
   }
   Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,5 +1,5 @@
 import angular from "angular";
-import { attach, delay } from "../utils.js";
+import { attach, delay, extractHashtags, mergeAsSet } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { doneTypingBufferNg, DomCache } from "../cstm-ng-utils.js";
 
@@ -19,9 +19,9 @@ function genComponentConf() {
         placeholder="e.g. #couch #free" type="text"
         ng-keyup="::self.doneTyping()"
       />
-      <!-- ng-keyup="::self.updateTags()" -->
 
-      <input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/>
+      <!-- ng-keyup="::self.updateTags()" -->
+      <!-- input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/ -->
     `;
 
   class Controller {
@@ -31,7 +31,8 @@ function genComponentConf() {
 
       window.tp4dbg = this;
 
-      this.addedTags = this.initialTags;
+      this.addedTags = this.initialTags || [];
+      console.log("initial tags: ", this.addedTags);
 
       // doneTypingBufferNg(
       //     e => this.doneTyping(e),
@@ -40,29 +41,35 @@ function genComponentConf() {
     }
 
     doneTyping() {
+      // TODO: do something with text that does not start with #
       const text = this.textfield().value;
 
       if (!text || text.trim().length === 0) {
         // do stuff
-      } else {
+      } else if (text.endsWith(" ")) {
+        this.addedTags = mergeAsSet(this.addedTags, extractHashtags(text));
+        this.onTagsUpdated({ tags: this.addedTags });
         // do stuff
         // if last character was a space, add tag
-        if (text.endsWith(" ")) {
-          this.addTag(text.trim());
-        }
+        // if (text.endsWith(" ")) {
+        //   this.addTag(text.trim());
+        // }
       }
+      console.log("TAGLIST: ", this.addedTags);
     }
 
-    addTag(tag) {
-      // TODO: check for duplicates
-      this.addedTags.push(tag);
-      console.log("TAGLIST: ", this.addedTags);
-      //this.onTagsUpdated({tags: this.addedTags});
-    }
+    // addTag(tag) {
+    //   // TODO: check for duplicates
+    //   this.addedTags.push(tag);
+    //   console.log("TAGLIST: ", this.addedTags);
+    //   //this.onTagsUpdated({tags: this.addedTags});
+    // }
 
     resetTags() {
       this.addedTags = [];
+      this.textfield().value = "";
       console.log("TAGLIST: ", this.addedTags);
+      this.onTagsUpdated({ tags: this.addedTags });
       //this.onTagsUpdated({tags: this.addedTags});
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -12,19 +12,20 @@ import {
 const serviceDependencies = ['$scope', '$element', '$sce'];
 function genComponentConf() {
     let template = `
-        <div class="cis__addDetail__header tags" ng-click="self.resetTags() && self.updateDraft()">
+        <div class="cis__addDetail__header tags" ng-click="self.resetTags()">
             <svg class="cis__circleicon">
                 <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
             </svg>
+            Remove All Tags
         </div>
-        <div class="cis__taglist">
-            <span class="cis__taglist__tag" ng-repeat="tag in self.tags">#{{tag}}</span>
+        <div class="tp__taglist">
+            <span class="tp__taglist__tag" ng-repeat="tag in self.addedTags">#{{tag}}</span>
         </div>
         <input class="tp__input"
             placeholder="e.g. #couch #free" type="text"
-            ng-keyup="::self.updateTags()"
+            ng-keyup="::self.doneTyping()"
         />
-
+        <!-- ng-keyup="::self.updateTags()" -->
 
 
         <input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/>
@@ -37,20 +38,39 @@ function genComponentConf() {
             
             window.tp4dbg = this;
 
-            doneTypingBufferNg(
-                e => this.doneTyping(e),
-                this.textfieldNg(), 1000
-            );
+            this.addedTags = this.initialTags;
+
+            // doneTypingBufferNg(
+            //     e => this.doneTyping(e),
+            //     this.textfieldNg(), 1000
+            // );
         }
 
         doneTyping() {
             const text = this.textfield().value;
 
-            if(!text) {
+            if(!text || text.trim().length === 0) {
                 // do stuff
             } else {
                 // do stuff
+                // if last character was a space, add tag
+                if(text.endsWith(" ")){
+                    this.addTag(text.trim());
+                }
             }
+        }
+
+        addTag(tag) {
+            // TODO: check for duplicates
+            this.addedTags.push(tag);
+            console.log("TAGLIST: ", this.addedTags);
+            //this.onTagsUpdated({tags: this.addedTags});
+        }
+
+        resetTags() {
+            this.addedTags = [];
+            console.log("TAGLIST: ", this.addedTags);
+            //this.onTagsUpdated({tags: this.addedTags});
         }
 
         
@@ -67,6 +87,8 @@ function genComponentConf() {
         controllerAs: 'self',
         bindToController: true, //scope-bindings -> ctrl
         scope: {
+            onTagsUpdated: "&",
+            initialTags: "=",
         },
         template: template
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,0 +1,63 @@
+import angular from 'angular';
+import {
+    attach,
+    delay,
+} from '../utils.js';
+import { actionCreators }  from '../actions/actions.js';
+import {
+    doneTypingBufferNg,
+    DomCache,
+} from '../cstm-ng-utils.js'
+
+const serviceDependencies = ['$scope', '$element', '$sce'];
+function genComponentConf() {
+    let template = `
+        <input type="text" id="tp__textbox" placeholder="#"/>
+            `;
+
+    class Controller {
+        constructor() {
+            attach(this, serviceDependencies, arguments);
+            this.domCache = new DomCache(this.$element);
+            
+            window.tp4dbg = this;
+
+            doneTypingBufferNg(
+                e => this.doneTyping(e),
+                this.textfieldNg(), 1000
+            );
+        }
+
+        doneTyping() {
+            const text = this.textfield().value;
+
+            if(!text) {
+                // do stuff
+            } else {
+                // do stuff
+            }
+        }
+
+        
+        textfieldNg() { return this.domCache.ng('#tp__textbox'); }
+
+        textfield() { return this.domCache.dom('#tp__textbox'); }
+    }
+    Controller.$inject = serviceDependencies;
+
+
+    return {
+        restrict: 'E',
+        controller: Controller,
+        controllerAs: 'self',
+        bindToController: true, //scope-bindings -> ctrl
+        scope: {
+        },
+        template: template
+    }
+}
+
+export default angular.module('won.owner.components.tagsPicker', [
+    ])
+    .directive('wonTagsPicker', genComponentConf)
+    .name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,7 +1,14 @@
 import angular from "angular";
-import { attach, delay, extractHashtags, mergeAsSet } from "../utils.js";
-import { actionCreators } from "../actions/actions.js";
-import { doneTypingBufferNg, DomCache } from "../cstm-ng-utils.js";
+import {
+  attach,
+  //delay,
+  extractHashtags,
+  mergeAsSet,
+} from "../utils.js";
+import {
+  //doneTypingBufferNg,
+  DomCache,
+} from "../cstm-ng-utils.js";
 
 const serviceDependencies = ["$scope", "$element", "$sce"];
 function genComponentConf() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/tags-picker.js
@@ -1,100 +1,94 @@
-import angular from 'angular';
-import {
-    attach,
-    delay,
-} from '../utils.js';
-import { actionCreators }  from '../actions/actions.js';
-import {
-    doneTypingBufferNg,
-    DomCache,
-} from '../cstm-ng-utils.js'
+import angular from "angular";
+import { attach, delay } from "../utils.js";
+import { actionCreators } from "../actions/actions.js";
+import { doneTypingBufferNg, DomCache } from "../cstm-ng-utils.js";
 
-const serviceDependencies = ['$scope', '$element', '$sce'];
+const serviceDependencies = ["$scope", "$element", "$sce"];
 function genComponentConf() {
-    let template = `
-        <div class="cis__addDetail__header tags" ng-click="self.resetTags()">
-            <svg class="cis__circleicon">
-                <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
-            </svg>
-            Remove All Tags
-        </div>
-        <div class="tp__taglist">
-            <span class="tp__taglist__tag" ng-repeat="tag in self.addedTags">#{{tag}}</span>
-        </div>
-        <input class="tp__input"
-            placeholder="e.g. #couch #free" type="text"
-            ng-keyup="::self.doneTyping()"
-        />
-        <!-- ng-keyup="::self.updateTags()" -->
+  let template = `
+    <div class="cis__addDetail__header tags" ng-click="self.resetTags()">
+      <svg class="cis__circleicon">
+        <use xlink:href="#ico36_tags_circle" href="#ico36_tags_circle"></use>
+      </svg>
+      Remove All Tags
+      </div>
+      <div class="tp__taglist">
+        <span class="tp__taglist__tag" ng-repeat="tag in self.addedTags">#{{tag}}</span>
+      </div>
+      <input class="tp__input"
+        placeholder="e.g. #couch #free" type="text"
+        ng-keyup="::self.doneTyping()"
+      />
+      <!-- ng-keyup="::self.updateTags()" -->
 
+      <input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/>
+    `;
 
-        <input type="text" class="tp__textbox" placeholder="e.g. #couch #free"/>
-            `;
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.domCache = new DomCache(this.$element);
 
-    class Controller {
-        constructor() {
-            attach(this, serviceDependencies, arguments);
-            this.domCache = new DomCache(this.$element);
-            
-            window.tp4dbg = this;
+      window.tp4dbg = this;
 
-            this.addedTags = this.initialTags;
+      this.addedTags = this.initialTags;
 
-            // doneTypingBufferNg(
-            //     e => this.doneTyping(e),
-            //     this.textfieldNg(), 1000
-            // );
-        }
-
-        doneTyping() {
-            const text = this.textfield().value;
-
-            if(!text || text.trim().length === 0) {
-                // do stuff
-            } else {
-                // do stuff
-                // if last character was a space, add tag
-                if(text.endsWith(" ")){
-                    this.addTag(text.trim());
-                }
-            }
-        }
-
-        addTag(tag) {
-            // TODO: check for duplicates
-            this.addedTags.push(tag);
-            console.log("TAGLIST: ", this.addedTags);
-            //this.onTagsUpdated({tags: this.addedTags});
-        }
-
-        resetTags() {
-            this.addedTags = [];
-            console.log("TAGLIST: ", this.addedTags);
-            //this.onTagsUpdated({tags: this.addedTags});
-        }
-
-        
-        textfieldNg() { return this.domCache.ng('.tp__input'); }
-
-        textfield() { return this.domCache.dom('.tp__input'); }
+      // doneTypingBufferNg(
+      //     e => this.doneTyping(e),
+      //     this.textfieldNg(), 1000
+      // );
     }
-    Controller.$inject = serviceDependencies;
 
+    doneTyping() {
+      const text = this.textfield().value;
 
-    return {
-        restrict: 'E',
-        controller: Controller,
-        controllerAs: 'self',
-        bindToController: true, //scope-bindings -> ctrl
-        scope: {
-            onTagsUpdated: "&",
-            initialTags: "=",
-        },
-        template: template
+      if (!text || text.trim().length === 0) {
+        // do stuff
+      } else {
+        // do stuff
+        // if last character was a space, add tag
+        if (text.endsWith(" ")) {
+          this.addTag(text.trim());
+        }
+      }
     }
+
+    addTag(tag) {
+      // TODO: check for duplicates
+      this.addedTags.push(tag);
+      console.log("TAGLIST: ", this.addedTags);
+      //this.onTagsUpdated({tags: this.addedTags});
+    }
+
+    resetTags() {
+      this.addedTags = [];
+      console.log("TAGLIST: ", this.addedTags);
+      //this.onTagsUpdated({tags: this.addedTags});
+    }
+
+    textfieldNg() {
+      return this.domCache.ng(".tp__input");
+    }
+
+    textfield() {
+      return this.domCache.dom(".tp__input");
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      onTagsUpdated: "&",
+      initialTags: "=",
+    },
+    template: template,
+  };
 }
 
-export default angular.module('won.owner.components.tagsPicker', [
-    ])
-    .directive('wonTagsPicker', genComponentConf)
-    .name;
+export default angular
+  .module("won.owner.components.tagsPicker", [])
+  .directive("wonTagsPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -20,7 +20,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"> <!-- see http://getbootstrap.com/css/#overview-mobile -->
     <title>Web Of Needs</title>
     <link rel="stylesheet" href="./generated/won.min.css" />
-    <link rel="stylesheet" href="./skin/config.css" />
+    <link rel="stylesheet" href="./skin/current/config.css" />
     <!-- link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" / -->
     <link rel="icon" type="image/png" href="skin/current/images/logo.png">
 </head>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
@@ -42,7 +42,8 @@ won-create-isseeks {
         //   --local-primary: $won-primary-color; // for the svg-icons
         // }
 
-        &.picked {
+        &.picked,
+        &.picked .cis__circleicon {
           //color: $won-line-gray;
           //--local-primary: $won-line-gray; // for the svg-icons
           color: $won-primary-color;
@@ -71,45 +72,6 @@ won-create-isseeks {
     .cis__header:hover {
       color: $won-primary-color;
       --local-primary: $won-primary-color; // for the svg-icons
-    }
-
-    .cis__tags {
-      .cis__taglist {
-        display: flex;
-        flex-wrap: wrap;
-        margin-bottom: 0.5rem;
-
-        .cis__taglist__tag {
-          border-radius: 0.5rem;
-          background: $won-dark-purple;
-          color: white;
-          margin: 0.25rem 0.25rem 0.25rem 0;
-          padding: 0.25rem 0.5rem;
-        }
-      }
-      .cis__tags__input {
-        border-width: $thinBorderWidth;
-        border-style: solid;
-        border-radius: 0.1rem;
-        background-color: white;
-
-        font-size: $normalFontSize;
-        min-height: $formInputHeight;
-
-        $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
-        $verticalPadding: ($formInputHeight - $realFontHeight) / 2 -
-          $thinBorderWidth;
-        padding: $verticalPadding 0.438rem;
-
-        box-sizing: border-box;
-
-        min-width: 0; // so a size is specified and break-word works
-        word-wrap: break-word;
-
-        border-color: $won-line-gray;
-
-        width: 100%;
-      }
     }
 
     .cis__description {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
@@ -1,6 +1,7 @@
 @import "won-config";
 @import "text";
 @import "locationpicker";
+@import "tagspicker";
 @import "animate";
 @import "sizing-utils";
 @import "textfield";

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_locationpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_locationpicker.scss
@@ -24,10 +24,7 @@ won-location-picker {
     }
 
     .lp__searchbox__inner {
-      border-width: $thinBorderWidth;
-      border-style: solid;
-      border-radius: 0.1rem;
-      border-color: $won-line-gray;
+      border: $thinGrayBorder;
       background-color: white;
 
       font-size: $normalFontSize;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -99,7 +99,7 @@ won-post-info {
 
       &__tag {
         border-radius: 0.5rem;
-        background: $won-dark-purple;
+        background: $won-primary-color;
         color: white;
         margin: 0.25rem 0.25rem 0.25rem 0;
         padding: 0.25rem 0.5rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
@@ -1,36 +1,50 @@
-@import "won";
+@import "won-config";
+@import "textfield";
 
 won-tags-picker {
   .tp__input {
-    border-width: $thinBorderWidth;
-    border-style: solid;
-    border-radius: 0.1rem;
-    background-color: white;
+    position: relative;
 
-    font-size: $normalFontSize;
-    min-height: $formInputHeight;
+    .tp__input__icon {
+      @include fixed-square($bigiconSize);
+      position: absolute;
+      right: 0.5rem;
+      top: $formInputHeight / 2 - $bigiconSize / 2;
+      z-index: 1;
+    }
 
-    $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
-    $verticalPadding: ($formInputHeight - $realFontHeight) / 2 -
-      $thinBorderWidth;
-    padding: $verticalPadding 0.438rem;
+    .tp__input__inner {
+      border: $thinGrayBorder;
+      box-sizing: border-box;
+      font-size: $normalFontSize;
+      min-height: $formInputHeight;
+      min-width: 0; // so a size is specified and break-word works
+      width: 100%;
+      word-wrap: break-word;
 
-    box-sizing: border-box;
+      $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
+      $verticalPadding: ($formInputHeight - $realFontHeight) / 2 -
+        $thinBorderWidth;
+      padding: $verticalPadding 0.438rem;
 
-    min-width: 0; // so a size is specified and break-word works
-    word-wrap: break-word;
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
+    }
 
-    border-color: $won-line-gray;
-
-    width: 100%;
+    .tp__input__inner::-ms-clear {
+      width: 0;
+      height: 0;
+    }
   }
 
-  .tp__tagslist {
+  .tp__taglist {
     display: flex;
     flex-wrap: wrap;
-    margin-bottom: 0.5rem;
+    margin: 0.5rem 0;
 
-    .__taglist__tag {
+    .tp__taglist__tag {
       border-radius: 0.5rem;
       background: $won-primary-color;
       color: white;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
@@ -1,0 +1,43 @@
+@import 'won';
+
+won-tags-picker{
+
+    .tp__input {
+        border-width: $thinBorderWidth;
+        border-style: solid;
+        border-radius: 0.1rem;
+        background-color: white;
+
+
+        font-size: $normalFontSize;
+        min-height: $formInputHeight;
+
+        $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
+        $verticalPadding: ($formInputHeight - $realFontHeight) / 2 - $thinBorderWidth;
+        padding: $verticalPadding 0.438rem;
+
+        box-sizing: border-box;
+
+        min-width: 0; // so a size is specified and break-word works
+        word-wrap: break-word;
+
+        border-color: $won-line-gray;
+
+        width: 100%;
+    }
+
+    .tp__tagslist {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: 0.5rem;
+
+        .__taglist__tag {
+          border-radius: 0.5rem;
+          background: $won-primary-color;
+          color: white;
+          margin: 0.25rem 0.25rem 0.25rem 0;
+          padding: 0.25rem 0.5rem;
+        }
+    }
+
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_tagspicker.scss
@@ -1,43 +1,41 @@
-@import 'won';
+@import "won";
 
-won-tags-picker{
+won-tags-picker {
+  .tp__input {
+    border-width: $thinBorderWidth;
+    border-style: solid;
+    border-radius: 0.1rem;
+    background-color: white;
 
-    .tp__input {
-        border-width: $thinBorderWidth;
-        border-style: solid;
-        border-radius: 0.1rem;
-        background-color: white;
+    font-size: $normalFontSize;
+    min-height: $formInputHeight;
 
+    $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
+    $verticalPadding: ($formInputHeight - $realFontHeight) / 2 -
+      $thinBorderWidth;
+    padding: $verticalPadding 0.438rem;
 
-        font-size: $normalFontSize;
-        min-height: $formInputHeight;
+    box-sizing: border-box;
 
-        $realFontHeight: $normalFontSize * 22/16; /* of one line of text */
-        $verticalPadding: ($formInputHeight - $realFontHeight) / 2 - $thinBorderWidth;
-        padding: $verticalPadding 0.438rem;
+    min-width: 0; // so a size is specified and break-word works
+    word-wrap: break-word;
 
-        box-sizing: border-box;
+    border-color: $won-line-gray;
 
-        min-width: 0; // so a size is specified and break-word works
-        word-wrap: break-word;
+    width: 100%;
+  }
 
-        border-color: $won-line-gray;
+  .tp__tagslist {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
 
-        width: 100%;
+    .__taglist__tag {
+      border-radius: 0.5rem;
+      background: $won-primary-color;
+      color: white;
+      margin: 0.25rem 0.25rem 0.25rem 0;
+      padding: 0.25rem 0.5rem;
     }
-
-    .tp__tagslist {
-        display: flex;
-        flex-wrap: wrap;
-        margin-bottom: 0.5rem;
-
-        .__taglist__tag {
-          border-radius: 0.5rem;
-          background: $won-primary-color;
-          color: white;
-          margin: 0.25rem 0.25rem 0.25rem 0;
-          padding: 0.25rem 0.5rem;
-        }
-    }
-
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -35,7 +35,8 @@ $normalFontSize: 1rem;
 $smallFontSize: 0.75rem;
 
 //$formInputHeight: 4.19rem;
-$formInputHeight: 3.69rem;
+//$formInputHeight: 3.69rem;
+$formInputHeight: 3.19rem;
 $thinBorderWidth: 0.0625rem; /* 1px @ 100% */
 $boldBorderWidth: 0.1875rem; /* 3px @ 100% */
 $thinGrayBorder: $thinBorderWidth solid $won-line-gray;


### PR DESCRIPTION
Moved tags picker to own component. Tags can now only be set via the tag picker and should not disappear while editing other details. 

Closes #1580, closes #1745 by restricting tag addition/deletion to only one textfield.