### PR TITLE
Fix autocreate whatsx

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -85,21 +85,6 @@ function genComponentConf() {
                 </span>
             </button>
         </div>
-        <!-- TODO: move whatsaround functionality somewhere else. i commented out the following code snippet because the fallback ng-if-clause has turned into an oxymoron
-            Excluded due to #1632 https://github.com/researchstudio-sat/webofneeds/issues/1632
-        -->
-        <!--div ng-if="!self.isPost && !self.isSearch">
-            <button type="submit"
-                    class="won-button--filled red"
-                    ng-click="::self.createWhatsAround()">
-                <span ng-show="!self.pendingPublishing">
-                    See What's Around
-                </span>
-                <span ng-show="self.pendingPublishing">
-                    Retrieving What's Around&nbsp;&hellip;
-                </span>
-            </button>
-        </div-->
         <!-- Excluded due to #1627 https://github.com/researchstudio-sat/webofneeds/issues/1627
         Be aware that the styling of these elements is not valid anymore
         <won-labelled-hr label="::'add context?'" class="cp__footer__labelledhr" ng-if="self.isValid()"></won-labelled-hr>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1273,7 +1273,7 @@ import won from "./won.js";
   }
 
   function dropUnnecessaryTriples(store, graph, roots) {
-    console.log("dropUnnecessaryTriples");
+    console.log("dropUnnecessaryTriples: roots: ", roots);
     ("use strict");
     let usedProperties = collectProperties(store, roots);
     //let usedPropertiesString = usedProperties.reduce( (acc, val) => acc + val);
@@ -1285,7 +1285,7 @@ import won from "./won.js";
   }
 
   function collectProperties(store, node) {
-    console.log("collectProperties");
+    console.log("collectProperties, node:", node);
     let usedProperties = [];
     if (Array.isArray(node)) {
       node.forEach(element => {


### PR DESCRIPTION
If a whatsaround or whatsnew already exists, the login process and duration is very fidgety -> the old whatsX is loaded and visible in the ui and then suddenly disappears (due to the fact that we create a new one each time we login and close the old ones), therefore we load alot of connections and needs unnecessarily

This PR is a fast fix for this problem -> the whatsnew is not automatically created if there is already an open whatsnew or whatsaround for this user, and the whats around need will not be created if there is already an open whatsaround need for this user.