### PR TITLE
Fix CSS-Class mismatch

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker-content.js
@@ -19,8 +19,8 @@ const serviceDependencies = [
 
 function genComponentConf() {
   const template = `
-      <div class="ucpc_createx won-pending-publishing" ng-if="self.pendingPublishing">
-          <button class="won-button--filled red ucpc_createx__button"
+      <div class="ucpc__createx won-pending-publishing" ng-if="self.pendingPublishing">
+          <button class="won-button--filled red ucpc__createx__button"
                   ng-disabled="self.pendingPublishing">
               <span>Finding out what's going on&hellip;</span>
           </button>
@@ -34,7 +34,7 @@ function genComponentConf() {
               </svg>
               <span>What's in your Area?</span>
           </button>
-          <button class="won-button--filled red ucpc_createx__button"
+          <button class="won-button--filled red ucpc__createx__button"
                   ng-click="self.createWhatsNew()"
                   ng-disabled="self.pendingPublishing">
               <span>What's new?</span>


### PR DESCRIPTION
there was a mistake in the template of the usecase-picker-content that made the intended styling not apply to the whatsX buttons -> once you clicked either one of the buttons the view should only display one button (to show that the creation is pending) and this button should span over the whole width of the component, instead of just on the left half