### PR TITLE
Feat posttitle latestmessage handling #2037 #1719

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -172,7 +172,7 @@ $ngRedux.getState();
        type: "won:Supply" | "won:Demand" | "won:Offer", //type of the need
        unread: true|false, //whether or not this need has new information that has not been read yet
        uri: string, //unique identifier of this need
-
+       humanReadable: string, //a human Readable String that parses the content from is or seeks and searchString and makes a title out of it based on a certain logic
        is : {...},
        seeks: {...}
    },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -399,7 +399,7 @@ export function needsClosedBySystem(event) {
       type: actionTypes.needs.closedBySystem,
       payload: {
         needUri: event.getReceiverNeed(),
-        needTitle: need.get("title"),
+        humanReadable: need.get("humanReadable"),
         message: event.getTextMessage(),
       },
     });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -496,7 +496,7 @@ export function needMessageReceived(event) {
       type: actionTypes.messages.needMessageReceived,
       payload: {
         needUri: event.getReceiverNeed(),
-        needTitle: need.get("title"),
+        humanReadable: need.get("humanReadable"),
         message: event.getTextMessage(),
       },
     });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -47,11 +47,18 @@ function genComponentConf() {
             <won-connection-state 
               connection-uri="self.connection.get('uri')">
             </won-connection-state>
-            <span class="ch__right__subtitle__type__state" ng-if="!self.unreadMessageCount">
+            <span class="ch__right__subtitle__type__state" ng-if="!self.unreadMessageCount && !self.latestMessageHumanReadableString">
               {{ self.connection && self.getTextForConnectionState(self.connection.get('state')) }}
             </span>
-            <span class="ch__right__subtitle__type__unreadcount" ng-if="self.unreadMessageCount">
+            <span class="ch__right__subtitle__type__unreadcount" ng-if="self.unreadMessageCount > 1">
               {{ self.unreadMessageCount }} unread Messages
+            </span>
+            <span class="ch__right__subtitle__type__unreadcount" ng-if="self.unreadMessageCount == 1 && !self.latestMessageHumanReadableString">
+              {{ self.unreadMessageCount }} unread Message
+            </span>
+            <span class="ch__right__subtitle__type__message" ng-if="!(self.unreadMessageCount > 1) && self.latestMessageHumanReadableString"
+              ng-class="{'won-unread': self.latestMessageUnread}">
+              {{ self.latestMessageHumanReadableString }}
             </span>
           </span>
           <div class="ch__right__subtitle__date">
@@ -95,9 +102,12 @@ function genComponentConf() {
             return b.get("date").getTime() - a.get("date").getTime();
           });
         }
+
+        const latestMessage = sortedMessages && sortedMessages[0];
         const latestMessageHumanReadableString =
-          sortedMessages &&
-          getHumanReadableStringFromMessage(sortedMessages[0]);
+          latestMessage && getHumanReadableStringFromMessage(latestMessage);
+        const latestMessageUnread =
+          latestMessage && latestMessage.get("unread");
         const theirNeedHumanReadableString =
           theirNeed && getHumanReadableStringFromNeed(theirNeed);
 
