### PR TITLE
fixes #2156

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
@@ -83,7 +83,7 @@ function genComponentConf() {
                     <use xlink:href="#ico36_plus" href="#ico36_plus"></use>
             </svg>
             <div class="cpi__item__text">
-                Add
+                I have or want…
             </div>
         </div>
     `;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
@@ -83,7 +83,7 @@ function genComponentConf() {
                     <use xlink:href="#ico36_plus" href="#ico36_plus"></use>
             </svg>
             <div class="cpi__item__text">
-                Add interest or suggestion
+                Add
             </div>
         </div>
     `;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -24,7 +24,7 @@ function genComponentConf() {
                 ng-click="self.router__stateGoCurrent({showUseCases: undefined, useCase: undefined})">
                 <svg style="--local-primary:var(--won-primary-color);"
                     class="ucp__header__back__icon">
-                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
+                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
                 </svg>
             </a>
             <span class="ucp__header__title">What would you like to post?</span>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -27,7 +27,7 @@ function genComponentConf() {
                     <use xlink:href="#ico36_close" href="#ico36_close"></use>
                 </svg>
             </a>
-            <span class="ucp__header__title">What would you like to post?</span>
+            <span class="ucp__header__title">What do you have or want?</span>
         </div>
         <won-usecase-picker-content>
         </won-usecase-picker-content>


### PR DESCRIPTION
fixes #2156 

- changes the label to "Add"
- uses the ico36_close instead of the backarrow (for the usecase-picker)-> so that we avoid > < in the mobile view