### PR TITLE
disable automatic need deactivation check on node

### DIFF
--- a/webofneeds/conf/node.properties
+++ b/webofneeds/conf/node.properties
@@ -133,7 +133,7 @@ client.authentication.behind.proxy=false
 #
 # The time period for checking need inactivity (in seconds)
 # Set to 0 or negative value to disable the check
-need.inactivity.check.interval=3600
+need.inactivity.check.interval=0
 # The node will send a warning to a need if its last owner-generated message is older than this value, in seconds
 # but not by more than need.inactivity.check.interval - to avoid sending multiple warnings
 need.inactivity.warn.timeout=604800


### PR DESCRIPTION
this change disables the automatic need deactivation check on the node, so we do not close needs after a certain timespan