### PR TITLE
Using standard javascript errors.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/.eslintrc.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/.eslintrc.js
@@ -22,7 +22,4 @@ module.exports = {
       },
     ],
   },
-  globals: {
-    Exception: true,
-  },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -130,7 +130,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       let changedState;
 
       if (!ownNeedFromState) {
-        throw new Exception(
+        throw new Error(
           "Would need to call addNeed with ownNeed, but it is not defined!"
         );
       } else {
@@ -299,7 +299,7 @@ export default function(allNeedsInState = initialState, action = {}) {
         // (see connectAdHoc)
         const needUri = needForTmpCnct.get("uri");
         if (!needForTmpCnct.get("ownNeed")) {
-          throw new Exception(
+          throw new Error(
             'Trying to add/change connection for need that\'s not an "ownNeed".'
           );
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -91,7 +91,7 @@ import won from "./won.js";
    */
   won.buildNeedRdf = function(args) {
     if (!args.is && !args.seeks) {
-      throw new Exception(
+      throw new Error(
         "Expected an object with an is- and/or a seeks-subobject. Something like `{ is: {...}, seeks: {...} }`. Got " +
           args
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -941,7 +941,7 @@ won.toWonMessage = function(message) {
   } else if (message instanceof WonMessage) {
     return Promise.resolve(message);
   } else {
-    throw new Exception(
+    throw new Error(
       "Couldn't convert the following to a WonMessage: ",
       message
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -740,7 +740,7 @@ export function get(obj, property) {
 
 /**
  * Tries to look up a property-path on a nested object-structure.
- * Where `obj.x.y` would throw an exception if `x` wasn't defined
+ * Where `obj.x.y` would throw an error if `x` wasn't defined
  * `get(obj, ['x','y'])` would return undefined.
  * @param obj
  * @param path
@@ -872,7 +872,7 @@ export function jsonld2simpleFormat(jsonldObj, context = undefined) {
           default: {
             const split = k.split(":");
             if (split.length !== 2) {
-              throw new Exception(
+              throw new Error(
                 'encountered unexpected predicate when parsing json-ld. it doesn\'t follow the "<prefix>:<postfix> structure: "' +
                   k
               );
@@ -886,7 +886,7 @@ export function jsonld2simpleFormat(jsonldObj, context = undefined) {
       return newObj;
     }
   } else {
-    throw new Exception(
+    throw new Error(
       "Encountered unexpected value while parsing json-ld: ",
       jsonldObj
     );
@@ -983,7 +983,7 @@ export function inlineSVGSpritesheet(path, id) {
     .then(xmlString => parseSVG(xmlString))
     .then(svgDocumentFragment => {
       if (!svgDocumentFragment)
-        throw new Exception("Couldn't parse icon-spritesheet.");
+        throw new Error("Couldn't parse icon-spritesheet.");
       document.body.appendChild(svgDocumentFragment);
       const svgNode = document.body.lastChild; // the node resulting from the fragment we just appended
       if (svgNode && svgNode.style) {
@@ -1001,7 +1001,7 @@ export function inlineSVGSpritesheet(path, id) {
 /**
  * Optionally prepends a string, and then throws
  * whatever it gets as proper javascript error.
- * Note, that throwing an exception will also
+ * Note, that throwing an error will also
  * reject in a `Promise`-constructor-callback.
  * @param {*} e
  * @param {*} prependedMsg

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -243,7 +243,7 @@ export function buildChatMessage({
           chatMessage
         );
       } else {
-        throw new Exception(
+        throw new Error(
           "No textmessage or valid graph as payload of chat message:" +
             JSON.stringify(chatMessage) +
             " " +

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -19,10 +19,11 @@ window.jsonld4dbg = jsonld;
 
 export function initLeaflet(mapMount) {
   if (!L) {
-    throw new Exception(
+    throw new Error(
       "Tried to initialize a leaflet widget while leaflet wasn't loaded."
     );
   }
+  Error;
 
   const baseMaps = initLeafletBaseMaps();
 
@@ -48,7 +49,7 @@ export function initLeaflet(mapMount) {
 
 export function initLeafletBaseMaps() {
   if (!L) {
-    throw new Exception(
+    throw new Error(
       "Tried to initialize leaflet map-sources while leaflet wasn't loaded."
     );
   }
@@ -79,7 +80,7 @@ export function selectTimestamp(event) {
      * container. The receivedTimestamp there
      * should have been placed by our own node.
      *
-     * The exception are events that haven't
+     * The error are events that haven't
      * been confirmed yet. They don't have a
      * received timestamp, as these are optimistic
      * assumptions with only sent timestamps.


### PR DESCRIPTION
`Exception` is a custom class defined by the rdfstore, whereas `Error` is the standard class used by the rest of the javascript world. This PR changes all occurrences of the former outside of the store for the latter, which gives us much better support in devtools (e.g. working error messages and stack traces for one)

Resolves #1983 