### PR TITLE
"phishing" "prevention"

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -171,15 +171,29 @@ app.config(configRouting).config([
     markedProvider.setRenderer({
       link: function(href, title, text) {
         if (urlSanitizationRegex.test(href)) {
-          return (
-            '<a href="' +
-            href +
-            '"' +
-            (title ? ' title="' + title + '"' : "") +
-            ' target="_blank">' +
-            text +
-            "</a>"
-          );
+          if (text === href) {
+            return (
+              '<a href="' +
+              href +
+              '"' +
+              (title ? ' title="' + title + '"' : "") +
+              ' target="_blank">' +
+              text +
+              "</a>"
+            );
+          } else {
+            return (
+              "[" +
+              text +
+              '](<a href="' +
+              href +
+              '"' +
+              (title ? ' title="' + title + '"' : "") +
+              ' target="_blank">' +
+              href +
+              "</a>)"
+            );
+          }
         } else {
           return text;
         }


### PR DESCRIPTION
remove the possibility to generate markdown links with a link text that is different from the href itself

this "prevents" "phishing"....

How To Test:
1.) `[test](https://www.example.com)` -> should result in a preview of `[test](https://www.example.com)` -> where example.com is marked as a link