### PR TITLE
Fix higher load behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ webofneeds/won-docker/image/owner/tomcat-libs/
 webofneeds/won-docker/image/wonnode/conf/
 webofneeds/won-docker/image/wonnode/tomcat-libs/
 webofneeds/won-docker/image/wonnode/won.war
-
+webofneeds/won-utils/won-utils-import/sample_needs/
 
 #local config and data
 webofneeds/conf.*

--- a/webofneeds/conf/matcher-solr/matcher-solr.properties
+++ b/webofneeds/conf/matcher-solr/matcher-solr.properties
@@ -36,7 +36,7 @@ matcher.solr.query.cutAfterIthElbowInScore=1
 # score threshold specifies hints to publish to the matching service (all hints with score higher than the specified value)
 # even though the final score will be a normalized value between 0 and 1, this threshold is applied to the raw Solr
 # score which is usually higher for our setup
-matcher.solr.query.score.threshold=0.0
+matcher.solr.query.score.threshold=1.0
 
 # factor which is used to normalize the Solr score
 matcher.solr.query.score.normalizationFactor=0.001

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/MatcherPubSubActor.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/actor/MatcherPubSubActor.java
@@ -120,7 +120,7 @@ public class MatcherPubSubActor extends UntypedActor
           loadNeedEvent = new LoadNeedEvent(1);
         } else {
           // request need events with date > last need event date
-          log.info("request missed needs from mataching service with crawl date > {}", lastSeenNeedDate);
+          log.info("request missed needs from matching service with crawl date > {}", lastSeenNeedDate);
           loadNeedEvent = new LoadNeedEvent(lastSeenNeedDate, Long.MAX_VALUE);
         }
 

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/index/NeedIndexer.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/index/NeedIndexer.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
 import won.matcher.service.common.service.http.HttpService;
 import won.matcher.solr.config.SolrMatcherConfig;
 import won.protocol.model.Coordinate;
@@ -117,6 +119,10 @@ public class NeedIndexer {
             indexUri += "?commit=" + config.isCommitIndexedNeedImmediately();
         }
         log.debug("Post need to solr index. \n Solr URI: {} \n Need (JSON): {}", indexUri, needJson);
-        httpService.postJsonRequest(indexUri, needJson);
+        try {
+          httpService.postJsonRequest(indexUri, needJson);
+        } catch (HttpClientErrorException e) {
+          log.info("Error indexing need with solr. \n Solr URI: {} \n Need (JSON): {}", indexUri, needJson);
+        }
     }
 }

--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/MatcherPubSubActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/MatcherPubSubActor.java
@@ -1,6 +1,7 @@
 package won.matcher.sparql.actor;
 
 import akka.actor.ActorRef;
+import akka.actor.Cancellable;
 import akka.actor.OneForOneStrategy;
 import akka.actor.SupervisorStrategy;
 import akka.actor.UntypedActor;
@@ -12,6 +13,8 @@ import akka.japi.Function;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import scala.Option;
 import scala.concurrent.duration.Duration;
 import won.matcher.service.common.event.*;
 import won.matcher.service.common.spring.SpringExtension;
@@ -21,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -48,6 +52,7 @@ public class MatcherPubSubActor extends UntypedActor
   private static final String LAST_SEEN_NEED_DATE_PROPERTY_NAME = "lastSeenNeedDate";
   private boolean needsUpdateRequestReceived = false;
   private Properties appStateProps = new Properties();
+  private Optional<Cancellable> scheduledTick = Optional.empty(); 
 
   @Override
   public void preStart() throws IOException {
@@ -61,9 +66,9 @@ public class MatcherPubSubActor extends UntypedActor
         getContext().system()).fromConfigProps(SparqlMatcherActor.class), "SparqlMatcherPool");
 
     // Create a scheduler to request missing need events from matching service while this matcher was not available
-    getContext().system().scheduler().schedule(
+    scheduledTick = Optional.of(getContext().system().scheduler().schedule(
       Duration.create(30, TimeUnit.SECONDS), Duration.create(60, TimeUnit.SECONDS), getSelf(), TICK,
-      getContext().dispatcher(), null);
+      getContext().dispatcher(), null))
 
     // read properties file that has the lastSeenNeedDate
     FileInputStream in = null;
