### PR TITLE
quick fix to use either dc:description/title when present and check/r…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -153,7 +153,8 @@ export const details = {
       return { "dc:title": value };
     },
     parseFromRDF: function(jsonLDImm) {
-      return won.parseFrom(jsonLDImm, ["dc:title"], "xsd:string");
+      const dcTitle = won.parseFrom(jsonLDImm, ["dc:title"], "xsd:string");
+      return dcTitle || won.parseFrom(jsonLDImm, ["s:title"], "xsd:string");
     },
     generateHumanReadable: function({ value, includeLabel }) {
       if (value) {
@@ -278,7 +279,15 @@ export const details = {
       return { "dc:description": value };
     },
     parseFromRDF: function(jsonLDImm) {
-      return won.parseFrom(jsonLDImm, ["dc:description"], "xsd:string");
+      const dcDescription = won.parseFrom(
+        jsonLDImm,
+        ["dc:description"],
+        "xsd:string"
+      );
+      return (
+        dcDescription ||
+        won.parseFrom(jsonLDImm, ["s:description"], "xsd:string")
+      );
     },
     generateHumanReadable: function({ value, includeLabel }) {
       if (value) {


### PR DESCRIPTION
…eturn s:description/title if it was not the case

fixes #2401 -> quick fix that also checks for s:description and s:title occurences in the is or seeks branch so we can parse a description or title from rdf even if only the s:description is present