### PR TITLE
Feat message status #1913

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -114,6 +114,7 @@ $ngRedux.getState();
                        uri: string //unique identifier of this message
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
                        isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)
+                       failedToSend: true|false //whether the sent message failed for whatever reason (default: false, only relevant in outgoingMessages)
                    }
                    ...
                },

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -112,6 +112,8 @@ $ngRedux.getState();
                        outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
                        text: string, //message text
                        uri: string //unique identifier of this message
+                       isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
+                       isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)
                    }
                    ...
                },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -50,8 +50,9 @@ function genComponentConf() {
     			      ng-class="{
     			        'agreement' : 	!self.isNormalMessage(),
     			        'info' : self.isInfoMessage(),
-                  'pending': self.message.get('outgoingMessage') && (!self.message.get('isReceivedByOwn') && !self.message.get('isReceivedByRemote')),
-                  'partiallyLoaded': self.message.get('outgoingMessage') && (!(self.message.get('isReceivedByOwn') && self.message.get('isReceivedByRemote')) && (self.message.get('isReceivedByOwn') || self.message.get('isReceivedByRemote')))
+                  'pending': self.message.get('outgoingMessage') && !self.message.get('failedToSend') && (!self.message.get('isReceivedByOwn') && !self.message.get('isReceivedByRemote')),
+                  'partiallyLoaded': self.message.get('outgoingMessage') && !self.message.get('failedToSend') && (!(self.message.get('isReceivedByOwn') && self.message.get('isReceivedByRemote')) && (self.message.get('isReceivedByOwn') || self.message.get('isReceivedByRemote'))),
+                  'failure': self.message.get('outgoingMessage') && self.message.get('failedToSend'),
     			      }">
                     <span class="won-cm__center__bubble__text">
                       <span ng-show="self.headerText">
