### PR TITLE
Removed "approximately" from timestamp-label. It's too long on mobile.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -67,9 +67,9 @@ export function relativeTime(now, previous) {
   } else if (elapsed < msPerMonth) {
     return labelGen(msPerDay, "day");
   } else if (elapsed < msPerYear) {
-    return "approximately " + labelGen(msPerMonth, "month");
+    return labelGen(msPerMonth, "month");
   } else {
-    return "approximately " + labelGen(msPerYear, "year");
+    return labelGen(msPerYear, "year");
   }
 }
 


### PR DESCRIPTION
Resolves #2030.