### PR TITLE
Added proper feedback if location access is not given

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -238,6 +238,7 @@ const actionHierarchy = {
   registerFailed: INJ_DEFAULT,
   geoLocationDenied: INJ_DEFAULT,
   lostConnection: INJ_DEFAULT,
+  failedToGetLocation: INJ_DEFAULT,
 
   reconnect: {
     start: reconnect,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -159,7 +159,6 @@ export function createWhatsAround() {
         {
           //options
           enableHighAccuracy: true,
-          timeout: 5000,
           maximumAge: 0,
         }
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -66,6 +66,8 @@ export function createWhatsNew() {
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
     const defaultContext = getIn(state, ["config", "theme", "defaultContext"]);
 
+    dispatch({ type: actionTypes.needs.whatsNew });
+
     const whatsNew = {
       title: "What's New?",
       type: "http://purl.org/webofneeds/model#DoTogether",
@@ -104,6 +106,8 @@ export function createWhatsAround() {
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
     const defaultContext = getIn(state, ["config", "theme", "defaultContext"]);
 
+    dispatch({ type: actionTypes.needs.whatsAround });
+
     if ("geolocation" in navigator) {
       navigator.geolocation.getCurrentPosition(
         currentLocation => {
@@ -127,10 +131,11 @@ export function createWhatsAround() {
             getIn(state, ["needs"])
               .filter(
                 need =>
-                  need.get("state") === "won:Active" && need.get("isWhatsNew")
+                  need.get("state") === "won:Active" &&
+                  (need.get("isWhatsAround") || need.get("isWhatsNew"))
               )
               .map(need => {
-                dispatch(actionCreators.needs__close(need.get("uri")));
+                dispatch(actionCreators.needs__close(need.get("uri"))); //TODO action creators should not call other action creators, according to Moru
               });
             const whatsAroundObject = {
               is: whatsAround,
@@ -143,6 +148,7 @@ export function createWhatsAround() {
         },
         error => {
           //error handler
+          dispatch({ type: actionTypes.failedToGetLocation });
           console.error(
             "Could not retrieve geolocation due to error: ",
             error.code,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker-content.js
@@ -79,14 +79,13 @@ function genComponentConf() {
     constructor(/* arguments <- serviceDependencies */) {
       attach(this, serviceDependencies, arguments);
 
-      this.pendingPublishing = false;
-
       window.ucpc4dbg = this;
       this.useCaseGroups = useCaseGroups;
       this.showUseCaseGroupHeaders = this.showUseCaseGroups();
 
       const selectFromState = state => {
         return {
+          pendingPublishing: state.get("creatingWhatsX"),
           connectionHasBeenLost: !selectIsConnected(state),
         };
       };
@@ -97,14 +96,12 @@ function genComponentConf() {
 
     createWhatsAround() {
       if (!this.pendingPublishing) {
-        this.pendingPublishing = true;
         this.needs__whatsAround();
       }
     }
 
     createWhatsNew() {
       if (!this.pendingPublishing) {
-        this.pendingPublishing = true;
         this.needs__whatsNew();
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -168,6 +168,19 @@ const reducers = {
     }
   },
 
+  creatingWhatsX: (creatingWhatsX = false, action = {}) => {
+    switch (action.type) {
+      case actionTypes.needs.whatsNew:
+      case actionTypes.needs.whatsAround:
+        return true;
+      case actionTypes.failedToGetLocation:
+      case actionTypes.needs.createSuccessful:
+        return false;
+      default:
+        return creatingWhatsX;
+    }
+  },
+
   //config: createReducer(
   config: (
     config = Immutable.fromJS({ theme: { name: "current" } }),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -120,6 +120,14 @@ export default function(allToasts = initialState, action = {}) {
       );
     }
 
+    case actionTypes.failedToGetLocation: {
+      return pushNewToast(
+        allToasts,
+        "Could not get location. You may need to allow this in your browser",
+        won.WON.errorToast
+      );
+    }
+
     //SPECIFIC TOAST ACTIONS
     case actionTypes.toasts.delete:
       return allToasts.deleteIn([action.payload.get("id")]);


### PR DESCRIPTION
Fixes #2202 

Also fixed bug(?) where old WhatsAround needs would not be closed when a new one was created.

Still missing: Disabling the "What's in your Area?" button if location access is already denied. Checking this repeatedly would be costly, and keeping it disabled even if the user reenables the permission might lead to bad UX.