### PR TITLE
remove highlight method for searchresults -> broke the component when…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.js
@@ -21,7 +21,7 @@ import "style/_locationpicker.scss";
 
 import "leaflet/dist/leaflet.css";
 
-const serviceDependencies = ["$scope", "$element", "$sce"];
+const serviceDependencies = ["$scope", "$element"];
 function genComponentConf() {
   let template = `
         <!-- LOCATION SEARCH BOX -->
@@ -52,8 +52,8 @@ function genComponentConf() {
                     <use xlink:href="#ico16_indicator_location" href="#ico36_location_current"></use>
                 </svg>
                 <a class="lp__searchresult__text" href=""
-                    ng-click="self.selectedLocation(self.currentLocation)"
-                    ng-bind-html="self.highlight(self.currentLocation.name, self.lastSearchedFor)">
+                    ng-click="self.selectedLocation(self.currentLocation)">
+                    {{ self.currentLocation.name }}
                 </a>
             </li>
             <!-- PREVIOUS LOCATION -->
@@ -64,8 +64,8 @@ function genComponentConf() {
                     <use xlink:href="#ico16_indicator_location" href="#ico16_indicator_location"></use>
                 </svg>
                 <a class="lp__searchresult__text" href=""
-                    ng-click="self.selectedLocation(self.previousLocation)"
-                    ng-bind-html="self.highlight(self.previousLocation.name, self.lastSearchedFor)">
+                    ng-click="self.selectedLocation(self.previousLocation)">
+                    {{ self.previousLocation.name }}
                 </a>
                 (previous)
             </li>
@@ -76,8 +76,8 @@ function genComponentConf() {
                     <use xlink:href="#ico16_indicator_location" href="#ico16_indicator_location"></use>
                 </svg>
                 <a class="lp__searchresult__text" href=""
-                    ng-click="self.selectedLocation(result)"
-                    ng-bind-html="self.highlight(result.name, self.lastSearchedFor)">
+                    ng-click="self.selectedLocation(result)">
+                    {{ result.name }}
                 </a>
             </li>
         </ul>
@@ -122,27 +122,6 @@ function genComponentConf() {
       if (inviewInfo.changed) {
         this.map.invalidateSize();
       }
-    }
-
-    /**
-     * Taken from <http://stackoverflow.com/questions/15519713/highlighting-a-filtered-result-in-angularjs>
-     * @param text
-     * @param search
-     * @return {*}
-     */
-    highlight(text, search) {
-      if (!text) {
-        text = "";
-      }
-      if (!search) {
-        return this.$sce.trustAsHtml(text);
-      }
-      return this.$sce.trustAsHtml(
-        text.replace(
-          new RegExp(search, "gi"),
-          '<span class="highlightedText">$&</span>'
-        )
-      );
     }
 
     placeMarkers(locations) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/travel-action-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/travel-action-picker.js
@@ -16,7 +16,7 @@ import { initLeaflet } from "../../../won-utils.js";
 import "style/_travelactionpicker.scss";
 import "leaflet/dist/leaflet.css";
 
-const serviceDependencies = ["$scope", "$element", "$sce"];
+const serviceDependencies = ["$scope", "$element"];
 function genComponentConf() {
   const prevLocationBlock = (
     displayBlock,
@@ -30,8 +30,8 @@ function genComponentConf() {
           <use xlink:href="#ico16_indicator_location" href="#ico16_indicator_location"></use>
       </svg>
       <a class="rp__searchresult__text" href=""
-          ng-click="${selectLocationFnctName}(${prevLocation})"
-          ng-bind-html="self.highlight(${prevLocation}.name, self.lastSearchedFor)">
+          ng-click="${selectLocationFnctName}(${prevLocation})">
+          {{ ${prevLocation}.name }}
       </a>
       (previous)
   </li>`;
@@ -44,8 +44,8 @@ function genComponentConf() {
           <use xlink:href="#ico16_indicator_location" href="#ico16_indicator_location"></use>
       </svg>
       <a class="rp__searchresult__text" href=""
-          ng-click="${selectLocationFnctName}(result)"
-          ng-bind-html="self.highlight(result.name, self.lastSearchedFor)">
+          ng-click="${selectLocationFnctName}(result)">
+          {{ result.name }}
       </a>
   </li>`;
 
@@ -77,8 +77,8 @@ function genComponentConf() {
                     <use xlink:href="#ico16_indicator_location" href="#ico36_location_current"></use>
                 </svg>
                 <a class="rp__searchresult__text" href=""
-                    ng-click="self.selectedFromLocation(self.currentLocation)"
-                    ng-bind-html="self.highlight(self.currentLocation.name, self.lastSearchedFor)">
+                    ng-click="self.selectedFromLocation(self.currentLocation)">
+                    {{ self.currentLocation.name }}
                 </a>
             </li>
             
@@ -522,27 +522,6 @@ function genComponentConf() {
           }
         );
       }
-    }
-
-    /**
-     * Taken from <http://stackoverflow.com/questions/15519713/highlighting-a-filtered-result-in-angularjs>
-     * @param text
-     * @param search
-     * @return {*}
-     */
-    highlight(text, search) {
-      if (!text) {
-        text = "";
-      }
-      if (!search) {
-        return this.$sce.trustAsHtml(text);
-      }
-      return this.$sce.trustAsHtml(
-        text.replace(
-          new RegExp(search, "gi"),
-          '<span class="highlightedText">$&</span>'
-        )
-      );
     }
 
     fromTextfieldNg() {


### PR DESCRIPTION
… inserting brackets

fixes #2347 

remove the ability to highlight the searchterm in the searchresults in general, since this was a security issue anyway (inserted 'trusted' html, without really looking at it) and broke sometimes due to it trying to parse a regex out of the searchterm