### PR TITLE
Fix need parsing and route rdf

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -1332,11 +1332,13 @@ function parseTravelAction(jsonTravelAction) {
       "http://schema.org/latitude",
     ]);
 
-  travelAction.fromLocation.lng = travelActionImm.getIn([
-    "http://schema.org/fromLocation",
-    "http://schema.org/geo",
-    "http://schema.org/longitude",
-  ]);
+  travelAction.fromLocation.lng =
+    travelActionImm.getIn(["s:fromLocation", "s:geo", "s:longitude"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/fromLocation",
+      "http://schema.org/geo",
+      "http://schema.org/longitude",
+    ]);
 
   travelAction.toAddress =
     travelActionImm.getIn(["s:toLocation", "s:name"]) ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -1088,7 +1088,9 @@ function parseNeed(jsonldNeed, ownNeed) {
 
     const wonHasMatchingContexts = jsonldNeedImm.get("won:hasMatchingContext");
 
-    const creationDate = jsonldNeedImm.get("http://purl.org/dc/terms/created");
+    const creationDate =
+      jsonldNeedImm.get("dct:created") ||
+      jsonldNeedImm.get("http://purl.org/dc/terms/created");
     if (creationDate) {
       parsedNeed.creationDate = new Date(creationDate);
       parsedNeed.lastUpdateDate = parsedNeed.creationDate;
@@ -1210,48 +1212,72 @@ function parseLocation(jsonldLocation) {
     },
   };
 
-  location.address = jsonldLocationImm.get("http://schema.org/name");
+  location.address =
+    jsonldLocationImm.get("s:name") ||
+    jsonldLocationImm.get("http://schema.org/name");
 
   location.lat = Number.parseFloat(
-    jsonldLocationImm.getIn([
-      "http://schema.org/geo",
-      "http://schema.org/latitude",
-    ])
+    jsonldLocationImm.getIn(["s:geo", "s:latitude"]) ||
+      jsonldLocationImm.getIn([
+        "http://schema.org/geo",
+        "http://schema.org/latitude",
+      ])
   );
   location.lng = Number.parseFloat(
-    jsonldLocationImm.getIn([
-      "http://schema.org/geo",
-      "http://schema.org/longitude",
-    ])
+    jsonldLocationImm.getIn(["s:geo", "s:longitude"]) ||
+      jsonldLocationImm.getIn([
+        "http://schema.org/geo",
+        "http://schema.org/longitude",
+      ])
   );
 
   location.nwCorner.lat = Number.parseFloat(
     jsonldLocationImm.getIn([
       "won:hasBoundingBox",
       "won:hasNorthWestCorner",
-      "http://schema.org/latitude",
-    ])
+      "s:latitude",
+    ]) ||
+      jsonldLocationImm.getIn([
+        "won:hasBoundingBox",
+        "won:hasNorthWestCorner",
+        "http://schema.org/latitude",
+      ])
   );
   location.nwCorner.lng = Number.parseFloat(
     jsonldLocationImm.getIn([
       "won:hasBoundingBox",
       "won:hasNorthWestCorner",
-      "http://schema.org/longitude",
-    ])
+      "s:longitude",
+    ]) ||
+      jsonldLocationImm.getIn([
+        "won:hasBoundingBox",
+        "won:hasNorthWestCorner",
+        "http://schema.org/longitude",
+      ])
   );
   location.seCorner.lat = Number.parseFloat(
     jsonldLocationImm.getIn([
       "won:hasBoundingBox",
       "won:hasSouthEastCorner",
-      "http://schema.org/latitude",
-    ])
+      "s:latitude",
+    ]) ||
+      jsonldLocationImm.getIn([
+        "won:hasBoundingBox",
+        "won:hasSouthEastCorner",
+        "http://schema.org/latitude",
+      ])
   );
   location.seCorner.lng = Number.parseFloat(
     jsonldLocationImm.getIn([
       "won:hasBoundingBox",
       "won:hasSouthEastCorner",
-      "http://schema.org/longitude",
-    ])
+      "s:longitude",
+    ]) ||
+      jsonldLocationImm.getIn([
+        "won:hasBoundingBox",
+        "won:hasSouthEastCorner",
+        "http://schema.org/longitude",
+      ])
   );
 
   if (
@@ -1291,16 +1317,20 @@ function parseTravelAction(jsonTravelAction) {
     },
   };
 
