### PR TITLE
Added shacl-constraint to range slider for number of rooms

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -185,18 +185,13 @@ import { Generator } from "sparqljs";
         // add to content node
         for (const key in detailRDF) {
           //if contentNode[key] and detailRDF[key] both have values we ommit adding new content (until we implement a merge function)
-          if (!contentNode[key]) {
+          if (contentNode[key]) {
+            if (!Array.isArray(contentNode[key]))
+              contentNode[key] = Array.of(contentNode[key]);
+
+            contentNode[key].concat(detailRDF[key]);
+          } else {
             contentNode[key] = detailRDF[key];
-          } else if (!detailRDF[key]) {
-            //TODO: impl merge function)
-            console.log(
-              "contentNode already contains key[",
-              key,
-              "] omitting adding new content - oldContent: ",
-              contentNode[key],
-              " newContent: ",
-              detailRDF[key]
-            );
           }
         }
       }


### PR DESCRIPTION
The constraint is not honored anywhere and is not entirely correctly embedded in the rdf (it should be referenced by a `sh:NodeShape`, but it is a valid way to display a range of values for a field that does not have a range as part of its ontology.

As a side effect of `sh:property` possibly appearing multiple times in a need, the need-builder has been updated to merge jsonld branches instead of discarding one of them.

Using jsonld as a working dataset doesn't seem ideal though. Selections on the structure need to be made manually on Immutable.js structures, and prefixed IRIs are not isomorphic to their unprefixed versions.