### PR TITLE
move show agreement data button to connection-context.dropdown

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
@@ -37,6 +37,12 @@ function genComponentConf() {
                         Show Details
                     </button>
                     <button
+                        ng-if="self.isConnected && !self.showAgreementData"
+                        class="won-button--outlined thin red"
+                        ng-click="self.showAgreementDataField()">
+                        Show Agreement Data
+                    </button>
+                    <button
                         ng-if="self.isConnected || self.isSuggested"
                         class="won-button--filled red"
                         ng-click="self.closeConnection()">
@@ -67,6 +73,7 @@ function genComponentConf() {
         return {
           connection,
           connectionUri,
+          showAgreementData: connection && connection.get("showAgreementData"),
           isConnected: connectionState === won.WON.Connected,
           isSentRequest: connectionState === won.WON.RequestSent,
           isReceivedRequest: connectionState === won.WON.RequestReceived,
@@ -110,7 +117,9 @@ function genComponentConf() {
     controller: Controller,
     controllerAs: "self",
     bindToController: true, //scope-bindings -> ctrl
-    scope: {},
+    scope: {
+      showAgreementDataField: "&",
+    },
     template: template,
   };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -1,5 +1,3 @@
-// TODO: WHAT IS HAPPENING HERE?!
-
 import won from "../won-es6.js";
 import angular from "angular";
 import chatTextFieldSimpleModule from "./chat-textfield-simple.js";
@@ -56,7 +54,7 @@ function genComponentConf() {
                 timestamp="self.lastUpdateTimestamp"
                 hide-image="::false">
             </won-connection-header>
-            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest"></won-connection-context-dropdown>
+            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
         </div>
         <div class="pm__content">
             <div class="pm__content__loadspinner"
@@ -171,15 +169,6 @@ function genComponentConf() {
                 is-code="self.shouldShowRdf? 'true' : ''"
             >
             </chat-textfield-simple>
-
-            <div class="pm__footer__agreement">
-                <!-- quick and dirty button to get agreements -->
-                <button class="won-button--filled thin black"
-                    ng-click="self.showAgreementDataField()"
-                    ng-show="!self.showAgreementData">
-                        Show Agreement Data
-                 </button>
-            </div>
         </div>
         <div class="pm__footer" ng-show="self.isSentRequest">
             Waiting for them to accept your chat request.

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -87,10 +87,6 @@
     .pm__footer {
       grid-area: footer;
 
-      &__agreement {
-        display: block;
-      }
-
       &__chattextfield {
         padding: 0.5rem 0;
       }


### PR DESCRIPTION
fixes #1905 

moves the show agreement data button from the footer to the connection-context-dropdown (for connections in state connected) in order to use less precious space in the footer