### PR TITLE
fixes #1950

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -324,7 +324,7 @@ function genComponentConf() {
     }
 
     updateTitle() {
-      const titleString = (this.titleInput() || {}).value || "";
+      const titleString = ((this.titleInput() || {}).value || "").trim();
       this.draftObject.title = titleString;
       this.updateDraft();
     }


### PR DESCRIPTION
fixes #1950 

adds trim to the updateTitle methods titleString to remove the ability to create needs with a sort-of blank title