### PR TITLE
Added missing reducer case statement so removing match works.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -47,6 +47,7 @@ export function messagesReducer(messages = initialState, action = {}) {
     case actionTypes.connections.open:
     case actionTypes.connections.sendChatMessage:
     case actionTypes.connections.rate:
+    case actionTypes.connections.close:
     case actionTypes.messages.send:
       return messages.setIn(
         ["enqueued", action.payload.eventUri],


### PR DESCRIPTION
This should have been part of #2029. `connections__close(...)` only dispatches one actions due to that pull-request. The message reducer now needs to react to this action!
```
connections-actions.js:247   export function connectionsClose(connectionUri) {
...
connections-actions.js:275      dispatch({
connections-actions.js:276        type: actionTypes.connections.close,
connections-actions.js:277        payload: {
connections-actions.js:278          connectionUri,
connections-actions.js:279          eventUri,
connections-actions.js:280          message,
connections-actions.js:281        },
connections-actions.js:282      });
```
```
message-reducer.js:50     case actionTypes.connections.close:
```