### PR TITLE
Feat  add new need immediately #1868

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -6,8 +6,6 @@ We're using the redux-architecture for the client.
 
 ![redux architecture in client-side owner-app](http://researchstudio-sat.github.io/webofneeds/images/owner_app_redux_architecture.svg)
 
-
-
 ## Action Creators
 
 Can be found in `app/actions/actions.js`
@@ -19,8 +17,8 @@ In both cases they cause a **single**(!) action to be dispatched (~= passed as i
 If you want to **add new action-creators** do so by adding to the `actionHierarcy`-object in `actions.js`.
 From that two objects are generated at the moment:
 
-* `actionTypes`, which contains string-constants (e.g. actionTypes.needs.close === 'needs.close')
-* `actionCreators`, which houses the action creators. for the sake of injecting them with ng-redux, they are organised with `__` as seperator (e.g. `actionCreators.needs__close()`)
+- `actionTypes`, which contains string-constants (e.g. actionTypes.needs.close === 'needs.close')
+- `actionCreators`, which houses the action creators. for the sake of injecting them with ng-redux, they are organised with `__` as seperator (e.g. `actionCreators.needs__close()`)
 
 Btw, the easiest way for actions without sideffects is to just placing an `myAction: INJ_DEFAULT`.
 This results in an action-creator that just dispatches all function-arguments as payload,
@@ -65,14 +63,14 @@ Routing(-states, aka URLs) are configured in `configRouting.js`.
 State changes can be triggered via `actionCreators.router__stateGo(stateName)`.
 The current routing-state and -parameters can be found in our app-state:
 
- ```javascript
-$ngRedux.getState().get('router')
+```javascript
+$ngRedux.getState().get("router");
 /* =>
 {
-  currentParams: {...},
-  currentState: {...},
-  prevParams: {...},
-  prevState: {...}
+ currentParams: {...},
+ currentState: {...},
+ prevParams: {...},
+ prevState: {...}
 }
 */
 ```
@@ -80,113 +78,165 @@ $ngRedux.getState().get('router')
 Also see: [Routing and Redux](https://github.com/researchstudio-sat/webofneeds/issues/344)
 
 ## State Structure
- ```javascript
-$ngRedux.getState()
+
+```javascript
+$ngRedux.getState();
 /* =>
 {
-  config: {
-    defaultNodeUri: [nodeuri]
-  },
-  events: {
-    events: {...},
-    unreadEventUris: {...},
-  },
-  initialLoadFinished: true|false,
-  lastUpdateTime: timeinmillis,
-  messages: {
-    enqueued: {...},
-    lostConnection: true|false,
-    reconnecting: true|false,
-    waitingForAnswer: {...}
-  },
-  needs: {
-    [needUri]: {
-        connections: { //Immutable.Map() containing all corresponding Connections to this need
-            [connectionUri]: {
-                creationDate: date, //creationDate of the connection
-                lastUpdateDate: date, //date of lastUpdate of this connection (last date of the message that was added)
-                messages: { //Immutable.Map() of all the TextMessages sent over this connection
-                    [messageUri]: {
-                        connectMessage: true|false, //whether or not this was the connectMessage(a.k.a firstMessage)
-                        date: date, //creation Date of this message
-                        unread: true|false, //whether or not this message is new (or already seen if you will)
-                        outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
-                        text: string, //message text
-                        uri: string //unique identifier of this message
-                    }
-                    ...
-                },
-                agreementData: { //contains agreementData that is necessary to display for the user
-                    agreementUris: Set(), //agreementUris with the current state uris of the connection
-                    cancellationPendingAgreementUris: Set(), ///proposeToCancelUris with the current state uris of the connection
-                    pendingProposalUris: Set(), //pendingProposalUris with the current state uris of the connection
-                },
-                isLoading: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
-                showAgreementData: true | false // default ist false, wheather or not the agreementDataPanel is active
-                unread: true|false, //whether or not this connection is new (or already seen if you will)
-                isRated: true|false, //whether or not this connection has been rated yet
-                remoteNeedUri: string, //corresponding remote Need identifier
-                state: string, //state of the connection
-                uri: string //unique identifier of this connection
-            }
-            ...
-        },
-        creationDate: Date, //creationDate of this need
-        lastUpdateDate: date, //date of lastUpdate of this need (last date of the message or connection that was added)
-        unread: true|false, //whether or not this need has new information that has not been read yet
-        description: string, //description of the need as a string (non mandatory, empty if not present)
-        location: { //non mandatory but if present it contains all elements below
-            address: string, //address as human readable string
-            lat: float, //latitude of address
-            lng: float, //longitude of address
-            nwCorner: { //north west corner of the boundingbox
-                lat: float,
-                lng: float,
-            },
-            seCorner: { //south east corner of the boundingbox
-                lat: float,
-                lng: float,
-            }
-        },
-        ownNeed: true|false, //whether this need is owned or not
-        state: "won:Active" | "won:Inactive", //state of the need
-        tags: Array of strings, //array of strings (non mandatory, empty if not present)
-        title: string, //title of the need
-        type: "won:Supply" | "won:Demand" | "won:Offer", //type of the need
-        uri: string //unique identifier of this need
-    },
-    ...
-  },
-  router: {
-    currentParams: {...},
-    currentState: {...},
-    prevParams: {...},
-    prevState: {...}
-  },
-  toasts: {...},
-  user: {...},
-  showRdf: true|false, //flag that is true if rawData mode is on (enables rdf view and rdf links) (default is false)
-  showClosedNeeds: true|false, //flag whether the drawer of the closedNeeds is open or closed (default is false)
-  showMainMenu: true|false, //flag whether the mainmenu dropdown is open or closed (default is false)
-  showModalDialog: true|false, //flag whether the omnipresent modal dialog is displayed or not (default is false)
-  modalDialog: {
-    caption: string, //header caption of the modal dialog
-    text: string,
-    buttons: [ //Array
-      {
-       caption: string //caption of the button
-       callback: callback //action of the button
-      }
-      ...
-    ]
-  }
+ config: {
+   defaultNodeUri: [nodeuri]
+ },
+ events: {
+   events: {...},
+   unreadEventUris: {...},
+ },
+ initialLoadFinished: true|false,
+ lastUpdateTime: timeinmillis,
+ messages: {
+   enqueued: {...},
+   lostConnection: true|false,
+   reconnecting: true|false,
+   waitingForAnswer: {...}
+ },
+ needs: {
+   [needUri]: {
+       connections: { //Immutable.Map() containing all corresponding Connections to this need
+           [connectionUri]: {
+               creationDate: date, //creationDate of the connection
+               lastUpdateDate: date, //date of lastUpdate of this connection (last date of the message that was added)
+               messages: { //Immutable.Map() of all the TextMessages sent over this connection
+                   [messageUri]: {
+                       connectMessage: true|false, //whether or not this was the connectMessage(a.k.a firstMessage)
+                       date: date, //creation Date of this message
+                       unread: true|false, //whether or not this message is new (or already seen if you will)
+                       outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
+                       text: string, //message text
+                       uri: string //unique identifier of this message
+                   }
+                   ...
+               },
+               agreementData: { //contains agreementData that is necessary to display for the user
+                   agreementUris: Set(), //agreementUris with the current state uris of the connection
+                   cancellationPendingAgreementUris: Set(), ///proposeToCancelUris with the current state uris of the connection
+                   pendingProposalUris: Set(), //pendingProposalUris with the current state uris of the connection
+               },
+               isLoading: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
+               showAgreementData: true | false // default ist false, wheather or not the agreementDataPanel is active
+               unread: true|false, //whether or not this connection is new (or already seen if you will)
+               isRated: true|false, //whether or not this connection has been rated yet
+               remoteNeedUri: string, //corresponding remote Need identifier
+               state: string, //state of the connection
+               uri: string //unique identifier of this connection
+           }
+           ...
+       },
+       creationDate: Date, //creationDate of this need
+       lastUpdateDate: date, //date of lastUpdate of this need (last date of the message or connection that was added)
+       nodeUri: string, //identifier of this need's server
+       ownNeed: true|false, //whether this need is owned or not
+       isBeingCreated: true|false, //whether or not the creation of this need was successfully completed yet
+       isWhatsAround: true|false, //whether or not the need is a whatsaround need
+       isWhatsNew: true|false, //whether or not this need is a whatsnew need
+       state: "won:Active" | "won:Inactive", //state of the need
+       title: string, //title of the need
+       type: "won:Supply" | "won:Demand" | "won:Offer", //type of the need
+       unread: true|false, //whether or not this need has new information that has not been read yet
+       uri: string, //unique identifier of this need
+
+       is : { 
+           title: string, //title of the need
+           description: string, //description of the need as a string (non mandatory, empty if not present)
+           tags: Array of strings, //array of strings (non mandatory, empty if not present)
+           location: { //non mandatory but if present it contains all elements below
+               address: string, //address as human readable string
+               lat: float, //latitude of address
+               lng: float, //longitude of address
+               nwCorner: { //north west corner of the boundingbox
+                   lat: float,
+                   lng: float,
+               },
+               seCorner: { //south east corner of the boundingbox
+                   lat: float,
+                   lng: float,
+               }
+           },
+           travelAction: { //non mandatory, may contain half or all of the elements below
+               fromAddress: string,
+               fromLocation: {
+                   lat: float, 
+                   lng: float,
+               },
+               toAddress: string,
+               toLocation: {
+                   lat: float, 
+                   lng: float, 
+               }
+           }
+       },
+       seeks: {
+           title: string, //title of the need
+           description: string, //description of the need as a string (non mandatory, empty if not present)
+           tags: Array of strings, //array of strings (non mandatory, empty if not present)
+           location: { //non mandatory but if present it contains all elements below
+               address: string, //address as human readable string
+               lat: float, //latitude of address
+               lng: float, //longitude of address
+               nwCorner: { //north west corner of the boundingbox
+                   lat: float,
+                   lng: float,
+               },
+               seCorner: { //south east corner of the boundingbox
+                   lat: float,
+                   lng: float,
+               }
+           },
+           travelAction: { //non mandatory, may contain half or all of the elements below
+               fromAddress: string,
+               fromLocation: {
+                   lat: float, 
+                   lng: float,
+               },
+               toAddress: string,
+               toLocation: {
+                   lat: float, 
+                   lng: float, 
+               }
+           }
+       }
+   },
+   ...
+ },
+ router: {
+   currentParams: {...},
+   currentState: {...},
+   prevParams: {...},
+   prevState: {...}
+ },
+ toasts: {...},
+ user: {...},
+ showRdf: true|false, //flag that is true if rawData mode is on (enables rdf view and rdf links) (default is false)
+ showClosedNeeds: true|false, //flag whether the drawer of the closedNeeds is open or closed (default is false)
+ showMainMenu: true|false, //flag whether the mainmenu dropdown is open or closed (default is false)
+ showModalDialog: true|false, //flag whether the omnipresent modal dialog is displayed or not (default is false)
+ modalDialog: {
+   caption: string, //header caption of the modal dialog
+   text: string,
+   buttons: [ //Array
+     {
+      caption: string //caption of the button
+      callback: callback //action of the button
+     }
+     ...
+   ]
+ }
 }
 */
 ```
-As you can see in this State all "visible" Data is stored within the needs and the corresponding connections and messages are stored within this tree.
-Example: If you want to retrieve all present connections for a given need you will access it by ````$ngRedux.getState().getIn(["needs", [needUri], "connections"])````.
 
-All The DataParsing happens within the ```need-reducer.js``` and should only be implemented here, in their respective Methods ```parseNeed(jsonLdNeed, ownNeed)```, ```parseConnection(jsonLdConnection, unread)``` and ```parseMessage(jsonLdMessage, outgoingMessage, unread)```.
+As you can see in this State all "visible" Data is stored within the needs and the corresponding connections and messages are stored within this tree.
+Example: If you want to retrieve all present connections for a given need you will access it by `$ngRedux.getState().getIn(["needs", [needUri], "connections"])`.
+
+All The DataParsing happens within the `need-reducer.js` and should only be implemented here, in their respective Methods `parseNeed(jsonLdNeed, ownNeed)`, `parseConnection(jsonLdConnection, unread)` and `parseMessage(jsonLdMessage, outgoingMessage, unread)`.
 It is very important to not parse needs/connections/messages in any other place or in any other way to make sure that the structure of the corresponding items is always the same, and so that the Views don't have to implement fail-safes when accessing elements, e.g. a Location is only present if the whole location data can be parsed/stored within the state, otherwise the location will stay empty.
 This is also true for every message connection and need, as soon as the data is in the state you can be certain that all the mandatory values are set correctly.
 
@@ -197,7 +247,7 @@ If it's **REST**-style, just use `fetch(...).then(...dispatch...)` in an action-
 If it's **linked-data-related**, use the utilities in `linkeddata-service-won.js`.
 They'll do standard HTTP(S) but will make sure to cache as much as possible via the local triplestore.
 
-If needs to **push to the web-socket**, add a hook for the respective *user(!)*-action in `message-reducers.js`.
+If needs to **push to the web-socket**, add a hook for the respective _user(!)_-action in `message-reducers.js`.
 The `messaging-agent.js` will pick up any messages in `$ngRedux.getState().getIn(['messages', 'enqueued'])`
 and push them to it's websocket. This solution appears rather hacky to me (see 'high-level interactions' under 'Action Creators') and I'd be thrilled to hear any alternative solutions :)
 
@@ -207,6 +257,5 @@ If you want to **receive stuff the web-socket**, go to `actions.js` and add your
 
 See:
 
-* [Angular 2.0](https://github.com/researchstudio-sat/webofneeds/issues/300) -> it wasn't ready at the time of the decision
-* [Precompilation and Tooling (Bundling, CSS, ES6)](https://github.com/researchstudio-sat/webofneeds/issues/314)
-
+- [Angular 2.0](https://github.com/researchstudio-sat/webofneeds/issues/300) -> it wasn't ready at the time of the decision
+- [Precompilation and Tooling (Bundling, CSS, ES6)](https://github.com/researchstudio-sat/webofneeds/issues/314)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -29,6 +29,19 @@ const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
   let template = `
         <won-create-post-item ng-class="{'selected' : self.showCreateView}"></won-create-post-item>
+        <div ng-repeat="need in self.beingCreatedNeeds" class="co__item">
+            <!-- ng-if="self.beingCreatedNeeds.size > 0" -->
+            <div class="co__item__need" ng-class="{'selected' : need.get('needUri') === self.needUriInRoute}">
+                <div class="co__item__need__header">
+                    <won-post-header
+                        need-uri="need.get('needUri')"
+                        timestamp="'TODOlatestOfThatType'"
+                        ng-click="self.toggleDetails(need.get('needUri'))"
+                        class="clickable">
+                    </won-post-header>
+                </div>
+            </div>
+        </div>
         <div ng-repeat="need in self.sortedOpenNeeds" class="co__item"
             ng-class="{'co__item--withconn' : self.isOpen(need.get('uri')) && self.hasOpenConnections(need)}">
             <div class="co__item__need" ng-class="{'won-unread': need.get('unread'), 'selected' : need.get('uri') === self.needUriInRoute}">
@@ -179,6 +192,10 @@ function genComponentConf() {
               !(post.get("isWhatsAround") || post.get("isWhatsNew"))
           ); //Filter whatsAround and whatsNew needs automatically
 
+        // needs that have been created but are not confirmed by the server yet
+        const beingCreatedNeeds =
+          allOwnNeeds && allOwnNeeds.filter(post => post.get("beingCreated"));
+
         const routerParams = selectRouterParams(state);
         const showCreateView = getIn(state, [
           "router",
@@ -203,6 +220,7 @@ function genComponentConf() {
           showCreateView,
           needUriInRoute,
           needUriImpliedInRoute,
+          beingCreatedNeeds: beingCreatedNeeds && beingCreatedNeeds.toArray(),
           sortedOpenNeeds,
           sortedClosedNeeds,
           closedNeedsSize:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -31,12 +31,12 @@ function genComponentConf() {
         <won-create-post-item ng-class="{'selected' : self.showCreateView}"></won-create-post-item>
         <div ng-repeat="need in self.beingCreatedNeeds" class="co__item">
             <!-- ng-if="self.beingCreatedNeeds.size > 0" -->
-            <div class="co__item__need" ng-class="{'selected' : need.get('needUri') === self.needUriInRoute}">
+            <div class="co__item__need" ng-class="{'selected' : need.get('uri') === self.needUriInRoute}">
                 <div class="co__item__need__header">
                     <won-post-header
-                        need-uri="need.get('needUri')"
+                        need-uri="need.get('uri')"
                         timestamp="'TODOlatestOfThatType'"
-                        ng-click="self.toggleDetails(need.get('needUri'))"
+                        ng-click="self.toggleDetails(need.get('uri'))"
                         class="clickable">
                     </won-post-header>
                 </div>
@@ -194,7 +194,7 @@ function genComponentConf() {
 
         // needs that have been created but are not confirmed by the server yet
         const beingCreatedNeeds =
-          allOwnNeeds && allOwnNeeds.filter(post => post.get("beingCreated"));
+          allOwnNeeds && allOwnNeeds.filter(post => post.get("isBeingCreated"));
 
         const routerParams = selectRouterParams(state);
         const showCreateView = getIn(state, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -16,13 +16,13 @@ const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
   let template = `
 
-    <won-square-image ng-if="!self.need.get('beingCreated')"
+    <won-square-image ng-if="!self.need.get('isBeingCreated')"
         ng-class="{'bigger' : self.biggerImage, 'inactive' : self.need.get('state') === self.WON.InactiveCompacted}"
         src="self.need.get('TODO')"
         uri="self.needUri"
         ng-show="!self.hideImage">
     </won-square-image>
-    <div class="ph__right" ng-if="!self.need.get('beingCreated')">
+    <div class="ph__right" ng-if="!self.need.get('isBeingCreated')">
       <div class="ph__right__topline">
         <div class="ph__right__topline__title">
           {{ self.need.get('title') }}
@@ -51,22 +51,21 @@ function genComponentConf() {
       </div>
     </div>
     
-    <won-square-image ng-if="self.need.get('beingCreated')"
+    <won-square-image ng-if="self.need.get('isBeingCreated')"
       ng-class="{'bigger' : self.biggerImage}"
       src="self.need.get('TODO')"
-      title="self.need.get('is') ? self.need.getIn('is', 'title') : self.need.getIn('search', 'title')"
       uri="self.needUri"
       ng-show="!self.hideImage">
     </won-square-image>
-    <div class="ph__right" ng-if="self.need.get('beingCreated')">
+    <div class="ph__right" ng-if="self.need.get('isBeingCreated')">
       <div class="ph__right__topline">
         <div class="ph__right__topline__title">
-          Creating {{self.need.get("is") ? "Post" : "Search"}}...
+          Creating...
         </div>
       </div>
       <div class="ph__right__subtitle">
         <span class="ph__right__subtitle__type">
-          {{self.need.get("is") ? "Post" : "Search"}}
+          {{self.labels.type[self.need.get('type')]}}
         </span>
       </div>
     </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -15,40 +15,61 @@ import won from "../won-es6.js";
 const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
   let template = `
-      <won-square-image
+
+    <won-square-image ng-if="!self.need.get('beingCreated')"
         ng-class="{'bigger' : self.biggerImage, 'inactive' : self.need.get('state') === self.WON.InactiveCompacted}"
         src="self.need.get('TODO')"
         uri="self.needUri"
         ng-show="!self.hideImage">
-      </won-square-image>
-      <div class="ph__right">
-        <div class="ph__right__topline">
-          <div class="ph__right__topline__title">
-            {{ self.need.get('title') }}
-          </div>
-          <div class="ph__right__topline__date">
-            {{ self.friendlyTimestamp }}
-          </div>
+    </won-square-image>
+    <div class="ph__right" ng-if="!self.need.get('beingCreated')">
+      <div class="ph__right__topline">
+        <div class="ph__right__topline__title">
+          {{ self.need.get('title') }}
         </div>
-        <div class="ph__right__subtitle">
-          <!--
-          <span class="piu__header__title__subtitle__group" ng-show="{{self.need.get('group')}}">
-            
-          <svg style="--local-primary:var(--won-primary-color);"
-            class="piu__header__title__subtitle__group__icon">
-              <use xlink:href="#ico36_group" href="#ico36_group"></use>
-          </svg>
-
-
-            {{self.need.get('group')}}
-            <span class="piu__header__title__subtitle__group__dash"> &ndash; </span>
-          </span>
-          -->
-          <span class="ph__right__subtitle__type">
-            {{self.labels.type[self.need.get('type')]}}{{self.need.get('matchingContexts')? ' in '+ self.need.get('matchingContexts').join(', ') : '' }}
-          </span>
+        <div class="ph__right__topline__date">
+          {{ self.friendlyTimestamp }}
         </div>
       </div>
+      <div class="ph__right__subtitle">
+        <!--
+        <span class="piu__header__title__subtitle__group" ng-show="{{self.need.get('group')}}">
+          
+        <svg style="--local-primary:var(--won-primary-color);"
+          class="piu__header__title__subtitle__group__icon">
+            <use xlink:href="#ico36_group" href="#ico36_group"></use>
+        </svg>
+
+
+          {{self.need.get('group')}}
+          <span class="piu__header__title__subtitle__group__dash"> &ndash; </span>
+        </span>
+        -->
+        <span class="ph__right__subtitle__type">
+          {{self.labels.type[self.need.get('type')]}}{{self.need.get('matchingContexts')? ' in '+ self.need.get('matchingContexts').join(', ') : '' }}
+        </span>
+      </div>
+    </div>
+    
+    <won-square-image ng-if="self.need.get('beingCreated')"
+      ng-class="{'bigger' : self.biggerImage}"
+      src="self.need.get('TODO')"
+      title="self.need.get('is') ? self.need.getIn('is', 'title') : self.need.getIn('search', 'title')"
+      uri="self.needUri"
+      ng-show="!self.hideImage">
+    </won-square-image>
+    <div class="ph__right" ng-if="self.need.get('beingCreated')">
+      <div class="ph__right__topline">
+        <div class="ph__right__topline__title">
+          Creating {{self.need.get("is") ? "Post" : "Search"}}...
+        </div>
+      </div>
+      <div class="ph__right__subtitle">
+        <span class="ph__right__subtitle__type">
+          {{self.need.get("is") ? "Post" : "Search"}}
+        </span>
+      </div>
+    </div>
     `;
 
   class Controller {


### PR DESCRIPTION
Shows a placeholder for needs that are already in the state, but not registered on the server yet. If the create fails and the need is removed from the state, the placeholder disappears, too. The placeholder only exists client-side and does not reflect server status. 

#1868 is not closed by this, as there is no toast displayed when creating the need fails.