### PR TITLE
use fully qualified name to get creation date of a need, somehow this…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -1088,7 +1088,7 @@ function parseNeed(jsonldNeed, ownNeed) {
 
     const wonHasMatchingContexts = jsonldNeedImm.get("won:hasMatchingContext");
 
-    const creationDate = jsonldNeedImm.get("dct:created");
+    const creationDate = jsonldNeedImm.get("http://purl.org/dc/terms/created");
     if (creationDate) {
       parsedNeed.creationDate = new Date(creationDate);
       parsedNeed.lastUpdateDate = parsedNeed.creationDate;


### PR DESCRIPTION
… changed and wasnt found with the prefixed version anymore

fixes #1871 

there was problem with the sorting because the creationDate was not parsed out of the jsonld correctly and thus resulting in an empty lastUpdateDate