### PR TITLE
Scrolling detail picker smoothly into view instead of always scrolling to bottom

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -19,7 +19,7 @@ function genComponentConf() {
           <div class="cis__detail__items__item" ng-repeat="detail in self.detailList">
               <!-- HEADER -->
               <div class="cis__detail__items__item__header"
-                  ng-click="self.toggleOpenDetail(detail.identifier)"
+                  ng-click="self.toggleOpenDetail($event, detail.identifier)"
                   ng-class="{'picked' : self.openDetail === detail.identifier}">
                   <svg class="cis__circleicon" ng-show="!self.details.has(detail.identifier)">
                       <use xlink:href={{detail.icon}} href={{detail.icon}}></use>
@@ -32,7 +32,6 @@ function genComponentConf() {
 
               <!-- COMPONENT -->
               <div class="cis__detail__items__item__component"
-                ng-click="self.onScroll({element: '.cis__detail__items__item__component'})"
                 ng-if="self.openDetail === detail.identifier"
                 detail-element="{{detail.component}}"
                 on-update="::self.updateDetail(identifier, value)"
@@ -110,13 +109,16 @@ function genComponentConf() {
       this.draftObject.thumbnail = image;
     }
 
-    toggleOpenDetail(detail) {
+    toggleOpenDetail($event, detail) {
       // open clicked detail
       if (this.openDetail === detail) {
         this.openDetail = undefined;
       } else {
         this.openDetail = detail;
-        this.onScroll({ element: ".cis__detail__items__item__component" });
+        const target = $event.currentTarget.parentElement;
+        setTimeout(() => {
+          this.onScroll({ element: target });
+        }, 0);
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -65,7 +65,7 @@ function genComponentConf() {
                 detail-list="self.useCase.isDetails"
                 initial-draft="self.useCase.draft.is"
                 on-update="::self.updateDraft(draft, 'is')" 
-                on-scroll="::self.scrollToBottom(element)">
+                on-scroll="::self.scrollIntoView(element)">
             </won-create-isseeks>
             <won-labelled-hr label="::'Looking For'" class="cp__content__labelledhr" ng-if="self.useCase.seeksDetails"> </won-labelled-hr>
             <won-create-isseeks 
@@ -74,7 +74,7 @@ function genComponentConf() {
                 detail-list="self.useCase.seeksDetails"
                 initial-draft="self.useCase.draft.seeks"
                 on-update="::self.updateDraft(draft, 'seeks')" 
-                on-scroll="::self.scrollToBottom(element)">
+                on-scroll="::self.scrollIntoView(element)">
             </won-create-isseeks>
 
             <!-- TUNE MATCHING -->
@@ -191,23 +191,18 @@ function genComponentConf() {
       if (this.focusedElement) {
         if (this.windowHeight < window.screen.height) {
           this.windowHeight < window.screen.height;
-          this.scrollToBottom(this.focusedElement);
+          this.scrollIntoView(document.querySelector(this.focusedElement));
         } else {
           this.windowHeight = window.screen.height;
         }
       }
     }
 
-    scrollToBottom(element) {
+    scrollIntoView(element) {
       this._programmaticallyScrolling = true;
 
       if (element) {
-        let heightHeader =
-          this.$element[0].querySelector(".cp__header").offsetHeight + 10;
-        let scrollTop = this.$element[0].querySelector(element).offsetTop;
-        this.scrollContainer().scrollTop = scrollTop - heightHeader;
-
-        this.focusedElement = element;
+        element.scrollIntoView({ behavior: "smooth", block: "nearest" });
       }
     }
 


### PR DESCRIPTION
Fixes #2195 

This is a bit clunky on iOS since Safari does not implement the new `scrollIntoView` options yet.