### PR TITLE
Linted post-messages.js

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/.babelrc
+++ b/webofneeds/won-owner-webapp/src/main/webapp/.babelrc
@@ -9,5 +9,5 @@
       }
     ]
   ],
-  "plugins": ["transform-object-rest-spread", "transform-remove-strict-mode"]
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -1656,12 +1656,6 @@
         "regenerator-transform": "^0.10.0"
       }
     },
-    "babel-plugin-transform-remove-strict-mode": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-strict-mode/-/babel-plugin-transform-remove-strict-mode-0.0.2.tgz",
-      "integrity": "sha1-kTaFqrlUOfOg7YjliPvV6ZeJBXk=",
-      "dev": true
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -47,7 +47,6 @@
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "copy-webpack-plugin": "^4.5.1",


### PR DESCRIPTION
Fixes #1777
This also allowes us to stop removing strict mode from our es6 modules.

To properly test, first run `npm i && npm prune` to assure the removed packages are actually removed.
Also restart your watch task if it is running, as the babel configuration has changed.