@@ -89,6 +94,23 @@ public class MatcherPubSubActor extends UntypedActor
     }
   }
 
+  @Override
+  public void preRestart(Throwable reason, Option<Object> message) throws Exception {
+    cancelScheduledTick();
+  }
+
+  @Override
+  public void postStop() throws Exception {
+    cancelScheduledTick();
+  }
+
+  private void cancelScheduledTick() {
+    if (scheduledTick.isPresent()) {
+      scheduledTick.get().cancel(); 
+    }
+  }
+  
+  
   public void saveLastSeenNeedDate() throws IOException {
 
     FileOutputStream out = null;
@@ -120,7 +142,7 @@ public class MatcherPubSubActor extends UntypedActor
           loadNeedEvent = new LoadNeedEvent(1);
         } else {
           // request need events with date > last need event date
-          log.info("request missed needs from mataching service with crawl date > {}", lastSeenNeedDate);
+          log.info("request missed needs from matching service with crawl date > {}", lastSeenNeedDate);
           loadNeedEvent = new LoadNeedEvent(lastSeenNeedDate, Long.MAX_VALUE);
         }
 

--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/MatcherPubSubActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/MatcherPubSubActor.java
@@ -68,7 +68,7 @@ public class MatcherPubSubActor extends UntypedActor
     // Create a scheduler to request missing need events from matching service while this matcher was not available
     scheduledTick = Optional.of(getContext().system().scheduler().schedule(
       Duration.create(30, TimeUnit.SECONDS), Duration.create(60, TimeUnit.SECONDS), getSelf(), TICK,
-      getContext().dispatcher(), null))
+      getContext().dispatcher(), null));
 
     // read properties file that has the lastSeenNeedDate
     FileInputStream in = null;

--- a/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
@@ -73,7 +73,11 @@ public class WonMessageRoutes extends RouteBuilder
         //sends the failure response, using the current transaction
         from("direct:sendFailureResponse")
                 .routeId("direct:sendFailureResponse")
-                .onException(Exception.class).handled(true).end()
+                .onException(Exception.class)
+                  .log("failure during direct:sendFailureResponse, rolling back transaction for exchange ${exchangeId}")
+                  .rollback()
+                  .handled(true)
+                  .end()
                 .transacted("PROPAGATION_REQUIRES_NEW")
                 .to("bean:parentLocker")
                 .to("bean:failResponder");

--- a/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
@@ -73,6 +73,7 @@ public class WonMessageRoutes extends RouteBuilder
         //sends the failure response, using the current transaction
         from("direct:sendFailureResponse")
                 .routeId("direct:sendFailureResponse")
+                .onException(Exception.class).handled(true).end()
                 .transacted("PROPAGATION_REQUIRES_NEW")
                 .to("bean:parentLocker")
                 .to("bean:failResponder");

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -812,12 +812,12 @@ const realEstateUseCases = {
     draft: {
       ...emptyDraft,
       seeks: {
-        type: "won:Rent",
-        tags: ["for-rent"],
+        type: "won:RealEstateRentOffer",
+        tags: ["RentOutRealEstate"],
       },
       is: {
-        type: "won:SearchRent",
-        tags: ["to-rent"],
+        type: "won:RealEstateRentDemand",
+        tags: ["SearchRealEstateToRent"],
       },
     },
     isDetails: undefined,
@@ -930,11 +930,13 @@ const realEstateUseCases = {
     draft: {
       ...emptyDraft,
       is: {
+        type: "won:RealEstateRentOffer",
         title: "For Rent",
-        tags: ["for-rent"],
+        tags: ["RentOutRealEstate"],
       },
       seeks: {
-        tags: ["to-rent"],
+        type: "won:RealEstateRentDemand",
+        tags: ["SearchRealEstateToRent"],
       },
     },
     isDetails: {


### PR DESCRIPTION
Fixes a number of problems revealed when testing with a larger number of needs generated by the RealEstateNeedGenerator
* scheduling of too many triggers in matcher
* failures when trying to send FailResponses
* enforces match count restriction
