### PR TITLE
remove angular-sanitize

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -9,7 +9,6 @@
 // import Medium from '../mediumjs-es6.js';
 import angular from "angular";
 import "ng-redux";
-import "angular-sanitize";
 import ngAnimate from "angular-animate";
 import { dispatchEvent, attach, delay } from "../utils.js";
 import won from "../won-es6.js";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/file-dropzone.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/file-dropzone.js
@@ -2,7 +2,6 @@
  * Created by ksinger on 16.09.2015.
  */
 import angular from "angular";
-import "angular-sanitize";
 import enterModule from "../directives/enter.js";
 import { dispatchEvent, attach, readAsDataURL } from "../utils.js";
 import globToRegexp from "glob-to-regexp";


### PR DESCRIPTION
implements #2139 (markdown viewer/picker)

How To Test:
1) DescriptionPicker and chat-message are now capable of submitting/creating markdown content
see [cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)

also fixes: #1786 and #1845 by removing the ng-bind-html completely and replacing it with the new marked directive (from angular-marked)