### PR TITLE
Feat disclaimer slidein #1888

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -213,7 +213,10 @@ $ngRedux.getState();
    prevState: {...}
  },
  toasts: {...},
- user: {...},
+ user: {
+    ...,
+    acceptedDisclaimer: true|false, //flag whether the user has accepted the ToS etc. already. (default is false)
+ },
  showRdf: true|false, //flag that is true if rawData mode is on (enables rdf view and rdf links) (default is false)
  showClosedNeeds: true|false, //flag whether the drawer of the closedNeeds is open or closed (default is false)
  showMainMenu: true|false, //flag whether the mainmenu dropdown is open or closed (default is false)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -14,7 +14,11 @@ import {
   parseCredentials,
   generatePrivateId,
 } from "../won-utils.js";
-import { clearPrivateId, savePrivateId } from "../won-localstorage.js";
+import {
+  clearPrivateId,
+  savePrivateId,
+  setDisclaimerAccepted,
+} from "../won-localstorage.js";
 import { stateGoCurrent } from "./cstm-router-actions.js";
 import { checkAccessToCurrentRoute } from "../configRouting.js";
 
@@ -386,4 +390,11 @@ export function accountTransfer(credentials) {
         console.error(registerError, error);
         dispatch(actionCreators.registerFailed({ registerError, error }));
       });
