### PR TITLE
Fixed url in img-tag used to speed up svg-loading.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -25,6 +25,8 @@
   <link rel="stylesheet" href="./skin/current/config.css" />
   <!-- link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" / -->
   <link rel="icon" type="image/png" href="skin/current/images/logo.png">
+  <!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
+  <link rel="preload" href="./generated/symbol/svg/sprite.symbol.svg" as="image">
 </head>
 
 <body>
@@ -36,9 +38,6 @@ jspm to dynamically load and compile the sources at runtime.
 this makes for easier debugging, as you get seperate
 source files in the dev-tools' source explorer.-->
   <script src="./generated/app_jspm.bundle.js"></script>
-
-  <!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
-  <img src="./generated/symbol/svg/sprite.symbol.svg" style="display:none">
 
 </body>
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/index.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/index.html
@@ -38,7 +38,7 @@ source files in the dev-tools' source explorer.-->
   <script src="./generated/app_jspm.bundle.js"></script>
 
   <!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
-  <img src="./generated/icon-sprite.svg" style="display:none">
+  <img src="./generated/symbol/svg/sprite.symbol.svg" style="display:none">
 
 </body>
 


### PR DESCRIPTION
svg-loading should look like this, and the 404'ing request should be gone (and there shouldn't be any related errors in the console):
![image](https://user-images.githubusercontent.com/1730492/42890132-5d18d462-8aac-11e8-9a84-2f3c14d9f3d7.png)
