### PR TITLE
OSM tile caching

### DIFF
--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -1,6 +1,5 @@
-version: '2'
+version: "2"
 services:
-
   # create self-signed server certificate for owner and wonnode 1
   gencert1:
     build: ../../image/gencert
@@ -91,13 +90,13 @@ services:
 
   # create self-signed server certificate for for owner and wonnode 2
   gencert2:
-      build: ../../image/gencert
-      image: webofneeds/gencert:int
-      environment:
-        - "CN=satvm05.researchstudio.at"
-        - "PASS=pass:$won_certificate_passwd"
-      volumes:
-        - $base_folder/won-server-certs2:/usr/local/certs/out/
+    build: ../../image/gencert
+    image: webofneeds/gencert:int
+    environment:
+      - "CN=satvm05.researchstudio.at"
+      - "PASS=pass:$won_certificate_passwd"
+    volumes:
+      - $base_folder/won-server-certs2:/usr/local/certs/out/
 
   # nginx proxy server for owner and wonnode 2
   nginx:
@@ -109,7 +108,7 @@ services:
     volumes:
       - $base_folder/nginx-int.conf:/etc/nginx/nginx.conf
       - $base_folder/won-server-certs2:/etc/nginx/won-server-certs/
-      - osm_cache:/data/osmcache/
+      - /data/osmcache/
     depends_on:
       - gencert2
 
@@ -159,7 +158,7 @@ services:
       - postgres2
       - gencert2
 
-   # owner 2 (proxied by nginx) => https://satvm05.researchstudio.at/owner
+    # owner 2 (proxied by nginx) => https://satvm05.researchstudio.at/owner
   owner2:
     build: ../../image/owner
     image: webofneeds/owner:int
@@ -217,7 +216,7 @@ services:
     environment:
       - "node.default.host=satvm05.researchstudio.at"
       - "node.default.http.port=8888"
-      - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot"  # set this for the trust store alias
+      - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
       - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
       - "botContext.impl=mongoBotContext"
       - "botContext.mongodb.user=won"
@@ -237,7 +236,7 @@ services:
       - "MAIN_BOT=won.bot.app.Mail2WonBotApp"
       - "node.default.host=satvm05.researchstudio.at"
       - "node.default.http.port=8888"
-      - "uri.prefix.owner=https://satvm05.researchstudio.at/mail_bot"  # set this for the trust store alias
+      - "uri.prefix.owner=https://satvm05.researchstudio.at/mail_bot" # set this for the trust store alias
       - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
       - "botContext.impl=mongoBotContext"
       - "botContext.mongodb.user=won"
@@ -375,5 +374,3 @@ services:
       - $base_folder/agent:/opt/agent/
     depends_on:
       - matcher_service
-
-volumes: osm_cache:

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     volumes:
       - $base_folder/nginx-int.conf:/etc/nginx/nginx.conf
       - $base_folder/won-server-certs2:/etc/nginx/won-server-certs/
+      - osm_cache:/data/osmcache/
     depends_on:
       - gencert2
 
@@ -374,3 +375,5 @@ services:
       - $base_folder/agent:/opt/agent/
     depends_on:
       - matcher_service
+
+volumes: osm_cache:

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -108,7 +108,6 @@ services:
     volumes:
       - $base_folder/nginx-int.conf:/etc/nginx/nginx.conf
       - $base_folder/won-server-certs2:/etc/nginx/won-server-certs/
-      - /data/osmcache/
     depends_on:
       - gencert2
 

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -1,6 +1,5 @@
-version: '2'
+version: "2"
 services:
-
   # letsencrypt container that helps renew the matchat.org (including www.match.org and node.matchat.org) certificate.
   # It is used by the nginx (external matchat representation of owner) and the wonnode.
   # This is only used around every 90 days to manually renew the certificate.
@@ -68,6 +67,7 @@ services:
       - $base_folder/nginx.conf:/etc/nginx/nginx.conf
       - $base_folder/nginx-uki-http.conf:/etc/nginx/conf.d/nginx-uki-http.conf
       - $base_folder/letsencrypt/acme-challenge:/usr/share/nginx/html/
