### PR TITLE
Feat enhance connuri crawling

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -91,7 +91,6 @@ const INJ_DEFAULT = "INJECT_DEFAULT_ACTION_CREATOR";
 const actionHierarchy = {
   initialPageLoad: pageLoadAction,
   connections: {
-    fetch: cnct.connectionsFetch,
     open: cnct.connectionsOpen,
     connectAdHoc: cnct.connectionsConnectAdHoc,
     close: cnct.connectionsClose,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -104,23 +104,6 @@ export function connectionsChatMessage(
   };
 }
 
-export function connectionsFetch(data) {
-  return dispatch => {
-    const allConnectionsPromise = won.executeCrawlableQuery(
-      won.queries["getAllConnectionUrisOfNeed"],
-      data.needUri
-    );
-    allConnectionsPromise.then(function(connections) {
-      dispatch(
-        actionCreators.needs__connectionsReceived({
-          needUri: data.needUri,
-          connections: connections,
-        })
-      );
-    });
-  };
-}
-
 export function connectionsOpen(connectionUri, textMessage) {
   return async (dispatch, getState) => {
     const ownNeed = getState()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -2493,16 +2493,6 @@ import won from "./won.js";
             "prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> ",
           propertyPath: "won:hasConnections",
         },
-        {
-          prefixes:
-            "prefix " +
-            won.WON.prefix +
-            ": <" +
-            won.WON.baseUri +
-            "> " +
-            "prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> ",
-          propertyPath: "won:hasConnections/rdfs:member",
-        },
       ],
       query:
         "prefix won: <http://purl.org/webofneeds/model#> \n" +

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -23,6 +23,7 @@ import {
   clearPrivateId,
   clearReadUris,
   clearClosedConnUris,
+  getClosedConnUris,
 } from "../won-localstorage.js";
 import jsonld from "jsonld";
 
@@ -42,6 +43,7 @@ won.showRdf = false; //if you set this to true, the RDF icons/links are visible
 won.clearPrivateId = clearPrivateId;
 won.clearReadUris = clearReadUris;
 won.clearClosedConnUris = clearClosedConnUris;
+won.getClosedConnUris = getClosedConnUris;
 
 won.WON = {};
 won.WON.baseUri = "http://purl.org/webofneeds/model#";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -19,7 +19,11 @@
  */
 "format es6" /* required to force babel to transpile this so the minifier is happy */;
 import { is, prefixOfUri, isArray, clone } from "../utils.js";
-import { clearPrivateId, clearReadUris } from "../won-localstorage.js";
+import {
+  clearPrivateId,
+  clearReadUris,
+  clearClosedConnUris,
+} from "../won-localstorage.js";
 import jsonld from "jsonld";
 
 import N3 from "n3";
@@ -37,6 +41,7 @@ won.showRdf = false; //if you set this to true, the RDF icons/links are visible
 
 won.clearPrivateId = clearPrivateId;
 won.clearReadUris = clearReadUris;
+won.clearClosedConnUris = clearClosedConnUris;
 
 won.WON = {};
 won.WON.baseUri = "http://purl.org/webofneeds/model#";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -429,10 +429,9 @@ export function flattenObj(objOfObj) {
 export function urisToLookupMap(uris, asyncLookupFunction, excludeUris = []) {
   //make sure we have an array and not a single uri.
   const urisAsArray = is("Array", uris) ? uris : [uris];
-  const excludeUrisAsArray = is(
-    "Array",
-    excludeUris ? excludeUris : [excludeUris]
-  );
+  const excludeUrisAsArray = is("Array", excludeUris)
+    ? excludeUris
+    : [excludeUris];
 
   const urisAsArrayWithoutExcludes = urisAsArray.filter(uri => {
     const exclude = excludeUrisAsArray.indexOf(uri) < 0;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -426,17 +426,32 @@ export function flattenObj(objOfObj) {
  * @param asyncLookupFunction
  * @return {*}
  */
-export function urisToLookupMap(uris, asyncLookupFunction) {
+export function urisToLookupMap(uris, asyncLookupFunction, excludeUris = []) {
   //make sure we have an array and not a single uri.
   const urisAsArray = is("Array", uris) ? uris : [uris];
-  const asyncLookups = urisAsArray.map(uri =>
+  const excludeUrisAsArray = is(
+    "Array",
+    excludeUris ? excludeUris : [excludeUris]
+  );
+
+  const urisAsArrayWithoutExcludes = urisAsArray.filter(uri => {
+    const exclude = excludeUrisAsArray.indexOf(uri) < 0;
+    if (exclude) {
+      return true;
+    } else {
+      console.log(uri, "closed, ommit further crawl for this uri");
+      return false;
+    }
+  });
+
+  const asyncLookups = urisAsArrayWithoutExcludes.map(uri =>
     asyncLookupFunction(uri).catch(error => {
       console.error(
         `failed lookup for ${uri} in utils.js:urisToLookupMap ` + error.message,
         "\n\n",
         error.stack,
         "\n\n",
-        urisAsArray,
+        urisAsArrayWithoutExcludes,
         "\n\n",
         uris,
         "\n\n",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -2,6 +2,7 @@
  * Created by fsuda on 25.04.2018.
  */
 const READ_URIS = "wonReadUris";
+const CLOSED_CONN_URIS = "wonClosedConnectionUris";
 
 export function markUriAsRead(uri) {
   //TODO: BETTER IMPL
@@ -50,4 +51,45 @@ export function clearPrivateId() {
 
 export function savePrivateId(privateId) {
   localStorage.setItem("privateId", privateId);
+}
+
+export function markConnUriAsClosed(uri) {
+  //TODO: BETTER IMPL
+  if (!isConnUriClosed(uri)) {
+    let closedConnUrisString = localStorage.getItem(CLOSED_CONN_URIS);
+    if (!closedConnUrisString) {
+      closedConnUrisString = JSON.stringify([uri]);
+    } else {
+      try {
+        let closedConnUriList = JSON.parse(closedConnUrisString);
+        closedConnUriList.push(uri);
+        closedConnUrisString = JSON.stringify(closedConnUriList);
+      } catch (e) {
+        clearClosedConnUris();
+        closedConnUrisString = JSON.stringify([uri]);
+      }
+    }
+
+    localStorage.setItem(CLOSED_CONN_URIS, closedConnUrisString);
+  }
+}
+
+export function isConnUriClosed(uri) {
+  //TODO: BETTER IMPL
+  let closedConnUrisString = localStorage.getItem(CLOSED_CONN_URIS);
+
+  if (closedConnUrisString) {
+    let closedConnUriList = JSON.parse(closedConnUrisString);
+
+    for (const closedUri of closedConnUriList) {
+      if (closedUri === uri) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function clearClosedConnUris() {
+  localStorage.removeItem(CLOSED_CONN_URIS);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -74,6 +74,16 @@ export function markConnUriAsClosed(uri) {
   }
 }
 
+export function getClosedConnUris() {
+  let closedConnUrisString = localStorage.getItem(CLOSED_CONN_URIS);
+
+  if (!closedConnUrisString) {
+    return [];
+  } else {
+    return JSON.parse(closedConnUrisString);
+  }
+}
+
 export function isConnUriClosed(uri) {
   //TODO: BETTER IMPL
   let closedConnUrisString = localStorage.getItem(CLOSED_CONN_URIS);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -10,7 +10,7 @@ import { ownerBaseUrl } from "config";
 import urljoin from "url-join";
 
 import { getRandomWonId } from "./won-utils.js";
-import { isConnUriClosed } from "./won-localstorage.js";
+import { getClosedConnUris } from "./won-localstorage.js";
 
 export const emptyDataset = Immutable.fromJS({
   ownNeeds: {},
@@ -513,16 +513,13 @@ function fetchAllAccessibleAndRelevantData(
           won
             .getConnectionUrisOfNeed(needUri, needUri, true)
             .then(connectionUris =>
-              urisToLookupMap(connectionUris, connUri => {
-                if (!isConnUriClosed(connUri)) {
-                  fetchConnectionAndDispatch(connUri, curriedDispatch);
-                } else {
-                  console.log(
-                    connUri,
-                    " closed, ommit further crawl for this connection"
-                  );
-                }
-              })
+              urisToLookupMap(
+                connectionUris,
+                uri => {
+                  fetchConnectionAndDispatch(uri, curriedDispatch);
+                },
+                getClosedConnUris()
+              )
             )
         )
       )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -509,15 +509,13 @@ function fetchAllAccessibleAndRelevantData(
   const allConnectionsPromise = allOwnNeedsPromise
     .then(() =>
       Promise.all(
-        ownNeedUris.map(needUri =>
+        ownNeedUris.map(uri =>
           won
-            .getConnectionUrisOfNeed(needUri, needUri, true)
+            .getConnectionUrisOfNeed(uri, uri, true)
             .then(connectionUris =>
               urisToLookupMap(
                 connectionUris,
-                uri => {
-                  return fetchConnectionAndDispatch(uri, curriedDispatch);
-                },
+                uri => fetchConnectionAndDispatch(uri, curriedDispatch),
                 getClosedConnUris()
               )
             )


### PR DESCRIPTION
instead of crawling all the connection uris directly and only returning the ones we actually want we just get all the connectionUris from a need, and then storing the closed ones similar to the process we will implement for deactivated needs (in the local storage) so we do not ever crawl a closed connection again on reload/login etc... the connection is marked as closed if the connection is added to the redux state and has a state of WON.Closed, or when the connectionState itself changes

Fixes in this branch:
-removed an unused method
-called the executeCrawlableQuery with the right set of parameters (3 instead of 2)
-omit further crawling for a connUri that has already been deemed as closed (from the localStorage)

This should enhance the login speed for users with alot of needs and connections tremendously in the future (first time and incognito access will not go any faster as we will not know which connections are already closed, but everybody else will hopefully experience a huge performance enhancement on the second reload and or login)

happy happy joy joy

ps: @fkleedorfer please don't be mad, that i did this, i needed a palate cleanser after the gui fixes

One should see the change by looking into the localStorage and finding a set of connectionUris that have already been closed, and also on login/reloads after the first one has been completed you should find the following logentry for connecitons that have been omitted in crawling  "[connUri] closed, ommit further crawl for this uri" (without the [])

calling won.clearClosedConnUris()  in the debug console, resets this localStorage element to nothing again (for testing purposes)