@@ -180,18 +181,24 @@ function genComponentConf() {
             <div class="won-cm__center__status">
                 <div class="won-cm__center__status__icons"
                     ng-if="self.message.get('outgoingMessage')">
-                    <svg class="won-cm__center__status__icons__icon" ng-class="{'received' : self.message.get('isReceivedByOwn')}">
+                    <svg class="won-cm__center__status__icons__icon" ng-if="!self.message.get('failedToSend')" ng-class="{'received' : self.message.get('isReceivedByOwn')}">
                         <use xlink:href="#ico36_added_circle" href="#ico36_added_circle"></use>
                     </svg>
-                    <svg class="won-cm__center__status__icons__icon" ng-class="{'received' : self.message.get('isReceivedByRemote')}">
+                    <svg class="won-cm__center__status__icons__icon" ng-if="!self.message.get('failedToSend')" ng-class="{'received' : self.message.get('isReceivedByRemote')}">
                         <use xlink:href="#ico36_added_circle" href="#ico36_added_circle"></use>
+                    </svg>
+                    <svg class="won-cm__center__status__icons__icon" ng-if="self.message.get('failedToSend')" style="--local-primary: red;">
+                        <use xlink:href="#ico16_indicator_warning" href="#ico16_indicator_warning"></use>
                     </svg>
                 </div>
-                <div class="won-cm__center__status__time" ng-show="!self.message.get('outgoingMessage') || (self.message.get('isReceivedByRemote') && self.message.get('isReceivedByOwn'))">
+                <div class="won-cm__center__status__time" ng-show="!self.message.get('outgoingMessage') || (!self.message.get('failedToSend') && (self.message.get('isReceivedByRemote') && self.message.get('isReceivedByOwn')))">
                     {{ self.relativeTime(self.lastUpdateTime, self.message.get('date')) }}
                 </div>
-                <div class="won-cm__center__status__time" ng-show="self.message.get('outgoingMessage') && (!self.message.get('isReceivedByRemote') || !self.message.get('isReceivedByOwn'))">
+                <div class="won-cm__center__status__time--pending" ng-show="self.message.get('outgoingMessage') && !self.message.get('failedToSend') && (!self.message.get('isReceivedByRemote') || !self.message.get('isReceivedByOwn'))">
                     Sending&nbsp;&hellip;
+                </div>
+                <div class="won-cm__center__status__time--failure" ng-show="self.message.get('outgoingMessage') && self.message.get('failedToSend')">
+                    Sending failed
                 </div>
             </div>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-message.js
@@ -47,7 +47,12 @@ function genComponentConf() {
             <div 
                 class="won-cm__center__bubble" 
                 title="{{ self.shouldShowRdf ? self.rdfToString(self.message.get('contentGraphs')) : undefined }}"
-    			      ng-class="{'agreement' : 	!self.isNormalMessage(), 'info' : self.isInfoMessage()}">
+    			      ng-class="{
+    			        'agreement' : 	!self.isNormalMessage(),
+    			        'info' : self.isInfoMessage(),
+                  'pending': self.message.get('outgoingMessage') && (!self.message.get('isReceivedByOwn') && !self.message.get('isReceivedByRemote')),
+                  'partiallyLoaded': self.message.get('outgoingMessage') && (!(self.message.get('isReceivedByOwn') && self.message.get('isReceivedByRemote')) && (self.message.get('isReceivedByOwn') || self.message.get('isReceivedByRemote')))
+    			      }">
                     <span class="won-cm__center__bubble__text">
                       <span ng-show="self.headerText">
                         <h3>
@@ -172,11 +177,24 @@ function genComponentConf() {
                 class="won-cm__center__time">
                     Pending&nbsp;&hellip;
             </div>
-            <div
-                ng-hide="self.message.get('unconfirmed')"
-                class="won-cm__center__time">
+            <div class="won-cm__center__status">
+                <div class="won-cm__center__status__icons"
+                    ng-if="self.message.get('outgoingMessage')">
+                    <svg class="won-cm__center__status__icons__icon" ng-class="{'received' : self.message.get('isReceivedByOwn')}">
+                        <use xlink:href="#ico36_added_circle" href="#ico36_added_circle"></use>
+                    </svg>
+                    <svg class="won-cm__center__status__icons__icon" ng-class="{'received' : self.message.get('isReceivedByRemote')}">
+                        <use xlink:href="#ico36_added_circle" href="#ico36_added_circle"></use>
+                    </svg>
+                </div>
+                <div class="won-cm__center__status__time" ng-show="!self.message.get('outgoingMessage') || (self.message.get('isReceivedByRemote') && self.message.get('isReceivedByOwn'))">
                     {{ self.relativeTime(self.lastUpdateTime, self.message.get('date')) }}
+                </div>
+                <div class="won-cm__center__status__time" ng-show="self.message.get('outgoingMessage') && (!self.message.get('isReceivedByRemote') || !self.message.get('isReceivedByOwn'))">
+                    Sending&nbsp;&hellip;
+                </div>
             </div>
+
             <a ng-show="self.rdfLinkURL"
                 target="_blank"
                 href="{{self.rdfLinkURL}}">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer.js
@@ -451,13 +451,34 @@ export default function(allNeedsInState = initialState, action = {}) {
       return allNeedsInState;
     }
 
+    case actionTypes.messages.chatMessage.failure: {
+      const wonMessage = getIn(action, ["payload"]);
+      const eventUri = wonMessage.isFromExternal()
+        ? wonMessage.getIsRemoteResponseTo()
+        : wonMessage.getIsResponseTo();
+      const needUri = wonMessage.getReceiverNeed();
+      const connectionUri = wonMessage.getReceiver();
+
+      allNeedsInState = allNeedsInState.setIn(
+        [
+          needUri,
+          "connections",
+          connectionUri,
+          "messages",
+          eventUri,
+          "failedToSend",
+        ],
+        true
+      );
+      return allNeedsInState;
+    }
+
     case actionTypes.messages.chatMessage.successRemote: {
       const wonMessage = getIn(action, ["payload"]);
       const eventUri = wonMessage.getIsRemoteResponseTo();
       const needUri = wonMessage.getReceiverNeed();
       const connectionUri = wonMessage.getReceiver();
-      // we want to use the response date to update the original message
-      // date
+
       allNeedsInState = allNeedsInState.setIn(
         [
           needUri,
@@ -1139,6 +1160,7 @@ function parseMessage(wonMessage, alreadyProcessed = false) {
       clauses: clauses,
       isReceivedByOwn: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway
       isReceivedByRemote: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway
+      failedToSend: false,
       isProposeMessage: wonMessage.isProposeMessage(),
       isAcceptMessage: wonMessage.isAcceptMessage(),
       isProposeToCancel: wonMessage.isProposeToCancel(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -100,6 +100,11 @@ won-connection-message {
       &.partiallyLoaded {
         opacity: 0.66;
       }
+
+      &.failure {
+        color: #ff0000;
+        //TODO: FAILURE MESSAGE STYLING
+      }
     }
     &__trig {
       max-width: 100%;
@@ -118,6 +123,16 @@ won-connection-message {
       &__time {
         display: inline-block;
         color: $won-line-gray;
+        --local-primary: #{$won-secondary-color};
+
+        &--pending {
+          display: inline-block;
+          color: $won-line-gray;
+        }
+        &--failure {
+          display: inline-block;
+          //TODO: FAILURE MESSAGE STYLING
+        }
       }
       &__icons {
         display: inline-block;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -93,6 +93,13 @@ won-connection-message {
     .won-cm__center__bubble {
       background-color: $won-light-gray; // like the error toast-notifications
       color: black;
+
+      &.pending {
+        opacity: 0.33;
+      }
+      &.partiallyLoaded {
+        opacity: 0.66;
+      }
     }
     &__trig {
       max-width: 100%;
@@ -107,8 +114,24 @@ won-connection-message {
         white-space: pre-wrap;
       }
     }
-    &__time {
-      color: $won-line-gray;
+    &__status {
+      &__time {
+        display: inline-block;
+        color: $won-line-gray;
+      }
+      &__icons {
+        display: inline-block;
+        &__icon {
+          display: inline-block;
+          @include fixed-square(0.5rem);
+
+          --local-primary: #{$won-line-gray};
+
+          &.received {
+            --local-primary: #{$won-secondary-color};
+          }
+        }
+      }
     }
     &__carret {
       @include fixed-square(1rem); // visually center icon on line

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-selection-item-line.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-selection-item-line.scss
@@ -8,7 +8,8 @@
 won-connection-selection-item {
   $triangleCutoutSize: $speechBubbleTailSize;
   $padding: 0.5rem;
-  display: block;
+  display: grid;
+  grid-auto-flow: column;
   position: relative; // to allow positioning the contextmenu in relation to this component-root
   padding-left: $padding + $triangleCutoutSize;
   padding-right: $padding;


### PR DESCRIPTION
this PR fixes #1913 

however this PR does not handle the complete failure of the server (since the messaging-agent will not push any actions into the state)
also this pr does not allow resending of the messages yet, since we do not have the original message in the redux store (afaik)

BUT:

it is now visible if the message is already successfully pushed to the own server and to the remote server, and will show if the message sending failed (only handle FailureResponse from server though, so it might mean that we only mark messages that are not valid)

This means the PR fixes the first part of the issue, please check this and alter the issue or create a new one for the missing parts