### PR TITLE
Fix disable publish #1926

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -8,10 +8,11 @@
 
 // import Medium from '../mediumjs-es6.js';
 import angular from "angular";
-// import 'ng-redux';
+import "ng-redux";
 import "angular-sanitize";
 import { dispatchEvent, attach, delay } from "../utils.js";
 import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
+import { actionCreators } from "../actions/actions.js";
 
 function genComponentConf() {
   let template = `
@@ -44,7 +45,8 @@ function genComponentConf() {
 
   const serviceDependencies = [
     "$scope",
-    "$element" /*'$ngRedux',/*injections as strings here*/,
+    "$element",
+    "$ngRedux" /*injections as strings here*/,
   ];
 
   class Controller {
@@ -52,13 +54,15 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
       window.ctfs4dbg = this;
 
-      /*
-            const selectFromState = (state) => ({
-                draftId: state.getIn(['router', 'currentParams', 'draftId'])
-            })
-            const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(this);
-            this.$scope.$on('$destroy', disconnect);
-            */
+      const selectFromState = state => ({
+        connectionHasBeenLost:
+          state.getIn(["messages", "reconnecting"]) ||
+          state.getIn(["messages", "lostConnection"]),
+      });
+      const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(
+        this
+      );
+      this.$scope.$on("$destroy", disconnect);
 
       this.textFieldNg().bind("input", () => {
         this.input();
@@ -126,6 +130,7 @@ function genComponentConf() {
     }
     valid() {
       return (
+        !this.connectionHasBeenLost &&
         (this.allowEmptySubmit || this.value().length > 0) &&
         this.belowMaxLength()
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -154,6 +154,9 @@ function genComponentConf() {
         const isPost = showCreateView && !isSearch;
 
         return {
+          connectionHasBeenLost:
+            state.getIn(["messages", "reconnecting"]) ||
+            state.getIn(["messages", "lostConnection"]),
           showCreateView,
           isSearch,
           isPost,
@@ -207,6 +210,7 @@ function genComponentConf() {
 
     isValid() {
       return (
+        !this.connectionHasBeenLost &&
         (this.draftObject[this.is] || this.draftObject[this.seeks]) &&
         (this.draftObject[this.is].title ||
           this.draftObject[this.seeks].title) &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -54,6 +54,14 @@ export function messagesReducer(messages = initialState, action = {}) {
     case actionTypes.lostConnection:
       return messages.set("lostConnection", true).set("reconnecting", false);
 
+    case actionTypes.initialPageLoad: {
+      const initialLoadFinished =
+        action && action.getIn(["payload", "initialLoadFinished"]);
+      return initialLoadFinished
+        ? messages.set("lostConnection", false).set("reconnecting", false)
+        : messages;
+    }
+
     case actionTypes.reconnect:
       return messages.set("reconnecting", true);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -4,6 +4,7 @@
 
 import { actionTypes } from "../actions/actions.js";
 import Immutable from "immutable";
+import { getIn } from "../utils.js";
 
 /* TODO this fragment is part of an attempt to sketch a different
  * approach to asynchronity (Remove it or the thunk-based
@@ -55,8 +56,10 @@ export function messagesReducer(messages = initialState, action = {}) {
       return messages.set("lostConnection", true).set("reconnecting", false);
 
     case actionTypes.initialPageLoad: {
-      const initialLoadFinished =
-        action && action.getIn(["payload", "initialLoadFinished"]);
+      const initialLoadFinished = getIn(action, [
+        "payload",
+        "initialLoadFinished",
+      ]);
       return initialLoadFinished
         ? messages.set("lostConnection", false).set("reconnecting", false)
         : messages;


### PR DESCRIPTION
fixes #1926 

this also removes the "race condition" that we have had on a reload of the page -> somehow messages.reconnecting within the state is set to true after a reload, however that was never set back to false, now we set both connLost indicator flags to false after the initialLoad has been finished