### PR TITLE
replace all occurences of line.uki.or.at with meicogsci.matchat.org

### DIFF
--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -32,11 +32,11 @@ services:
     image: webofneeds/letsencrypt:live
     environment:
       - "key_store_password=$uki_certificate_passwd"
-      - "domain_params=-d line.uki.or.at"
-      - "key_pem_file=/etc/letsencrypt/live/line.uki.or.at/privkey.pem"
-      - "cert_pem_file=/etc/letsencrypt/live/line.uki.or.at/fullchain.pem"
-      - "pfx_store_file=/etc/letsencrypt/live/line.uki.or.at/t-key-cert.pfx"
-      - "jks_store_file=/etc/letsencrypt/live/line.uki.or.at/t-keystore.jks"
+      - "domain_params=-d meicogsci.matchat.org"
+      - "key_pem_file=/etc/letsencrypt/live/meicogsci.matchat.org/privkey.pem"
+      - "cert_pem_file=/etc/letsencrypt/live/meicogsci.matchat.org/fullchain.pem"
+      - "pfx_store_file=/etc/letsencrypt/live/meicogsci.matchat.org/t-key-cert.pfx"
+      - "jks_store_file=/etc/letsencrypt/live/meicogsci.matchat.org/t-keystore.jks"
     volumes:
       - $base_folder/letsencrypt/certs:/etc/letsencrypt
       - $base_folder/letsencrypt/acme-challenge:/usr/share/nginx/html

--- a/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gencert:
     build: ../../image/gencert
     environment:
-      - "CN=line.uki.or.at"
+      - "CN=meicogsci.matchat.org"
       - "PASS=file:/usr/local/certs/out/uki_certificate_passwd_file"
       - "OPENSSL_CONFIG_FILE=/usr/local/openssl.conf"
     volumes:
@@ -27,8 +27,8 @@ services:
   wonnode:
     build: ../../image/wonnode
     environment:
-      - "uri.host=line.uki.or.at"
-      - "uri.prefix=https://line.uki.or.at/won"
+      - "uri.host=meicogsci.matchat.org"
+      - "uri.prefix=https://meicogsci.matchat.org/won"
       - "http.port=8443"
       - "db.sql.jdbcDriverClass=org.postgresql.Driver"
       - "db.sql.jdbcUrl=jdbc:postgresql://satvm06.researchstudio.at:5433/won_node"
@@ -43,10 +43,10 @@ services:
       - "8443:8443"
       - "61627:61626"
     volumes:
-      - $base_folder/letsencrypt/certs/live/line.uki.or.at/fullchain.pem:/usr/local/tomcat/conf/ssl/t-cert.pem
-      - $base_folder/letsencrypt/certs/live/line.uki.or.at/privkey.pem:/usr/local/tomcat/conf/ssl/t-key.pem
-      - $base_folder/letsencrypt/certs/live/line.uki.or.at/t-key-cert.pfx:/usr/local/tomcat/conf/ssl/t-key-cert.pfx
-      - $base_folder/letsencrypt/certs/live/line.uki.or.at/t-keystore.jks:/usr/local/tomcat/conf/ssl/t-keystore.jks
+      - $base_folder/letsencrypt/certs/live/meicogsci.matchat.org/fullchain.pem:/usr/local/tomcat/conf/ssl/t-cert.pem
+      - $base_folder/letsencrypt/certs/live/meicogsci.matchat.org/privkey.pem:/usr/local/tomcat/conf/ssl/t-key.pem
+      - $base_folder/letsencrypt/certs/live/meicogsci.matchat.org/t-key-cert.pfx:/usr/local/tomcat/conf/ssl/t-key-cert.pfx
+      - $base_folder/letsencrypt/certs/live/meicogsci.matchat.org/t-keystore.jks:/usr/local/tomcat/conf/ssl/t-keystore.jks
       - $base_folder/won-client-certs/wonnode:/usr/local/tomcat/won/client-certs/
     depends_on:
       - postgres_node
@@ -66,12 +66,12 @@ services:
   owner:
     build: ../../image/owner
     environment:
-      - "node.default.host=line.uki.or.at"
-      - "uri.host=line.uki.or.at"
+      - "node.default.host=meicogsci.matchat.org"
+      - "uri.host=meicogsci.matchat.org"
       - "http.port=8082"
       - "node.default.http.port=443"
-      - "uri.prefix=https://line.uki.or.at/owner"
-      - "uri.prefix.node.default=https://line.uki.or.at/won"
+      - "uri.prefix=https://meicogsci.matchat.org/owner"
+      - "uri.prefix.node.default=https://meicogsci.matchat.org/won"
       - "db.sql.jdbcDriverClass=org.postgresql.Driver"
       - "db.sql.jdbcUrl=jdbc:postgresql://satvm06.researchstudio.at:5432/won_owner"
       - "db.ddl.strategy=validate"
@@ -106,10 +106,10 @@ services:
     build: ../../image/matcher-service
     environment:
       - "node.host=satvm06.researchstudio.at"
-      - "matcher.uri=https://line.uki.or.at/matcher_service"
+      - "matcher.uri=https://meicogsci.matchat.org/matcher_service"
       - "cluster.seedNodes=satvm06.researchstudio.at:2561,satvm06.researchstudio.at:2562"
       - "uri.sparql.endpoint=http://satvm06.researchstudio.at:10000/bigdata/namespace/kb/sparql"