+}
+
+export function accountAcceptDisclaimer() {
+  return dispatch => {
+    setDisclaimerAccepted();
+    dispatch({ type: actionTypes.acceptDisclaimerSuccess });
+  };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -72,6 +72,7 @@ import {
   accountLogout,
   accountRegister,
   accountTransfer,
+  accountAcceptDisclaimer,
 } from "./account-actions.js";
 
 import * as cnct from "./connections-actions.js";
@@ -223,6 +224,8 @@ const actionHierarchy = {
   logout: accountLogout,
   register: accountRegister,
   transfer: accountTransfer,
+  acceptDisclaimer: accountAcceptDisclaimer,
+  acceptDisclaimerSuccess: INJ_DEFAULT,
   typedAtLoginCredentials: INJ_DEFAULT,
   registerReset: INJ_DEFAULT,
   registerFailed: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
@@ -42,6 +42,7 @@
         </div>
     </section>
     <section class="imprint">
+        <a id="imprint"></a>
         <div class="title">Imprint</div>
         <div class="sub title" ng-include="self.imprintTemplate"></div>
     </section>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
@@ -46,4 +46,9 @@
         <div class="title">Imprint</div>
         <div class="sub title" ng-include="self.imprintTemplate"></div>
     </section>
+    <section class="privacyPolicy">
+        <a id="privacyPolicy"></a>
+        <div class="title">Privacy Policy</div>
+        <div class="sub title" ng-include="self.privacyPolicyTemplate"></div>
+    </section>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
@@ -10,24 +10,17 @@
             <span class="wd__text">A need helps you find people who can help you - or who share your interest.</span>
             <span class="wd__more clickable" ng-click="::self.toggleMoreInfo()">Read more</span>
 
-            <svg style="--local-primary:var(--won-primary-color);"
-                class="wd__arrow clickable" 
-                ng-click="::self.toggleMoreInfo()" 
-                ng-show="!self.moreInfo">
-                    <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+            <svg style="--local-primary:var(--won-primary-color);" class="wd__arrow clickable" ng-click="::self.toggleMoreInfo()" ng-show="!self.moreInfo">
+                <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
             </svg>
 
-            <svg style="--local-primary:var(--won-primary-color);"
-                class="wd__arrow clickable" 
-                ng-click="::self.toggleMoreInfo()" 
-                ng-show="self.moreInfo">
-                    <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+            <svg style="--local-primary:var(--won-primary-color);" class="wd__arrow clickable" ng-click="::self.toggleMoreInfo()" ng-show="self.moreInfo">
+                <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
             </svg>
 
-            <span class="wd__text"  ng-show="self.moreInfo" >A need is much like an automatic classified ad. You say
-                what you are looking for, and other such ads will be matched with yours. You could think of it as
-            of a long-lived search query that can itself be found by others. Once you found a useful match, you can
-	    connect to it and start to chat.</span>
+            <span class="wd__text" ng-show="self.moreInfo">A need is much like an automatic classified ad. You say what you are looking for, and other such ads will be
+                matched with yours. You could think of it as of a long-lived search query that can itself be found by others.
+                Once you found a useful match, you can connect to it and start to chat.</span>
         </div>
     </section>
     <section>
@@ -35,7 +28,7 @@
             <div class="title">How it works</div>
             <won-flex-grid class="fourimgs" items="::self.workGrid"></won-flex-grid>
         </div>
-        <hr class="splitter-within-section"/>
+        <hr class="splitter-within-section" />
         <div class="faq">
             <div class="title">FAQs</div>
             <won-accordion items="::self.questions"></won-accordion>
@@ -49,6 +42,6 @@
     <section class="privacyPolicy">
         <a id="privacyPolicy"></a>
         <div class="title">Privacy Policy</div>
-        <div class="sub title" ng-include="self.privacyPolicyTemplate"></div>
+        <div ng-include="self.privacyPolicyTemplate"></div>
     </section>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
@@ -208,6 +208,11 @@ class AboutController {
           theme +
           "/" +
           getIn(state, ["config", "theme", "imprintTemplate"]),
+        privacyPolicyTemplate:
+          "./skin/" +
+          theme +
+          "/" +
+          getIn(state, ["config", "theme", "privacyPolicyTemplate"]),
         peopleGrid: peopleGrid({ theme }),
       };
     };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -50,7 +50,7 @@ function genTopnavConf() {
                 	<li> Your conversation messags with others are private, but stored in clear text on our servers. Do not write anything you are not comfortable with writing on a postcard.</li>
                 </ul>     
                 <a target="_blank"
-                   href="{{ self.absHRef(self.$state, 'about#imprint', {'#': 'imprint'}) }}">
+                   href="{{ self.absHRef(self.$state, 'about', {'#': 'privacyPolicy'}) }}">
                    See Privacy Policy.
                 </a>
                 <br />

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -38,6 +38,24 @@ function genTopnavConf() {
                 ng-show="self.reconnecting"
                 class="hspinner"/>
         </div>
+        <div class="slide-in" ng-class="{'visible': !self.acceptedDisclaimer}">
+            <svg class="si__icon" style="--local-primary:white;">
+                <use xlink:href="#ico16_indicator_warning" href="#ico16_indicator_info"></use>
+            </svg>
+            <div class="si__text">
+                This is Webapp is in development. Lorem Ipsum dolor blablabla whatever i dont know lets see
+                <a target="_blank"
+                   href="{{ self.absHRef(self.$state, 'about') }}">
+                   Terms Of Use and Stuff
+                </a>
+                If you do not agree with this. Please leave now!
+            </div>
+            <button
+                ng-click="self.acceptDisclaimer()"
+                class="si__button">
+                    Accept
+            </button>
+        </div>
         <won-modal-dialog ng-if="self.showModalDialog"></won-modal-dialog>
 
         <nav class="topnav" ng-class="{'hide-in-responsive': self.connectionOrPostDetailOpen}">
@@ -167,6 +185,7 @@ function genTopnavConf() {
           adminEmail: getIn(state, ["config", "theme", "adminEmail"]),
           WON: won.WON,
           loggedIn: state.getIn(["user", "loggedIn"]),
+          acceptedDisclaimer: state.getIn(["user", "acceptedDisclaimer"]),
           email: state.getIn(["user", "email"]),
           isPrivateIdUser: !!privateId,
           connectionOrPostDetailOpen:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -45,9 +45,9 @@ function genTopnavConf() {
             <div class="si__text">
                 This Website demonstrates the output of an ongoing research project. We are doing our best to make it secure and protect your privacy. Please keep in mind:
                 <ul>
-                	<li> Your postings are public. Do not post anyhting you are not comfortable with if everyone sees it. </li>
+                	<li> Your postings are public. Do not post anyhting you are not comfortable with everyone seeing. </li>
                 	<li> The information which posts your posts are connected to is public. </li>
-                	<li> Your conversation messags with others are private, but stored in clear text on our servers. Do not write anything you are not comfortable with writing on a postcard.</li>
+                	<li> Your conversation messages with others are private, but stored in clear text on our servers. Do not write anything you are not comfortable with writing on a postcard.</li>
                 </ul>     
                 <a target="_blank"
                    href="{{ self.absHRef(self.$state, 'about', {'#': 'privacyPolicy'}) }}">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -45,7 +45,7 @@ function genTopnavConf() {
             <div class="si__text">
                 This is Webapp is in development. Lorem Ipsum dolor blablabla whatever i dont know lets see
                 <a target="_blank"
-                   href="{{ self.absHRef(self.$state, 'about') }}">
+                   href="{{ self.absHRef(self.$state, 'about#imprint', {'#': 'imprint'}) }}">
                    Terms Of Use and Stuff
                 </a>
                 If you do not agree with this. Please leave now!

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -43,13 +43,23 @@ function genTopnavConf() {
                 <use xlink:href="#ico16_indicator_warning" href="#ico16_indicator_info"></use>
             </svg>
             <div class="si__text">
-                This is Webapp is in development. Lorem Ipsum dolor blablabla whatever i dont know lets see
+                This Website demonstrates the output of an ongoing research project. We are doing our best to make it secure and protect your privacy. Please keep in mind:
+                <ul>
+                	<li> Your postings are public. Do not post anyhting you are not comfortable with if everyone sees it. </li>
+                	<li> The information which posts your posts are connected to is public. </li>
+                	<li> Your conversation messags with others are private, but stored in clear text on our servers. Do not write anything you are not comfortable with writing on a postcard.</li>
+                </ul>     
                 <a target="_blank"
                    href="{{ self.absHRef(self.$state, 'about#imprint', {'#': 'imprint'}) }}">
-                   Terms Of Use and Stuff
+                   See Privacy Policy.
                 </a>
-                If you do not agree with this. Please leave now!
-            </div>
+                <br />
+                We use cookies for tracking your session, if you choose to be logged in automatically, you will receive another cookie to do that. Furthermore, we use Piwik on our own servers to track your visit an improve the application, which also identifies you with a cookie.
+                <a target="_blank"
+                   href="/piwik/index.php?module=CoreAdminHome&action=optOut&language=en">
+                   Suppress tracking.
+                </a>
+	  		</div>
             <button
                 ng-click="self.acceptDisclaimer()"
                 class="si__button">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/user-reducer.js
@@ -4,7 +4,12 @@
 import { actionTypes } from "../actions/actions.js";
 import Immutable from "immutable";
 
-const initialState = Immutable.fromJS({ loggedIn: false });
+import { isDisclaimerAccepted } from "../won-localstorage.js";
+
+const initialState = Immutable.fromJS({
+  loggedIn: false,
+  acceptedDisclaimer: isDisclaimerAccepted(),
+});
 
 export default function(userData = initialState, action = {}) {
   switch (action.type) {
@@ -17,19 +22,27 @@ export default function(userData = initialState, action = {}) {
       const email = immutablePayload.get("email");
 
       if (loggedIn) {
-        return Immutable.fromJS({ loggedIn: true, email: email });
+        return Immutable.fromJS({
+          loggedIn: true,
+          email: email,
+          acceptedDisclaimer: userData.get("acceptedDisclaimer"),
+        });
       } else {
         return userData;
       }
     }
 
     case actionTypes.logout:
-      return Immutable.fromJS({ loggedIn: false });
+      return Immutable.fromJS({
+        loggedIn: false,
+        acceptedDisclaimer: userData.get("acceptedDisclaimer"),
+      });
 
     case actionTypes.loginFailed:
       return Immutable.fromJS({
         loginError: action.payload.loginError,
         loggedIn: false,
+        acceptedDisclaimer: userData.get("acceptedDisclaimer"),
       });
 
     case actionTypes.typedAtLoginCredentials:
@@ -43,7 +56,13 @@ export default function(userData = initialState, action = {}) {
       return Immutable.fromJS({ registerError: undefined });
 
     case actionTypes.registerFailed:
-      return Immutable.fromJS({ registerError: action.payload.registerError });
+      return Immutable.fromJS({
+        registerError: action.payload.registerError,
+        acceptedDisclaimer: userData.get("acceptedDisclaimer"),
+      });
+
+    case actionTypes.acceptDisclaimerSuccess:
+      return userData.set("acceptedDisclaimer", true);
 
     default:
       return userData;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -24,6 +24,9 @@ import {
   clearReadUris,
   clearClosedConnUris,
   getClosedConnUris,
+  clearDisclaimerAccepted,
+  isDisclaimerAccepted,
+  setDisclaimerAccepted,
 } from "../won-localstorage.js";
 import jsonld from "jsonld";
 
@@ -44,6 +47,9 @@ won.clearPrivateId = clearPrivateId;
 won.clearReadUris = clearReadUris;
 won.clearClosedConnUris = clearClosedConnUris;
 won.getClosedConnUris = getClosedConnUris;
+won.isDisclaimerAccepted = isDisclaimerAccepted;
+won.clearDisclaimerAccepted = clearDisclaimerAccepted;
+won.setDisclaimerAccepted = setDisclaimerAccepted;
 
 won.WON = {};
 won.WON.baseUri = "http://purl.org/webofneeds/model#";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -4,6 +4,7 @@
 const READ_URIS = "wonReadUris";
 const CLOSED_CONN_URIS = "wonClosedConnectionUris";
 const INACTIVE_NEED_URIS = "inactiveNeedUris";
+const DISCLAIMER_ACCEPTED = "disclaimerAccepted";
 
 export function markUriAsRead(uri) {
   //TODO: BETTER IMPL
@@ -142,4 +143,16 @@ export function getInactiveNeedUris() {
 
 export function clearInactiveNeedUris() {
   localStorage.removeItem(INACTIVE_NEED_URIS);
+}
+
+export function isDisclaimerAccepted() {
+  return !!localStorage.getItem(DISCLAIMER_ACCEPTED);
+}
+
+export function setDisclaimerAccepted() {
+  localStorage.setItem(DISCLAIMER_ACCEPTED, true);
+}
+
+export function clearDisclaimerAccepted() {
+  localStorage.removeItem(DISCLAIMER_ACCEPTED);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/config.json
@@ -2,5 +2,6 @@
   "title": "Web of Needs – Master Blue",
   "adminEmail": "office.sat@researchstudio.at",
   "imprintTemplate": "imprint.html",
+  "privacyPolicyTemplate": "privacyPolicy.html",
   "defaultContext": []
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/privacyPolicy.html
@@ -1,0 +1,84 @@
+<p>
+Date: June 13, 2018
+</p>
+
+<p>
+The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+</p>
+<h2>Contact us</h2>
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+
+<h2>Data Storage</h2>
+<p>
+We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+</p>
+<p>
+You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+</p>
+<p>
+As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+</p>
+<p>
+In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+</p>
+<p>
+The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+</p>
+<p>
+Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+</p>
+
+
+<h2>Cookies</h2>
+<p>
+Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+</p>
+<p>
+We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+</p>
+<p>
+If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+</p>
+<p>
+Disabling cookies may limit the functionality of our website.
+</p>
+
+<h2>Web analytics</h2>
+<p>
+Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+</p>
+<p>
+You can prevent this by setting up your browser so that no cookies are stored.
+</p>
+<p>
+The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+</p>
+<p>
+Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+</p>
+<p>
+The user data is kept for the duration of 30 days.
+</p>
+
+<h2>Emails</h2>
+<p> 
+You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+</p>
+<p>
+You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+</p>
+
+<h2>Your rights</h2>
+<p>
+You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+</p>
+<p>
+You can reach us under the following contact details:
+</p>
+<p>
+Research Studio Smart Agent Technologies
+Thurngasse 8/16
+1090 Vienna
+Austria
+office.sat@researchstudio.at
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/privacyPolicy.html
@@ -1,84 +1,107 @@
 <p>
-Date: June 13, 2018
+    Date: June 13, 2018
 </p>
 
 <p>
-The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+    The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of
+    the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data
+    processing within our website.
 </p>
 <h2>Contact us</h2>
-If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request
+and in case of follow-up questions. We will not share this information without your consent.
 
 <h2>Data Storage</h2>
 <p>
-We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+    We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address
+    you provide. The e-mail address is not made publicly available. We do not associate information about your ip address
+    or location with your user account. We associate your user account with the Posts you create, but only internally.
 </p>
 <p>
-You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+    You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of
+    matching them with other posts. Without the information you provide, we are not able to provide matches. As there is
+    no public information about the association of user accounts to posts, we don't consider posts to be personal data. If
+    you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
 </p>
 <p>
-As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+    As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not
+    conclude any data processing contract with those third parties.
 </p>
 <p>
-In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+    In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available,
+    including the information about the last update date and time, the state (connected, closed, request received, request
+    sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each
+    other.
 </p>
 <p>
-The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+    The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however,
+    stored in clear text on our servers.
 </p>
 <p>
-Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+    Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they
+    remain publicly available so that a) other users can verify the conversations they had with that posting and b) third
+    parties can use this data for improving their matching algorithms.
 </p>
 
 
 <h2>Cookies</h2>
 <p>
-Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+    Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do
+    no harm.
 </p>
 <p>
-We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+    We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow
+    us to recognize your browser on your next visit.
 </p>
 <p>
-If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+    If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this
+    only in individual cases.
 </p>
 <p>
-Disabling cookies may limit the functionality of our website.
+    Disabling cookies may limit the functionality of our website.
 </p>
 
 <h2>Web analytics</h2>
 <p>
-Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+    Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used
+    that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server
+    and stored there. Piwik is open source software created by Matomo (https://matomo.org).
 </p>
 <p>
-You can prevent this by setting up your browser so that no cookies are stored.
+    You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+    The data processing takes place on the basis of the legal regulations of the &sect; 96 Abs 3 TKG as well as the Article 6
+    Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
-Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+    Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy
+    of our users is important to us, the user data are pseudonymized. Moreover
 </p>
 <p>
-The user data is kept for the duration of 30 days.
+    The user data is kept for the duration of 30 days.
 </p>
 
 <h2>Emails</h2>
-<p> 
-You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+<p>
+    You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive
+    while not logged in, we send emails to the address you provide in your user account. You can set your email preferences
+    in your account settings (including disabling all notifications).
 </p>
 <p>
-You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+    You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address:
+    office.sat@researchstudio.at
 </p>
 
 <h2>Your rights</h2>
 <p>
-You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+    You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you
+    believe that the processing of your data violates data protection law or if your data protection claims have otherwise
+    been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
 </p>
 <p>
-You can reach us under the following contact details:
+    You can reach us under the following contact details:
 </p>
 <p>
-Research Studio Smart Agent Technologies
-Thurngasse 8/16
-1090 Vienna
-Austria
-office.sat@researchstudio.at
+    Research Studio Smart Agent Technologies Thurngasse 8/16 1090 Vienna Austria office.sat@researchstudio.at
 </p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/config.json
@@ -2,5 +2,6 @@
   "title": "Your Title",
   "adminEmail": "admin@yourdomain.org",
   "imprintTemplate": "imprint.html",
+  "privacyPolicyTemplate": "privacyPolicy.html",  
   "defaultContext": []
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
@@ -1,4 +1,3 @@
-<h1>Privacy Policy</h1>
 <p>
 Date: June 13, 2018
 </p>
@@ -52,7 +51,7 @@ Our website uses the web analytics software Piwik, hosted on our own Servers in 
 You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+The data processing takes place on the basis of the legal regulations of the ï¿½ 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
 Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
@@ -1,0 +1,85 @@
+<h1>Privacy Policy</h1>
+<p>
+Date: June 13, 2018
+</p>
+
+<p>
+The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+</p>
+<h2>Contact us</h2>
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+
+<h2>Data Storage</h2>
+<p>
+We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+</p>
+<p>
+You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+</p>
+<p>
+As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+</p>
+<p>
+In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+</p>
+<p>
+The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+</p>
+<p>
+Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+</p>
+
+
+<h2>Cookies</h2>
+<p>
+Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+</p>
+<p>
+We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+</p>
+<p>
+If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+</p>
+<p>
+Disabling cookies may limit the functionality of our website.
+</p>
+
+<h2>Web analytics</h2>
+<p>
+Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+</p>
+<p>
+You can prevent this by setting up your browser so that no cookies are stored.
+</p>
+<p>
+The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+</p>
+<p>
+Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+</p>
+<p>
+The user data is kept for the duration of 30 days.
+</p>
+
+<h2>Emails</h2>
+<p> 
+You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+</p>
+<p>
+You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+</p>
+
+<h2>Your rights</h2>
+<p>
+You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+</p>
+<p>
+You can reach us under the following contact details:
+</p>
+<p>
+Research Studio Smart Agent Technologies
+Thurngasse 8/16
+1090 Vienna
+Austria
+office.sat@researchstudio.at
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/privacyPolicy.html
@@ -1,84 +1,107 @@
 <p>
-Date: June 13, 2018
+    Date: June 13, 2018
 </p>
 
 <p>
-The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+    The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of
+    the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data
+    processing within our website.
 </p>
 <h2>Contact us</h2>
-If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request
+and in case of follow-up questions. We will not share this information without your consent.
 
 <h2>Data Storage</h2>
 <p>
-We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+    We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address
+    you provide. The e-mail address is not made publicly available. We do not associate information about your ip address
+    or location with your user account. We associate your user account with the Posts you create, but only internally.
 </p>
 <p>
-You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+    You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of
+    matching them with other posts. Without the information you provide, we are not able to provide matches. As there is
+    no public information about the association of user accounts to posts, we don't consider posts to be personal data. If
+    you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
 </p>
 <p>
-As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+    As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not
+    conclude any data processing contract with those third parties.
 </p>
 <p>
-In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+    In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available,
+    including the information about the last update date and time, the state (connected, closed, request received, request
+    sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each
+    other.
 </p>
 <p>
-The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+    The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however,
+    stored in clear text on our servers.
 </p>
 <p>
-Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+    Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they
+    remain publicly available so that a) other users can verify the conversations they had with that posting and b) third
+    parties can use this data for improving their matching algorithms.
 </p>
 
 
 <h2>Cookies</h2>
 <p>
-Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+    Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do
+    no harm.
 </p>
 <p>
-We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+    We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow
+    us to recognize your browser on your next visit.
 </p>
 <p>
-If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+    If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this
+    only in individual cases.
 </p>
 <p>
-Disabling cookies may limit the functionality of our website.
+    Disabling cookies may limit the functionality of our website.
 </p>
 
 <h2>Web analytics</h2>
 <p>
-Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+    Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used
+    that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server
+    and stored there. Piwik is open source software created by Matomo (https://matomo.org).
 </p>
 <p>
-You can prevent this by setting up your browser so that no cookies are stored.
+    You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+    The data processing takes place on the basis of the legal regulations of the &sect; 96 Abs 3 TKG as well as the Article 6
+    Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
-Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+    Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy
+    of our users is important to us, the user data are pseudonymized. Moreover
 </p>
 <p>
-The user data is kept for the duration of 30 days.
+    The user data is kept for the duration of 30 days.
 </p>
 
 <h2>Emails</h2>
-<p> 
-You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+<p>
+    You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive
+    while not logged in, we send emails to the address you provide in your user account. You can set your email preferences
+    in your account settings (including disabling all notifications).
 </p>
 <p>
-You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+    You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address:
+    office.sat@researchstudio.at
 </p>
 
 <h2>Your rights</h2>
 <p>
-You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+    You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you
+    believe that the processing of your data violates data protection law or if your data protection claims have otherwise
+    been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
 </p>
 <p>
-You can reach us under the following contact details:
+    You can reach us under the following contact details:
 </p>
 <p>
-Research Studio Smart Agent Technologies
-Thurngasse 8/16
-1090 Vienna
-Austria
-office.sat@researchstudio.at
+    Research Studio Smart Agent Technologies Thurngasse 8/16 1090 Vienna Austria office.sat@researchstudio.at
 </p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/green/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/green/config.json
@@ -2,5 +2,6 @@
   "title": "Web of Needs – Master Green",
   "adminEmail": "office.sat@researchstudio.at",
   "imprintTemplate": "imprint.html",
+  "privacyPolicyTemplate": "privacyPolicy.html",  
   "defaultContext": []
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
@@ -1,4 +1,3 @@
-<h1>Privacy Policy</h1>
 <p>
 Date: June 13, 2018
 </p>
@@ -52,7 +51,7 @@ Our website uses the web analytics software Piwik, hosted on our own Servers in 
 You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+The data processing takes place on the basis of the legal regulations of the ï¿½ 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
 Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
@@ -1,0 +1,85 @@
+<h1>Privacy Policy</h1>
+<p>
+Date: June 13, 2018
+</p>
+
+<p>
+The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+</p>
+<h2>Contact us</h2>
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+
+<h2>Data Storage</h2>
+<p>
+We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+</p>
+<p>
+You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+</p>
+<p>
+As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+</p>
+<p>
+In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+</p>
+<p>
+The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+</p>
+<p>
+Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+</p>
+
+
+<h2>Cookies</h2>
+<p>
+Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+</p>
+<p>
+We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+</p>
+<p>
+If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+</p>
+<p>
+Disabling cookies may limit the functionality of our website.
+</p>
+
+<h2>Web analytics</h2>
+<p>
+Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+</p>
+<p>
+You can prevent this by setting up your browser so that no cookies are stored.
+</p>
+<p>
+The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+</p>
+<p>
+Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+</p>
+<p>
+The user data is kept for the duration of 30 days.
+</p>
+
+<h2>Emails</h2>
+<p> 
+You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+</p>
+<p>
+You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+</p>
+
+<h2>Your rights</h2>
+<p>
+You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+</p>
+<p>
+You can reach us under the following contact details:
+</p>
+<p>
+Research Studio Smart Agent Technologies
+Thurngasse 8/16
+1090 Vienna
+Austria
+office.sat@researchstudio.at
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/green/privacyPolicy.html
@@ -1,84 +1,107 @@
 <p>
-Date: June 13, 2018
+    Date: June 13, 2018
 </p>
 
 <p>
-The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+    The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of
+    the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data
+    processing within our website.
 </p>
 <h2>Contact us</h2>
-If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request
+and in case of follow-up questions. We will not share this information without your consent.
 
 <h2>Data Storage</h2>
 <p>
-We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+    We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address
+    you provide. The e-mail address is not made publicly available. We do not associate information about your ip address
+    or location with your user account. We associate your user account with the Posts you create, but only internally.
 </p>
 <p>
-You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+    You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of
+    matching them with other posts. Without the information you provide, we are not able to provide matches. As there is
+    no public information about the association of user accounts to posts, we don't consider posts to be personal data. If
+    you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
 </p>
 <p>
-As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+    As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not
+    conclude any data processing contract with those third parties.
 </p>
 <p>
-In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+    In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available,
+    including the information about the last update date and time, the state (connected, closed, request received, request
+    sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each
+    other.
 </p>
 <p>
-The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+    The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however,
+    stored in clear text on our servers.
 </p>
 <p>
-Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+    Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they
+    remain publicly available so that a) other users can verify the conversations they had with that posting and b) third
+    parties can use this data for improving their matching algorithms.
 </p>
 
 
 <h2>Cookies</h2>
 <p>
-Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+    Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do
+    no harm.
 </p>
 <p>
-We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+    We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow
+    us to recognize your browser on your next visit.
 </p>
 <p>
-If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+    If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this
+    only in individual cases.
 </p>
 <p>
-Disabling cookies may limit the functionality of our website.
+    Disabling cookies may limit the functionality of our website.
 </p>
 
 <h2>Web analytics</h2>
 <p>
-Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+    Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used
+    that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server
+    and stored there. Piwik is open source software created by Matomo (https://matomo.org).
 </p>
 <p>
-You can prevent this by setting up your browser so that no cookies are stored.
+    You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+    The data processing takes place on the basis of the legal regulations of the &sect; 96 Abs 3 TKG as well as the Article 6
+    Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
-Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+    Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy
+    of our users is important to us, the user data are pseudonymized. Moreover
 </p>
 <p>
-The user data is kept for the duration of 30 days.
+    The user data is kept for the duration of 30 days.
 </p>
 
 <h2>Emails</h2>
-<p> 
-You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+<p>
+    You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive
+    while not logged in, we send emails to the address you provide in your user account. You can set your email preferences
+    in your account settings (including disabling all notifications).
 </p>
 <p>
-You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+    You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address:
+    office.sat@researchstudio.at
 </p>
 
 <h2>Your rights</h2>
 <p>
-You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+    You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you
+    believe that the processing of your data violates data protection law or if your data protection claims have otherwise
+    been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
 </p>
 <p>
-You can reach us under the following contact details:
+    You can reach us under the following contact details:
 </p>
 <p>
-Research Studio Smart Agent Technologies
-Thurngasse 8/16
-1090 Vienna
-Austria
-office.sat@researchstudio.at
+    Research Studio Smart Agent Technologies Thurngasse 8/16 1090 Vienna Austria office.sat@researchstudio.at
 </p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/config.json
@@ -2,5 +2,6 @@
   "title": "Mat(ch)²at",
   "adminEmail": "office.sat@researchstudio.at",
   "imprintTemplate": "imprint.html",
+  "privacyPolicyTemplate": "privacyPolicy.html",
   "defaultContext": []
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
@@ -1,4 +1,3 @@
-<h1>Privacy Policy</h1>
 <p>
 Date: June 13, 2018
 </p>
@@ -52,7 +51,7 @@ Our website uses the web analytics software Piwik, hosted on our own Servers in 
 You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+The data processing takes place on the basis of the legal regulations of the ï¿½ 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
 Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
@@ -1,0 +1,85 @@
+<h1>Privacy Policy</h1>
+<p>
+Date: June 13, 2018
+</p>
+
+<p>
+The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+</p>
+<h2>Contact us</h2>
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+
+<h2>Data Storage</h2>
+<p>
+We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+</p>
+<p>
+You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+</p>
+<p>
+As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+</p>
+<p>
+In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+</p>
+<p>
+The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+</p>
+<p>
+Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+</p>
+
+
+<h2>Cookies</h2>
+<p>
+Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+</p>
+<p>
+We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+</p>
+<p>
+If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+</p>
+<p>
+Disabling cookies may limit the functionality of our website.
+</p>
+
+<h2>Web analytics</h2>
+<p>
+Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+</p>
+<p>
+You can prevent this by setting up your browser so that no cookies are stored.
+</p>
+<p>
+The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+</p>
+<p>
+Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+</p>
+<p>
+The user data is kept for the duration of 30 days.
+</p>
+
+<h2>Emails</h2>
+<p> 
+You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+</p>
+<p>
+You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+</p>
+
+<h2>Your rights</h2>
+<p>
+You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+</p>
+<p>
+You can reach us under the following contact details:
+</p>
+<p>
+Research Studio Smart Agent Technologies
+Thurngasse 8/16
+1090 Vienna
+Austria
+office.sat@researchstudio.at
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/privacyPolicy.html
@@ -1,84 +1,107 @@
 <p>
-Date: June 13, 2018
+    Date: June 13, 2018
 </p>
 
 <p>
-The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+    The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of
+    the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data
+    processing within our website.
 </p>
 <h2>Contact us</h2>
-If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request
+and in case of follow-up questions. We will not share this information without your consent.
 
 <h2>Data Storage</h2>
 <p>
-We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+    We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address
+    you provide. The e-mail address is not made publicly available. We do not associate information about your ip address
+    or location with your user account. We associate your user account with the Posts you create, but only internally.
 </p>
 <p>
-You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+    You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of
+    matching them with other posts. Without the information you provide, we are not able to provide matches. As there is
+    no public information about the association of user accounts to posts, we don't consider posts to be personal data. If
+    you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
 </p>
 <p>
-As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+    As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not
+    conclude any data processing contract with those third parties.
 </p>
 <p>
-In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+    In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available,
+    including the information about the last update date and time, the state (connected, closed, request received, request
+    sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each
+    other.
 </p>
 <p>
-The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+    The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however,
+    stored in clear text on our servers.
 </p>
 <p>
-Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+    Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they
+    remain publicly available so that a) other users can verify the conversations they had with that posting and b) third
+    parties can use this data for improving their matching algorithms.
 </p>
 
 
 <h2>Cookies</h2>
 <p>
-Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+    Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do
+    no harm.
 </p>
 <p>
-We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+    We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow
+    us to recognize your browser on your next visit.
 </p>
 <p>
-If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+    If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this
+    only in individual cases.
 </p>
 <p>
-Disabling cookies may limit the functionality of our website.
+    Disabling cookies may limit the functionality of our website.
 </p>
 
 <h2>Web analytics</h2>
 <p>
-Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+    Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used
+    that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server
+    and stored there. Piwik is open source software created by Matomo (https://matomo.org).
 </p>
 <p>
-You can prevent this by setting up your browser so that no cookies are stored.
+    You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+    The data processing takes place on the basis of the legal regulations of the &sect; 96 Abs 3 TKG as well as the Article 6
+    Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
-Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+    Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy
+    of our users is important to us, the user data are pseudonymized. Moreover
 </p>
 <p>
-The user data is kept for the duration of 30 days.
+    The user data is kept for the duration of 30 days.
 </p>
 
 <h2>Emails</h2>
-<p> 
-You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+<p>
+    You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive
+    while not logged in, we send emails to the address you provide in your user account. You can set your email preferences
+    in your account settings (including disabling all notifications).
 </p>
 <p>
-You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+    You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address:
+    office.sat@researchstudio.at
 </p>
 
 <h2>Your rights</h2>
 <p>
-You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+    You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you
+    believe that the processing of your data violates data protection law or if your data protection claims have otherwise
+    been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
 </p>
 <p>
-You can reach us under the following contact details:
+    You can reach us under the following contact details:
 </p>
 <p>
-Research Studio Smart Agent Technologies
-Thurngasse 8/16
-1090 Vienna
-Austria
-office.sat@researchstudio.at
+    Research Studio Smart Agent Technologies Thurngasse 8/16 1090 Vienna Austria office.sat@researchstudio.at
 </p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/config.json
@@ -2,5 +2,6 @@
   "title": "UKI-Line",
   "adminEmail": "office@uki.or.at",
   "imprintTemplate": "imprint.html",
+  "privacyPolicyTemplate": "privacyPolicy.html",  
   "defaultContext": ["uki"]
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
@@ -1,4 +1,3 @@
-<h1>Privacy Policy</h1>
 <p>
 Date: June 13, 2018
 </p>
@@ -52,7 +51,7 @@ Our website uses the web analytics software Piwik, hosted on our own Servers in 
 You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+The data processing takes place on the basis of the legal regulations of the ï¿½ 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
 Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
@@ -1,0 +1,85 @@
+<h1>Privacy Policy</h1>
+<p>
+Date: June 13, 2018
+</p>
+
+<p>
+The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+</p>
+<h2>Contact us</h2>
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+
+<h2>Data Storage</h2>
+<p>
+We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+</p>
+<p>
+You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+</p>
+<p>
+As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+</p>
+<p>
+In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+</p>
+<p>
+The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+</p>
+<p>
+Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+</p>
+
+
+<h2>Cookies</h2>
+<p>
+Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+</p>
+<p>
+We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+</p>
+<p>
+If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+</p>
+<p>
+Disabling cookies may limit the functionality of our website.
+</p>
+
+<h2>Web analytics</h2>
+<p>
+Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+</p>
+<p>
+You can prevent this by setting up your browser so that no cookies are stored.
+</p>
+<p>
+The data processing takes place on the basis of the legal regulations of the § 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+</p>
+<p>
+Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+</p>
+<p>
+The user data is kept for the duration of 30 days.
+</p>
+
+<h2>Emails</h2>
+<p> 
+You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+</p>
+<p>
+You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+</p>
+
+<h2>Your rights</h2>
+<p>
+You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+</p>
+<p>
+You can reach us under the following contact details:
+</p>
+<p>
+Research Studio Smart Agent Technologies
+Thurngasse 8/16
+1090 Vienna
+Austria
+office.sat@researchstudio.at
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/privacyPolicy.html
@@ -1,84 +1,107 @@
 <p>
-Date: June 13, 2018
+    Date: June 13, 2018
 </p>
 
 <p>
-The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data processing within our website.
+    The protection of your personal data is very important to us. Therefore we process your data exclusively on the basis of
+    the legal regulations (GDPR, TKG 2003). In this privacy policy we inform you about the most important aspects of data
+    processing within our website.
 </p>
 <h2>Contact us</h2>
-If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request and in case of follow-up questions. We will not share this information without your consent.
+If you contact us via the form on the website or by e-mail, your data will be stored for six months to process the request
+and in case of follow-up questions. We will not share this information without your consent.
 
 <h2>Data Storage</h2>
 <p>
-We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address you provide. The e-mail address is not made publicly available. We do not associate information about your ip address or location with your user account. We associate your user account with the Posts you create, but only internally. 
+    We point out that for the purpose of maintaining your Posts on the site, we associate a user account with the e-mail address
+    you provide. The e-mail address is not made publicly available. We do not associate information about your ip address
+    or location with your user account. We associate your user account with the Posts you create, but only internally.
 </p>
 <p>
-You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of matching them with other posts. Without the information you provide, we are not able to provide matches. As there is no public information about the association of user accounts to posts, we don't consider posts to be personal data. If you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
+    You should note that the posts you create are publicly visible on the WWW under their respective URL, for the purpose of
+    matching them with other posts. Without the information you provide, we are not able to provide matches. As there is
+    no public information about the association of user accounts to posts, we don't consider posts to be personal data. If
+    you choose to enter personally identifiable information in posts, you do so knowing that it will be publicly available.
 </p>
 <p>
-As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not conclude any data processing contract with those third parties.
+    As posts are publicly available, third parties can download your posts and analyze them for the sake of matching. We do not
+    conclude any data processing contract with those third parties.
 </p>
 <p>
-In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available, including the information about the last update date and time, the state (connected, closed, request received, request sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each other. 
+    In addition to your posts, data about their connections with other posts ("conversations") is also made publicly available,
+    including the information about the last update date and time, the state (connected, closed, request received, request
+    sent, suggested). Making this information public allows third parties to analyze which posts are good matches for each
+    other.
 </p>
 <p>
-The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however, stored in clear text on our servers.
+    The messages you exchange with other users are only visible to you and the user you are communicating with. They are, however,
+    stored in clear text on our servers.
 </p>
 <p>
-Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they remain publicly available so that a) other users can verify the conversations they had with that posting and b) third parties can use this data for improving their matching algorithms.
+    Posts are archived (status is changed to 'inactive') after a period of 10 days, or when you archive them manually, but they
+    remain publicly available so that a) other users can verify the conversations they had with that posting and b) third
+    parties can use this data for improving their matching algorithms.
 </p>
 
 
 <h2>Cookies</h2>
 <p>
-Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do no harm.
+    Our website uses so-called cookies. These are small text files that are stored on your device using the browser. They do
+    no harm.
 </p>
 <p>
-We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow us to recognize your browser on your next visit.
+    We use cookies to make our offer user-friendly. Some cookies remain stored on your device until you delete them. They allow
+    us to recognize your browser on your next visit.
 </p>
 <p>
-If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this only in individual cases.
+    If you do not want this, you can set up your browser so that it informs you about the setting of cookies and you allow this
+    only in individual cases.
 </p>
 <p>
-Disabling cookies may limit the functionality of our website.
+    Disabling cookies may limit the functionality of our website.
 </p>
 
 <h2>Web analytics</h2>
 <p>
-Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server and stored there. Piwik is open source software created by Matomo (https://matomo.org).
+    Our website uses the web analytics software Piwik, hosted on our own Servers in Austria. For this purpose, cookies are used
+    that allow an analysis of the use of the website. The information generated thereby is transmitted to our Piwik server
+    and stored there. Piwik is open source software created by Matomo (https://matomo.org).
 </p>
 <p>
-You can prevent this by setting up your browser so that no cookies are stored.
+    You can prevent this by setting up your browser so that no cookies are stored.
 </p>
 <p>
-The data processing takes place on the basis of the legal regulations of the � 96 Abs 3 TKG as well as the Article 6 Subsection 1 f) legitimate interest of the GDPR.
+    The data processing takes place on the basis of the legal regulations of the &sect; 96 Abs 3 TKG as well as the Article 6
+    Subsection 1 f) legitimate interest of the GDPR.
 </p>
 <p>
-Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy of our users is important to us, the user data are pseudonymized. Moreover 
+    Our concern in the sense of the DSGVO (legitimate interest) is the improvement of our offer and our website. Since the privacy
+    of our users is important to us, the user data are pseudonymized. Moreover
 </p>
 <p>
-The user data is kept for the duration of 30 days.
+    The user data is kept for the duration of 30 days.
 </p>
 
 <h2>Emails</h2>
-<p> 
-You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive while not logged in, we send emails to the address you provide in your user account. You can set your email preferences in your account settings (including disabling all notifications).
+<p>
+    You post on our Website with the intention of communicating with other users. In order to notify you of messages you receive
+    while not logged in, we send emails to the address you provide in your user account. You can set your email preferences
+    in your account settings (including disabling all notifications).
 </p>
 <p>
-You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address: office.sat@researchstudio.at 
+    You can cancel the subscription to the newsletter at any time. Please send your cancellation to the following e-mail address:
+    office.sat@researchstudio.at
 </p>
 
 <h2>Your rights</h2>
 <p>
-You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you believe that the processing of your data violates data protection law or if your data protection claims have otherwise been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
+    You have the rights to information, correction, deletion, restriction, data portability, revocation and opposition. If you
+    believe that the processing of your data violates data protection law or if your data protection claims have otherwise
+    been violated in a way, you can complain to the supervisory authority. In Austria, this is the data protection authority.
 </p>
 <p>
-You can reach us under the following contact details:
+    You can reach us under the following contact details:
 </p>
 <p>
-Research Studio Smart Agent Technologies
-Thurngasse 8/16
-1090 Vienna
-Austria
-office.sat@researchstudio.at
+    Research Studio Smart Agent Technologies Thurngasse 8/16 1090 Vienna Austria office.sat@researchstudio.at
 </p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_about.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_about.scss
@@ -138,4 +138,21 @@ main.about {
       margin-bottom: 1em;
     }
   }
+  .privacyPolicy {
+    background-color: $won-lighter-gray;
+    .title {
+      position: relative;
+      z-index: 101;
+    }
+    .sub {
+      font-size: $normalFontSize;
+    }
+    a {
+      text-decoration: none;
+      color: $won-primary-color;
+    }
+    p {
+      margin-bottom: 1em;
+    }
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_about.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_about.scss
@@ -123,8 +123,6 @@ main.about {
   .imprint {
     background-color: $won-primary-color;
     .title {
-      position: relative;
-      z-index: 101;
       color: white;
     }
     .sub {
@@ -140,12 +138,12 @@ main.about {
   }
   .privacyPolicy {
     background-color: $won-lighter-gray;
-    .title {
-      position: relative;
-      z-index: 101;
-    }
-    .sub {
-      font-size: $normalFontSize;
+    max-width: $maxContentWidth;
+    margin: 0 auto;
+
+    h2 {
+      margin-top: 2em;
+      margin-bottom: 1em;
     }
     a {
       text-decoration: none;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
@@ -50,6 +50,10 @@
         text-decoration: underline;
       }
     }
+
+    ul {
+      padding: 1rem;
+    }
   }
 
   & > .si__button {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
@@ -43,6 +43,13 @@
       margin-right: 1rem;
       text-align: left;
     }
+
+    a {
+      color: $won-primary-color;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   & > .si__button {


### PR DESCRIPTION
- Adds a slide-in if a webapp visitor/user has not accepted the disclaimer yet.
- It shows a message with a link within the text (links to the about page) and a button to accept the disclaimer.
-The Status is currently saved into the localStorage and is retrieved on page load and saved in the redux state (subelement of user), accepting also saves the status to the localstorage and the state.

There are 3 new debug methods to be used for testing (these only change the localstorage state and not the redux state!):
```
won.isDisclaimerAccepted() //to see if the disclaimer has already been accepted
won.clearDisclaimerAccepted() //to clear the disclaimer acceptance within the localstorage (refresh should show the disclaimer again)
won.setDisclaimerAccepted() //to programmatically set the disclaimer as accepted (refresh should show no disclaimer then)
```

Please Note that any Text within the imprint.html (thats the thing we will adapt i assume) or the disclaimer itself (including button labels etc) are not in the scope of this PR as this is not my concern (@fkleedorfer will update the texts accordingly)
@fkleedorfer, if there is a need to include more templates into the about page (e.g. if we do not want to use the imprint.html template for everything, please create an issue for that (child of cogsci #1866))
if we do want to update the about page as well then let us push the issue into the ready column in waffle and also make it a child of cogsci (about update issue number is: #1669)

fixes #1888 