+      - /data/osmcache/
     depends_on:
       - gencert
 
@@ -250,7 +250,7 @@ services:
     build: ../../image/bots
     image: webofneeds/bots:live
     environment:
-      - "uri.prefix.owner=https://matchat.org/debug_bot"  # set this for the trust store alias
+      - "uri.prefix.owner=https://matchat.org/debug_bot" # set this for the trust store alias
       - "node.default.host=node.matchat.org"
       - "node.default.http.port=443"
       - "uri.prefix.node.default=https://node.matchat.org/won"
@@ -285,21 +285,19 @@ services:
     depends_on:
       - mysql
 
-
   matcher_sparql:
     build: ../../image/matcher-sparql
     image: webofneeds/matcher_sparql:int
     environment:
-    - "node.host=satvm01.researchstudio.at"
-    - "cluster.seedNodes=satvm01.researchstudio.at:2561,satvm01.researchstudio.at:2563"
-    - "cluster.local.port=2564"
-    - "matcher.sparql.uri.sparql.endpoint=http://satvm01.researchstudio.at:10000/blazegraph/namespace/kb/sparql"
-    - "matcher.sparql.uri.public=http://satvm01.researchstudio.at/sparql/"
-    - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
+      - "node.host=satvm01.researchstudio.at"
+      - "cluster.seedNodes=satvm01.researchstudio.at:2561,satvm01.researchstudio.at:2563"
+      - "cluster.local.port=2564"
+      - "matcher.sparql.uri.sparql.endpoint=http://satvm01.researchstudio.at:10000/blazegraph/namespace/kb/sparql"
+      - "matcher.sparql.uri.public=http://satvm01.researchstudio.at/sparql/"
+      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
     ports:
-    - "2564:2564"
+      - "2564:2564"
     depends_on:
-    - matcher_service
+      - matcher_service
     volumes:
-    - $base_folder/won-client-certs/matcher_sparql:/usr/src/matcher-sparql/client-certs/
-
+      - $base_folder/won-client-certs/matcher_sparql:/usr/src/matcher-sparql/client-certs/

--- a/webofneeds/won-docker/image/nginx/nginx-int.conf
+++ b/webofneeds/won-docker/image/nginx/nginx-int.conf
@@ -47,6 +47,16 @@ http {
 	      return          301 https://$server_name$request_uri;
     }
 
+    # set up OSM tile proxy
+    proxy_cache_path  /data/osmcache levels=1:2 keys_zone=openstreetmap-tilecache:8m max_size=50M inactive=30d;
+    proxy_temp_path   /data/osmcache/tmp;
+
+    upstream openstreetmap_backend {
+        server  a.tile.openstreetmap.org;
+        server  b.tile.openstreetmap.org;
+        server  c.tile.openstreetmap.org;
+    }
+
     # pass https requests to owner and node instances
     server {
         ssl                 on;
@@ -106,6 +116,18 @@ http {
             # proxy_cookie_path exactly to handle sessions correctly when webapp is accessed in two ways:
             # with and without /owner prefix => so redirect seems to be the easiest solution for now
             return 301 https://$server_name/owner$request_uri;
+        }
+
+        location /tile/ {
+            # access cache for OSM tiles
+            proxy_pass http://openstreetmap_backend/;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X_FORWARDED_PROTO http;
+            proxy_set_header Host $http_host;
+            proxy_cache openstreetmap-tilecache;
+            proxy_cache_valid  200 302  30d;
+            proxy_cache_valid  404      1m;
+            proxy_redirect off;
         }
     }
 

--- a/webofneeds/won-docker/image/nginx/nginx-int.conf
+++ b/webofneeds/won-docker/image/nginx/nginx-int.conf
@@ -47,16 +47,6 @@ http {
 	      return          301 https://$server_name$request_uri;
     }
 
