### PR TITLE
Feat mandatory details

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -24,19 +24,24 @@ function genComponentConf() {
           <div class="cis__detail__items__item__header"
               ng-class="{
                 'cis__detail__items__item__header--won-showvalue': self.details.has(detail.identifier) && self.openDetail !== detail.identifier,
+                'cis__detail__items__item__header--won-showmandatoryindicator': detail.mandatory && !(self.details.has(detail.identifier) || self.openDetail === detail.identifier),
               }"
-              ng-click="self.toggleOpenDetail($event, detail.identifier)"
-              ng-class="{'picked' : self.openDetail === detail.identifier}">
+              ng-click="self.toggleOpenDetail($event, detail.identifier)">
               <svg class="cis__circleicon">
                   <use xlink:href={{detail.icon}} href={{detail.icon}}></use>
               </svg>
-              <span class="cis__detail__items__item__header__label">
+              <div class="cis__detail__items__item__header__label">
                 {{detail.label}}
-              </span>
-              <span class="cis__detail__items__item__header__content"
+              </div>
+              <div class="cis__detail__items__item__header__content"
                 ng-if="self.details.has(detail.identifier) && self.openDetail !== detail.identifier">
                 {{ self.generateHumanReadable(detail) }}
-              </span>
+              </div>
+              <div class="cis__mandatory" ng-if="detail.mandatory && !(self.details.has(detail.identifier) || self.openDetail === detail.identifier)" title="This is a mandatory Detail">
+                <svg class="cis__mandatory__icon">
+                    <use xlink:href="#ico16_indicator_warning" href="#ico16_indicator_warning"></use>
+                </svg>
+              </div>
           </div>
 
           <!-- COMPONENT -->

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -855,11 +855,17 @@ const realEstateUseCases = {
     isDetails: {
       title: { ...details.title },
       description: { ...details.description },
-      location: { ...details.location },
+      location: {
+        ...details.location,
+        mandatory: true,
+      },
       floorSize: { ...realEstateFloorSizeDetail },
       numberOfRooms: { ...realEstateNumberOfRoomsDetail },
       features: { ...realEstateFeaturesDetail },
-      rent: { ...realEstateRentDetail },
+      rent: {
+        ...realEstateRentDetail,
+        mandatory: true,
+      },
     },
     seeksDetails: undefined,
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-isseeks.scss
@@ -43,6 +43,13 @@ won-create-isseeks {
       &--won-expanded,
       &:hover {
         background: $won-light-gray;
+
+        .cis__detail__items__item__header__label {
+          color: $won-primary-color;
+        }
+        .cis__circleicon {
+          --local-primary: #{$won-primary-color};
+        }
       }
 
       &--won-hasvalue,
@@ -69,6 +76,10 @@ won-create-isseeks {
           grid-template-columns: min-content 1fr 2fr;
         }
 
+        &--won-showmandatoryindicator {
+          grid-template-columns: min-content 1fr min-content;
+        }
+
         &__label {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -89,12 +100,13 @@ won-create-isseeks {
           @include fixed-width(2rem);
         }
 
-        &.picked,
-        &.picked .cis__circleicon {
-          //color: $won-line-gray;
-          //--local-primary: #{$won-line-gray}; // for the svg-icons
-          color: $won-primary-color;
+        .cis__mandatory {
           --local-primary: #{$won-primary-color};
+
+          .cis__mandatory__icon {
+            @include fixed-height(1rem);
+            @include fixed-width(1rem);
+          }
         }
       }
     }


### PR DESCRIPTION
Created the possibility to set a detail to be mandatory (just set the mandatory parameter to true)

What has been done:
- styled the mandatory details in the create-isseeks view
- added the check for mandatory details in create-post
- altered the existing isValid method by adding the check for mandatoryDetails
- refactored the ols isOrSeeksPresent to isBranchContentPresent, and removed the "fixed" title check, since this is not needed anymore
 
So to recap: 
The Post is valid if ->
- all the mandatoryDetails of both is and seeks are set
- at least one Detail is set within is or seeks (this could also be the case if there are default values set within the useCase itself) e.g. a usecase with fixed/non-editable tags in is or seeks would be valid even if all the visible detailpickers are empty

How To Test:
1) Select the "Rent a place out" usecase
2) see that location and price are mandatory fields, and the submit button is disabled
3) add the mandatory values, and see that publish is possible

![mandatorydetail](https://user-images.githubusercontent.com/8503486/43306436-665e4f0e-917b-11e8-94ba-3b9c7e979502.PNG)
![mandatorydetail2](https://user-images.githubusercontent.com/8503486/43306437-667b70fc-917b-11e8-922f-7efb9dfe3989.PNG)
