### PR TITLE
Made app work on Edge and Safari Mobile < 11 again

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
+++ b/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
@@ -63,6 +63,7 @@ function config(env, argv): Configuration {
           "angular-ui-router/release/stateEvents.js"
         ),
         config$: path.resolve(__dirname, "config", `${nodeEnv}.js`),
+        jsonld$: require.resolve("jsonld/dist/jsonld.js"), // This is needed because `jsonld`s entrypoint is not compiled to compatible js (uses spread operators). With this resolve hook we instead use the compiled version.
       },
     },
     module: {


### PR DESCRIPTION
Fixes #1533
 
The error was that `jsonld` lists its uncompiled source (containing spread operators) as main entrypoint, and we don't transform our dependencies.
We solve this by instead redirecting every require of `jsonld` to its compiled output at `jsonld/dist/jsonld.js`
Related: https://github.com/digitalbazaar/jsonld.js/issues/251

## Todo
- [x] Write report entry