-  travelAction.fromAddress = travelActionImm.getIn([
-    "http://schema.org/fromLocation",
-    "http://schema.org/name",
-  ]);
+  travelAction.fromAddress =
+    travelActionImm.getIn(["s:fromLocation", "s:name"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/fromLocation",
+      "http://schema.org/name",
+    ]);
 
-  travelAction.fromLocation.lat = travelActionImm.getIn([
-    "http://schema.org/fromLocation",
-    "http://schema.org/geo",
-    "http://schema.org/latitude",
-  ]);
+  travelAction.fromLocation.lat =
+    travelActionImm.getIn(["s:fromLocation", "s:geo", "s:latitude"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/fromLocation",
+      "http://schema.org/geo",
+      "http://schema.org/latitude",
+    ]);
 
   travelAction.fromLocation.lng = travelActionImm.getIn([
     "http://schema.org/fromLocation",
@@ -1308,22 +1338,28 @@ function parseTravelAction(jsonTravelAction) {
     "http://schema.org/longitude",
   ]);
 
-  travelAction.toAddress = travelActionImm.getIn([
-    "http://schema.org/toLocation",
-    "http://schema.org/name",
-  ]);
+  travelAction.toAddress =
+    travelActionImm.getIn(["s:toLocation", "s:name"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/toLocation",
+      "http://schema.org/name",
+    ]);
 
-  travelAction.toLocation.lat = travelActionImm.getIn([
-    "http://schema.org/toLocation",
-    "http://schema.org/geo",
-    "http://schema.org/latitude",
-  ]);
+  travelAction.toLocation.lat =
+    travelActionImm.getIn(["s:toLocation", "s:geo", "s:latitude"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/toLocation",
+      "http://schema.org/geo",
+      "http://schema.org/latitude",
+    ]);
 
-  travelAction.toLocation.lng = travelActionImm.getIn([
-    "http://schema.org/toLocation",
-    "http://schema.org/geo",
-    "http://schema.org/longitude",
-  ]);
+  travelAction.toLocation.lng =
+    travelActionImm.getIn(["s:toLocation", "s:geo", "s:longitude"]) ||
+    travelActionImm.getIn([
+      "http://schema.org/toLocation",
+      "http://schema.org/geo",
+      "http://schema.org/longitude",
+    ]);
 
   if (
     (travelAction.fromAddress &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -191,7 +191,7 @@ import won from "./won.js";
               : {
                   "@type": "s:Place",
                   "s:geo": {
-                    "@Type": "s:GeoCoordinates",
+                    "@type": "s:GeoCoordinates",
                     "s:latitude": isOrSeeksData.travelAction.fromLocation.lat.toFixed(
                       6
                     ),
@@ -206,7 +206,7 @@ import won from "./won.js";
               : {
                   "@type": "s:Place",
                   "s:geo": {
-                    "@Type": "s:GeoCoordinates",
+                    "@type": "s:GeoCoordinates",
                     "s:latitude": isOrSeeksData.travelAction.toLocation.lat.toFixed(
                       6
                     ),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -191,7 +191,7 @@ import won from "./won.js";
               : {
                   "@type": "s:Place",
                   "s:geo": {
-                    "@Type": "s:Geocoordinates",
+                    "@Type": "s:GeoCoordinates",
                     "s:latitude": isOrSeeksData.travelAction.fromLocation.lat.toFixed(
                       6
                     ),
@@ -206,7 +206,7 @@ import won from "./won.js";
               : {
                   "@type": "s:Place",
                   "s:geo": {
-                    "@Type": "s:Geocoordinates",
+                    "@Type": "s:GeoCoordinates",
                     "s:latitude": isOrSeeksData.travelAction.toLocation.lat.toFixed(
                       6
                     ),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -185,7 +185,7 @@ import won from "./won.js";
       "won:travelAction": !isOrSeeksData.travelAction
         ? undefined
         : {
-            "@type": "s:travelAction",
+            "@type": "s:TravelAction",
             "s:fromLocation": !isOrSeeksData.travelAction.fromLocation
               ? undefined
               : {


### PR DESCRIPTION
There were some issues within the routepicker rdf creation see need-builder.js changes

also somehow we got the prefixed attributes in the need-reducer again and therefore couldnt parse the creationDate and the location as they assumed a fully qualified name, since i didnt want to go on a fact finding mission to find out why this is different again i added resilience to our need-reducer parsing -> now it will work with either of the two options (prefixed and fully qualified name)