@@ -106,6 +116,7 @@ function genComponentConf() {
           ownNeed,
           theirNeed,
           latestMessageHumanReadableString,
+          latestMessageUnread,
           theirNeedHumanReadableString,
           unreadMessageCount:
             unreadMessages && unreadMessages.size > 0

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -11,7 +11,6 @@ import { labels, relativeTime } from "../won-label-utils.js";
 import { attach } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
-import { getHumanReadableStringFromNeed } from "../reducers/need-reducer/parse-need.js";
 import {
   selectLastUpdateTime,
   selectNeedByConnectionUri,
@@ -28,17 +27,17 @@ function genComponentConf() {
             class="ch__icon__theirneed"
             ng-class="{'bigger' : self.biggerImage, 'inactive' : self.theirNeed.get('state') === self.WON.InactiveCompacted}"
             src="self.theirNeed.get('TODO')"
-            title="self.theirNeed.get('title')"
+            title="self.theirNeed.get('humanReadable')"
             uri="self.theirNeed.get('uri')"
             ng-show="!self.hideImage">
           </won-square-image>
       </div>
       <div class="ch__right" ng-if="!self.isLoading()">
         <div class="ch__right__topline">
-          <div class="ch__right__topline__title" ng-if="self.theirNeedHumanReadableString" title="{{ self.theirNeedHumanReadableString }}">
-            {{ self.theirNeedHumanReadableString }}
+          <div class="ch__right__topline__title" ng-if="self.theirNeed.get('humanReadable')" title="{{ self.theirNeed.get('humanReadable') }}">
+            {{ self.theirNeed.get('humanReadable') }}
           </div>
-          <div class="ch__right__topline__notitle" ng-if="!self.latestMessageString && !self.theirNeedHumanReadableString" title="no title">
+          <div class="ch__right__topline__notitle" ng-if="!self.theirNeed.get('humanReadable')" title="no title">
             no title
           </div>
         </div>
@@ -108,8 +107,6 @@ function genComponentConf() {
           latestMessage && getHumanReadableStringFromMessage(latestMessage);
         const latestMessageUnread =
           latestMessage && latestMessage.get("unread");
-        const theirNeedHumanReadableString =
-          theirNeed && getHumanReadableStringFromNeed(theirNeed);
 
         return {
           connection,
@@ -117,7 +114,6 @@ function genComponentConf() {
           theirNeed,
           latestMessageHumanReadableString,
           latestMessageUnread,
-          theirNeedHumanReadableString,
           unreadMessageCount:
             unreadMessages && unreadMessages.size > 0
               ? unreadMessages.size

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -30,7 +30,7 @@ function genComponentConf() {
   let template = `
         <won-square-image
             class="clickable"
-            title="self.theirNeed.get('title')"
+            title="self.theirNeed.get('humanReadable')"
             src="self.theirNeed.get('TODOtitleImgSrc')"
             uri="self.theirNeed.get('uri')"
             ng-click="self.router__stateGoCurrent({postUri: self.theirNeed.get('uri')})"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
@@ -15,7 +15,7 @@ function genComponentConf() {
         <div class="pcm__icon__skeleton" ng-if="self.isLoading()"></div>
         <won-square-image
             class="clickable"
-            title="self.post.get('title')"
+            title="self.post.get('humanReadable')"
             src="self.post.get('TODOtitleImgSrc')"
             uri="self.postUri"
             ng-if="!self.isLoading()"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -12,7 +12,6 @@ import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors.js";
 import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
-import { getHumanReadableStringFromNeed } from "../reducers/need-reducer/parse-need.js";
 
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
@@ -27,10 +26,10 @@ function genComponentConf() {
     </won-square-image>
     <div class="ph__right" ng-if="!self.need.get('isBeingCreated') && !self.isLoading()">
       <div class="ph__right__topline">
-        <div class="ph__right__topline__title" ng-if="self.needHumanReadableString">
-         {{ self.needHumanReadableString }}
+        <div class="ph__right__topline__title" ng-if="self.need.get('humanReadable')">
+         {{ self.need.get('humanReadable') }}
         </div>
-        <div class="ph__right__topline__notitle" ng-if="!self.needHumanReadableString">
+        <div class="ph__right__topline__notitle" ng-if="!self.need.get('humanReadable')">
          no title
         </div>
       </div>
@@ -46,7 +45,7 @@ function genComponentConf() {
     
     <div class="ph__right" ng-if="self.need.get('isBeingCreated')">
       <div class="ph__right__topline">
-        <div class="ph__right__topline__notitle>
+        <div class="ph__right__topline__notitle">
           Creating...
         </div>
       </div>
@@ -75,12 +74,9 @@ function genComponentConf() {
       this.WON = won.WON;
       const selectFromState = state => {
         const need = state.getIn(["needs", this.needUri]);
-        const needHumanReadableString =
-          need && getHumanReadableStringFromNeed(need);
 
         return {
           need,
-          needHumanReadableString,
           friendlyTimestamp:
             need &&
             relativeTime(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -12,6 +12,7 @@ import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors.js";
 import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
+import { getHumanReadableStringFromNeed } from "../reducers/need-reducer/parse-need.js";
 
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
@@ -26,14 +27,11 @@ function genComponentConf() {
     </won-square-image>
     <div class="ph__right" ng-if="!self.need.get('isBeingCreated') && !self.isLoading()">
       <div class="ph__right__topline">
-        <div class="ph__right__topline__title" ng-show="self.need.get('title')">
-         {{ self.need.get('state') === self.WON.InactiveCompacted ? "[Inactive] " : ""}}{{ self.need.get('title') }}
+        <div class="ph__right__topline__title" ng-if="self.needHumanReadableString">
+         {{ self.needHumanReadableString }}
         </div>
-        <div class="ph__right__topline__title" ng-show="!self.need.get('title') && self.need.get('searchString')">
-         Search: {{ self.need.get('state') === self.WON.InactiveCompacted ? "[Inactive] " : ""}}{{ self.need.get('searchString') }}
-        </div>
-        <div class="ph__right__topline__notitle" ng-show="!self.need.get('title') && !self.need.get('searchString')">
-         {{ self.need.get('state') === self.WON.InactiveCompacted ? "[Inactive] " : ""}} no title
+        <div class="ph__right__topline__notitle" ng-if="!self.needHumanReadableString">
+         no title
         </div>
       </div>
       <div class="ph__right__subtitle">
@@ -48,7 +46,7 @@ function genComponentConf() {
     
     <div class="ph__right" ng-if="self.need.get('isBeingCreated')">
       <div class="ph__right__topline">
-        <div class="ph__right__topline__title">
+        <div class="ph__right__topline__notitle>
           Creating...
         </div>
       </div>
@@ -77,9 +75,12 @@ function genComponentConf() {
       this.WON = won.WON;
       const selectFromState = state => {
         const need = state.getIn(["needs", this.needUri]);
+        const needHumanReadableString =
+          need && getHumanReadableStringFromNeed(need);
 
         return {
           need,
+          needHumanReadableString,
           friendlyTimestamp:
             need &&
             relativeTime(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -15,12 +15,12 @@ function genComponentConf() {
             <div class="vtb__inner">
                 <div class="vtb__inner__left">
                     <won-square-image
-                        title="self.post.get('title')"
+                        title="self.post.get('humanReadable')"
                         src="self.post.get('titleImgSrc')"
                         uri="self.post.get('uri')">
                     </won-square-image>
                     <hgroup>
-                        <h1 class="vtb__title">{{ self.post.get('title') }}</h1>
+                        <h1 class="vtb__title">{{ self.post.get('humanReadable') }}</h1>
                         <div class="vtb__titles__type">{{self.labels.type[self.post.get("type")]}}{{self.post.get('matchingContexts')? ' in '+ self.post.get('matchingContexts').join(', ') : '' }}</div>
                     </hgroup>
                 </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -132,3 +132,8 @@ function hasReferences(refContent) {
   }
   return false;
 }
+
+export function getHumanReadableStringFromMessage(message) {
+  const text = message && message.getIn(["content", "text"]);
+  return text;
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -194,3 +194,14 @@ function extractFlags(wonHasFlags) {
 
   return hasFlags;
 }
+
+export function getHumanReadableStringFromNeed(need) {
+  const searchString = need && need.get("searchString");
+  const title = need && need.get("title");
+  if (title) {
+    return title;
+  } else if (searchString) {
+    return "Search: " + searchString;
+  }
+  return undefined;
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -34,15 +34,6 @@ export function parseNeed(jsonldNeed, ownNeed) {
 
     const searchString = jsonldNeedImm.get("won:hasSearchString");
 
-    //TODO: We need to decide which is the main title? Or combine?
-    //TODO: search for hasHumanReadable or something similar, see #2037
-    const title = isPresent
-      ? is.get("dc:title")
-      : seeksPresent
-        ? seeks.get("dc:title")
-        : undefined;
-    parsedNeed.title = title;
-
     if (uri) {
       parsedNeed.uri = uri;
     } else {
@@ -138,6 +129,7 @@ export function parseNeed(jsonldNeed, ownNeed) {
       : undefined;
     parsedNeed.hasFlags = hasFlags;
     parsedNeed.nodeUri = nodeUri;
+    parsedNeed.humanReadable = getHumanReadableStringFromNeed(parsedNeed);
   } else {
     console.error(
       "Cant parse need, data is an invalid need-object: ",
@@ -160,7 +152,6 @@ export function parseNeed(jsonldNeed, ownNeed) {
  */
 function generateContent(contentJsonLd, type, detailsToParse) {
   let content = {
-    //title: contentJsonLd.get("dc:title"),
     type: type,
   };
 
@@ -195,11 +186,20 @@ function extractFlags(wonHasFlags) {
   return hasFlags;
 }
 
-export function getHumanReadableStringFromNeed(need) {
-  const searchString = need && need.get("searchString");
-  const title = need && need.get("title");
-  if (title) {
-    return title;
+function getHumanReadableStringFromNeed(need) {
+  const searchString = need && need.searchString;
+  const isPresent = !!need.is;
+  const seeksPresent = !!need.seeks;
+  const isTitle = isPresent && need.is.title;
+  const seeksTitle = seeksPresent && need.seeks.title;
+
+  if (isTitle && seeksTitle) {
+    return isTitle + " - " + seeksTitle;
+  }
+  if (seeksTitle) {
+    return seeksTitle;
+  } else if (isTitle) {
+    return isTitle;
   } else if (searchString) {
     return "Search: " + searchString;
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -209,7 +209,7 @@ export function addNeedInCreation(needs, needInCreation, needUri) {
     }
 
     need = need.set("type", type);
-    need = need.set("title", title);
+    need = need.set("humanReadable", title);
 
     let isWhatsAround = false;
     let isWhatsNew = false;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -101,21 +101,21 @@ export default function(allToasts = initialState, action = {}) {
       );
 
     case actionTypes.messages.needMessageReceived: {
-      const title = action.payload.needTitle;
+      const humanReadable = action.payload.humanReadable;
       const message = action.payload.message;
       return pushNewToast(
         allToasts,
-        "Notification for your posting '" + title + "': " + message,
+        "Notification for your posting '" + humanReadable + "': " + message,
         won.WON.infoToast
       );
     }
 
     case actionTypes.needs.closedBySystem: {
-      const title = action.payload.needTitle;
+      const humanReadable = action.payload.humanReadable;
       const message = action.payload.message;
       return pushNewToast(
         allToasts,
-        "Closed your posting '" + title + "'. Cause: " + message,
+        "Closed your posting '" + humanReadable + "'. Cause: " + message,
         won.WON.infoToast
       );
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -85,8 +85,13 @@ won-connection-header {
           }
         }
 
+        &__message.won-unread,
         &__unreadcount {
           color: $won-primary-color;
+        }
+
+        &__message {
+          font-style: italic;
         }
       }
 


### PR DESCRIPTION
Because we changed the Post Structure in a way that does not expect a title for a post, i changed the title in the state to humanReadable, and there is a funciton that determines the humanReadable String now, which is called upon need parsing

The current logic is as follows:
- if there is a title in seeks and in the is we use "isTitle - seeksTitle" as the humanReadable
- if there is a title in is or seeks alone we use that title
- if there is no title in is or seeks but a searchString we use "Search: searchString" as the humanReadable
- if none of the above clauses are met we set it to undefined

the method is called "getHumanReadableStringFromNeed(need)" and is located in the parse-need.js, if we want to display additional information in the humanReadable we should implement it here.

A Similar approach is used for messages, however we do not parse this humanReadableMessage during the reduce time, but call the function to calculate latestHumanReadableMessageString right in the connection-header.js.
That way we made it possible to display a humanReadableMessageString instead of the connection-type subtitle (i tried to use the message to replace the title of the connection-header itself, but that was not very clear and could possibly confuse the users as the general title would have changed to often)

The logic of the latestMessageHumanReadable is as follows:
- if there is text in the message, then we use this text
- if there is no text then we return undefined

the method is called "getHumanReadableStringFromMessage(message)" and is located in the parse-message.js, if we want to display additional information in the return value we should implement it here.

fixes #2037 
fixes #1719 