-    # set up OSM tile proxy
-    proxy_cache_path  /data/osmcache levels=1:2 keys_zone=openstreetmap-tilecache:8m max_size=50M inactive=30d;
-    proxy_temp_path   /data/osmcache/tmp;
-
-    upstream openstreetmap_backend {
-        server  a.tile.openstreetmap.org;
-        server  b.tile.openstreetmap.org;
-        server  c.tile.openstreetmap.org;
-    }
-
     # pass https requests to owner and node instances
     server {
         ssl                 on;
@@ -116,18 +106,6 @@ http {
             # proxy_cookie_path exactly to handle sessions correctly when webapp is accessed in two ways:
             # with and without /owner prefix => so redirect seems to be the easiest solution for now
             return 301 https://$server_name/owner$request_uri;
-        }
-
-        location /tile/ {
-            # access cache for OSM tiles
-            proxy_pass http://openstreetmap_backend/;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X_FORWARDED_PROTO http;
-            proxy_set_header Host $http_host;
-            proxy_cache openstreetmap-tilecache;
-            proxy_cache_valid  200 302  30d;
-            proxy_cache_valid  404      1m;
-            proxy_redirect off;
         }
     }
 

--- a/webofneeds/won-docker/image/nginx/nginx.conf
+++ b/webofneeds/won-docker/image/nginx/nginx.conf
@@ -54,6 +54,17 @@ http {
     sendfile           off;
     keepalive_timeout  65;
 
+    # ==============================================
+    # reverse proxy for openstreetmap tiles config
+    # ==============================================
+    proxy_cache_path  /data/osmcache levels=1:2 keys_zone=openstreetmap-tilecache:8m max_size=1G inactive=30d;
+    proxy_temp_path   /data/osmcache/tmp;
+
+    upstream openstreetmap_backend {
+        server  a.tile.openstreetmap.org;
+        server  b.tile.openstreetmap.org;
+        server  c.tile.openstreetmap.org;
+    }
 
     # ==============================================
     # matchat.org owner config
@@ -133,6 +144,18 @@ http {
             # sessions correctly when webapp is accessed in two ways: with and without /owner prefix => so redirect
             # seems to be the easiest solution for now
             return 301 https://$server_name/owner$request_uri;
+        }
+
+        # openstreetmap tile reverse proxy
+        location /tile/ {
+            proxy_pass http://openstreetmap_backend/;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X_FORWARDED_PROTO http;
+            proxy_set_header Host $http_host;
+            proxy_cache openstreetmap-tilecache;
+            proxy_cache_valid  200 302  30d;
+            proxy_cache_valid  404      1m;
+            proxy_redirect off;
         }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -64,8 +64,7 @@ export function initLeafletBaseMaps() {
     );
   }
   //const secureOsmSource = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"; // secure osm.org
-  const secureOsmSource =
-    "https://satvm05.researchstudio.at/tile/{z}/{x}/{y}.png"; // FIXME: proxy should not be hardcoded
+  const secureOsmSource = "https://www.matchat.org/tile/{z}/{x}/{y}.png"; // TODO: use own tile server instead of proxy
   const secureOsm = L.tileLayer(secureOsmSource, {
     attribution:
       '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -63,7 +63,9 @@ export function initLeafletBaseMaps() {
       "Tried to initialize leaflet map-sources while leaflet wasn't loaded."
     );
   }
-  const secureOsmSource = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"; // secure osm.org
+  //const secureOsmSource = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"; // secure osm.org
+  const secureOsmSource =
+    "https://satvm05.researchstudio.at/tile/{z}/{x}/{y}.png"; // FIXME: proxy should not be hardcoded
   const secureOsm = L.tileLayer(secureOsmSource, {
     attribution:
       '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',


### PR DESCRIPTION
Fixes #2331 

Uses matchat.org/tile/ for caching -> new nginx.conf needs to be deployed to live to be tested. 

Tiles should then be available from URIs like https://www.matchat.org/tile/5/7/7.png - this can also be tested via the location picker, which should still work. 