### PR TITLE
Feat modal dialog #1780

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -168,6 +168,18 @@ $ngRedux.getState()
   showRdf: true|false, //flag that is true if rawData mode is on (enables rdf view and rdf links) (default is false)
   showClosedNeeds: true|false, //flag whether the drawer of the closedNeeds is open or closed (default is false)
   showMainMenu: true|false, //flag whether the mainmenu dropdown is open or closed (default is false)
+  showModalDialog: true|false, //flag whether the omnipresent modal dialog is displayed or not (default is false)
+  modalDialog: {
+    caption: string, //header caption of the modal dialog
+    text: string,
+    buttons: [ //Array
+      {
+       caption: string //caption of the button
+       callback: callback //action of the button
+      }
+      ...
+    ]
+  }
 }
 */
 ```

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -231,6 +231,9 @@ const actionHierarchy = {
   showMainMenuDisplay: INJ_DEFAULT,
   hideMainMenuDisplay: INJ_DEFAULT,
 
+  openModalDialog: INJ_DEFAULT,
+  closeModalDialog: INJ_DEFAULT,
+
   toasts: {
     delete: INJ_DEFAULT,
     test: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
@@ -13,10 +13,16 @@ function genComponentConf() {
     <span class="dd__userlabel show-in-responsive" ng-if="self.loggedIn" title="{{ self.email }}">{{ self.email }}</span>
     <hr class="show-in-responsive"/>
     <a
+        href="{{ self.absHRef(self.$state, 'settings') }}"
+        class="won-button--outlined thin red"
+        ng-click="self.hideMainMenuDisplay()">
+        <span>Account Settings</span>
+    </a>
+    <a
         href="{{ self.absHRef(self.$state, 'about') }}"
         class="won-button--outlined thin red"
         ng-click="self.hideMainMenuDisplay()">
-            About
+        <span>About</span>
     </a>
     <a class="won-button--outlined thin red"
         ng-click="self.toggleRdfDisplay()">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -1,0 +1,67 @@
+/**
+ * Created by quasarchimaere on 24.05.2018.
+ */
+
+import angular from "angular";
+import { actionCreators } from "../actions/actions.js";
+import { attach } from "../utils.js";
+import { connect2Redux } from "../won-utils.js";
+
+const serviceDependencies = ["$scope", "$ngRedux", "$element"];
+function genComponentConf() {
+  let template = `
+      <div class="md__dialog">
+          <div class="md__dialog__header">
+             <span class="md__dialog__header__caption">{{self.modalDialogCaption}}</span>
+          </div>
+          <div class="md__dialog__content">
+             <span class="md__dialog__content__text">{{self.modalDialogText}}</span>
+          </div>
+          <div class="md__dialog__footer">
+             <button
+                ng-repeat="button in self.modalDialogButtons"
+                class="won-button--filled lighterblue"
+                ng-click="button.get('callback')()">
+                    <span>{{button.get("caption")}}</span>
+             </button>
+          </div>
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+
+      const selectFromState = state => {
+        const modalDialog = state.get("modalDialog");
+        const modalDialogCaption = modalDialog && modalDialog.get("caption");
+        const modalDialogText = modalDialog && modalDialog.get("text");
+        const modalDialogButtons = modalDialog && modalDialog.get("buttons");
+
+        return {
+          modalDialogCaption,
+          modalDialogText,
+          modalDialogButtons:
+            modalDialogButtons && modalDialogButtons.toArray(),
+        };
+      };
+
+      connect2Redux(selectFromState, actionCreators, [], this);
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    // //scope: { }, // not isolated on purpose to allow using parent's scope
+    scope: {},
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.modalDialog", [])
+  .directive("wonModalDialog", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -82,8 +82,29 @@ function genComponentConf() {
     closePost() {
       if (this.isOwnPost) {
         console.log("CLOSING THE POST: " + this.post.get("uri"));
-        this.needs__close(this.post.get("uri"));
-        this.router__stateGoCurrent({ postUri: null });
+
+        const payload = {
+          caption: "Attention!",
+          text:
+            "Archiving the Post will close all connections, do you want to proceed?",
+          buttons: [
+            {
+              caption: "Yes, Archive!",
+              callback: () => {
+                this.needs__close(this.post.get("uri"));
+                this.router__stateGoCurrent({ postUri: null });
+                this.closeModalDialog();
+              },
+            },
+            {
+              caption: "No, I'm scared",
+              callback: () => {
+                this.closeModalDialog();
+              },
+            },
+          ],
+        };
+        this.openModalDialog(payload);
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -3,10 +3,12 @@
  */
 import won from "../won-es6.js";
 import angular from "angular";
+import ngAnimate from "angular-animate";
 //import loginComponent from './login.js';
 //import logoutComponent from './logout.js';
 import dropdownModule from "./covering-dropdown.js";
 import accountMenuModule from "./account-menu.js";
+import modalDialogModule from "./modal-dialog.js";
 import { attach, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
@@ -37,7 +39,7 @@ function genTopnavConf() {
                 ng-show="self.reconnecting"
                 class="hspinner"/>
         </div>
-
+        <won-modal-dialog ng-if="self.showModalDialog"></won-modal-dialog>
 
         <nav class="topnav" ng-class="{'hide-in-responsive': self.connectionOrPostDetailOpen}">
             <div class="topnav__inner">
@@ -163,6 +165,7 @@ function genTopnavConf() {
           toastsArray: state.getIn(["toasts"]).toArray(),
           connectionHasBeenLost: state.getIn(["messages", "lostConnection"]), // name chosen to avoid name-clash with the action-creator
           reconnecting: state.getIn(["messages", "reconnecting"]),
+          showModalDialog: state.get("showModalDialog"),
         };
       };
 
@@ -188,5 +191,7 @@ export default angular
     //logoutComponent,
     dropdownModule,
     accountMenuModule,
+    modalDialogModule,
+    ngAnimate,
   ])
   .directive("wonTopnav", genTopnavConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -117,6 +117,27 @@ const reducers = {
     }
   },
 
+  showModalDialog: (isShowingModalDialog = false, action = {}) => {
+    switch (action.type) {
+      case actionTypes.openModalDialog:
+        return true;
+      case actionTypes.closeModalDialog:
+        return false;
+      default:
+        return isShowingModalDialog;
+    }
+  },
+
+  modalDialog: (modalDialog = undefined, action = {}) => {
+    switch (action.type) {
+      case actionTypes.openModalDialog:
+        return Immutable.fromJS(action.payload);
+      case actionTypes.closeModalDialog:
+      default:
+        return modalDialog;
+    }
+  },
+
   //config: createReducer(
   config: (
     config = Immutable.fromJS({ theme: { name: "current" } }),

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_modal-dialog.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_modal-dialog.scss
@@ -1,0 +1,39 @@
+@import "won-config";
+
+won-modal-dialog {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+
+  align-items: center;
+  justify-content: center;
+  align-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.5);
+
+  .md__dialog {
+    background: white;
+    display: grid;
+    grid-row-gap: 0.5rem;
+    padding: 0.5rem;
+
+    &__header {
+      &__caption {
+      }
+    }
+
+    &__content {
+      &__text {
+      }
+    }
+
+    &__footer {
+      display: grid;
+      grid-auto-flow: column;
+      grid-column-gap: 0.5rem;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
@@ -6,6 +6,8 @@
 @import "topnav-toasts";
 @import "button";
 @import "responsiveness-utils";
+@import "modal-dialog";
+@import "animate";
 
 .topnav {
   //TODO split into single-purpose-classes
@@ -91,4 +93,8 @@
     @include won-button--filled(white, $won-secondary-color-lighter);
     @extend .topnav__button;
   }
+}
+
+won-modal-dialog {
+  @include appearAnimation(0.5s);
 }


### PR DESCRIPTION
fixes #1780 
fixes #1779 

-enables access to the already present "stub" of a settings page via the main dropdown menu
-includes a new component that is a modal dialog (usage seen in README.md and testwise implementation when archiving a post)

I chose the callback variant instead of a promise based architecture to make it easier to understand which button calls which function instead of having to parse an argument in a promise

currently there is no option to support parameters in the given callback functions