### PR TITLE
moves "detail" button to the header and display it there instead redu…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -58,6 +58,16 @@ function genComponentConf() {
                         need-uri="need.get('uri')"
                         ng-if="!self.isOpen(need.get('uri'))">
                     </won-connection-indicators>
+                    <button
+                        class="co__item__need__header__button red"
+                        ng-if="self.isOpen(need.get('uri'))"
+                        ng-click="need.get('uri') === self.needUriInRoute ? self.selectNeed(undefined) : self.selectNeed(need.get('uri'))"
+                        ng-class="{
+                          'won-button--filled' : need.get('uri') === self.needUriInRoute,
+                          'won-button--outlined thin': need.get('uri') !== self.needUriInRoute
+                        }">
+                        Details
+                    </button>
                     <div class="co__item__need__header__carret" ng-click="self.toggleDetails(need.get('uri'))">
                         <svg
                             style="--local-primary:var(--won-secondary-color);"
@@ -78,17 +88,6 @@ function genComponentConf() {
                         on-selected-connection="self.selectConnection(connectionUri)"
                         need-uri="need.get('uri')">
                     </won-extended-connection-indicators>
-                    <div class="co__item__need__detail__actions">
-                        <button
-                            class="co__item__need__detail__actions__button red"
-                            ng-click="need.get('uri') === self.needUriInRoute ? self.selectNeed(undefined) : self.selectNeed(need.get('uri'))"
-                            ng-class="{
-                              'won-button--filled' : need.get('uri') === self.needUriInRoute,
-                              'won-button--outlined thin': need.get('uri') !== self.needUriInRoute
-                            }">
-                            Details
-                        </button>
-                    </div>
                 </div>
             </div>
             <div class="co__item__connections"
@@ -125,6 +124,16 @@ function genComponentConf() {
                             ng-click="self.toggleDetails(need.get('uri'))"
                             class="clickable">
                         </won-post-header>
+                        <button
+                            class="co__item__need__header__button red"
+                            ng-if="self.isOpen(need.get('uri'))"
+                            ng-click="need.get('uri') === self.needUriInRoute ? self.selectNeed(undefined) : self.selectNeed(need.get('uri'))"
+                            ng-class="{
+                              'won-button--filled' : need.get('uri') === self.needUriInRoute,
+                              'won-button--outlined thin': need.get('uri') !== self.needUriInRoute
+                            }">
+                            Details
+                        </button>
                         <div class="co__item__need__header__carret" ng-click="self.toggleDetails(need.get('uri'))">
                             <svg
                                 style="--local-primary:var(--won-secondary-color);"
@@ -145,17 +154,6 @@ function genComponentConf() {
                             on-selected-connection="self.selectConnection(connectionUri)"
                             need-uri="need.get('uri')">
                         </won-extended-connection-indicators>
-                        <div class="co__item__need__detail__actions">
-                            <button
-                                class="co__item__need__detail__actions__button red"
-                                ng-click="need.get('uri') === self.needUriInRoute ? self.selectNeed(undefined) : self.selectNeed(need.get('uri'))"
-                                ng-class="{
-                                  'won-button--filled' : need.get('uri') === self.needUriInRoute,
-                                  'won-button--outlined thin': need.get('uri') !== self.needUriInRoute
-                                }">
-                                Details
-                            </button>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections-overview.scss
@@ -34,7 +34,10 @@ won-connections-overview {
 
         won-connection-indicators {
           padding-left: 0.5rem;
-          @include appearAnimation(0.25s);
+        }
+
+        &__button {
+          font-size: $smallFontSize;
         }
 
         &__carret {
@@ -48,34 +51,7 @@ won-connections-overview {
       }
 
       &__detail {
-        display: grid;
-
-        @media (min-width: $responsivenessBreakPoint) {
-          grid-column-gap: 0.5rem;
-          grid-template-areas: "indicators actions";
-          grid-template-columns: 1fr min-content;
-        }
-
-        @media (max-width: $responsivenessBreakPoint) {
-          grid-row-gap: 0.5rem;
-          grid-template-areas: "actions" "indicators";
-        }
-
-        @include slideWithOpacityAnimation(0.25s, linear, 4rem, 0.5rem 0 0 0);
-
-        &__actions {
-          grid-area: actions;
-
-          &__button {
-            width: 100%;
-            padding: 0.66em;
-            font-size: $smallFontSize;
-          }
-        }
-
-        &__indicators {
-          grid-area: indicators;
-        }
+        @include slideWithOpacityAnimation(0.25s, linear, 4rem, 0);
       }
 
       @media (min-width: $responsivenessBreakPoint) {


### PR DESCRIPTION
…ces the height of an expanded need element

additional change for #1880, talked to @fkleedorfer recently and we decided that the details button could be or should be next to the carret (position instead of the collapsed indicators), that way we reduce confusion for the cases where there is only one connection in the need, and we reduce expanded element height as well

i had to remove the animation that made the icons appear though as it did jitter due to the addition of the button