### PR TITLE
Feat silent conversations #1790 fix #2002

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -75,7 +75,7 @@ function genComponentConf() {
                 message-uri="msg.get('uri')"
                 hide-option="msg.hide"
                 ng-class="{
-                    'won-unread' : msg.get('newMessage'),
+                    'won-unread' : msg.get('unread'),
                     'won-not-relevant': !msg.get('isRelevant') || msg.hide,
                     'won-cm--left' : !msg.get('outgoingMessage'),
                     'won-cm--right' : msg.get('outgoingMessage')

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -54,6 +54,16 @@ export function selectAllConnections(state) {
   return connections;
 }
 
+/**
+ * Get all connections stored within your own needs as a map with a status of Connected
+ * @returns Immutable.Map with all connections
+ */
+export function selectAllConnectionsInStateConnected(state) {
+  return selectAllConnections(state).filter(
+    conn => conn.get("state") === won.WON.Connected
+  );
+}
+
 export function selectAllMessages(state) {
   const connections = selectAllConnections(state);
   let messages = Immutable.Map();


### PR DESCRIPTION
fix #1790 -> to remove the "silent conversations"-issue we have after a reload the connections-overview will start crawling messages already even before clicking the connection to see the chat-view:

this was implemented as follows, a crawlableConnection is every connection in the state "Connected" which either has no messages stored at all so far, or has all messages loaded already (connectMessage is present)

each of these connections will dispatch either a showLatestMessages or a showMoreMessages action:
showLatestMessages will be called if there are no messages present so far

showMoreMessages will be called if there are already messages present and at none of the present received messages is unread

fix #2002 -> unread messages should be visible in the chat again