### PR TITLE
Update tag extraction in utils.js

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1110,9 +1110,9 @@ export function extractHashtags(str) {
   if (!is("String", str)) {
     "utils.js: extractHashtags expects a string but got: " + str;
   }
-    const tags = (str.trim().split(/\s*,\s*|\s+/) || []).map(
-    str => (str.startsWith("#") ? str.substring(1) : str)
-  ); // remove leading `#`-character
+  const tags = (str.trim().split(/\s*,\s*|\s+/) || [])
+    .map(str => (str.startsWith("#") ? str.substring(1) : str))
+    .filter(str => str != ""); // remove leading `#`-character
 
   return Array.from(new Set(tags)); // filter out duplicates and return
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1110,7 +1110,7 @@ export function extractHashtags(str) {
   if (!is("String", str)) {
     "utils.js: extractHashtags expects a string but got: " + str;
   }
-  const tags = (str.match(/#?(\S+)/gi) || []).map(
+    const tags = (str.trim().split(/\s*,\s*|\s+/) || []).map(
     str => (str.startsWith("#") ? str.substring(1) : str)
   ); // remove leading `#`-character
 


### PR DESCRIPTION
Tags can be separated by either "," or whitespace now. Only affects the tags-detail-picker.