### PR TITLE
Fix clear unloaded needs #1909

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -138,6 +138,8 @@ $ngRedux.getState();
        nodeUri: string, //identifier of this need's server
        ownNeed: true|false, //whether this need is owned or not
        isBeingCreated: true|false, //whether or not the creation of this need was successfully completed yet
+       isLoading: true|false, //whether or not the need is currently in the process of being loaded
+       toLoad: true|false, //whether or not the need is flagged as toLoad (for future loading purposes)
        isWhatsAround: true|false, //whether or not the need is a whatsaround need
        isWhatsNew: true|false, //whether or not this need is a whatsnew need
        state: "won:Active" | "won:Inactive", //state of the need

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestNeedController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestNeedController.java
@@ -17,14 +17,6 @@
 package won.owner.web.rest;
 
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,12 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-
+import org.springframework.web.bind.annotation.*;
 import won.owner.model.Draft;
 import won.owner.model.User;
 import won.owner.model.UserNeed;
@@ -50,6 +37,15 @@ import won.owner.repository.DraftRepository;
 import won.owner.repository.UserRepository;
 import won.owner.service.impl.URIService;
 import won.owner.service.impl.WONUserDetailService;
+import won.protocol.model.NeedState;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 @Controller
 @RequestMapping("/rest/needs")
