### PR TITLE
change styling (color and mobile positioning) of the ws-sock problem …

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -18,7 +18,6 @@ import * as srefUtils from "../sref-utils.js";
 
 function genTopnavConf() {
   let template = `
-        <!-- <div class="slide-in" ng-show="self.connectionHasBeenLost">-->
         <div class="slide-in" ng-class="{'visible': self.connectionHasBeenLost}">
             <svg class="si__icon" style="--local-primary:white;">
                 <use xlink:href="#ico16_indicator_warning" href="#ico16_indicator_warning"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -75,14 +75,6 @@ export default function(allToasts = initialState, action = {}) {
         { unsafeHtmlEnabled: true }
       );
 
-    /*case actionTypes.lostConnection:
-      return pushNewToast(
-        allToasts,
-        "Lost connection - progress " +
-          "can't be saved any more. Make sure your " +
-          'internet-connection is working, then click "Reconnect"',
-        won.WON.warnToast
-      );*/
     //INFO TOASTS: won.WON.infoToast
 
     //WARN TOASTS: won.WON.warnToast

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -75,14 +75,14 @@ export default function(allToasts = initialState, action = {}) {
         { unsafeHtmlEnabled: true }
       );
 
-    case actionTypes.lostConnection:
+    /*case actionTypes.lostConnection:
       return pushNewToast(
         allToasts,
         "Lost connection - progress " +
           "can't be saved any more. Make sure your " +
           'internet-connection is working, then click "Reconnect"',
         won.WON.warnToast
-      );
+      );*/
     //INFO TOASTS: won.WON.infoToast
 
     //WARN TOASTS: won.WON.warnToast

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
@@ -1,3 +1,4 @@
+@import "won-config";
 @import "button";
 @import "collapsible";
 @import "button";
@@ -7,7 +8,7 @@
 
   color: white;
 
-  background: $won-primary-color;
+  background: $won-secondary-color-lighter;
 
   padding: 1rem;
 
@@ -15,19 +16,45 @@
   justify-content: center;
   align-items: center;
 
+  @media (max-width: $responsivenessBreakPoint) {
+    flex-direction: column;
+  }
+
   & > .si__icon {
-    margin-left: 1rem;
+    @media (max-width: $responsivenessBreakPoint) {
+      margin: 0;
+    }
+
+    @media (min-width: $responsivenessBreakPoint) {
+      margin-left: 1rem;
+    }
+
     @include fixed-square(2rem);
   }
 
   & > .si__text {
-    margin-left: 0.5rem;
-    margin-right: 1rem;
+    @media (max-width: $responsivenessBreakPoint) {
+      margin: 0;
+      text-align: center;
+    }
+
+    @media (min-width: $responsivenessBreakPoint) {
+      margin-left: 0.5rem;
+      margin-right: 1rem;
+      text-align: left;
+    }
   }
 
   & > .si__button {
-    margin-left: 1.3rem;
-    margin-right: 1rem;
+    @media (max-width: $responsivenessBreakPoint) {
+      margin: 0.5rem 0 0 0;
+    }
+
+    @media (min-width: $responsivenessBreakPoint) {
+      margin-left: 1.3rem;
+      margin-right: 1rem;
+    }
+
     @include won-button--outlined(white);
   }
 


### PR DESCRIPTION
…slide-in #1872 

fixes #1872

changes the background of the conn lost slide-in (to won-secondary-lighter) and the positioning for the mobile view (flex column instead of flex row)

also removes the rather redundant toast that tells you about the exact same problem (see screenshot of the issue)