### PR TITLE
Switched back to stock update-timer and also removed livereload plugin

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -2002,18 +2002,6 @@
       "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
-    "body": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-      "dev": true,
-      "requires": {
-        "continuable-cache": "^0.3.1",
-        "error": "^7.0.0",
-        "raw-body": "~1.1.0",
-        "safe-json-parse": "~1.0.1"
-      }
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2198,12 +2186,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true
-    },
-    "bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
       "dev": true
     },
     "cacache": {
@@ -2757,12 +2739,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
-    },
-    "continuable-cache": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
       "dev": true
     },
     "convert-source-map": {
@@ -7695,12 +7671,6 @@
         }
       }
     },
-    "livereload-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
-      "integrity": "sha1-w6si6Kr1vzUF2A0JjLrWdyZUjJo=",
-      "dev": true
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -10633,24 +10603,6 @@
       "resolved": "https://registry.npmjs.org/rangy/-/rangy-1.3.0.tgz",
       "integrity": "sha1-t8mnCuoF5djNx0qNTIJz1pcnGQQ="
     },
-    "raw-body": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-      "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-      "dev": true,
-      "requires": {
-        "bytes": "1",
-        "string_decoder": "0.10"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "rdf-canonize": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-0.2.4.tgz",
@@ -11266,12 +11218,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-    },
-    "safe-json-parse": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
-      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -12277,40 +12223,6 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "tiny-lr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-      "integrity": "sha1-n6VHQS8jj+2waO4pWvi2gsmLKqs=",
-      "dev": true,
-      "requires": {
-        "body": "^5.1.0",
-        "debug": "^3.1.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.3.0",
-        "object-assign": "^4.1.0",
-        "qs": "^6.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        }
       }
     },
     "tmp": {
@@ -13542,15 +13454,6 @@
         }
       }
     },
-    "webpack-livereload-plugin": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.1.1.tgz",
-      "integrity": "sha1-0suQ1dg5tcBCWffq8CWBzqxnoQc=",
-      "dev": true,
-      "requires": {
-        "tiny-lr": "^1.1.1"
-      }
-    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -13560,6 +13463,12 @@
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
       }
+    },
+    "webpack-watch-time-plugin": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-watch-time-plugin/-/webpack-watch-time-plugin-0.2.2.tgz",
+      "integrity": "sha1-TQjHf9qbDLkwmCznk3DwqprWOW8=",
+      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -81,6 +81,6 @@
     "unused-webpack-plugin": "^1.2.0",
     "webpack": "^4.8.1",
     "webpack-cli": "^2.0.14",
-    "webpack-livereload-plugin": "^2.1.1"
+    "webpack-watch-time-plugin": "^0.2.2"
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
+++ b/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
@@ -6,7 +6,7 @@ import * as UglifyJsPlugin from "uglifyjs-webpack-plugin";
 import * as OptimizeCSSAssetsPlugin from "optimize-css-assets-webpack-plugin";
 import * as SpriteLoaderPlugin from "svg-sprite-loader/plugin";
 import * as CopyWebpackPlugin from "copy-webpack-plugin";
-import * as LiveReloadPlugin from "webpack-livereload-plugin";
+import * as WatchTimePlugin from "webpack-watch-time-plugin";
 import * as UnusedWebpackPlugin from "unused-webpack-plugin";
 
 export default config;
@@ -16,25 +16,6 @@ function config(env, argv): Configuration {
     argv.mode || (argv.watch ? "development" : "production");
 
   const nodeEnv = process.env.WON_DEPLOY_NODE_ENV || "default";
-
-  //TODO: When `webpack-watch-time-plugin` is updated for newer versions of webpack switch to that.
-  const WatchTimePlugin = {
-    apply: compiler => {
-      const RED = "\x1B[0;31m";
-      const GREEN = "\x1B[0;32m";
-      const NC = "\x1B[0m";
-
-      compiler.hooks.watchRun.tap("TimePrinter", () => {
-        const time = new Date();
-        console.log(
-          `_____________\n`,
-          `${GREEN}${time.getHours()}:${RED}${("0" + time.getMinutes()).slice(
-            -2
-          )}:${("0" + time.getSeconds()).slice(-2)} ${GREEN}⇩${NC}`
-        );
-      });
-    },
-  };
 
   return {
     entry: "./app/app_webpack.js",
@@ -62,8 +43,16 @@ function config(env, argv): Configuration {
         "angular-ui-router-shim$": require.resolve(
           "angular-ui-router/release/stateEvents.js"
         ),
-        detailDefinitions$: path.resolve(__dirname, "config", `detail-definitions.js`),
-        useCaseDefinitions$: path.resolve(__dirname, "config", `usecase-definitions.js`),
+        detailDefinitions$: path.resolve(
+          __dirname,
+          "config",
+          `detail-definitions.js`
+        ),
+        useCaseDefinitions$: path.resolve(
+          __dirname,
+          "config",
+          `usecase-definitions.js`
+        ),
         config$: path.resolve(__dirname, "config", `${nodeEnv}.js`),
         jsonld$: require.resolve("jsonld/dist/jsonld.js"), // This is needed because `jsonld`s entrypoint is not compiled to compatible js (uses spread operators). With this resolve hook we instead use the compiled version.
       },
@@ -148,8 +137,12 @@ function config(env, argv): Configuration {
         ],
         {}
       ),
-      new LiveReloadPlugin(),
-      WatchTimePlugin,
+      new WatchTimePlugin({
+        noChanges: {
+          detect: true,
+          report: true,
+        },
+      }),
       new UnusedWebpackPlugin({
         // Source directories
         directories: [


### PR DESCRIPTION
The timer showing when the watch task triggers a rebuild can now detect wether there were actually any changes.
There seems to be a problem with our scss loader causing sources to become unavailable to the plugin (see https://github.com/sca-/webpack-watch-time-plugin/issues/5 ) but that does not seem to interfere with the functionality, just print a bunch of warnings when first starting the watch task.

The livereload plugin was removed because no one seems to have been using it and it might be the culprit behind out-of-memory issues.