@@ -74,18 +70,27 @@ public class RestNeedController {
    */
   @ResponseBody
   @RequestMapping(
-    value = "/",
+    value = {"/",""},
     produces = MediaType.APPLICATION_JSON_VALUE,
     method = RequestMethod.GET
   )
-  public List<URI> getAllNeedsOfUser() {
-    logger.info("Getting all needs of user: ");
-
+  public List<URI> getAllNeedsOfUser(@RequestParam(value = "state", required = false) NeedState state) {
     User user = getCurrentUser();
     List<UserNeed> userNeeds = user.getUserNeeds();
     List<URI> needUris = new ArrayList(userNeeds.size());
-    for(UserNeed userNeed: userNeeds){
-      needUris.add(userNeed.getUri());
+
+    if(state == null) {
+        logger.debug("Getting all needuris of user: " + user.getUsername());
+        for (UserNeed userNeed : userNeeds) {
+            needUris.add(userNeed.getUri());
+        }
+    } else {
+        logger.debug("Getting all needuris of user: " + user.getUsername() + "filtered by state: " + state);
+        for (UserNeed userNeed : userNeeds) {
+            if(state.equals(userNeed.getState())) {
+                needUris.add(userNeed.getUri());
+            }
+        }
     }
     return needUris;
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -25,7 +25,6 @@ import {
   selectRouterParams,
   selectNeedByConnectionUri,
 } from "../selectors.js";
-import { getInactiveNeedUris } from "../won-localstorage.js";
 
 const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
@@ -215,9 +214,7 @@ function genComponentConf() {
         let sortedOpenNeeds = sortByDate(openNeeds);
         let sortedClosedNeeds = sortByDate(closedNeeds);
 
-        const unloadedNeeds = getInactiveNeedUris().filter(uri =>
-          (allOwnNeeds || []).every(need => need.get("uri") != uri)
-        );
+        const unloadedNeeds = closedNeeds.filter(need => need.get("toLoad"));
 
         return {
           allNeeds,
@@ -229,7 +226,7 @@ function genComponentConf() {
           beingCreatedNeeds: beingCreatedNeeds && beingCreatedNeeds.toArray(),
           sortedOpenNeeds,
           sortedClosedNeeds,
-          unloadedNeedsSize: unloadedNeeds.length,
+          unloadedNeedsSize: unloadedNeeds ? unloadedNeeds.size : 0,
           closedNeedsSize: closedNeeds ? closedNeeds.size : 0,
         };
       };
@@ -259,7 +256,7 @@ function genComponentConf() {
     }
 
     hasClosedNeeds() {
-      return this.unloadedNeedsSize + this.closedNeedsSize > 0;
+      return this.closedNeedsSize > 0;
     }
 
     getClosedNeedsText() {
@@ -271,11 +268,13 @@ function genComponentConf() {
         output.push(`${this.unloadedNeedsSize} unloaded`);
       }
 
-      return output.join(" + ");
+      return output.join(" - ");
     }
 
     toggleClosedNeeds() {
-      this.needs__fetchUnloadedNeeds();
+      if (this.unloadedNeedsSize > 0) {
+        this.needs__fetchUnloadedNeeds();
+      }
       this.toggleClosedNeedsDisplay();
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -11,13 +11,14 @@ import { attach } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors.js";
 import won from "../won-es6.js";
+import { classOnComponentRoot } from "../cstm-ng-utils.js";
 
-const serviceDependencies = ["$ngRedux", "$scope"];
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
 
-    <won-square-image ng-if="!self.need.get('isBeingCreated')"
-        ng-class="{'bigger' : self.biggerImage, 'inactive' : self.need.get('state') === self.WON.InactiveCompacted}"
+    <won-square-image
+        ng-class="{'bigger' : self.biggerImage, 'inactive' : !self.need.get('isBeingCreated') && self.need.get('state') === self.WON.InactiveCompacted}"
         src="self.need.get('TODO')"
         uri="self.needUri"
         ng-show="!self.hideImage">
@@ -39,8 +40,6 @@ function genComponentConf() {
           class="piu__header__title__subtitle__group__icon">
             <use xlink:href="#ico36_group" href="#ico36_group"></use>
         </svg>
-
-
           {{self.need.get('group')}}
           <span class="piu__header__title__subtitle__group__dash"> &ndash; </span>
         </span>
@@ -51,12 +50,6 @@ function genComponentConf() {
       </div>
     </div>
     
-    <won-square-image ng-if="self.need.get('isBeingCreated')"
-      ng-class="{'bigger' : self.biggerImage}"
-      src="self.need.get('TODO')"
-      uri="self.needUri"
-      ng-show="!self.hideImage">
-    </won-square-image>
     <div class="ph__right" ng-if="self.need.get('isBeingCreated')">
       <div class="ph__right__topline">
         <div class="ph__right__topline__title">
@@ -97,6 +90,16 @@ function genComponentConf() {
         ["self.needUri", "self.timestamp"],
         this
       );
+
+      classOnComponentRoot("won-is-loading", () => this.isLoading(), this);
+      classOnComponentRoot("won-is-toload", () => this.isToLoad(), this);
+    }
+
+    isLoading() {
+      return !this.need || this.need.get("isLoading");
+    }
+    isToLoad() {
+      return !this.need || this.need.get("toLoad");
     }
   }
   Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -3,7 +3,6 @@
  */
 const READ_URIS = "wonReadUris";
 const CLOSED_CONN_URIS = "wonClosedConnectionUris";
-const INACTIVE_NEED_URIS = "inactiveNeedUris";
 const DISCLAIMER_ACCEPTED = "disclaimerAccepted";
 
 export function markUriAsRead(uri) {
@@ -104,45 +103,6 @@ export function isConnUriClosed(uri) {
 
 export function clearClosedConnUris() {
   localStorage.removeItem(CLOSED_CONN_URIS);
-}
-
-export function addInactiveNeed(needUri) {
-  const inactiveNeeds = getInactiveNeedUris();
-  if (inactiveNeeds.includes(needUri)) {
-    return false;
-  } else {
-    localStorage.setItem(
-      INACTIVE_NEED_URIS,
-      JSON.stringify(inactiveNeeds.concat([needUri]))
-    );
-    return true;
-  }
-}
-
-export function removeInactiveNeed(needUri) {
-  localStorage.setItem(
-    INACTIVE_NEED_URIS,
-    JSON.stringify(getInactiveNeedUris().filter(uri => uri != needUri))
-  );
-}
-
-export function getInactiveNeedUris() {
-  try {
-    const needUris = JSON.parse(localStorage.getItem(INACTIVE_NEED_URIS)) || [];
-    if (Array.isArray(needUris)) {
-      return needUris;
-    } else {
-      return [];
-    }
-  } catch (e) {
-    console.warn(e);
-    clearInactiveNeedUris();
-    return [];
-  }
-}
-
-export function clearInactiveNeedUris() {
-  localStorage.removeItem(INACTIVE_NEED_URIS);
 }
 
 export function isDisclaimerAccepted() {

--- a/webofneeds/won-owner/src/main/java/won/owner/model/UserNeed.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/UserNeed.java
@@ -16,19 +16,12 @@
 
 package won.owner.model;
 
+import won.protocol.model.NeedState;
+import won.protocol.model.URIConverter;
+
+import javax.persistence.*;
 import java.net.URI;
 import java.util.Date;
-
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.PrePersist;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
-import won.protocol.model.URIConverter;
 
 /**
  * Entity wrapping a uri identifying a user's need.
@@ -59,14 +52,16 @@ public class UserNeed
   @Column( name = "creationDate", nullable = false)
   private Date creationDate;
 
-
+  @Column( name = "state" )
+  private NeedState state;
 
   public UserNeed() {
   }
 
   @PrePersist
   protected void onCreate() {
-    creationDate = new Date();
+      creationDate = new Date();
+      state = NeedState.ACTIVE;
   }
 
   public UserNeed(URI uri) {
@@ -119,5 +114,13 @@ public class UserNeed
 
   public void setCreationDate(final Date creationDate) {
     this.creationDate = creationDate;
+  }
+
+  public NeedState getState() {
+    return state;
+  }
+
+  public void setState(NeedState state) {
+    this.state = state;
   }
 }

--- a/webofneeds/won-owner/src/main/java/won/owner/model/UserNeed.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/UserNeed.java
@@ -52,6 +52,7 @@ public class UserNeed
   @Column( name = "creationDate", nullable = false)
   private Date creationDate;
 
+  @Enumerated(EnumType.STRING)
   @Column( name = "state" )
   private NeedState state;
 

--- a/webofneeds/won-owner/src/main/java/won/owner/repository/UserNeedRepository.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/repository/UserNeedRepository.java
@@ -16,13 +16,17 @@
 
 package won.owner.repository;
 
+import org.springframework.data.jpa.repository.Query;
 import won.owner.model.UserNeed;
 import won.protocol.repository.WonRepository;
+
+import java.net.URI;
 
 /**
  * User: fkleedorfer
  * Date: 15.10.2014
  */
 public interface UserNeedRepository  extends WonRepository<UserNeed> {
-
+    @Query(value = "SELECT n from UserNeed n where n.uri = ?1")
+    public UserNeed findByNeedUri(URI needUri);
 }

--- a/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
 -- add userneed state
-ALTER TABLE userneed ADD COLUMN state VARCHAR(255) DEFAULT "ACTIVE";
+ALTER TABLE userneed ADD COLUMN state VARCHAR(255) DEFAULT 'ACTIVE';
 
 COMMIT;

--- a/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- add userneed state
+ALTER TABLE userneed ADD COLUMN state VARCHAR(255) DEFAULT "Active";
+
+COMMIT;

--- a/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
+++ b/webofneeds/won-owner/src/main/resources/db/migration/V5_0__add_userneed_state.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
 -- add userneed state
-ALTER TABLE userneed ADD COLUMN state VARCHAR(255) DEFAULT "Active";
+ALTER TABLE userneed ADD COLUMN state VARCHAR(255) DEFAULT "ACTIVE";
 
 COMMIT;


### PR DESCRIPTION
fixes #1909:

is fixed by removing the handling from the localStorage, and adding the state of a need to the userneeds, the state changes due to websocket message "sniffing", a login should retrieve two sets of lists -> a activeUri list and a inactiveUri list, theses needuris are saved in the state as isLoading or toLoad, and therefore are subject to update, and the preliminary work for skeletonScreens is done for the needs