### PR TITLE
Feat systemmessages

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -110,6 +110,8 @@ $ngRedux.getState();
                        date: date, //creation Date of this message
                        unread: true|false, //whether or not this message is new (or already seen if you will)
                        outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
+                       systemMessage: true|false, //flag to indicate if this message came from the system (e.g. hint messages) !wonMessage.isFromOwner() && !wonMessage.getSenderNeed() && wonMessage.getSenderNode(),
+                       senderUri: uri //to indicate which need or node sent the message itself, wonMessage.getSenderNeed() || wonMessage.getSenderNode(),
                        content: {
                            text: wonMessage.getTextMessage(),
                            matchScore: wonMessage.getMatchScore(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
@@ -22,8 +22,7 @@
         <won-usecase-picker ng-if="!self.useCase && self.showUseCases && !self.selectedPost && !self.connection"></won-usecase-picker>
         <won-create-post ng-if="(!!self.useCase) && self.useCase !== 'search' && !self.selectedPost && !self.connection"></won-create-post>
         <won-create-search ng-if="(!!self.useCase) && self.useCase === 'search' && !self.selectedPost && !self.connection"></won-create-search>
-        <won-send-request include-header="true" ng-if="!self.selectedPost && !self.showUseCases && self.connectionType === self.WON.Suggested"></won-send-request>
-        <won-post-messages ng-if="!self.selectedPost && !self.showUseCases && (self.connectionType === self.WON.Connected || self.connectionType === self.WON.RequestReceived || self.connectionType === self.WON.RequestSent)"></won-post-messages>
+        <won-post-messages ng-if="!self.selectedPost && !self.showUseCases && (self.connectionType === self.WON.Connected || self.connectionType === self.WON.RequestReceived || self.connectionType === self.WON.RequestSent || self.connectionType === self.WON.Suggested)"></won-post-messages>
         <won-post-info include-header="true" ng-if="self.selectedPost && !self.showUseCases"></won-post-info>
     </div>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -30,14 +30,24 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
         <won-square-image
+            class="clickable"
             title="self.theirNeed.get('title')"
             src="self.theirNeed.get('TODOtitleImgSrc')"
             uri="self.theirNeed.get('uri')"
             ng-click="self.router__stateGoCurrent({postUri: self.theirNeed.get('uri')})"
             ng-if="!self.message.get('outgoingMessage')">
         </won-square-image>
+        <won-square-image
+            title="System"
+            src=""
+            uri="self.message.get('senderUri')"
+            ng-if="self.message.get('systemMessage')">
+        </won-square-image>
         <div class="won-cm__center"
-                ng-class="{'won-cm__center--nondisplayable': (self.message.get('messageType') === self.won.WONMSG.connectionMessage) && !self.message.get('isParsable')}"
+                ng-class="{
+                  'won-cm__center--nondisplayable': (self.message.get('messageType') === self.won.WONMSG.connectionMessage) && !self.message.get('isParsable'),
+                  'won-cm__center--system': self.message.get('systemMessage')
+                }"
                 in-view="$inview && self.markAsRead()">
             <div 
                 class="won-cm__center__bubble"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -4,7 +4,6 @@ import inviewModule from "angular-inview";
 import won from "../../won-es6.js";
 import Immutable from "immutable";
 import squareImageModule from "../square-image.js";
-import labelledHrModule from "../labelled-hr.js";
 import connectionMessageStatusModule from "./connection-message-status.js";
 import messageContentModule from "./message-content.js"; // due to our need of recursivley integrating the combinedMessageContentModule within referencedMessageModule, we need to import the components here otherwise we will not be able to generate the component
 import referencedMessageContentModule from "./referenced-message-content.js";
@@ -190,11 +189,6 @@ function genComponentConf() {
         () => this.isOutgoingMessage(),
         this
       );
-      classOnComponentRoot(
-        "won-cm--system",
-        () => this.isSystemMessage(),
-        this
-      );
       classOnComponentRoot("won-is-rejected", () => this.isRejected(), this);
       classOnComponentRoot("won-is-retracted", () => this.isRetracted(), this);
       classOnComponentRoot("won-is-accepted", () => this.isAccepted(), this);
@@ -209,11 +203,6 @@ function genComponentConf() {
 
     isReceivedMessage() {
       return this.message && !this.message.get("outgoingMessage");
-    }
-
-    isSystemMessage() {
-      //TODO: IMPLEMENT THIS METHOD
-      return false;
     }
 
     isOutgoingMessage() {
@@ -398,10 +387,6 @@ function genComponentConf() {
       this.markAsRejected(true);
     }
 
-    rdfToString(jsonld) {
-      return JSON.stringify(jsonld);
-    }
-
     /**
      * determines if the sent message is not received by any of the servers yet but not failed either
      */
@@ -433,10 +418,6 @@ function genComponentConf() {
     encodeParam(param) {
       return encodeURIComponent(param);
     }
-
-    isConnectionMessage() {
-      return this.message.get("messageType") === won.WONMSG.connectionMessage;
-    }
   }
   Controller.$inject = serviceDependencies;
 
@@ -448,7 +429,6 @@ function genComponentConf() {
     scope: {
       messageUri: "=",
       connectionUri: "=",
-      // Usage: on-update="::myCallback(draft)"
     },
     template: template,
   };
@@ -457,7 +437,6 @@ function genComponentConf() {
 export default angular
   .module("won.owner.components.connectionMessage", [
     squareImageModule,
-    labelledHrModule,
     connectionMessageStatusModule,
     messageContentModule,
     referencedMessageContentModule,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
@@ -1,0 +1,71 @@
+import angular from "angular";
+
+import squareImageModule from "../square-image.js";
+import postContentModule from "../post-content.js";
+
+import { connect2Redux } from "../../won-utils.js";
+import { attach } from "../../utils.js";
+import { actionCreators } from "../../actions/actions.js";
+import { classOnComponentRoot } from "../../cstm-ng-utils.js";
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+
+function genComponentConf() {
+  let template = `
+        <div class="pcm__icon__skeleton" ng-if="self.isLoading()"></div>
+        <won-square-image
+            class="clickable"
+            title="self.post.get('title')"
+            src="self.post.get('TODOtitleImgSrc')"
+            uri="self.postUri"
+            ng-if="!self.isLoading()"
+            ng-click="self.router__stateGoCurrent({postUri: self.postUri})">
+        </won-square-image>
+        <div class="won-cm__center">
+            <div class="won-cm__center__bubble">
+                <won-post-content post-uri="self.postUri">
+            </div>
+        </div>
+    `;
+
+  class Controller {
+    constructor(/* arguments = dependency injections */) {
+      attach(this, serviceDependencies, arguments);
+      window.pcm4dbg = this;
+
+      const selectFromState = state => {
+        const post = this.postUri && state.getIn(["needs", this.postUri]);
+
+        return {
+          post,
+        };
+      };
+
+      connect2Redux(selectFromState, actionCreators, ["self.postUri"], this);
+      classOnComponentRoot("won-is-loading", () => this.isLoading(), this);
+    }
+
+    isLoading() {
+      return !this.post || this.post.get("isLoading");
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      postUri: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.postContentMessage", [
+    squareImageModule,
+    postContentModule,
+  ])
+  .directive("wonPostContentMessage", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -33,7 +33,7 @@ function genComponentConf() {
             </div>
           </div>
         </div>
-        <div class="pcg__columns__right" ng-if="self.hasFlags">
+        <div class="pcg__columns__right" ng-if="self.hasFlags && self.hasFlags.size > 0">
           <div class="pcg__columns__right__item">
             <div class="pcg__columns__right__item__label">
               Flags
@@ -45,7 +45,7 @@ function genComponentConf() {
         </div>
       </div>
       <won-post-share-link
-        ng-if="!(self.post.get('state') === self.WON.InactiveCompacted || self.post.get('isWhatsAround') || self.post.get('isWhatsNew'))"
+        ng-if="!self.preventSharing"
         post-uri="self.post.get('uri')">
       </won-post-share-link>
     `;
@@ -53,7 +53,7 @@ function genComponentConf() {
   class Controller {
     constructor() {
       attach(this, serviceDependencies, arguments);
-
+      window.pcg4dbg = this;
       this.labels = labels;
 
       const selectFromState = state => {
@@ -65,6 +65,12 @@ function genComponentConf() {
           post,
           type: post && post.get("type"),
           hasFlags,
+          preventSharing:
+            (post && post.get("state") === won.WON.InactiveCompacted) ||
+            (hasFlags &&
+              hasFlags.filter(
+                flag => flag === won.WON.NoHintForCounterpartCompacted
+              ).size > 0),
           friendlyTimestamp:
             post &&
             relativeTime(selectLastUpdateTime(state), post.get("creationDate")),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -1,0 +1,150 @@
+/**
+ * Created by ksinger on 10.05.2016.
+ */
+
+import angular from "angular";
+import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
+import labelledHrModule from "./labelled-hr.js";
+import postContentGeneral from "./post-content-general.js";
+import trigModule from "./trig.js";
+import { attach } from "../utils.js";
+import won from "../won-es6.js";
+import { labels } from "../won-label-utils.js";
+import { connect2Redux } from "../won-utils.js";
+import { selectOpenConnectionUri } from "../selectors.js";
+import { actionCreators } from "../actions/actions.js";
+import { classOnComponentRoot } from "../cstm-ng-utils.js";
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+function genComponentConf() {
+  let template = `
+        <div class="post-skeleton" ng-if="self.isLoading()">
+            <h2 class="post-skeleton__heading"></h2>
+            <p class="post-skeleton__details"></p>
+            <h2 class="post-skeleton__heading"></h2>
+            <p class="post-skeleton__details"></p>
+            <h2 class="post-skeleton__heading"></h2>
+            <p class="post-skeleton__details"></p>
+            <p class="post-skeleton__details"></p>
+            <p class="post-skeleton__details"></p>
+            <p class="post-skeleton__details"></p>
+            <p class="post-skeleton__details"></p>
+            <h2 class="post-skeleton__heading"></h2>
+            <div class="post-skeleton__details"></div>
+        </div>
+        <div class="post-content" ng-if="!self.isLoading()">
+          <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
+
+          <won-gallery ng-if="self.post.get('hasImages')">
+          </won-gallery>
+
+          <!-- SEARCH STRING -->
+          <won-title-viewer
+            ng-if="self.isPureSearch && self.searchString"
+            content="self.searchString"
+            detail="::{ label: 'Searching for' }">
+          </won-title-viewer>
+
+          <!-- DETAIL INFORMATION -->
+          <won-post-is-or-seeks-info branch="::'is'" ng-if="self.hasIsBranch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
+          <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.hasIsBranch && self.hasSeeksBranch"></won-labelled-hr>
+          <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.hasSeeksBranch && !self.isPureSearch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
+          <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
+            <h2 class="post-info__heading">
+                RDF
+            </h2>
+            <a class="rdflink clickable"
+              target="_blank"
+              href="{{self.post.get('uri')}}">
+                  <svg class="rdflink__small">
+                      <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
+                  </svg>
+                  <span class="rdflink__label">Post</span>
+            </a>
+            <a class="rdflink clickable"
+             ng-if="self.openConnectionUri"
+             target="_blank"
+             href="{{ self.openConnectionUri }}">
+                  <svg class="rdflink__small">
+                      <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
+                  </svg>
+                  <span class="rdflink__label">Connection</span>
+            </a>
+            <won-trig
+              ng-if="self.post.get('jsonld')"
+              jsonld="self.post.get('jsonld')">
+            </won-trig>
+          </div>
+        </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+
+      this.is = "is";
+      this.seeks = "seeks";
+      this.labels = labels;
+
+      window.postcontent4dbg = this;
+
+      const selectFromState = state => {
+        const openConnectionUri = selectOpenConnectionUri(state);
+        const post = state.getIn(["needs", this.postUri]);
+        const is = post ? post.get("is") : undefined;
+
+        //TODO it will be possible to have more than one seeks
+        const seeks = post ? post.get("seeks") : undefined;
+
+        const isPureSearch =
+          post &&
+          is === undefined &&
+          seeks === undefined &&
+          post.get("searchString");
+
+        const searchString = post ? post.get("searchString") : undefined; //workaround to display searchString only in seeks
+
+        return {
+          WON: won.WON,
+          hasIsBranch: !!is,
+          hasSeeksBranch: !!seeks,
+          post,
+          createdTimestamp: post && post.get("creationDate"),
+          shouldShowRdf: state.get("showRdf"),
+          fromConnection: !!openConnectionUri,
+          openConnectionUri,
+          isPureSearch: isPureSearch,
+          searchString: searchString,
+        };
+      };
+      connect2Redux(selectFromState, actionCreators, ["self.postUri"], this);
+
+      classOnComponentRoot("won-is-loading", () => this.isLoading(), this);
+    }
+
+    isLoading() {
+      return !this.post || this.post.get("isLoading");
+    }
+  }
+
+  Controller.$inject = serviceDependencies;
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    template: template,
+    scope: {
+      postUri: "=",
+    },
+  };
+}
+
+export default angular
+  .module("won.owner.components.postContent", [
+    postIsOrSeeksInfoModule,
+    labelledHrModule,
+    postContentGeneral,
+    trigModule,
+  ])
+  .directive("wonPostContent", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -3,17 +3,12 @@
  */
 
 import angular from "angular";
-import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
 import postHeaderModule from "./post-header.js";
-import labelledHrModule from "./labelled-hr.js";
 import postContextDropdownModule from "./post-context-dropdown.js";
-import postContentGeneral from "./post-content-general.js";
-import trigModule from "./trig.js";
+import postContentModule from "./post-content.js";
 import { attach } from "../utils.js";
-import won from "../won-es6.js";
-import { labels } from "../won-label-utils.js";
 import { connect2Redux } from "../won-utils.js";
-import { selectOpenPostUri, selectOpenConnectionUri } from "../selectors.js";
+import { selectOpenPostUri } from "../selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 
@@ -22,7 +17,6 @@ function genComponentConf() {
   let template = `
         <div class="post-info__header" ng-if="self.includeHeader">
             <a class="post-info__header__back clickable"
-               ng-class="{'show-in-responsive': !self.fromConnection}"
                ng-click="self.router__stateGoCurrent({postUri : null})">
                 <svg style="--local-primary:var(--won-primary-color);"
                      class="post-info__header__back__icon clickable">
@@ -36,55 +30,7 @@ function genComponentConf() {
             </won-post-header>
             <won-post-context-dropdown ng-if="self.post.get('ownNeed')"></won-post-context-dropdown>
         </div>
-        <div class="post-info__content" ng-if="self.isLoading()">
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <div class="post-info__details"></div>
-        </div>
-        <div class="post-info__content" ng-if="!self.isLoading()">
-            <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
-
-            <won-gallery ng-if="self.post.get('hasImages')">
-            </won-gallery>
-
-            <!-- SEARCH STRING -->
-            <won-title-viewer 
-              ng-if="self.isPureSearch && self.searchString" 
-              content="self.searchString" 
-              detail="::{ label: 'Searching for' }">
-            </won-title-viewer>
-
-            <!-- DETAIL INFORMATION -->
-            <won-post-is-or-seeks-info branch="::'is'" ng-if="self.hasIsBranch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
-            <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.hasIsBranch && self.hasSeeksBranch"></won-labelled-hr>
-            <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.hasSeeksBranch && !self.isPureSearch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
-            <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
-              <h2 class="post-info__heading">
-                  RDF
-              </h2>
-              <a class="rdflink clickable"
-                target="_blank"
-                href="{{self.post.get('uri')}}">
-                      <svg class="rdflink__small">
-                          <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
-                      </svg>
-                      <span class="rdflink__label">RDF on Server</span>
-              </a>
-              <won-trig
-                ng-if="self.post.get('jsonld')"
-                jsonld="self.post.get('jsonld')">
-              </won-trig>
-            </div>
-        </div>
+        <won-post-content post-uri="self.postUri"></won-post-content>
         <div class="post-info__footer" ng-if="!self.isLoading()">
             <button class="won-button--filled red post-info__footer__button"
                 ng-if="self.post.get('ownNeed') && self.post.get('isWhatsNew')"
@@ -103,41 +49,18 @@ function genComponentConf() {
     constructor() {
       attach(this, serviceDependencies, arguments);
 
-      this.is = "is";
-      this.seeks = "seeks";
-      this.labels = labels;
-
       this.pendingPublishing = false;
 
       window.pi4dbg = this;
 
       const selectFromState = state => {
         const postUri = selectOpenPostUri(state);
-        const openConnectionUri = selectOpenConnectionUri(state);
         const post = state.getIn(["needs", postUri]);
-        const is = post ? post.get("is") : undefined;
-
-        //TODO it will be possible to have more than one seeks
-        const seeks = post ? post.get("seeks") : undefined;
-
-        const isPureSearch =
-          post &&
-          is === undefined &&
-          seeks === undefined &&
-          post.get("searchString");
-
-        const searchString = post ? post.get("searchString") : undefined; //workaround to display searchString only in seeks
 
         return {
-          WON: won.WON,
-          hasIsBranch: !!is,
-          hasSeeksBranch: !!seeks,
+          postUri,
           post,
           createdTimestamp: post && post.get("creationDate"),
-          shouldShowRdf: state.get("showRdf"),
-          fromConnection: !!openConnectionUri,
-          isPureSearch: isPureSearch,
-          searchString: searchString,
         };
       };
       connect2Redux(
@@ -177,11 +100,8 @@ function genComponentConf() {
 
 export default angular
   .module("won.owner.components.postInfo", [
-    postIsOrSeeksInfoModule,
     postHeaderModule,
-    labelledHrModule,
     postContextDropdownModule,
-    postContentGeneral,
-    trigModule,
+    postContentModule,
   ])
   .directive("wonPostInfo", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -67,6 +67,11 @@ function genComponentConf() {
                 {{self.unreadMessageCount}} unread Messages
               </div>
             </div>
+            <won-post-content-message
+              class="won-cm--left"
+              ng-if="self.theirNeedUri"
+              post-uri="self.theirNeedUri">
+            </won-post-content-message>
             <div class="pm__content__loadspinner"
                 ng-if="self.connection.get('isLoadingMessages')">
                 <img src="images/spinner/on_white.gif"
@@ -78,11 +83,6 @@ function genComponentConf() {
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
-            <won-post-content-message
-              class="won-cm--left"
-              ng-if="self.theirNeedUri"
-              post-uri="self.theirNeedUri">
-            </won-post-content-message>
             <won-connection-message
                 ng-if="!self.showAgreementData"
                 ng-repeat="msg in self.sortedMessages"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -3,6 +3,7 @@ import Immutable from "immutable";
 import angular from "angular";
 import chatTextFieldSimpleModule from "./chat-textfield-simple.js";
 import connectionMessageModule from "./messages/connection-message.js";
+import postContentMessageModule from "./messages/post-content-message.js";
 import connectionHeaderModule from "./connection-header.js";
 import labelledHrModule from "./labelled-hr.js";
 import connectionContextDropdownModule from "./connection-context-dropdown.js";
@@ -56,7 +57,7 @@ function genComponentConf() {
                 ng-click="self.setShowAgreementData(false)">
               Showing Agreement Data
             </div>
-            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
+            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest || (self.isSuggested && self.connection.get('isRated'))" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
         </div>
         <div class="pm__content" ng-class="{'won-agreement-content': self.showAgreementData}">
             <div class="pm__content__unreadindicator"
@@ -73,10 +74,15 @@ function genComponentConf() {
                     class="hspinner"/>
             </div>
             <button class="pm__content__loadbutton won-button--outlined thin red"
-                ng-if="!self.showAgreementData && !self.connection.get('isLoadingMessages') && !self.allLoaded"
+                ng-if="!self.isSuggested && !self.showAgreementData && !self.connection.get('isLoadingMessages') && !self.allLoaded"
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
+            <won-post-content-message
+              class="won-cm--left"
+              ng-if="self.theirNeedUri"
+              post-uri="self.theirNeedUri">
+            </won-post-content-message>
             <won-connection-message
                 ng-if="!self.showAgreementData"
                 ng-repeat="msg in self.sortedMessages"
@@ -804,5 +810,6 @@ export default angular
     labelledHrModule,
     connectionContextDropdownModule,
     feedbackGridModule,
+    postContentMessageModule,
   ])
   .directive("wonPostMessages", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -42,7 +42,7 @@ function genComponentConf() {
                 timestamp="self.lastUpdateTimestamp"
                 hide-image="::false">
             </won-connection-header>
-            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
+            <won-connection-context-dropdown ng-if="self.isConnected || self.isSentRequest || self.isReceivedRequest || (self.isSuggested && self.connection.get('isRated'))" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
         </div>
         <div class="pm__header" ng-if="self.showAgreementData">
             <a class="pm__header__back clickable"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -5,6 +5,6 @@
 </header>
 <main class="postcontent">
     <!-- Post info view when there's no connection-state/-type selected -->
-    <won-send-request include-header="::false" ng-if="self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
+    <won-send-request ng-if="self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
     <button ng-click="self.goToOwnPost()" ng-if="self.post && self.isOwnPost " class="won-button--filled red">GO TO POST VIEW TODO: AUTOMATICALLY DO THIS</button>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -1,17 +1,12 @@
 import angular from "angular";
 import "ng-redux";
-import connectionHeaderModule from "./connection-header.js";
 import feedbackGridModule from "./feedback-grid.js";
-import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
-import postContentGeneral from "./post-content-general.js";
-import labelledHrModule from "./labelled-hr.js";
+import postContentModule from "./post-content.js";
 import chatTextFieldSimpleModule from "./chat-textfield-simple.js";
 import connectionContextDropdownModule from "./connection-context-dropdown.js";
-import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import { selectOpenPostUri, selectNeedByConnectionUri } from "../selectors.js";
 import { connect2Redux } from "../won-utils.js";
-import { labels } from "../won-label-utils.js";
 import { attach, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 
@@ -19,48 +14,7 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 
 function genComponentConf() {
   let template = `
-        <div class="post-info__content" ng-if="self.isLoading()">
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <p class="post-info__details"></p>
-            <h2 class="post-info__heading"></h2>
-            <div class="post-info__details"></div>
-        </div>
-        <div class="post-info__content" ng-if="!self.isLoading()">
-            <won-post-content-general post-uri="self.displayedPost.get('uri')"></won-post-content-general>
-
-            <won-gallery ng-show="self.displayedPost.get('hasImages')">
-            </won-gallery>
-
-            <won-post-is-or-seeks-info branch="::'is'" ng-if="self.hasIsBranch" post-uri="self.displayedPost.get('uri')"></won-post-is-or-seeks-info>
-            <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.hasIsBranch && self.hasSeeksBranch"></won-labelled-hr>
-            <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.hasSeeksBranch" post-uri="self.displayedPost.get('uri')"></won-post-is-or-seeks-info>
-            <a class="rdflink clickable"
-               ng-if="self.shouldShowRdf && self.connection"
-               target="_blank"
-               href="{{ self.connectionUri }}">
-                    <svg class="rdflink__small">
-                        <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
-                    </svg>
-                    <span class="rdflink__label">Connection</span>
-            </a>
-            <a class="rdflink clickable"
-               ng-if="self.shouldShowRdf"
-               target="_blank"
-               href="{{ self.postUriToConnectTo }}">
-                    <svg class="rdflink__small">
-                        <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
-                    </svg>
-                    <span class="rdflink__label">Post</span>
-            </a>
-        </div>
+        <won-post-content post-uri="self.postUriToConnectTo"></won-post-content>
         <div class="post-info__footer" ng-if="!self.isLoading()">
             <won-feedback-grid ng-if="self.connection && !self.connection.get('isRated')" connection-uri="self.connectionUri"></won-feedback-grid>
 
@@ -78,10 +32,6 @@ function genComponentConf() {
   class Controller {
     constructor() {
       attach(this, serviceDependencies, arguments);
-      this.message = "";
-      this.labels = labels;
-      this.WON = won.WON;
-      window.openMatch4dbg = this;
 
       const selectFromState = state => {
         const connectionUri = decodeURIComponent(
@@ -97,19 +47,12 @@ function genComponentConf() {
 
         const displayedPost = state.getIn(["needs", postUriToConnectTo]);
 
-        const is = displayedPost ? displayedPost.get("is") : undefined;
-        //TODO it will be possible to have more than one seeks
-        const seeks = displayedPost ? displayedPost.get("seeks") : undefined;
-
         return {
           connection,
           connectionUri,
           ownNeed,
-          hasIsBranch: !!is,
-          hasSeeksBranch: !!seeks,
           displayedPost,
           postUriToConnectTo,
-          shouldShowRdf: state.get("showRdf"),
         };
       };
       connect2Redux(selectFromState, actionCreators, [], this);
@@ -166,12 +109,9 @@ function genComponentConf() {
 
 export default angular
   .module("won.owner.components.sendRequest", [
-    postIsOrSeeksInfoModule,
-    connectionHeaderModule,
     feedbackGridModule,
-    labelledHrModule,
     chatTextFieldSimpleModule,
     connectionContextDropdownModule,
-    postContentGeneral,
+    postContentModule,
   ])
   .directive("wonSendRequest", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -19,21 +19,6 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 
 function genComponentConf() {
   let template = `
-        <div class="post-info__header" ng-if="self.includeHeader">
-            <a class="post-info__header__back clickable"
-               ng-click="self.router__stateGoCurrent({connectionUri : undefined, sendAdHocRequest: undefined})">
-                <svg style="--local-primary:var(--won-primary-color);"
-                     class="post-info__header__back__icon clickable">
-                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
-                </svg>
-            </a>
-            <won-connection-header
-                connection-uri="self.connection.get('uri')"
-                timestamp="self.connection.get('lastUpdateDate')"
-                hide-image="::false">
-            </won-connection-header>
-            <won-connection-context-dropdown ng-if="self.connection && self.connection.get('isRated')"></won-connection-context-dropdown>
-        </div>
         <div class="post-info__content" ng-if="self.isLoading()">
             <h2 class="post-info__heading"></h2>
             <p class="post-info__details"></p>
@@ -174,9 +159,7 @@ function genComponentConf() {
     controller: Controller,
     controllerAs: "self",
     bindToController: true, //scope-bindings -> ctrl
-    scope: {
-      includeHeader: "=", //only read once
-    },
+    scope: {},
     template: template,
   };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -52,6 +52,11 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
       isParsable: false, //will be determined by the clause (hasReferences || hasContent) function
       date: msStringToDate(wonMessage.getTimestamp()),
       outgoingMessage: wonMessage.isFromOwner(),
+      systemMessage:
+        !wonMessage.isFromOwner() &&
+        !wonMessage.getSenderNeed() &&
+        wonMessage.getSenderNode(),
+      senderUri: wonMessage.getSenderNeed() || wonMessage.getSenderNode(),
       messageType: wonMessage.getMessageType(),
       messageStatus: {
         isRetracted: false,
@@ -93,7 +98,8 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
   if (
     !parsedMessage.data.uri ||
     !parsedMessage.belongsToUri ||
-    !parsedMessage.data.date
+    !parsedMessage.data.date ||
+    !parsedMessage.data.senderUri
   ) {
     console.error(
       "Cant parse chat-message, data is an invalid message-object: ",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1469,19 +1469,7 @@ import won from "./won.js";
     const event = await won.getNode(eventUri, fetchParams);
 
     event.rawJsonLd = await won.getRawEvent(eventUri, fetchParams);
-    const wonMessage = await won.wonMessageFromJsonLd(event.rawJsonLd);
 
-    console.log(
-      "graphs in event \n",
-      event.rawJsonLd,
-      "\n",
-      wonMessage,
-      "\n",
-      Array.from(privateData.documentToGraph[eventUri]),
-      "\n\n\n"
-    );
-
-    // event.rawJsonLd = eventJsonLd;
     await addContentGraphTrig(event, fetchParams);
 
     // framing will find multiple timestamps (one from each node and owner) -> only use latest for the client
@@ -1502,20 +1490,16 @@ import won from "./won.js";
         return event;
       }
       /*
-            * there's some messages (e.g. incoming connect) where there's
-            * vital information in the correspondingRemoteMessage. So
-            * we fetch it here.
-            */
+       * there's some messages (e.g. incoming connect) where there's
+       * vital information in the correspondingRemoteMessage. So
+       * we fetch it here.
+       */
       fetchParams.doNotFetch = true;
       const correspondingEventUri = event.hasCorrespondingRemoteMessage;
       const correspondingEvent = await won.getNode(
         correspondingEventUri,
         fetchParams
       );
-      // const correspondingEventJsonLd = await won.getGraph(
-      //     correspondingEventUri, correspondingEventUri, fetchParams
-      // );
-      // correspondingEvent.rawJsonLd = correspondingEventJsonLd;
       await addContentGraphTrig(correspondingEvent, fetchParams);
       if (correspondingEvent.type) {
         //if we have at least a type attribute, we add the remote event to the

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -402,12 +402,16 @@ export const details = {
       if (!value) {
         return undefined;
       }
+      return undefined;
       // TODO: return value
     },
     parseFromRDF: function(jsonLDImm) {
-      // TODO: return value
-      console.error("IMPLEMENT ME", jsonLDImm);
+      //console.error("IMPLEMENT ME", jsonLDImm);
+      if (!jsonLDImm) {
+        return undefined;
+      }
       return undefined;
+      // TODO: return value
     },
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -15,7 +15,6 @@ won-connection-message {
   grid-template-columns: min-content minmax(min-content, max-content);
 
   won-square-image {
-    cursor: pointer; /* the image links to their post info */
     grid-area: icon;
   }
 
@@ -141,6 +140,7 @@ won-connection-message {
         //TODO: FAILURE MESSAGE STYLING
       }
     }
+    &.won-cm__center--system,
     &.won-cm__center--nondisplayable {
       // hsla(57, 100%, 95%, 1);
       // lighten bg and text color? (might just suggest pending)

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -2,10 +2,23 @@
 @import "square-image";
 @import "connection-message-status";
 @import "combined-message-content";
+@import "animate";
 
+won-post-content-message,
 won-connection-message {
   &.won-unread {
     background-color: $won-unread;
+  }
+
+  &.won-is-loading {
+    @include animateOpacityHeartBeat();
+
+    .pcm__icon__skeleton {
+      grid-area: icon;
+      @include fixed-square($postIconSize);
+      background-color: $won-skeleton-color;
+      margin: 0 0.5rem 0 0;
+    }
   }
 
   padding: 0.5rem 0;
@@ -106,7 +119,7 @@ won-connection-message {
           @include fixed-square(1rem); // visually center icon on line
         }
       }
-
+      > won-post-content,
       > won-combined-message-content {
         grid-area: content;
       }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -1,0 +1,48 @@
+@import "won-config";
+@import "sizing-utils";
+@import "animate";
+@import "responsiveness-utils";
+@import "trig";
+@import "post-is-or-seeks-info";
+@import "post-content-general";
+
+won-post-content {
+  .post-skeleton,
+  .post-content {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    overflow: auto;
+    word-wrap: break-word;
+
+    won-labelled-hr span {
+      background-color: white;
+    }
+
+    won-trig {
+      background-color: $won-light-gray;
+      border: $thinGrayBorder;
+      padding: 0.5rem;
+    }
+  }
+
+  &.won-is-loading {
+    @include animateOpacityHeartBeat();
+
+    .post-skeleton__details {
+      height: $normalFontSize;
+      width: 100%;
+      background-color: $won-skeleton-color;
+      margin-top: 0.25rem;
+    }
+    .post-skeleton__heading {
+      height: $normalFontSize;
+      width: 5rem;
+      background-color: $won-skeleton-color;
+      margin-top: 1rem;
+      font-size: $normalFontSize;
+      font-weight: 700;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -2,28 +2,10 @@
 @import "sizing-utils";
 @import "animate";
 @import "responsiveness-utils";
-@import "trig";
-@import "post-is-or-seeks-info";
-@import "post-content-general";
+@import "post-content";
 
 won-send-request,
 won-post-info {
-  &.won-is-loading {
-    @include animateOpacityHeartBeat();
-
-    .post-info__details {
-      height: $normalFontSize;
-      width: 100%;
-      background-color: $won-skeleton-color;
-      margin-top: 0.25rem;
-    }
-    .post-info__heading {
-      height: $normalFontSize;
-      width: 5rem;
-      background-color: $won-skeleton-color;
-    }
-  }
-
   display: grid;
   grid-template-areas: "header" "main" "footer";
   grid-template-rows: min-content minmax($minimalGridRows, 1fr) min-content;
@@ -39,7 +21,7 @@ won-post-info {
     grid-template-areas: "main" "footer";
     grid-template-rows: minmax($minimalGridRows, 1fr) min-content;
 
-    .post-info__content {
+    won-post-content {
       border-top: none;
     }
   }
@@ -72,38 +54,9 @@ won-post-info {
     }
   }
 
-  .post-info__content {
+  won-post-content {
     grid-area: main;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
     border-top: $thinGrayBorder;
-    overflow: auto;
-    word-wrap: break-word;
-
-    won-labelled-hr span {
-      background-color: white;
-    }
-
-    won-trig {
-      background-color: $won-light-gray;
-      border: $thinGrayBorder;
-      padding: 0.5rem;
-    }
-
-    .post-info__carret {
-      @include fixed-square(1rem);
-
-      // visually center icon on line
-      position: relative;
-      top: 0.1em;
-    }
-
-    .post-info__heading {
-      margin-top: 1rem;
-      font-size: $normalFontSize;
-      font-weight: 700;
-    }
   }
 
   .post-info__footer {


### PR DESCRIPTION
- Refactors the Hint/Suggested Connection view to just use the conversation component we use for all the other connection states
- Implemented a Special Message that represents the post-content of the counterpart post within every conversation as the first message

fixes #2137 (unread messages that never clear)
fixes #2001 (unread counters show incorrect values)
fixes #803 (show human-friendly matcher name -> we use the matcher url to generate a identicon so we kinda see the matcher that produced the hint or distinguish between matchers)

ps: this pull also implements the following:
depending on the presence of a NoHintForCounterPart flag, we prevent the ability to share this post by not rendering the share-component