### PR TITLE
Usecase search #2315

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -276,6 +276,7 @@ function genComponentConf() {
     }
 
     getUngroupedUseCases(allUseCases) {
+      let ungroupedUseCases = JSON.parse(JSON.stringify(allUseCases));
       for (const identifier in this.useCaseGroups) {
         const group = this.useCaseGroups[identifier];
         // show use cases from groups that can't be displayed
@@ -289,10 +290,10 @@ function genComponentConf() {
         }
         // don't show usecases in groups as single use cases
         for (const useCase in group.useCases) {
-          delete allUseCases[useCase];
+          delete ungroupedUseCases[useCase];
         }
       }
-      return allUseCases;
+      return ungroupedUseCases;
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -203,7 +203,7 @@ function genComponentConf() {
     // search start
 
     // TODO: deal with use cases that are in more than one group - they might show up repeatedly
-    // TODO: group search results by use case groups - maybe by iterating over groups and only showing groups with results
+    // TODO: group search results by use case groups - only showing groups with results
     updateSearch() {
       const query = this.textfield().value;
       let results = [];
@@ -211,11 +211,13 @@ function genComponentConf() {
       if (query && query.trim().length > 1) {
         this.isSearching = true;
 
-        for (const key in this.useCases) {
-          const useCase = this.useCases[key];
+        for (const key in this.useCaseGroups) {
+          const group = Object.values(this.useCaseGroups[key].useCases);
 
-          if (this.searchFunction(useCase, query)) {
-            results.push(useCase);
+          for (const useCase of group) {
+            if (this.searchFunction(useCase, query)) {
+              results.push(useCase);
+            }
           }
         }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -68,11 +68,36 @@ function genComponentConf() {
         <div class="ucp__main">
 
         <!-- TODO: SEARCH FIELD -->
-        <!-- TODO: SEARCH RESULTS -->
+        <input
+            type="text"
+            class="ucp__main__search"
+            ng-model="searchInput"
+            ng-init="searchInput =''"
+            placeholder="Search for use cases"
+            won-input="::self.updateSearch()" />
+
+        <!-- SEARCH RESULTS -->
+        <!-- easier: show all the usecases found, regardless of group -->
+        <!-- nicer: show group titles -->
+        <!-- potential problem: use cases that are in more than one group -->
+        <div class="ucp__main__searchresult clickable"
+            ng-repeat="useCase in self.searchArray | filter:searchInput"
+            ng-if="searchInput.length > 1">
+            <svg class="ucp__main__searchresult__icon"
+                ng-if="!!useCase.icon">
+                <use xlink:href="{{ useCase.icon }}" href="{{ useCase.icon }}"></use>
+              </svg>
+              <div class="ucp__main__searchresult__label"
+                ng-if="!!useCase.label">
+                  {{ useCase.label }}
+              </div>
+        </div>
+
+
         <!-- USE CASE GROUPS - TODO: only show while not searching --> 
         <div class="ucp__main__usecase-group clickable"
           ng-repeat="useCaseGroup in self.useCaseGroups"
-          ng-if="self.displayableUseCaseGroup(useCaseGroup) && self.countDisplayableUseCasesInGroup(useCaseGroup) > self.showGroupsThreshold"
+          ng-if="searchInput.length === 0 && self.displayableUseCaseGroup(useCaseGroup) && self.countDisplayableUseCasesInGroup(useCaseGroup) > self.showGroupsThreshold"
           ng-click="self.viewUseCaseGroup(useCaseGroup)">
               <svg class="ucp__main__usecase-group__icon"
                 ng-if="!!useCaseGroup.icon">
@@ -86,7 +111,7 @@ function genComponentConf() {
         <!-- USE CASES WITHOUT GROUPS - TODO: only show while not searching --> 
         <div class="ucp__main__usecase-group clickable"
           ng-repeat="useCase in self.ungroupedUseCases"
-          ng-if="self.displayableUseCase(useCase)"
+          ng-if="searchInput.length === 0 && self.displayableUseCase(useCase)"
           ng-click="self.startFrom(useCase)">
               <svg class="ucp__main__usecase-group__icon"
                 ng-if="!!useCase.icon">
@@ -109,6 +134,8 @@ function genComponentConf() {
       this.useCaseGroups = useCaseGroups;
       this.showGroupsThreshold = 1; // only show groups at least 1 use case(s)
       // this.showGroups = this.countDisplayableUseCaseGroups() > 0;
+      this.searchArray = Object.keys(useCases).map(i => useCases[i]);
+      this.ungroupedUseCases = this.getUngroupedUseCases(useCases);
 
       const selectFromState = state => {
         const useCaseGroup = getIn(state, [
@@ -123,8 +150,6 @@ function genComponentConf() {
           connectionHasBeenLost: !selectIsConnected(state),
         };
       };
-
-      this.ungroupedUseCases = this.getUngroupedUseCases(useCases);
 
       // Using actionCreators like this means that every action defined there is available in the template.
       connect2Redux(selectFromState, actionCreators, [], this);
@@ -177,6 +202,16 @@ function genComponentConf() {
     }
 
     // redirects end
+
+    // search start
+
+    updateSearch() {} // TODO: do something here
+
+    searchFunction() {}
+
+    // search end
+
+    // helper functions for displaying use case groups and use cases
 
     /**
      * return the amount of displayable useCases in a useCaseGroup

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -1394,6 +1394,7 @@ const musicianUseCases = {
   },
 };
 
+// TODO: get these from useCaseGroups so this list stays up to date
 export const useCases = {
   ...complainUseCases,
   ...socialUseCases,
@@ -1401,8 +1402,8 @@ export const useCases = {
   ...realEstateUseCases,
   ...transportUseCases,
   ...mobilityUseCases,
-  ...allDetailsUseCase,
   ...musicianUseCases,
+  ...allDetailsUseCase,
 };
 
 export const useCaseGroups = {
@@ -1414,13 +1415,13 @@ export const useCaseGroups = {
   },
   transport: {
     identifier: "transportgroup",
-    label: "Transport",
+    label: "Transport and Delivery",
     icon: undefined,
     useCases: { ...transportUseCases },
   },
   mobility: {
     identifier: "mobilitygroup",
-    label: "Mobility",
+    label: "Personal Mobility",
     icon: undefined,
     useCases: { ...mobilityUseCases },
   },
@@ -1432,25 +1433,25 @@ export const useCaseGroups = {
   },
   musician: {
     identifier: "musiciangroup",
-    label: "Musician",
+    label: "Artists and Bands",
     icon: undefined,
     useCases: { ...musicianUseCases },
   },
   social: {
     identifier: "socialgroup",
-    label: "Fun activities to do together",
+    label: "Social Activities",
     icon: undefined,
     useCases: { ...socialUseCases },
   },
   professional: {
     identifier: "professionalgroup",
-    label: "Professional networking",
+    label: "Professional Networking",
     icon: undefined,
     useCases: { ...professionalUseCases },
   },
   other: {
     identifier: "othergroup",
-    label: "Something else",
+    label: "Something Else",
     icon: undefined,
     useCases: { ...allDetailsUseCase },
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -1394,18 +1394,6 @@ const musicianUseCases = {
   },
 };
 
-// TODO: get these from useCaseGroups so this list stays up to date
-export const useCases = {
-  ...complainUseCases,
-  ...socialUseCases,
-  ...professionalUseCases,
-  ...realEstateUseCases,
-  ...transportUseCases,
-  ...mobilityUseCases,
-  ...musicianUseCases,
-  ...allDetailsUseCase,
-};
-
 export const useCaseGroups = {
   complain: {
     identifier: "complaingroup",
@@ -1456,3 +1444,25 @@ export const useCaseGroups = {
     useCases: { ...allDetailsUseCase },
   },
 };
+
+// generate a list of usecases from all use case groups
+// TODO: find a good way to handle potential ungrouped use cases
+let tempUseCases = {};
+for (let key in useCaseGroups) {
+  const useCases = useCaseGroups[key].useCases;
+  for (let identifier in useCases) {
+    tempUseCases[identifier] = useCases[identifier];
+  }
+}
+
+export const useCases = tempUseCases;
+// export const useCases = {
+//   ...complainUseCases,
+//   ...socialUseCases,
+//   ...professionalUseCases,
+//   ...realEstateUseCases,
+//   ...transportUseCases,
+//   ...mobilityUseCases,
+//   ...musicianUseCases,
+//   ...allDetailsUseCase,
+// };

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -102,6 +102,7 @@ won-usecase-picker {
       grid-column: 1/-1;
     }
 
+    &__searchresult,
     &__usecase-group {
       display: flex;
       align-items: center;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -101,6 +101,7 @@ won-usecase-picker {
     &__search {
       grid-column: 1/-1;
     }
+    // TODO: search styling
 
     &__searchresult,
     &__usecase-group {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -1,6 +1,7 @@
 @import "won-config";
 @import "animate";
 @import "sizing-utils";
+@import "textfield";
 
 won-usecase-picker {
   display: grid;
@@ -101,7 +102,12 @@ won-usecase-picker {
     &__search {
       grid-column: 1/-1;
     }
-    // TODO: search styling
+
+    &__search {
+      @extend .won-txt;
+      min-height: $formInputHeight;
+      max-height: $formInputHeight;
+    }
 
     &__searchresult,
     &__usecase-group {


### PR DESCRIPTION
Adds a search function for use cases and changed view behaviour to directly show use cases from groups with only one use case.

Words separated by spaces are treated as separate search requests, i.e. searching for "taxi" and "rent" should show all use cases that match for either "taxi" or "rent". Fixes #2315 