-      - "wonNodeController.wonNode.crawl=https://line.uki.or.at/won/resource,https://node.matchat.org/won/resource" # crawl uki won node and matchat won node
+      - "wonNodeController.wonNode.crawl=https://meicogsci.matchat.org/won/resource,https://node.matchat.org/won/resource" # crawl uki won node and matchat won node
       - "cluster.local.port=2561"
       - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
     ports:
@@ -162,11 +162,11 @@ services:
   debug_bot:
     build: ../../image/bots
     environment:
-      - "uri.prefix.owner=https://line.uki.or.at/debug_bot"  # set this for the trust store alias
-      - "node.default.host=line.uki.or.at"
+      - "uri.prefix.owner=https://meicogsci.matchat.org/debug_bot"  # set this for the trust store alias
+      - "node.default.host=meicogsci.matchat.org"
       - "node.default.http.port=443"
-      - "uri.prefix.node.default=https://line.uki.or.at/won"
-      - "won.node.uris=https://line.uki.or.at/won/resource"
+      - "uri.prefix.node.default=https://meicogsci.matchat.org/won"
+      - "won.node.uris=https://meicogsci.matchat.org/won/resource"
       - "botContext.impl=mongoBotContext"
       - "botContext.mongodb.user=won"
       - "botContext.mongodb.pass=$mongo_db_passwd"

--- a/webofneeds/won-docker/deploy_uki.sh
+++ b/webofneeds/won-docker/deploy_uki.sh
@@ -14,15 +14,15 @@ rm uki_certificate_passwd_file
 
 # copy the openssl.conf file to the server where the certificates are generated
 # the conf file is needed to specify alternative server names, see conf file in won-docker/image/gencert/openssl.conf
-# for entries of alternative server names: line.uki.or.at, satvm06.researchstudio.at
+# for entries of alternative server names: meicogsci.matchat.org, satvm06.researchstudio.at
 scp $WORKSPACE/webofneeds/won-docker/image/gencert/openssl-uki.conf won@satvm06:$base_folder/openssl.conf
 
 # copy the nginx.conf file to the proxy server
 scp $WORKSPACE/webofneeds/won-docker/image/nginx/nginx-uki-http.conf won@satvm01:$live_base_folder/nginx-uki-http.conf
 
 # copy letsencrypt certificate files from satvm01 (live/matchat) to satvm06
-ssh won@satvm06 mkdir -p $base_folder/letsencrypt/certs/live/line.uki.or.at
-scp -3 won@satvm01:$live_base_folder/letsencrypt/certs/live/line.uki.or.at/* won@satvm06:$base_folder/letsencrypt/certs/live/line.uki.or.at/
+ssh won@satvm06 mkdir -p $base_folder/letsencrypt/certs/live/meicogsci.matchat.org
+scp -3 won@satvm01:$live_base_folder/letsencrypt/certs/live/meicogsci.matchat.org/* won@satvm06:$base_folder/letsencrypt/certs/live/meicogsci.matchat.org/
 
 # create the solr data directories (if not available yet) with full rights for every user.
 # This is done so that the directory on the host can be written by the solr user from inside the container

--- a/webofneeds/won-docker/image/gencert/openssl-uki.conf
+++ b/webofneeds/won-docker/image/gencert/openssl-uki.conf
@@ -353,6 +353,6 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 				
 [ alt_names ]
 
-DNS.1 = line.uki.or.at
+DNS.1 = meicogsci.matchat.org
 DNS.2 = satvm06.researchstudio.at
 

--- a/webofneeds/won-docker/image/nginx/nginx-uki-http.conf
+++ b/webofneeds/won-docker/image/nginx/nginx-uki-http.conf
@@ -1,4 +1,4 @@
-# this config file describes the behavior of the line.uki.or.at behavior.
+# this config file describes the behavior of the meicogsci.matchat.org behavior.
 # It is included by the main matchat "nginx.conf" file in the http section
 
 
@@ -9,7 +9,7 @@
 # redirect all http requests to https
 server {
     listen          80;
-    server_name     line.uki.or.at;
+    server_name     meicogsci.matchat.org;
     root            /data;
 
     # configuration for letsencrypt certbot ssl challenge
@@ -27,7 +27,7 @@ server {
     ssl                 on;
     listen              443 ssl;
     root                /data;
-    server_name         line.uki.or.at;
+    server_name         meicogsci.matchat.org;
 
     # request the client certificate but does not require it to be signed by a trusted CA certificate
     ssl_verify_client optional_no_ca;
@@ -38,8 +38,8 @@ server {
     proxy_set_header Connection "upgrade";
 
     # certificate data
-    ssl_certificate     /etc/letsencrypt/live/line.uki.or.at/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/line.uki.or.at/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/meicogsci.matchat.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/meicogsci.matchat.org/privkey.pem;
 
     location /owner {
         proxy_pass https://satvm06.researchstudio.at:8082/owner;

--- a/webofneeds/won-docker/image/nginx/nginx.conf
+++ b/webofneeds/won-docker/image/nginx/nginx.conf
@@ -24,7 +24,7 @@ stream {
         proxy_pass satvm01.researchstudio.at:61617;
     }
 
-    # pass tcp jms messages to line.uki.or.at
+    # pass tcp jms messages to meicogsci.matchat.org
     server {
         listen 61626;
         proxy_pass satvm06.researchstudio.at:61627;


### PR DESCRIPTION
Needs to be deployed:
on master (just cuz)
on live (for our nginx load balancer)
on uki (to deploy the actual instance in the correct place)

we currently do not have the dns entry for meicogsci.matchat.org and thats why we can't re-generate the letsencrypt certificate yet, but once this has happened someone will update it and then we should be able to use the instance from meicogsci.matchat.org

Child of #1866 
