### PR TITLE
show need type for hints within the "post-info"

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -16,7 +16,7 @@ import {
   selectLastUpdateTime,
 } from "../selectors.js";
 import { connect2Redux } from "../won-utils.js";
-import { relativeTime } from "../won-label-utils.js";
+import { labels, relativeTime } from "../won-label-utils.js";
 import { attach, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 
@@ -49,6 +49,12 @@ function genComponentConf() {
             </h2>
             <p class="post-info__details" ng-show="self.friendlyTimestamp">
                 {{ self.friendlyTimestamp }}
+            </p>
+            <h2 class="post-info__heading" ng-show="self.suggestedPost.get('type')">
+                Type
+            </h2>
+            <p class="post-info__details" ng-show="self.suggestedPost.get('type')">
+                {{self.labels.type[self.suggestedPost.get('type')]}}{{self.suggestedPost.get('matchingContexts')? ' in '+ self.suggestedPost.get('matchingContexts').join(', ') : '' }}
             </p>
             <!-- IS Part -->
             <div ng-show="self.isPart">
@@ -104,6 +110,7 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
       this.maxThumbnails = 9;
       this.message = "";
+      this.labels = labels;
       this.WON = won.WON;
       window.openMatch4dbg = this;
 


### PR DESCRIPTION
fixes #1949 

adds the type to the post-info for hints (because the header is only showing the connection status, whereas the post-header of a normal post-info shows the type as well)