### PR TITLE
Fix #2362

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -152,6 +152,7 @@ import { Generator } from "sparqljs";
           ...detail.parseToRDF({
             value: isOrSeeksData[detail.identifier],
             identifier: detail.identifier,
+            contentUri: isOrSeeksData["publishedContentUri"],
           }),
         };
         // add to content node

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -274,6 +274,7 @@ export function buildChatMessage({
               detail.parseToRDF({
                 value: value,
                 identifier: detail.identifier,
+                contentUri: eventUri,
               });
 
             if (detailRDF) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -8,6 +8,7 @@ import {
   isValidDate,
   parseDatetimeStrictly,
   toLocalISODateString,
+  generateIdString,
 } from "../app/utils.js";
 import Immutable from "immutable";
 import won from "../app/won-es6.js";
@@ -178,13 +179,17 @@ export const details = {
       { value: "HUR", label: "per hour" },
       { value: "", label: "total", default: true },
     ],
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value || !value.amount || !value.currency) {
         return { "s:priceSpecification": undefined };
       }
 
       return {
         "s:priceSpecification": {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + generateIdString(10)
+              : undefined,
           "@type": "s:CompoundPriceSpecification",
           "s:price": [{ "@value": value.amount, "@type": "xsd:float" }],
           "s:priceCurrency": value.currency,
@@ -357,16 +362,31 @@ export const details = {
     placeholder: "Search for location",
     component: "won-location-picker",
     viewerComponent: "won-location-viewer",
-    parseToRDF: function({ value, identifier }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value) {
         // TODO: this should happen in need-builder
         return { "won:hasLocation": undefined };
       }
+
+      const randomLocationId = generateIdString(10);
+
       return {
         "won:hasLocation": {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + randomLocationId
+              : undefined,
           "@type": "s:Place",
           "s:geo": {
-            "@id": "_:" + identifier + "-location",
+            "@id":
+              contentUri && identifier
+                ? contentUri +
+                  "/" +
+                  identifier +
+                  "/" +
+                  randomLocationId +
+                  "/locationgeo"
+                : undefined,
             "@type": "s:GeoCoordinates",
             "s:latitude": value.lat.toFixed(6),
             "s:longitude": value.lng.toFixed(6),
@@ -381,14 +401,39 @@ export const details = {
             !value.nwCorner || !value.seCorner
               ? undefined
               : {
+                  "@id":
+                    contentUri && identifier
+                      ? contentUri +
+                        "/" +
+                        identifier +
+                        "/" +
+                        randomLocationId +
+                        "/Bounds"
+                      : undefined,
                   "won:hasNorthWestCorner": {
-                    "@id": "_:" + identifier + "BoundsNW",
+                    "@id":
+                      contentUri && identifier
+                        ? contentUri +
+                          "/" +
+                          identifier +
+                          "/" +
+                          randomLocationId +
+                          "/Bounds/NW"
+                        : undefined,
                     "@type": "s:GeoCoordinates",
                     "s:latitude": value.nwCorner.lat.toFixed(6),
                     "s:longitude": value.nwCorner.lng.toFixed(6),
                   },
                   "won:hasSouthEastCorner": {
-                    "@id": "_:" + identifier + "BoundsSE",
+                    "@id":
+                      contentUri && identifier
+                        ? contentUri +
+                          "/" +
+                          identifier +
+                          "/" +
+                          randomLocationId +
+                          "/Bounds/SE"
+                        : undefined,
                     "@type": "s:GeoCoordinates",
                     "s:latitude": value.seCorner.lat.toFixed(6),
                     "s:longitude": value.seCorner.lng.toFixed(6),
@@ -497,7 +542,7 @@ export const details = {
     placeholder: undefined,
     component: "won-person-picker",
     viewerComponent: "won-person-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value) {
         return { "foaf:person": undefined };
       }
@@ -510,6 +555,15 @@ export const details = {
           : undefined,
         "s:worksFor": getIn(value, ["company"])
           ? {
+              "@id":
+                contentUri && identifier
+                  ? contentUri +
+                    "/" +
+                    identifier +
+                    "/" +
+                    generateIdString(10) +
+                    "/organization"
+                  : undefined,
               "@type": "s:Organization",
               "s:name": getIn(value, ["company"]),
             }
@@ -599,18 +653,43 @@ export const details = {
     },
     component: "won-travel-action-picker",
     viewerComponent: "won-travel-action-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value) {
         return { "won:travelAction": undefined };
       }
+
+      const randomTravelActionId = generateIdString(10);
+
       return {
         "won:travelAction": {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + randomTravelActionId
+              : undefined,
           "@type": "s:TravelAction",
           "s:fromLocation": !value.fromLocation
             ? undefined
             : {
+                "@id":
+                  contentUri && identifier
+                    ? contentUri +
+                      "/" +
+                      identifier +
+                      "/" +
+                      randomTravelActionId +
+                      "/fromLocation"
+                    : undefined,
                 "@type": "s:Place",
                 "s:geo": {
+                  "@id":
+                    contentUri && identifier
+                      ? contentUri +
+                        "/" +
+                        identifier +
+                        "/" +
+                        randomTravelActionId +
+                        "/fromLocation/geocoords"
+                      : undefined,
                   "@type": "s:GeoCoordinates",
                   "s:latitude": value.fromLocation.lat.toFixed(6),
                   "s:longitude": value.fromLocation.lng.toFixed(6),
@@ -627,8 +706,26 @@ export const details = {
           "s:toLocation": !value.toLocation
             ? undefined
             : {
+                "@id":
+                  contentUri && identifier
+                    ? contentUri +
+                      "/" +
+                      identifier +
+                      "/" +
+                      randomTravelActionId +
+                      "/toLocation"
+                    : undefined,
                 "@type": "s:Place",
                 "s:geo": {
+                  "@id":
+                    contentUri && identifier
+                      ? contentUri +
+                        "/" +
+                        identifier +
+                        "/" +
+                        randomTravelActionId +
+                        "/toLocation/geocoords"
+                      : undefined,
                   "@type": "s:GeoCoordinates",
                   "s:latitude": value.toLocation.lat.toFixed(6),
                   "s:longitude": value.toLocation.lng.toFixed(6),
@@ -828,7 +925,7 @@ export const details = {
     multiSelect: true,
     component: "won-file-picker",
     viewerComponent: "won-file-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value) {
         return { "won:hasFile": undefined };
       }
@@ -837,6 +934,10 @@ export const details = {
         //TODO: SAVE CORRECT RDF THIS METHOD
         if (file.name && file.type && file.data) {
           let f = {
+            "@id":
+              contentUri && identifier
+                ? contentUri + "/" + identifier + "/" + generateIdString(10)
+                : undefined,
             "@type": "s:FileObject",
             "s:name": file.name,
             "s:type": file.type,
@@ -906,7 +1007,7 @@ export const details = {
     multiSelect: true,
     component: "won-file-picker",
     viewerComponent: "won-file-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value) {
         return { "won:hasImage": undefined };
       }
@@ -915,6 +1016,10 @@ export const details = {
         //TODO: SAVE CORRECT RDF THIS METHOD
         if (image.name && image.type && image.data) {
           let img = {
+            "@id":
+              contentUri && identifier
+                ? contentUri + "/" + identifier + "/" + generateIdString(10)
+                : undefined,
             "@type": "s:ImageObject",
             "s:name": image.name,
             "s:type": image.type,
@@ -984,10 +1089,14 @@ export const details = {
     accepts: "",
     component: "won-workflow-picker",
     viewerComponent: "won-workflow-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (value && value.name && value.data) {
         //do not check for value.type might not be present on some systems
         let workflow = {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + generateIdString(10)
+              : undefined,
           "@type": "s:FileObject",
           "s:name": value.name,
           "s:type": value.type,
@@ -1029,10 +1138,14 @@ export const details = {
     accepts: "",
     component: "won-petrinet-picker",
     viewerComponent: "won-petrinet-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (value && value.name && value.data) {
         //do not check for value.type might not be present on some systems
         let workflow = {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + generateIdString(10)
+              : undefined,
           "@type": "s:FileObject",
           "s:name": value.name,
           "s:type": value.type,
@@ -1087,12 +1200,16 @@ export const details = {
     ],
     component: "won-price-range-picker",
     viewerComponent: "won-price-viewer",
-    parseToRDF: function({ value }) {
+    parseToRDF: function({ value, identifier, contentUri }) {
       if (!value || !(value.min || value.max) || !value.currency) {
         return { "s:priceSpecification": undefined };
       }
       return {
         "s:priceSpecification": {
+          "@id":
+            contentUri && identifier
+              ? contentUri + "/" + identifier + "/" + generateIdString(10)
+              : undefined,
           "@type": "s:CompoundPriceSpecification",
           "s:minPrice": value.min && [
             { "@value": value.min, "@type": "xsd:float" },

--- a/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
+++ b/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
@@ -237,8 +237,8 @@ public class GoalInstantiationTest {
                 Coordinate departureAddress = getAddress(loadSparqlQuery("/won/utils/goals/extraction/address/fromLocationQuery.rq"), res.getInstanceModel());
                 Coordinate destinationAddress = getAddress(loadSparqlQuery("/won/utils/goals/extraction/address/toLocationQuery.rq"), res.getInstanceModel());
 
-                Assert.assertEquals(departureAddress, new Coordinate(10.0f, 11.0f));
-                Assert.assertEquals(destinationAddress, new Coordinate(12.0f, 13.0f));
+                Assert.assertEquals(new Coordinate(10.0f, 11.0f), departureAddress);
+                Assert.assertEquals(new Coordinate(12.0f, 13.0f), destinationAddress);
             }
         }
 

--- a/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
+++ b/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
@@ -201,7 +201,10 @@ public class GoalInstantiationTest {
             System.out.println(res.toString());
             if(res.isConform()) {
                 Coordinate departureAddress = getAddress(loadSparqlQuery("/won/utils/goals/extraction/address/fromLocationQuery.rq"), res.getInstanceModel());
+                String departureName = getName(loadSparqlQuery("/won/utils/goals/extraction/address/fromLocationQuery.rq"), res.getInstanceModel());
                 Coordinate destinationAddress = getAddress(loadSparqlQuery("/won/utils/goals/extraction/address/toLocationQuery.rq"), res.getInstanceModel());
+                String destinationName = getName(loadSparqlQuery("/won/utils/goals/extraction/address/toLocationQuery.rq"), res.getInstanceModel());
+
 
                 //Assert.assertEquals(departureAddress, new Coordinate(10.0f, 11.0f));
                 //Assert.assertEquals(destinationAddress, new Coordinate(12.0f, 13.0f));
@@ -330,6 +333,16 @@ public class GoalInstantiationTest {
             float lat = solution.getLiteral("lat").getFloat();
             float lon = solution.getLiteral("lon").getFloat();
             return new Coordinate(lat, lon);
+        }else{
+            return null;
+        }
+    }
+
+    private static String getName(String query, Model payload) {
+        QuerySolution solution = executeQuery(query, payload);
+
+        if(solution != null){
+            return solution.getLiteral("name").getString();
         }else{
             return null;
         }

--- a/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/extraction/address/fromLocationQuery.rq
+++ b/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/extraction/address/fromLocationQuery.rq
@@ -1,12 +1,13 @@
 prefix s:     <http://schema.org/>
 
-select ?lat ?lon
+select ?lat ?lon ?name
 
 where {
 	?main a s:TravelAction;
     	  s:fromLocation ?location.
   	?location a s:Place;
-          s:geo ?geo.
+          s:geo ?geo;
+          s:name ?name.
   	?geo a s:GeoCoordinates;
           s:latitude ?lat;
           s:longitude ?lon.

--- a/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/extraction/address/toLocationQuery.rq
+++ b/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/extraction/address/toLocationQuery.rq
@@ -1,12 +1,13 @@
 prefix s:     <http://schema.org/>
 
-select ?lat ?lon
+select ?lat ?lon ?name
 
 where {
 	?main a s:TravelAction;
     	  s:toLocation ?location.
   	?location a s:Place;
-          s:geo ?geo.
+          s:geo ?geo;
+          s:name ?name.
   	?geo a s:GeoCoordinates;
           s:latitude ?lat;
           s:longitude ?lon.

--- a/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/ex6_taxi.trig
+++ b/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/ex6_taxi.trig
@@ -60,6 +60,7 @@
                                                                             s:latitude   "10.0" ;
                                                                             s:longitude  "11.0"
                                                                         ] ;
+                                                                s:name              "From Location"
                                                              ] ;
                                               s:toLocation   [
                                                                 a       s:Place;
@@ -68,6 +69,7 @@
                                                                             s:latitude   "12.0" ;
                                                                             s:longitude  "13.0"
                                                                         ] ;
+                                                                s:name              "To Location"
                                                              ] ;
                                             ] ;
                           ] ;

--- a/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/ex6_taxioffer.trig
+++ b/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/ex6_taxioffer.trig
@@ -63,57 +63,63 @@
 }
 
 <https://satvm05.researchstudio.at/won/resource/event/qkrivynfftr9gtl3u8im#content-fsw0> {
-    <http://example.org/2/SelfShape>
-            a   sh:NodeShape ;
-            sh:targetNode   s:TravelAction ;
-            sh:property [
-                            sh:path [ sh:inversePath rdf:type ];
-                            sh:minCount 1 ;
-                            sh:maxCount 1 ;
-                        ] .
-    <http://example.org/2/TaxiRideShape>
-            a                     sh:NodeShape ;
-            sh:closed             true ;
-            sh:ignoredProperties  ( rdf:type ) ;
-            sh:property [
-                            sh:path s:fromLocation ;
-                            sh:class s:Place ;
-                            sh:minCount 1;
-                            sh:maxCount 1;
-                        ] ;
-            sh:property [
-                            sh:path s:toLocation;
-                            sh:class s:Place ;
-                            sh:minCount 0;
-                            sh:maxCount 1;
-                        ] ;
-            sh:targetClass       s:TravelAction .
-
     <http://example.org/2/PlaceShape>
-        a sh:NodeShape;
-        sh:targetClass s:Place ;
-        sh:property [
-            sh:path s:geo ;
-            sh:class s:GeoCoordinates ;
-            sh:minCount 1 ;
-            sh:maxCount 1 ;
-        ] ;
-        sh:ignoredProperties ( rdf:type ) ;
-        sh:closed true .
+                a               sh:NodeShape ;
+                sh:closed       true ;
+                sh:property     [ sh:minCount  1 ;
+                                  sh:path      rdf:type
+                                ] ;
+                sh:property     [ sh:class     s:GeoCoordinates ;
+                                  sh:maxCount  1 ;
+                                  sh:minCount  1 ;
+                                  sh:path      s:geo
+                                ] ;
+                sh:property [
+                            sh:path s:name ;
+                            sh:minCount 0 ;
+                            sh:maxCount 1 ;
+                          ] ;
+                sh:targetClass  s:Place .
 
-    <http://example.org/2/GeoCoordinateShape>
-        a sh:NodeShape;
-        sh:targetClass s:GeoCoordinates ;
-        sh:property [
-            sh:path s:latitude ;
-            sh:minCount 1 ;
-            sh:maxCount 1 ;
-        ] ;
-        sh:property [
-            sh:path s:longitude ;
-            sh:minCount 1 ;
-            sh:maxCount 1 ;
-        ] ;
-        sh:ignoredProperties ( rdf:type ) ;
-        sh:closed true .
+        <http://example.org/2/GeoCoordinateShape>
+                a               sh:NodeShape ;
+                sh:closed       true ;
+                sh:property     [ sh:minCount  1 ;
+                                  sh:path      rdf:type
+                                ] ;
+                sh:property     [ sh:maxCount  1 ;
+                                  sh:minCount  1 ;
+                                  sh:path      s:longitude
+                                ] ;
+                sh:property     [ sh:maxCount  1 ;
+                                  sh:minCount  1 ;
+                                  sh:path      s:latitude
+                                ] ;
+                sh:targetClass  s:GeoCoordinates .
+
+        <http://example.org/2/TaxiRideShape>
+                a               sh:NodeShape ;
+                sh:closed       true ;
+                sh:property     [ sh:class     s:Place ;
+                                  sh:maxCount  1 ;
+                                  sh:minCount  0 ;
+                                  sh:path      s:toLocation
+                                ] ;
+                sh:property     [ sh:class     s:Place ;
+                                  sh:maxCount  1 ;
+                                  sh:minCount  1 ;
+                                  sh:path      s:fromLocation
+                                ] ;
+                sh:property     [ sh:minCount  1 ;
+                                  sh:path      rdf:type
+                                ] ;
+                sh:targetClass  s:TravelAction .
+
+        <http://example.org/2/SelfShape>
+                a              sh:NodeShape ;
+                sh:property    [ sh:maxCount  1 ;
+                                 sh:minCount  1 ;
+                                 sh:path      [ sh:inversePath  rdf:type ]
+                               ] ;
+                sh:targetNode  s:TravelAction .
 }

--- a/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/exCorrect_taxioffer.trig
+++ b/webofneeds/won-utils/won-utils-goals/src/test/resources/won/utils/goals/instantiation/exCorrect_taxioffer.trig
@@ -29,6 +29,11 @@
                               sh:minCount  1 ;
                               sh:path      s:geo
                             ] ;
+            sh:property [
+                        sh:path s:name ;
+                        sh:minCount 0 ;
+                        sh:maxCount 1 ;
+                      ] ;
             sh:targetClass  s:Place .
     
     <http://example.org/2/GeoCoordinateShape>


### PR DESCRIPTION
updated unittests to represent the updated taxibot goal retrieval

fixes #2362 -> the problem was a racecondition that caused the blanknodes to be stored in the rdfstore multiple times, resulting in contentduplication in chatmessages:
How To Test:
1) Connect with debug bot
2) Send a Location Message
3) Send a TravelAction Message
4) Send a File Message
5) Send a Image Message
6) Send a PersonDetail (including a company)
7) Send a Price
8) Send a PriceRange
9) notice that all the details are visible and not duplicated or missing
10) Reload the page (notice that the messages still did not disappear or duplicate their content) -> if you want to see what the actual problem was just go on a instance without this fix and send a single image as a chatmessage, and reload, you will see that the image is going to be present twice, same with locaiton or travelaction only that a reload will make the location/travelaction invisible due to parsing issues