### PR TITLE
Feat morerangepickers

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/date-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/date-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="datep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateDate()"/>
+              ng-change="::self.updateDate()"
+              ng-class="{'datep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/datetime-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/datetime-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="datetimep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateDatetime()"/>
+              ng-change="::self.updateDatetime()"
+              ng-class="{'datetimep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/month-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/month-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="monthp__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateMonth()"/>
+              ng-change="::self.updateMonth()"
+              ng-class="{'monthp__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/time-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/time-picker.js
@@ -17,7 +17,8 @@ function genComponentConf() {
               class="timep__input__inner won-txt"
               placeholder="{{self.detail.placeholder}}"
               ng-model="self.value"
-              ng-change="::self.updateTime()"/>
+              ng-change="::self.updateTime()"
+              ng-class="{'timep__input__inner--withreset' : self.showResetButton}"/>
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -15,12 +15,6 @@ import { Generator } from "sparqljs";
 (function() {
   // <need-builder-js> scope
 
-  function hasPriceSpecification() {
-    return false; //TODO price-specification not fully implemented yet
-  }
-  function hasTimeConstraint() {
-    return false; //TODO time-constraint-attachment not implemented yet
-  }
   function hasAttachmentUrls(args) {
     return (
       args.attachmentUris &&
@@ -147,29 +141,6 @@ import { Generator } from "sparqljs";
         "won:hasAttachment": hasAttachmentUrls(isOrSeeksData)
           ? isOrSeeksData.attachmentUris.map(uri => ({ "@id": uri }))
           : undefined,
-
-        //TODO: Different id for is and seeks
-        "won:hasTimeSpecification": !hasTimeConstraint(isOrSeeksData)
-          ? undefined
-          : {
-              "@id": "_:timeSpecification",
-              "@type": "won:TimeSpecification",
-              "won:hasRecurInfiniteTimes": isOrSeeksData.recurInfinite,
-              "won:hasRecursIn": isOrSeeksData.recursIn,
-              "won:hasStartTime": isOrSeeksData.startTime,
-              "won:hasEndTime": isOrSeeksData.endTime,
-            },
-
-        "won:hasPriceSpecificationhas": !hasPriceSpecification(isOrSeeksData)
-          ? undefined
-          : {
-              "@id": "_:priceSpecification",
-              "@type": "won:PriceSpecification",
-              "won:hasCurrency": isOrSeeksData.currency,
-              "won:hasLowerPriceLimit": isOrSeeksData.lowerPriceLimit,
-              "won:hasUpperPriceLimit": isOrSeeksData.upperPriceLimit,
-            },
-        //TODO images, time, currency(?)
       };
 
       const detailList = getAllDetails();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -189,7 +189,7 @@ import { Generator } from "sparqljs";
             if (!Array.isArray(contentNode[key]))
               contentNode[key] = Array.of(contentNode[key]);
 
-            contentNode[key].concat(detailRDF[key]);
+            contentNode[key] = contentNode[key].concat(detailRDF[key]);
           } else {
             contentNode[key] = detailRDF[key];
           }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -755,15 +755,15 @@ const realEstateFloorSizeRangeDetail = {
     if (!Immutable.List.isList(properties))
       properties = Immutable.List.of(properties);
 
-    const numberOfRooms = properties.find(
+    const floorSize = properties.find(
       property =>
         property.get("https://www.w3.org/ns/shacl#path") == "s:floorSize"
     );
 
-    if (numberOfRooms) {
+    if (floorSize) {
       return Immutable.fromJS({
-        min: numberOfRooms.get("https://www.w3.org/ns/shacl#minInclusive"),
-        max: numberOfRooms.get("https://www.w3.org/ns/shacl#maxInclusive"),
+        min: floorSize.get("https://www.w3.org/ns/shacl#minInclusive"),
+        max: floorSize.get("https://www.w3.org/ns/shacl#maxInclusive"),
       });
     } else {
       return undefined;
@@ -939,8 +939,8 @@ const realEstateUseCases = {
     isDetails: undefined,
     seeksDetails: {
       location: { ...details.location },
-      floorSize: { ...realEstateFloorSizeRangeDetail },
-      numberOfRooms: { ...realEstateNumberOfRoomsRangeDetail },
+      floorSizeRange: { ...realEstateFloorSizeRangeDetail },
+      numberOfRoomsRange: { ...realEstateNumberOfRoomsRangeDetail },
       features: { ...realEstateFeaturesDetail },
       rentRange: { ...realEstateRentRangeDetail },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -651,8 +651,35 @@ const realEstateFloorSizeDetail = {
 };
 
 const realEstateNumberOfRoomsDetail = {
-  ...abstractDetails.range,
+  ...abstractDetails.number,
   identifier: "numberOfRooms",
+  label: "Number of Rooms",
+  icon: "#ico36_plus_circle", // TODO: better icon
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return { "s:numberOfRooms": undefined };
+    }
+    return { "s:numberOfRooms": [{ "@value": value, "@type": "xsd:float" }] };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    const numberOfRooms = jsonLDImm && jsonLDImm.get("s:numberOfRooms");
+    if (!numberOfRooms) {
+      return undefined;
+    } else {
+      return numberOfRooms;
+    }
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return (includeLabel ? this.label + ": " + value : value) + " Rooms";
+    }
+    return undefined;
+  },
+};
+
+const realEstateNumberOfRoomsRangeDetail = {
+  ...abstractDetails.range,
+  identifier: "numberOfRoomsRange",
   label: "Number of Rooms",
   minLabel: "From",
   maxLabel: "To",
@@ -862,7 +889,7 @@ const realEstateUseCases = {
     seeksDetails: {
       location: { ...details.location },
       floorSize: { ...realEstateFloorSizeDetail },
-      numberOfRooms: { ...realEstateNumberOfRoomsDetail },
+      numberOfRooms: { ...realEstateNumberOfRoomsRangeDetail },
       features: { ...realEstateFeaturesDetail },
       rentRange: { ...realEstateRentRangeDetail },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -691,8 +691,12 @@ const realEstateNumberOfRoomsRangeDetail = {
     return {
       "https://www.w3.org/ns/shacl#property": {
         "https://www.w3.org/ns/shacl#path": "s:numberOfRooms",
-        "https://www.w3.org/ns/shacl#minInclusive": value.min,
-        "https://www.w3.org/ns/shacl#maxInclusive": value.max,
+        "https://www.w3.org/ns/shacl#minInclusive": value.min && [
+          { "@value": value.min, "@type": "xsd:float" },
+        ],
+        "https://www.w3.org/ns/shacl#maxInclusive": value.max && [
+          { "@value": value.max, "@type": "xsd:float" },
+        ],
       },
     };
   },
@@ -748,8 +752,12 @@ const realEstateFloorSizeRangeDetail = {
     return {
       "https://www.w3.org/ns/shacl#property": {
         "https://www.w3.org/ns/shacl#path": "s:floorSize",
-        "https://www.w3.org/ns/shacl#minInclusive": value.min,
-        "https://www.w3.org/ns/shacl#maxInclusive": value.max,
+        "https://www.w3.org/ns/shacl#minInclusive": value.min && [
+          { "@value": value.min, "@type": "xsd:float" },
+        ],
+        "https://www.w3.org/ns/shacl#maxInclusive": value.max && [
+          { "@value": value.max, "@type": "xsd:float" },
+        ],
       },
     };
   },
@@ -958,6 +966,9 @@ const realEstateUseCases = {
     generateQuery: (draft, resultName) => {
       const seeksBranch = draft && draft.seeks;
       const rentRange = seeksBranch && seeksBranch.rentRange;
+      const floorSizeRange = seeksBranch && seeksBranch.floorSizeRange;
+      const numberOfRoomsRange = seeksBranch && seeksBranch.numberOfRoomsRange;
+
       let filterStrings = [];
 
       if (rentRange) {
@@ -976,6 +987,36 @@ const realEstateUseCases = {
         }
       }
 
+      if (floorSizeRange) {
+        if (floorSizeRange.min) {
+          filterStrings.push(
+            "FILTER (?floorSize >= " + draft.seeks.floorSizeRange.min + " )"
+          );
+        }
+        if (floorSizeRange.max) {
+          filterStrings.push(
+            "FILTER (?floorSize <= " + draft.seeks.floorSizeRange.max + " )"
+          );
+        }
+      }
+
+      if (numberOfRoomsRange) {
+        if (numberOfRoomsRange.min) {
+          filterStrings.push(
+            "FILTER (?numberOfRooms >= " +
+              draft.seeks.numberOfRoomsRange.min +
+              " )"
+          );
+        }
+        if (numberOfRoomsRange.max) {
+          filterStrings.push(
+            "FILTER (?numberOfRooms <= " +
+              draft.seeks.numberOfRoomsRange.max +
+              " )"
+          );
+        }
+      }
+
       const prefixes = `
         prefix s:     <http://schema.org/>
         prefix won:   <http://purl.org/webofneeds/model#>
@@ -990,7 +1031,9 @@ const realEstateUseCases = {
         ` won:is ?is.
           ?is s:priceSpecification ?pricespec.
           ?pricespec s:price ?price.
-          ?pricespec s:priceCurrency ?currency. ` +
+          ?pricespec s:priceCurrency ?currency.
+          ?is s:floorSize ?floorSize.
+          ?is s:numberOfRooms ?numberOfRooms.` +
         (filterStrings && filterStrings.join(" ")) +
         " }";
 
@@ -1018,8 +1061,14 @@ const realEstateUseCases = {
         ...details.location,
         mandatory: true,
       },
-      floorSize: { ...realEstateFloorSizeDetail },
-      numberOfRooms: { ...realEstateNumberOfRoomsDetail },
+      floorSize: {
+        ...realEstateFloorSizeDetail,
+        mandatory: true,
+      },
+      numberOfRooms: {
+        ...realEstateNumberOfRoomsDetail,
+        mandatory: true,
+      },
       features: { ...realEstateFeaturesDetail },
       rent: {
         ...realEstateRentDetail,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -728,6 +728,57 @@ const realEstateNumberOfRoomsRangeDetail = {
   },
 };
 
+const realEstateFloorSizeRangeDetail = {
+  ...abstractDetails.range,
+  identifier: "floorSizeRange",
+  label: "Floor size in square meters",
+  minLabel: "From",
+  maxLabel: "To",
+  icon: "#ico36_plus_circle", // TODO: better icon
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return {};
+    }
+    return {
+      "https://www.w3.org/ns/shacl#property": {
+        "https://www.w3.org/ns/shacl#path": "s:floorSize",
+        "https://www.w3.org/ns/shacl#minInclusive": value.min,
+        "https://www.w3.org/ns/shacl#maxInclusive": value.max,
+      },
+    };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    let properties =
+      jsonLDImm && jsonLDImm.get("https://www.w3.org/ns/shacl#property");
+    if (!properties) return undefined;
+
+    if (!Immutable.List.isList(properties))
+      properties = Immutable.List.of(properties);
+
+    const numberOfRooms = properties.find(
+      property =>
+        property.get("https://www.w3.org/ns/shacl#path") == "s:floorSize"
+    );
+
+    if (numberOfRooms) {
+      return Immutable.fromJS({
+        min: numberOfRooms.get("https://www.w3.org/ns/shacl#minInclusive"),
+        max: numberOfRooms.get("https://www.w3.org/ns/shacl#maxInclusive"),
+      });
+    } else {
+      return undefined;
+    }
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return `${includeLabel ? `${this.label}: ` : ""}${value.min} - ${
+        value.max
+      } m²`;
+    }
+    return undefined;
+  },
+};
+
 const realEstateFeaturesDetail = {
   ...details.tags,
   identifier: "features",
@@ -888,7 +939,7 @@ const realEstateUseCases = {
     isDetails: undefined,
     seeksDetails: {
       location: { ...details.location },
-      floorSize: { ...realEstateFloorSizeDetail },
+      floorSize: { ...realEstateFloorSizeRangeDetail },
       numberOfRooms: { ...realEstateNumberOfRoomsRangeDetail },
       features: { ...realEstateFeaturesDetail },
       rentRange: { ...realEstateRentRangeDetail },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -708,11 +708,17 @@ const realEstateNumberOfRoomsRangeDetail = {
       property =>
         property.get("https://www.w3.org/ns/shacl#path") == "s:numberOfRooms"
     );
+    const minNumberOfRooms =
+      numberOfRooms &&
+      numberOfRooms.get("https://www.w3.org/ns/shacl#minInclusive");
+    const maxNumberOfRooms =
+      numberOfRooms &&
+      numberOfRooms.get("https://www.w3.org/ns/shacl#maxInclusive");
 
-    if (numberOfRooms) {
+    if (minNumberOfRooms || maxNumberOfRooms) {
       return Immutable.fromJS({
-        min: numberOfRooms.get("https://www.w3.org/ns/shacl#minInclusive"),
-        max: numberOfRooms.get("https://www.w3.org/ns/shacl#maxInclusive"),
+        min: minNumberOfRooms,
+        max: maxNumberOfRooms,
       });
     } else {
       return undefined;
@@ -760,10 +766,15 @@ const realEstateFloorSizeRangeDetail = {
         property.get("https://www.w3.org/ns/shacl#path") == "s:floorSize"
     );
 
-    if (floorSize) {
+    const minFloorSize =
+      floorSize && floorSize.get("https://www.w3.org/ns/shacl#minInclusive");
+    const maxFloorSize =
+      floorSize && floorSize.get("https://www.w3.org/ns/shacl#maxInclusive");
+
+    if (minFloorSize || maxFloorSize) {
       return Immutable.fromJS({
-        min: floorSize.get("https://www.w3.org/ns/shacl#minInclusive"),
-        max: floorSize.get("https://www.w3.org/ns/shacl#maxInclusive"),
+        min: minFloorSize && minFloorSize + "m²",
+        max: maxFloorSize && maxFloorSize + "m²",
       });
     } else {
       return undefined;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_datepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_datepicker.scss
@@ -28,13 +28,21 @@ won-date-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .datep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="date"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
@@ -28,13 +28,21 @@ won-datetime-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .datetimep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="datetime-local"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_monthpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_monthpicker.scss
@@ -28,13 +28,21 @@ won-month-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .monthp__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="month"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_timepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_timepicker.scss
@@ -28,13 +28,21 @@ won-time-picker {
         $thinBorderWidth,
         $formInputHeight
       );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
+      padding: $verticalPadding 0.438rem $verticalPadding 0.438rem;
+
+      &--withreset {
+        padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+          0.438rem;
+      }
     }
 
     .timep__input__inner::-ms-clear {
       width: 0;
       height: 0;
+    }
+
+    input[type="time"]::-webkit-clear-button {
+      -webkit-appearance: none;
     }
   }
 }


### PR DESCRIPTION
created another rangepicker, and fixed the inclusion of the rangepicker for the number Of Rooms within the real estate offer

however the additon of another picker that produces shackle rdf data seems to fail when there is already one present, e.g one could only add either the number of rooms range or the size range... @peacememories maybe you can see where i am making the mistake

fixes #2233 
fixes #2235 parseToRdf does not use more than one range if defined within a shaclprop... -> see commit 7b191b3 for the solution, the problem was that the array was concatinated but not saved within the original array

fixes #2182 -> the generated sparql query inlcudes the min/max numberOfRooms, min/max Price, min/max floorSize within its filters of a real estate seeks,  it does not include the amenities yet but this is negligible for now