### PR TITLE
Fix disable publish on disconnect #1926

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -6,12 +6,12 @@
  * Created by ksinger on 16.02.2018.
  */
 
-// import Medium from '../mediumjs-es6.js';
 import angular from "angular";
-// import 'ng-redux';
+import "ng-redux";
 import "angular-sanitize";
 import { dispatchEvent, attach, delay } from "../utils.js";
 import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
+import { actionCreators } from "../actions/actions.js";
 
 function genComponentConf() {
   let template = `
@@ -44,7 +44,8 @@ function genComponentConf() {
 
   const serviceDependencies = [
     "$scope",
-    "$element" /*'$ngRedux',/*injections as strings here*/,
+    "$element",
+    "$ngRedux" /*injections as strings here*/,
   ];
 
   class Controller {
@@ -52,13 +53,13 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
       window.ctfs4dbg = this;
 
-      /*
-            const selectFromState = (state) => ({
-                draftId: state.getIn(['router', 'currentParams', 'draftId'])
-            })
-            const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);
-            this.$scope.$on('$destroy', disconnect);
-            */
+      const selectFromState = state => ({
+        connectionHasBeenLost: state.getIn(["messages", "lostConnection"]),
+      });
+      const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(
+        this
+      );
+      this.$scope.$on("$destroy", disconnect);
 
       this.textFieldNg().bind("input", () => {
         this.input();
@@ -126,6 +127,7 @@ function genComponentConf() {
     }
     valid() {
       return (
+        !this.connectionHasBeenLost &&
         (this.allowEmptySubmit || this.value().length > 0) &&
         this.belowMaxLength()
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -54,7 +54,9 @@ function genComponentConf() {
       window.ctfs4dbg = this;
 
       const selectFromState = state => ({
-        connectionHasBeenLost: state.getIn(["messages", "lostConnection"]),
+        connectionHasBeenLost:
+          state.getIn(["messages", "reconnecting"]) ||
+          state.getIn(["messages", "lostConnection"]),
       });
       const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(
         this

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -154,6 +154,7 @@ function genComponentConf() {
         const isPost = showCreateView && !isSearch;
 
         return {
+          connectionHasBeenLost: state.getIn(["messages", "lostConnection"]),
           showCreateView,
           isSearch,
           isPost,
@@ -207,6 +208,7 @@ function genComponentConf() {
 
     isValid() {
       return (
+        !this.connectionHasBeenLost &&
         (this.draftObject[this.is] || this.draftObject[this.seeks]) &&
         (this.draftObject[this.is].title ||
           this.draftObject[this.seeks].title) &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -154,7 +154,9 @@ function genComponentConf() {
         const isPost = showCreateView && !isSearch;
 
         return {
-          connectionHasBeenLost: state.getIn(["messages", "lostConnection"]),
+          connectionHasBeenLost:
+            state.getIn(["messages", "reconnecting"]) ||
+            state.getIn(["messages", "lostConnection"]),
           showCreateView,
           isSearch,
           isPost,


### PR DESCRIPTION
fixes #1926 

we disable the publish button in the create post view if the connection has been lost or is currently reconnecting

addition:
i also added the same handler for the chat-textfield send (included the accept and send request fields as well)