### PR TITLE
remove the default chrome clear button from the date/time/datetime/month pickers

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/date-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/date-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="datep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateDate()"/>
+              ng-change="::self.updateDate()"
+              ng-class="{'datep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/datetime-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/datetime-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="datetimep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateDatetime()"/>
+              ng-change="::self.updateDatetime()"
+              ng-class="{'datetimep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/month-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/month-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="monthp__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateMonth()"/>
+              ng-change="::self.updateMonth()"
+              ng-class="{'monthp__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/time-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/time-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="timep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateTime()"/>
+              ng-change="::self.updateTime()"
+              ng-class="{'timep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_datepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_datepicker.scss
@@ -28,13 +28,21 @@ won-date-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .datep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="date"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
@@ -28,13 +28,21 @@ won-datetime-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .datetimep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="datetime-local"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_monthpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_monthpicker.scss
@@ -28,13 +28,21 @@ won-month-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .monthp__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="month"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_timepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_timepicker.scss
@@ -28,13 +28,21 @@ won-time-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .timep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="time"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }


### PR DESCRIPTION
fixes #2217 

How To Test (in Chrome):
1) Create a custom Post
2) type some date/time/datetime/month in the respective details
3) you should only see the red X -reset button and not a blueish button anymore