### PR TITLE
Fix http headers

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/rest/RdfModelConverter.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/RdfModelConverter.java
@@ -22,6 +22,7 @@ import org.apache.jena.atlas.web.ContentType;
 import org.apache.jena.riot.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -29,6 +30,7 @@ import org.springframework.http.converter.AbstractHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -69,7 +71,11 @@ public class RdfModelConverter extends AbstractHttpMessageConverter<Model> {
     @Override
     protected void writeInternal(Model model, HttpOutputMessage httpOutputMessage) throws IOException, HttpMessageNotWritableException {
       Lang rdfLanguage = mimeTypeToJenaLanguage(httpOutputMessage.getHeaders().getContentType(), Lang.N3);
-      RDFDataMgr.write(httpOutputMessage.getBody(), model, rdfLanguage);
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      RDFDataMgr.write(out, model, rdfLanguage);
+      byte[] outBytes = out.toByteArray();
+      httpOutputMessage.getHeaders().add(HttpHeaders.CONTENT_LENGTH, Integer.toString(out.size()));
+      httpOutputMessage.getBody().write(outBytes);
       httpOutputMessage.getBody().flush();
     }
 

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -552,7 +552,7 @@ public class LinkedDataWebController {
 
 	/**
 	 * If the request URI is the URI of a list page (list of needs, list of
-	 * connections) it gets the header that says 'already expired' so that crawlers
+	 * connections), or a need uri, it gets the header that says 'already expired' so that crawlers
 	 * re-download these data. For other URIs, the 'never expires' header is added.
 	 *
 	 * @param headers
@@ -565,7 +565,7 @@ public class LinkedDataWebController {
 		// these data
 		URI requestUriAsURI = URI.create(requestUri);
 		String requestPath = requestUriAsURI.getPath();
-		if (uriService.isConnectionEventsURI(requestUriAsURI) || uriService.isNeedEventsURI(requestUriAsURI)) {
+		if (uriService.isConnectionEventsURI(requestUriAsURI) || uriService.isNeedEventsURI(requestUriAsURI) || uriService.isNeedURI(requestUriAsURI)) {
 			addMutableResourceHeaders(headers);
 		} else {
 			addImmutableResourceHeaders(headers);
@@ -780,7 +780,6 @@ public class LinkedDataWebController {
 			public void addHeaders(final HttpHeaders headers) {
 				addCORSHeader(headers);
 				addPublicHeaders(headers);
-				addHeadersForShortTermCaching(headers);
 			}
 		});
 	}
@@ -883,7 +882,6 @@ public class LinkedDataWebController {
 			public void addHeaders(final HttpHeaders headers) {
 				addCORSHeader(headers);
 				addPublicHeaders(headers);
-				addHeadersForShortTermCaching(headers);
 			}
 		});
 	}

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
@@ -236,11 +236,11 @@ public class BridgeForLinkedDataController implements InitializingBean {
 			final HttpServletResponse toResponse) {
 		for (String headerName : fromHeaders.keySet()) {
 			for (String headerValue : fromHeaders.get(headerName)) {
-
-				if ((headerName != "Transfer-Encoding") || (headerValue != "chunked")) {
+				
+				if ((headerName != "Transfer-Encoding") || (headerValue != "chunked") && ! toResponse.containsHeader(headerName)) {
 					// we allow all transfer codings except chunked, because we don't do chunking
 					// here!
-					toResponse.addHeader(headerName, headerValue);
+					toResponse.setHeader(headerName, headerValue);
 				}
 			}
 		}


### PR DESCRIPTION
* Reduces caching, increased ETAG validation
* No more duplicate headers in linked data bridge responses
* Adds a content-length header to RDF responses

Fixes #1891 
Fixes #1996 