### PR TITLE
Fix xss linkinnewtab

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -163,25 +163,28 @@ app.config(configRouting).config([
   "$compileProvider",
   "markedProvider",
   function($compileProvider, markedProvider) {
-    $compileProvider.aHrefSanitizationWhitelist(
-      /^\s*(https?|ftp|mailto|tel|file|blob|data):/
-    );
+    const urlSanitizationRegex = /^\s*(https?|ftp|mailto|tel|file|blob|data):/;
+
+    $compileProvider.aHrefSanitizationWhitelist(urlSanitizationRegex);
     markedProvider.setOptions({ sanitize: true });
-    /*
     //removed this codesnippet due to problems with link rendering -> xss vulnerability
     markedProvider.setRenderer({
       link: function(href, title, text) {
-        return (
-          '<a href="' +
-          href +
-          '"' +
-          (title ? ' title="' + title + '"' : "") +
-          ' target="_blank">' +
-          text +
-          "</a>"
-        );
+        if (urlSanitizationRegex.test(href)) {
+          return (
+            '<a href="' +
+            href +
+            '"' +
+            (title ? ' title="' + title + '"' : "") +
+            ' target="_blank">' +
+            text +
+            "</a>"
+          );
+        } else {
+          return text;
+        }
       },
-    });*/
+    });
   },
 ]);
 app.run(["$ngRedux", $ngRedux => runMessagingAgent($ngRedux)]);


### PR DESCRIPTION
implements the generated markdown links as "open in new tab" again (target _blank) but also add the already exisiting hrefSanitizationWhiteListRegex to remove the ability to include any xss javascript within the href

How To Test:
Using the https://ponyfoo.com/articles/fixing-xss-vulnerability-marked as an example, try adding following links to a description of a costum post:
1. `[Gotcha](javascript:alert(1))` - should not create a link in the preview
2. `[Gotcha](javascript&#58;alert(1&#41;)` - should not create a link in the preview
3. `[Gotcha](javascript&#58this;alert(1&#41;)` - should not create a link in the preview
4. `www.orf.at` - should create a link with the title orf.at in the preview
5. `[matchat](matchat.org)` - should not create a link in the preview as the href is not a valid url (protocol is missing)
6. `[matchat](https://matchat.org)` - should create a link with the title matchat in the preview