### PR TITLE
Fix  refresh cncts after reconnect  #2019

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -24,6 +24,8 @@ import { stateGoCurrent } from "./cstm-router-actions.js";
 import { checkAccessToCurrentRoute } from "../configRouting.js";
 
 import { getIn } from "../utils.js";
+import { selectAllConnectionUris } from "../selectors.js";
+import { loadLatestMessagesOfConnection } from "./connections-actions.js";
 
 /**
  * @param privateId
@@ -213,7 +215,7 @@ export function accountLogin(credentials, options) {
          * TODO this action is part of the session-upgrade hack documented in:
          * https://github.com/researchstudio-sat/webofneeds/issues/381#issuecomment-172569377
          */
-        dispatch(actionCreators.reconnect())
+        dispatch(actionCreators.reconnect__start())
       )
       .then(() => {
         if ("geolocation" in navigator && navigator.permissions) {
@@ -334,7 +336,7 @@ export function accountLogout(options) {
            * TODO this action is part of the session-upgrade hack documented in:
            * https://github.com/researchstudio-sat/webofneeds/issues/381#issuecomment-172569377
            */
-          dispatch(actionCreators.reconnect());
+          dispatch(actionCreators.reconnect__start());
         })
         .then(
           () =>
@@ -401,19 +403,43 @@ export function accountAcceptDisclaimer() {
 }
 
 export function reconnect() {
-  return dispatch => {
-    return checkLoginStatus()
-      .then(() => {
-        dispatch({ type: actionTypes.reconnect });
-      })
-      .catch(e => {
-        if (e.message == "Unauthorized") {
-          dispatch({ type: actionTypes.logout });
-          dispatch({ type: actionTypes.showMainMenuDisplay });
-        } else {
-          dispatch(actionCreators.lostConnection());
-        }
-        console.warn(e);
+  return async (dispatch, getState) => {
+    dispatch({ type: actionTypes.reconnect.start });
+    try {
+      await checkLoginStatus();
+      dispatch({ type: actionTypes.reconnect.success });
+
+      /* 
+       * -- loading latest messages for all connections (we might have missed some during the dc) --
+       */
+      const state = getState();
+      const connectionUris = selectAllConnectionUris(state);
+      connectionUris.forEach(async connectionUri => {
+        console.log("in reconnect; deletme; ", connectionUri);
+        await loadLatestMessagesOfConnection({
+          connectionUri,
+          numberOfEvents: 10, //TODO magic number :|
+          state,
+          curriedDispatch: payload => {
+            console.log(
+              "in reconnect 2; deletme; ",
+              connectionUri /*, payload*/
+            );
+            dispatch({
+              type: actionTypes.reconnect.receivedConnectionData,
+              payload,
+            });
+          },
+        });
       });
+    } catch (e) {
+      if (e.message == "Unauthorized") {
+        dispatch({ type: actionTypes.logout });
+        dispatch({ type: actionTypes.showMainMenuDisplay });
+      } else {
+        dispatch(actionCreators.lostConnection());
+      }
+      console.warn(e);
+    }
   };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -238,8 +238,13 @@ const actionHierarchy = {
   registerFailed: INJ_DEFAULT,
   geoLocationDenied: INJ_DEFAULT,
   lostConnection: INJ_DEFAULT,
-  reconnect: reconnect,
-  reconnectSuccess: INJ_DEFAULT,
+
+  reconnect: {
+    start: reconnect,
+    success: INJ_DEFAULT,
+    receivedConnectionData: INJ_DEFAULT,
+  },
+
   mainViewScrolled: INJ_DEFAULT,
 
   toggleRdfDisplay: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -242,7 +242,9 @@ const actionHierarchy = {
   reconnect: {
     start: reconnect,
     success: INJ_DEFAULT,
+    startingToLoadConnectionData: INJ_DEFAULT,
     receivedConnectionData: INJ_DEFAULT,
+    connectionFailedToLoad: INJ_DEFAULT,
   },
 
   mainViewScrolled: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -362,54 +362,70 @@ export function connectionsRate(connectionUri, rating) {
  * @return {Function}
  */
 export function showLatestMessages(connectionUriParam, numberOfEvents) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const state = getState();
-    const connectionUri = connectionUriParam || selectOpenConnectionUri(state);
-    const need =
-      connectionUri && selectNeedByConnectionUri(state, connectionUri);
-    const needUri = need && need.get("uri");
-    const connection = connectionUri && selectConnection(state, connectionUri);
-    if (!connectionUri || !connection) return;
+    await loadLatestMessagesOfConnection({
+      connectionUri: connectionUriParam,
+      numberOfEvents,
+      state,
+      curriedDispatch: payload =>
+        dispatch({
+          type: actionTypes.connections.showLatestMessages,
+          payload,
+        }),
+    });
+  };
+}
 
-    const connectionMessages = connection.get("messages");
-    if (
-      connection.get("isLoadingMessages") ||
-      !connectionMessages ||
-      connectionMessages.size > 0
-    )
-      return; // only start loading once.
+export async function loadLatestMessagesOfConnection({
+  connectionUri,
+  numberOfEvents,
+  state,
+  curriedDispatch,
+}) {
+  const connectionUri_ = connectionUri || selectOpenConnectionUri(state);
+  const need =
+    connectionUri_ && selectNeedByConnectionUri(state, connectionUri_);
+  const needUri = need && need.get("uri");
+  const connection = connectionUri_ && selectConnection(state, connectionUri_);
+  if (!connectionUri_ || !connection) {
+    return;
+  }
 
-    dispatch({
-      type: actionTypes.connections.showLatestMessages,
-      payload: Immutable.fromJS({ connectionUri, isLoadingMessages: true }),
+  const connectionMessages = connection.get("messages");
+  if (
+    connection.get("isLoadingMessages") ||
+    !connectionMessages ||
+    connectionMessages.size > 0
+  ) {
+    return; // only start loading once.
+  }
+
+  curriedDispatch(
+    Immutable.fromJS({ connectionUri_, isLoadingMessages: true })
+  );
+
+  try {
+    const events = await won.getWonMessagesOfConnection(connectionUri_, {
+      requesterWebId: needUri,
+      pagingSize: numOfEvts2pageSize(numberOfEvents),
+      deep: true,
     });
 
-    won
-      .getWonMessagesOfConnection(connectionUri, {
-        requesterWebId: needUri,
-        pagingSize: numOfEvts2pageSize(numberOfEvents),
-        deep: true,
+    curriedDispatch(
+      Immutable.fromJS({
+        connectionUri: connectionUri_,
+        events: events,
       })
-      .then(events =>
-        dispatch({
-          type: actionTypes.connections.showLatestMessages,
-          payload: Immutable.fromJS({
-            connectionUri: connectionUri,
-            events: events,
-          }),
-        })
-      )
-      .catch(error => {
-        console.error("Failed loading the latest events: ", error);
-        dispatch({
-          type: actionTypes.connections.showLatestMessages,
-          payload: Immutable.fromJS({
-            connectionUri: connectionUri,
-            error: error,
-          }),
-        });
-      });
-  };
+    );
+  } catch (error) {
+    curriedDispatch(
+      Immutable.fromJS({
+        connectionUri: connectionUri_,
+        error: error,
+      })
+    );
+  }
 }
 
 //TODO replace the won.getEventsOfConnection with this version (and make sure it works for all previous uses).

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -112,7 +112,7 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
 
 function loginSuccess(username, loginStatus, dispatch, getState) {
   // reset websocket to make sure it's using the logged-in session
-  dispatch(actionCreators.reconnect());
+  dispatch(actionCreators.reconnect__start());
 
   /* quickly dispatch log-in status, even before loading data, to
      * allow making correct access-control decisions

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -16,16 +16,20 @@ import extendedConnectionIndicatorsModule from "./extended-connection-indicators
 import connectionSelectionItemModule from "./connection-selection-item.js";
 import createPostItemModule from "./create-post-item.js";
 
-import { attach, delay, sortByDate, getIn } from "../utils.js";
+import { attach, delay, sortByDate, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { actionCreators } from "../actions/actions.js";
 
 import {
-  selectAllOwnNeeds,
   selectAllNeeds,
   selectRouterParams,
   selectNeedByConnectionUri,
-  selectAllConnectionsInStateConnected,
+  selectOpenNeeds,
+  selectClosedNeeds,
+  selectNeedsInCreationProcess,
+  selectConnectionsWithoutConnectMessage,
+  selectOpenConnectionUri,
+  selectOpenPostUri,
 } from "../selectors.js";
 
 const serviceDependencies = ["$ngRedux", "$scope"];
@@ -202,61 +206,27 @@ function genComponentConf() {
       const self = this;
       const selectFromState = state => {
         const allNeeds = selectAllNeeds(state);
-        const allOwnNeeds = selectAllOwnNeeds(state); //FILTER ALL CLOSED WHATS AROUNDS
-
-        const openNeeds =
-          allOwnNeeds &&
-          allOwnNeeds.filter(
-            post => post.get("state") === won.WON.ActiveCompacted
-          );
-        const closedNeeds =
-          allOwnNeeds &&
-          allOwnNeeds.filter(
-            post =>
-              post.get("state") === won.WON.InactiveCompacted &&
-              !(post.get("isWhatsAround") || post.get("isWhatsNew"))
-          ); //Filter whatsAround and whatsNew needs automatically
+        const openNeeds = selectOpenNeeds(state);
+        const closedNeeds = selectClosedNeeds(state);
 
         // needs that have been created but are not confirmed by the server yet
-        const beingCreatedNeeds =
-          allOwnNeeds && allOwnNeeds.filter(post => post.get("isBeingCreated"));
+        const beingCreatedNeeds = selectNeedsInCreationProcess(state);
 
-        const connectionsInStateConnected =
-          openNeeds && selectAllConnectionsInStateConnected(state);
-
-        const connectionsWithoutConnectMessage =
-          connectionsInStateConnected &&
-          connectionsInStateConnected.filter(
-            conn =>
-              !conn.get("messages") ||
-              conn
-                .get("messages")
-                .filter(
-                  msg => msg.get("messageType") === won.WONMSG.connectMessage
-                ).size == 0
-          );
-
-        const connectionsToCrawl = connectionsWithoutConnectMessage
-          ? connectionsWithoutConnectMessage
-          : Immutable.Map();
+        const connectionsToCrawl = selectConnectionsWithoutConnectMessage(
+          state
+        );
 
         const routerParams = selectRouterParams(state);
-        const showCreateView = getIn(state, [
-          "router",
-          "currentParams",
-          "showCreateView",
-        ]);
-        const connUriInRoute =
-          routerParams && decodeURIComponent(routerParams["connectionUri"]);
-        const needUriInRoute =
-          routerParams && decodeURIComponent(routerParams["postUri"]);
+        const showCreateView = get(routerParams, "showCreateView");
+        const connUriInRoute = selectOpenConnectionUri(state);
+        const needUriInRoute = selectOpenPostUri(state);
         const needImpliedInRoute =
           connUriInRoute && selectNeedByConnectionUri(state, connUriInRoute);
         const needUriImpliedInRoute =
           needImpliedInRoute && needImpliedInRoute.get("uri");
 
-        let sortedOpenNeeds = sortByDate(openNeeds);
-        let sortedClosedNeeds = sortByDate(closedNeeds);
+        const sortedOpenNeeds = sortByDate(openNeeds);
+        const sortedClosedNeeds = sortByDate(closedNeeds);
 
         const unloadedNeeds = closedNeeds.filter(need => need.get("toLoad"));
 
@@ -269,7 +239,7 @@ function genComponentConf() {
           beingCreatedNeeds: beingCreatedNeeds && beingCreatedNeeds.toArray(),
           sortedOpenNeeds,
           sortedClosedNeeds,
-          connectionsToCrawl,
+          connectionsToCrawl: connectionsToCrawl || Immutable.Map(),
           unloadedNeedsSize: unloadedNeeds ? unloadedNeeds.size : 0,
           closedNeedsSize: closedNeeds ? closedNeeds.size : 0,
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -287,20 +287,20 @@ function genComponentConf() {
         }
       });
 
-      this.$scope.$watchGroup(["self.connectionsToCrawl"], () =>
-        this.ensureUnreadMessagesAreLoaded()
+      this.$scope.$watch("self.connectionsToCrawl", cnctToCrawl =>
+        this.ensureUnreadMessagesAreLoaded(cnctToCrawl)
       );
     }
 
-    ensureUnreadMessagesAreLoaded() {
+    ensureUnreadMessagesAreLoaded(connectionsToCrawl) {
       delay(0).then(() => {
         const MESSAGECOUNT = 10;
 
-        if (this.connectionsToCrawl.size == 0) {
+        if (connectionsToCrawl.size == 0) {
           console.log("ensureUnreadMessagesAreLoaded - nothing to crawl");
         }
 
-        this.connectionsToCrawl.map(conn => {
+        connectionsToCrawl.map(conn => {
           if (conn.get("isLoadingMessages")) return;
           const messages = conn.get("messages");
           const messageCount = messages ? messages.size : 0;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -28,7 +28,7 @@ function genTopnavConf() {
             </span>
             <button
                 ng-show="self.connectionHasBeenLost && !self.reconnecting"
-                ng-click="self.reconnect()"
+                ng-click="self.reconnect__start()"
                 class="si__button">
                     Reconnect
             </button>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -67,10 +67,10 @@ export function messagesReducer(messages = initialState, action = {}) {
         : messages;
     }
 
-    case actionTypes.reconnect:
+    case actionTypes.reconnect.start:
       return messages.set("reconnecting", true);
 
-    case actionTypes.reconnectSuccess:
+    case actionTypes.reconnect.success:
       return messages.set("lostConnection", false).set("reconnecting", false);
 
     case actionTypes.messages.dispatchActionOn.registerSuccessOwn: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -610,7 +610,9 @@ export default function(allNeedsInState = initialState, action = {}) {
       return allNeedsInState;
     }
 
+    case actionTypes.reconnect.startingToLoadConnectionData:
     case actionTypes.reconnect.receivedConnectionData:
+    case actionTypes.reconnect.connectionFailedToLoad:
     case actionTypes.connections.showLatestMessages:
     case actionTypes.connections.showMoreMessages: {
       const isLoadingMessages = action.payload.get("isLoadingMessages");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -610,6 +610,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       return allNeedsInState;
     }
 
+    case actionTypes.reconnect.receivedConnectionData:
     case actionTypes.connections.showLatestMessages:
     case actionTypes.connections.showMoreMessages: {
       const isLoadingMessages = action.payload.get("isLoadingMessages");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -77,6 +77,11 @@ export function selectAllConnections(state) {
   return connections;
 }
 
+export function selectAllConnectionUris(state) {
+  const connections = selectAllConnections(state);
+  return connections && connections.keySeq().toSet();
+}
+
 /**
  * Get all connections stored within your own needs as a map with a status of Connected
  * @returns Immutable.Map with all connections

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -17,6 +17,30 @@ export const selectAllOwnNeeds = state =>
 export const selectAllTheirNeeds = state =>
   selectAllNeeds(state).filter(need => !need.get("ownNeed"));
 
+export function selectOpenNeeds(state) {
+  const allOwnNeeds = selectAllOwnNeeds(state);
+  return (
+    allOwnNeeds &&
+    allOwnNeeds.filter(post => post.get("state") === won.WON.ActiveCompacted)
+  );
+}
+export function selectClosedNeeds(state) {
+  const allOwnNeeds = selectAllOwnNeeds(state);
+  return (
+    allOwnNeeds &&
+    allOwnNeeds.filter(
+      post =>
+        post.get("state") === won.WON.InactiveCompacted &&
+        !(post.get("isWhatsAround") || post.get("isWhatsNew"))
+    )
+  ); //Filter whatsAround and whatsNew needs automatically
+}
+export function selectNeedsInCreationProcess(state) {
+  const allOwnNeeds = selectAllOwnNeeds(state);
+  // needs that have been created but are not confirmed by the server yet
+  return allOwnNeeds && allOwnNeeds.filter(post => post.get("isBeingCreated"));
+}
+
 export const selectIsConnected = state =>
   !state.getIn(["messages", "reconnecting"]) &&
   !state.getIn(["messages", "lostConnection"]);
@@ -49,12 +73,7 @@ export function selectConnection(state, connectionUri) {
  */
 export function selectAllConnections(state) {
   const needs = selectAllOwnNeeds(state); //we only check own needs as these are the only ones who have connections stored
-  let connections = Immutable.Map();
-
-  needs.map(function(need) {
-    connections = connections.merge(need.get("connections"));
-  });
-
+  const connections = needs && needs.flatMap(need => need.get("connections"));
   return connections;
 }
 
@@ -63,32 +82,40 @@ export function selectAllConnections(state) {
  * @returns Immutable.Map with all connections
  */
 export function selectAllConnectionsInStateConnected(state) {
-  return selectAllConnections(state).filter(
-    conn => conn.get("state") === won.WON.Connected
+  const allConnections = selectAllConnections(state);
+  return (
+    allConnections &&
+    allConnections.filter(conn => conn.get("state") === won.WON.Connected)
   );
+}
+
+export function selectConnectionsWithoutConnectMessage(state) {
+  const connectionsInStateConnected = selectAllConnectionsInStateConnected(
+    state
+  );
+
+  const connectionsWithoutConnectMessage =
+    connectionsInStateConnected &&
+    connectionsInStateConnected.filter(
+      conn =>
+        !conn.get("messages") ||
+        conn
+          .get("messages")
+          .filter(msg => msg.get("messageType") === won.WONMSG.connectMessage)
+          .size == 0
+    );
+  return connectionsWithoutConnectMessage;
 }
 
 export function selectAllMessages(state) {
   const connections = selectAllConnections(state);
-  let messages = Immutable.Map();
-
-  connections.map(function(conn) {
-    messages = messages.merge(conn.get("messages"));
-  });
-
+  const messages = connections && connections.flatMap(c => c.get("messages"));
   return messages;
 }
 
 export function selectAllMessagesByNeedUri(state, needUri) {
   const connections = state.getIn(["needs", needUri, "connections"]);
-  let messages = Immutable.Map();
-
-  if (connections) {
-    connections.map(function(conn) {
-      messages = messages.merge(conn.get("messages"));
-    });
-  }
-
+  const messages = connections && connections.flatMap(c => c.get("messages"));
   return messages;
 }
 


### PR DESCRIPTION
test: 

1. create need
2. copy share link and connect from a different browser-session (accept with the original need)
3. go to the network tab and disable the network connection. then run `ws4dbg.close()` in your terminal (note: you might need to reload before doing that as the dev-tools disconnect doesn't usually apply to web-sockets and `ws.close()` is a bit wonky)
4. write some messages from the other need
5. make another connection request from another browser session
6. set your network to "online" again
7. press "reconnect"
8. the new messages and the incoming request should show up

open issue: the new connection isn't found

Resolves #2019