### PR TITLE
Fix dont show latest msg

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -366,13 +366,11 @@ public interface LinkedDataService {
 	 * 
 	 * @param connectionUri
 	 * @param includeEventContainer
-	 * @param includeLatestEvent
 	 * @param etag
 	 * @return
 	 * @throws NoSuchConnectionException
 	 */
-	DataWithEtag<Dataset> getConnectionDataset(URI connectionUri, boolean includeEventContainer,
-			boolean includeLatestEvent, String etag);
+	DataWithEtag<Dataset> getConnectionDataset(URI connectionUri, boolean includeEventContainer, String etag);
 
 	/**
 	 * Returns a dataset containing all event uris belonging to the specified

--- a/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
@@ -1657,8 +1657,8 @@ public class RdfUtils {
 	 */
 	public static Dataset addDatasetToDataset(final Dataset baseDataset, final Dataset toBeAddedtoBase,
 			boolean replaceNamedModel) {
-		assert baseDataset != null : "baseDataset must not be null";
-		assert toBeAddedtoBase != null : "toBeAddedToBase must not be null";
+		if (baseDataset == null) throw new IllegalArgumentException("baseDataset must not be null");
+		if (toBeAddedtoBase != null) throw new IllegalArgumentException("toBeAddedToBase must not be null");
 		baseDataset.getDefaultModel().add(toBeAddedtoBase.getDefaultModel());
 		for (Iterator<String> nameIt = toBeAddedtoBase.listNames(); nameIt.hasNext();) {
 			String modelName = nameIt.next();

--- a/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
@@ -1658,7 +1658,7 @@ public class RdfUtils {
 	public static Dataset addDatasetToDataset(final Dataset baseDataset, final Dataset toBeAddedtoBase,
 			boolean replaceNamedModel) {
 		if (baseDataset == null) throw new IllegalArgumentException("baseDataset must not be null");
-		if (toBeAddedtoBase != null) throw new IllegalArgumentException("toBeAddedToBase must not be null");
+		if (toBeAddedtoBase == null) throw new IllegalArgumentException("toBeAddedToBase must not be null");
 		baseDataset.getDefaultModel().add(toBeAddedtoBase.getDefaultModel());
 		for (Iterator<String> nameIt = toBeAddedtoBase.listNames(); nameIt.hasNext();) {
 			String modelName = nameIt.next();

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -199,7 +199,7 @@ public class LinkedDataWebController {
 	@RequestMapping("${uri.path.page.connection}/{identifier}")
 	public String showConnectionPage(@PathVariable String identifier, Model model, HttpServletResponse response) {
 		URI connectionURI = uriService.createConnectionURIForId(identifier);
-		DataWithEtag<Dataset> rdfDataset = linkedDataService.getConnectionDataset(connectionURI, true, true, null);
+		DataWithEtag<Dataset> rdfDataset = linkedDataService.getConnectionDataset(connectionURI, true, null);
 		if (rdfDataset.isNotFound()) {
 			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
 			return "notFoundView";
@@ -875,7 +875,7 @@ public class LinkedDataWebController {
 
 			@Override
 			public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
-				return linkedDataService.getConnectionDataset(uri, true, true, etag);
+				return linkedDataService.getConnectionDataset(uri, true, etag);
 			}
 
 			@Override

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -398,9 +398,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
    */
   @Override
   @Transactional
-  public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final
-  boolean
-    includeLatestEvent, final String etag)
+  public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final String etag)
 
   {
     DataWithEtag<Connection> data = null;
@@ -435,19 +433,6 @@ public class LinkedDataServiceImpl implements LinkedDataService
       Resource eventContainer = model.createResource(connection.getConnectionURI().toString()+"/events");
       connectionResource.addProperty(WON.HAS_EVENT_CONTAINER, eventContainer);
       eventContainer.addProperty(RDF.type, WON.EVENT_CONTAINER);
-      if (includeLatestEvent) {
-        //we add the latest event in the connection
-        Slice<MessageEventPlaceholder> latestEvents =
-          messageEventRepository.findByParentURIFetchDatasetEagerly(connectionUri, new PageRequest(0, 1, new Sort(Sort
-                                                                                                           .Direction.DESC, "creationDate")));
-        if (latestEvents.hasContent()) {
-          MessageEventPlaceholder event = latestEvents.getContent().get(0);
-          //add the event's dataset
-          eventDataset = setDefaults(event.getDatasetHolder().getDataset());
-          //connect the event to its container
-          eventContainer.addProperty(RDFS.member, model.getResource(event.getMessageURI().toString()));
-        }
-      }
       DatasetHolder datasetHolder = connection.getDatasetHolder();
       if (datasetHolder != null) {
         addAdditionalData(model, datasetHolder.getDataset().getDefaultModel(), connectionResource);
@@ -916,7 +901,7 @@ public class LinkedDataServiceImpl implements LinkedDataService
     //add the connection model for each connection URI
     for (URI connectionURI : connectionURIs) {
       DataWithEtag<Dataset> connectionDataset =
-        getConnectionDataset(connectionURI, true, true, null);
+        getConnectionDataset(connectionURI, true, null);
       RdfUtils.addDatasetToDataset(dataset, connectionDataset.getData());
     }
   }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -427,7 +427,6 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
     // add WON node link
     connectionResource.addProperty(WON.HAS_WON_NODE, model.createResource(this.resourceURIPrefix));
-    Dataset eventDataset = null;
     if (includeEventContainer) {
       //create event container and attach it to the member
       Resource eventContainer = model.createResource(connection.getConnectionURI().toString()+"/events");
@@ -441,7 +440,6 @@ public class LinkedDataServiceImpl implements LinkedDataService
 
     Dataset connectionDataset = addBaseUriAndDefaultPrefixes(newDatasetWithNamedModel(createDataGraphUriFromResource
                                                                        (connectionResource), model));
-    RdfUtils.addDatasetToDataset(connectionDataset, eventDataset);
     return new DataWithEtag<>(connectionDataset,newEtag, etag);
   }
 

--- a/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/blending/GraphBlendingTest.java
+++ b/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/blending/GraphBlendingTest.java
@@ -7,7 +7,12 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import won.utils.goals.GraphBlendingIterator;
 
 import java.io.IOException;
@@ -20,6 +25,13 @@ public class GraphBlendingTest {
 
     private static final String baseFolder = "/won/utils/goals/blending/";
 
+
+    @BeforeClass
+    public static void setLogLevel() {
+        Logger root = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.INFO);  
+    }
+    
     @Test
     public void blendSameTriples() throws IOException {
         Dataset ds = loadDataset(baseFolder + "same.trig");

--- a/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/extraction/GoalDataExtractionTest.java
+++ b/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/extraction/GoalDataExtractionTest.java
@@ -8,7 +8,12 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import won.utils.goals.GoalUtils;
 
 import java.io.IOException;
@@ -17,6 +22,13 @@ import java.io.InputStream;
 public class GoalDataExtractionTest {
 
     private static final String baseFolder = "/won/utils/goals/extraction/";
+    
+
+    @BeforeClass
+    public static void setLogLevel() {
+        Logger root = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.INFO);  
+    }
 
     @Test
     public void additionalNodeNotCoveredByShape() throws IOException {

--- a/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
+++ b/webofneeds/won-utils/won-utils-goals/src/test/java/won/utils/goals/instantiation/GoalInstantiationTest.java
@@ -11,8 +11,12 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.shared.NotFoundException;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import won.protocol.model.Coordinate;
 import won.protocol.model.NeedContentPropertyType;
 import won.protocol.util.DefaultNeedModelWrapper;
@@ -29,6 +33,13 @@ import java.util.LinkedList;
 public class GoalInstantiationTest {
 
     private static final String baseFolder = "/won/utils/goals/instantiation/";
+    
+
+    @BeforeClass
+    public static void setLogLevel() {
+        Logger root = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.INFO);  
+    }
 
     @Test
     public void example1_allInfoInTwoGoals() throws IOException {


### PR DESCRIPTION
When we were serving linked data requests to connection resources, we were adding the latest event, too. We don't do that any more.