### PR TITLE
Jobsearch Use-Case

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/person-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/person-picker.js
@@ -78,11 +78,8 @@ function genComponentConf() {
           let personIndex = this.personDetails.findIndex(
             personDetail => personDetail.name === dtl
           );
-          if (personIndex !== -1 && dtl !== "skills") {
+          if (personIndex !== -1) {
             this.personDetails[personIndex].value = value;
-          } else if (personIndex !== -1 && dtl === "skills") {
-            let valueText = value.size > 0 ? value.toJS() : [];
-            this.personDetails[personIndex].value = valueText.toString();
           }
           if (value && value.length > 0) {
             this.visibleResetButtons.add(dtl);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/tags-picker.js
@@ -1,10 +1,5 @@
 import angular from "angular";
-import {
-  attach,
-  delay,
-  extractHashtags,
-  dispatchEvent,
-} from "../../../utils.js";
+import { attach, delay, dispatchEvent, is } from "../../../utils.js";
 import { DomCache } from "../../../cstm-ng-utils.js";
 import wonInput from "../../../directives/input.js";
 
@@ -127,3 +122,19 @@ function genComponentConf() {
 export default angular
   .module("won.owner.components.tagsPicker", [wonInput])
   .directive("wonTagsPicker", genComponentConf).name;
+
+function extractHashtags(str) {
+  if (!str) {
+    return [];
+  }
+  if (!is("String", str)) {
+    "utils.js: extractHashtags expects a string but got: " + str;
+  }
+  const seperatorChars = ",;#";
+  const tags = str
+    .split(new RegExp(`[${seperatorChars}]+`, "i"))
+    .map(t => t.trim())
+    .filter(t => t); // filter empty after trimming
+
+  return Array.from(new Set(tags)); // filter out duplicates and return
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/tags-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/tags-picker.js
@@ -63,7 +63,7 @@ function genComponentConf() {
             : undefined,
       };
       this.onUpdate(payload);
-      dispatchEvent(this.$lement[0], "update", payload);
+      dispatchEvent(this.$element[0], "update", payload);
     }
 
     showInitialTags() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1177,20 +1177,6 @@ export function mergeAsSet(arr1, arr2) {
   return Array.from(res);
 }
 
-export function extractHashtags(str) {
-  if (!str) {
-    return [];
-  }
-  if (!is("String", str)) {
-    "utils.js: extractHashtags expects a string but got: " + str;
-  }
-  const tags = (str.trim().split(/\s*,\s*|\s+/) || [])
-    .map(str => (str.startsWith("#") ? str.substring(1) : str))
-    .filter(str => str != ""); // remove leading `#`-character
-
-  return Array.from(new Set(tags)); // filter out duplicates and return
-}
-
 export function generateHexColor(text) {
   let hash = 0;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -26,7 +26,6 @@ export const details = {
   datetimeRange: timeDetails.datetimeRange,
 
   location: locationDetails.location,
-  jobLocation: locationDetails.jobLocation,
   travelAction: locationDetails.travelAction,
 
   person: personDetails.person,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -14,8 +14,6 @@ export const emptyDraft = {
   matchingContext: undefined,
 };
 
-console.log(timeDetails);
-
 export const details = {
   title: basicDetails.title,
   description: basicDetails.description,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -26,6 +26,7 @@ export const details = {
   datetimeRange: timeDetails.datetimeRange,
 
   location: locationDetails.location,
+  jobLocation: locationDetails.jobLocation,
   travelAction: locationDetails.travelAction,
 
   person: personDetails.person,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -8,10 +8,11 @@ export const title = {
   component: "won-title-picker",
   viewerComponent: "won-title-viewer",
   parseToRDF: function({ value }) {
-    if (!value) {
-      return { "dc:title": undefined };
-    }
-    return { "dc:title": value };
+    const val = value ? value : undefined;
+    return {
+      "dc:title": val,
+      "s:title": val,
+    };
   },
   parseFromRDF: function(jsonLDImm) {
     const dcTitle = won.parseFrom(jsonLDImm, ["dc:title"], "xsd:string");

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -34,10 +34,11 @@ export const description = {
   component: "won-description-picker",
   viewerComponent: "won-description-viewer",
   parseToRDF: function({ value }) {
-    if (!value) {
-      return { "dc:description": undefined };
-    }
-    return { "dc:description": value };
+    const val = value ? value : undefined;
+    return {
+      "dc:description": val,
+      "s:description": val,
+    };
   },
   parseFromRDF: function(jsonLDImm) {
     const dcDescription = won.parseFrom(

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -1,4 +1,5 @@
 import won from "../../app/won-es6.js";
+import { is } from "../../app/utils.js";
 
 export const title = {
   identifier: "title",
@@ -76,19 +77,11 @@ export const tags = {
     return won.parseListFrom(jsonLDImm, ["won:hasTag"], "xsd:string");
   },
   generateHumanReadable: function({ value, includeLabel }) {
-    if (value) {
-      let humanReadable = "";
-
-      for (const key in value) {
-        humanReadable += value[key] + ", ";
-      }
-      humanReadable = humanReadable.trim();
-
-      if (humanReadable.length > 0) {
-        humanReadable = humanReadable.substr(0, humanReadable.length - 1);
-        return includeLabel ? this.label + ": " + humanReadable : humanReadable;
-      }
+    if (value && is("Array", value) && value.length > 0) {
+      const prefix = includeLabel ? this.label + ": " : "";
+      return prefix + value.join(", ");
+    } else {
+      return undefined;
     }
-    return undefined;
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/jobs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/jobs.js
@@ -1,0 +1,81 @@
+import won from "../../app/won-es6.js";
+import { details } from "../detail-definitions.js";
+import { is } from "../../app/utils.js";
+
+export const industryDetail = {
+  ...details.tags,
+  identifier: "industry",
+  label: "Industries and Fields",
+  placeholder: "e.g. constrution, graphic design, metal industry, etc",
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return { "s:industry": undefined };
+    } else {
+      return { "s:industry": value };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseListFrom(jsonLDImm, ["s:industry"], "xsd:string");
+  },
+};
+
+export const employmentTypesDetail = {
+  ...details.tags,
+  identifier: "employmentTypes",
+  label: "Employment Types",
+  placeholder: "e.g. full-time, part-time, internship, self-employed, etc",
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return { "s:employmentType": undefined };
+    } else {
+      return { "s:employmentType": value };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseListFrom(jsonLDImm, ["s:employmentType"], "xsd:string");
+  },
+};
+
+export const organizationNamesDetail = {
+  ...details.tags,
+  identifier: "organizationNames",
+  label: "Organization Names",
+  placeholder:
+    "e.g. Shiawase Corp., Simmerling Constructions, Daily Bugle, etc",
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return { "s:hiringOrganization": undefined };
+    } else {
+      return {
+        "s:hiringOrganization": value.map(industry => ({
+          // for ppl who only want offers from a specific organization (rather niche tho)
+          "@type": "s:Organization",
+          "s:name": industry, // JSON - company
+        })),
+      };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseListFrom(
+      jsonLDImm,
+      ["s:hiringOrganization", "s:name"],
+      "xsd:string"
+    );
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value && is("Array", value) && value.length > 0) {
+      const prefix = includeLabel ? this.label + ": " : "";
+      //   const industryNames = value.map(industry => )
+      return prefix + value.join(", ");
+    } else {
+      return undefined;
+    }
+  },
+};
+
+/*
+    "s:hiringOrganization": { // for ppl who only want offers from a specific organization (rather niche tho)
+      "@type": "s:Organization",
+      "s:name": "", // JSON - company
+    },
+    */

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
@@ -28,9 +28,12 @@ export const location = {
 };
 
 export const jobLocation = {
-  ...location,
-  identifier: "joblocation",
+  identifier: "jobLocation",
+  label: "Jobs Near…",
   placeholder: "Location: Jobs in Vicinity of...",
+  icon: "#ico36_detail_location",
+  component: "won-location-picker",
+  viewerComponent: "won-location-viewer",
   parseToRDF: function({ value, identifier, contentUri }) {
     return {
       "s:jobLocation": genSPlace({
@@ -42,6 +45,9 @@ export const jobLocation = {
   parseFromRDF: function(jsonLDImm) {
     const jsonldLocation = jsonLDImm && jsonLDImm.get("s:jobLocation");
     return parseSPlace(jsonldLocation);
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    return sPlaceToHumanReadable({ value, includeLabel });
   },
 };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
@@ -28,7 +28,10 @@ export const location = {
     return parseSPlace(jsonldLocation);
   },
   generateHumanReadable: function({ value, includeLabel }) {
-    return sPlaceToHumanReadable({ value, includeLabel });
+    return sPlaceToHumanReadable({
+      value,
+      label: includeLabel ? this.label : "",
+    });
   },
 };
 
@@ -53,7 +56,10 @@ export const jobLocation = {
     return parseSPlace(jsonldLocation);
   },
   generateHumanReadable: function({ value, includeLabel }) {
-    return sPlaceToHumanReadable({ value, includeLabel });
+    return sPlaceToHumanReadable({
+      value,
+      label: includeLabel ? this.label : "",
+    });
   },
 };
 
@@ -355,7 +361,7 @@ function parsePlaceLeniently(jsonldLocation) {
   return place;
 }
 
-function sPlaceToHumanReadable({ value, includeLabel }) {
+function sPlaceToHumanReadable({ value, label }) {
   if (value) {
     let humanReadable;
     if (value.name) {
@@ -370,9 +376,7 @@ function sPlaceToHumanReadable({ value, includeLabel }) {
       }
     }
     if (humanReadable) {
-      return includeLabel
-        ? this.label + ": " + humanReadable.trim()
-        : humanReadable.trim();
+      return (label ? `${label}: ` : "") + humanReadable.trim();
     }
   }
   return undefined;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
@@ -72,7 +72,7 @@ export const professionalGroup = {
       },
       seeksDetails: {
         description: { ...details.description },
-        location: { ...details.location },
+        jobLocation: { ...details.jobLocation },
         skills: { ...skillsDetail },
         interests: { ...interestsDetail },
       },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
@@ -4,6 +4,11 @@
 import { details, emptyDraft } from "../detail-definitions.js";
 import { interestsDetail, skillsDetail } from "../details/person.js";
 import { jobLocation } from "../details/location.js";
+import {
+  industryDetail,
+  employmentTypesDetail,
+  organizationNamesDetail,
+} from "../details/jobs.js";
 import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
 
 export const professionalGroup = {
@@ -35,7 +40,7 @@ export const professionalGroup = {
       "s:name": "", // JSON - company
     },
 
-    "s:jobLocation": [
+    "s:jobLocation":
       {
         "@type": "s:Place",
         "s:geo": {
@@ -44,24 +49,10 @@ export const professionalGroup = {
           "s:latitude": "48.216931",
           "s:longitude": "16.361197"
         },
-        "s:address": {
-          "@type": "s:PostalAddress",
-          "s:addressCountry": "AT",
-          "s:addressLocality": "Vienna"
-        }
       },
-      {
-        "@type": "s:Place",
-        //...
-        "s:address": {
-          //...
-          "s:addressLocality": "Graz"
-        }
-      }
-    ],
     */
         },
-        searchString: ["offer-job", "job"],
+        searchString: ["offer-job"],
       },
       isDetails: {
         title: { ...details.title },
@@ -76,6 +67,9 @@ export const professionalGroup = {
         jobLocation: { ...jobLocation },
         skills: { ...skillsDetail },
         interests: { ...interestsDetail },
+        industry: { ...industryDetail },
+        employmentTypes: { ...employmentTypesDetail },
+        organizationNames: { ...organizationNamesDetail },
       },
     },
     getToKnow: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
@@ -57,16 +57,14 @@ export const professionalGroup = {
       isDetails: {
         title: { ...details.title },
         description: { ...details.description },
-        location: { ...details.location },
-        person: { ...details.person },
+        // location: { ...details.location }, // why would your current location of residency matter?
+        // person: { ...details.person }, // has current company fields, that are weird for a search
         skills: { ...skillsDetail },
         interests: { ...interestsDetail },
       },
       seeksDetails: {
         description: { ...details.description },
         jobLocation: { ...jobLocation },
-        skills: { ...skillsDetail },
-        interests: { ...interestsDetail },
         industry: { ...industryDetail },
         employmentTypes: { ...employmentTypesDetail },
         organizationNames: { ...organizationNamesDetail },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
@@ -3,6 +3,7 @@
  */
 import { details, emptyDraft } from "../detail-definitions.js";
 import { interestsDetail, skillsDetail } from "../details/person.js";
+import { jobLocation } from "../details/location.js";
 import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
 
 export const professionalGroup = {
@@ -60,7 +61,7 @@ export const professionalGroup = {
     ],
     */
         },
-        searchString: "offer-job",
+        searchString: ["offer-job", "job"],
       },
       isDetails: {
         title: { ...details.title },
@@ -72,7 +73,7 @@ export const professionalGroup = {
       },
       seeksDetails: {
         description: { ...details.description },
-        jobLocation: { ...details.jobLocation },
+        jobLocation: { ...jobLocation },
         skills: { ...skillsDetail },
         interests: { ...interestsDetail },
       },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional.js
@@ -10,32 +10,73 @@ export const professionalGroup = {
   label: "Professional Networking",
   icon: undefined,
   useCases: {
-    // jobSearch: {
-    //   label: "Search a Job",
-    //   icon: "#ico36_uc_find_people",
-    //   doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
-    //   draft: {
-    //     ...emptyDraft,
-    //     is: {
-    //       tags: ["search-job"],
-    //     },
-    //     searchString: "offer-job",
-    //   },
-    //   isDetails: {
-    //     title: { ...details.title },
-    //     description: { ...details.description },
-    //     location: { ...details.location },
-    //     person: { ...details.person },
-    //     skills: { ...skillsDetail },
-    //     interests: { ...interestsDetail },
-    //   },
-    //   seeksDetails: {
-    //     description: { ...details.description },
-    //     location: { ...details.location },
-    //     skills: { ...skillsDetail },
-    //     interests: { ...interestsDetail },
-    //   },
-    // },
+    jobSearch: {
+      identifier: "getToKnow",
+      label: "Search a Job",
+      // icon: "#ico36_uc_find_people", TODO
+      doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+      draft: {
+        ...emptyDraft,
+        is: {
+          "@type": "s:Person",
+          tags: ["search-job"],
+        },
+        seeks: {
+          "@type": "s:JobPosting",
+          /* example to match hokify-offers:
+          "s:employmentType": "Full-time", // full-time/vollzeit, part-time,... - use a dropdown
+    "s:industry": ["Computer Software", "Design"], // match by checking for intersection + text-similarity and translations
+
+    //"s:baseSalary": {...}, // free-form-text in hokify json :|
+
+    "s:hiringOrganization": { // for ppl who only want offers from a specific organization (rather niche tho)
+      "@type": "s:Organization",
+      "s:name": "", // JSON - company
+    },
+
+    "s:jobLocation": [
+      {
+        "@type": "s:Place",
+        "s:geo": {
+          "@id": "https://satvm05.researchstudio.at/won/resource/need/rsiiungn085u/location/6l7plycz2g", // unique id; i assume it's necessary for the geo-service
+          "@type": "s:GeoCoordinates",
+          "s:latitude": "48.216931",
+          "s:longitude": "16.361197"
+        },
+        "s:address": {
+          "@type": "s:PostalAddress",
+          "s:addressCountry": "AT",
+          "s:addressLocality": "Vienna"
+        }
+      },
+      {
+        "@type": "s:Place",
+        //...
+        "s:address": {
+          //...
+          "s:addressLocality": "Graz"
+        }
+      }
+    ],
+    */
+        },
+        searchString: "offer-job",
+      },
+      isDetails: {
+        title: { ...details.title },
+        description: { ...details.description },
+        location: { ...details.location },
+        person: { ...details.person },
+        skills: { ...skillsDetail },
+        interests: { ...interestsDetail },
+      },
+      seeksDetails: {
+        description: { ...details.description },
+        location: { ...details.location },
+        skills: { ...skillsDetail },
+        interests: { ...interestsDetail },
+      },
+    },
     getToKnow: {
       identifier: "getToKnow",
       label: "Find people",

--- a/webofneeds/won-owner-webapp/src/main/webapp/icons-demo.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/icons-demo.html
@@ -1,0 +1,181 @@
+<!--
+  ~ Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width">
+  <!-- see http://getbootstrap.com/css/#overview-mobile -->
+  <title>Style Demo - Web Of Needs</title>
+  <link rel="stylesheet" href="./generated/won.min.css" />
+  <link rel="stylesheet" href="./skin/current/config.css" />
+  <!-- link rel="icon" type="image/png" href="images/won-icons/won-icon64.png" / -->
+  <link rel="icon" type="image/png" href="skin/current/images/logo.png">
+
+  <style>
+    main {
+      /* overwrite normal height:100% */
+      height: auto;
+
+      display: grid;
+      grid-row-gap: 2rem;
+      justify-items: center;
+      padding-top: 2rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      padding-bottom: 2rem;
+    }
+
+    body>section {
+      background-color: white;
+    }
+
+    main>section {
+      width: 25rem;
+    }
+
+    pre {
+      background-color: var(--won-light-gray);
+      border: 1px solid var(--won-line-gray);
+      padding: 0.5rem;
+    }
+
+    h2 {
+      /* margin-top: 3rem; */
+    }
+  </style>
+</head>
+
+<body>
+
+
+
+  <section ui-view="" class="ng-scope">
+    <header class="ng-scope">
+      <won-topnav class="ng-isolate-scope">
+        <nav class="topnav hide-in-responsive" ng-class="{'hide-in-responsive': !self.isPostView &amp;&amp; self.connectionOrPostDetailOpen}">
+          <div class="topnav__inner">
+            <div class="topnav__inner__left">
+              <a href="#!/connections?privateId=b92ks59q-m5n7f9aq" class="topnav__button">
+                <img src="skin/current/images/logo.svg" class="topnav__button__icon">
+                <span class="topnav__page-title topnav__button__caption hide-in-responsive ng-binding">
+                  Icons Demo
+                </span>
+              </a>
+            </div>
+            <div class="topnav__inner__center"></div>
+            <div class="topnav__inner__right"> </div>
+          </div>
+        </nav>
+      </won-topnav>
+    </header>
+    <main>
+
+      <div class="icon-mount"></div>
+
+      <section>
+        <img src="./generated/symbol/svg/sprite.symbol.svg">
+
+      </section>
+
+      <!-- This works, why doesn't the scripted variant?
+      <svg style="--local-primary:var(--won-primary-color);">
+        <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+      </svg> -->
+
+
+    </main>
+  </section>
+
+
+
+
+  <!-- start loading the svg so it's already in the cache once angular has finished loading its templates -->
+  <img src="./generated/symbol/svg/sprite.symbol.svg" style="display:none">
+  <script>
+
+    (async function () {
+
+
+      // from https://github.com/gagan-bansal/parse-svg/blob/master/index.js
+      function parseSVG(xmlString) {
+        const div = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
+        div.innerHTML =
+          '<svg xmlns="http://www.w3.org/2000/svg">' + xmlString + "</svg>";
+        const frag = document.createDocumentFragment();
+        while (div.firstChild.firstChild) frag.appendChild(div.firstChild.firstChild);
+        return frag;
+      }
+      /**
+       * Fetch and inline an icon-spritemap so it can be colored using css-constiables.
+       */
+      function inlineSVGSpritesheet(path, id) {
+        return fetch(path)
+          .then(res => res.text())
+          .then(xmlString => parseSVG(xmlString))
+          .then(svgDocumentFragment => {
+            if (!svgDocumentFragment)
+              throw new Error("Couldn't parse icon-spritesheet.");
+            document.body.appendChild(svgDocumentFragment);
+            const svgNode = document.body.lastChild; // the node resulting from the fragment we just appended
+            if (svgNode && svgNode.style) {
+              svgNode.style.display = "none";
+            }
+            if (id) {
+              svgNode.id = id;
+            }
+          });
+      }
+      await inlineSVGSpritesheet("./generated/symbol/svg/sprite.symbol.svg", "icon-sprite");
+
+
+      function map(iterable, fn) {
+        const acc = [];
+        for (let el of iterable) acc.push(fn(el))
+        return acc;
+      }
+      function forEAch(iterable, fn) {
+        map(iterable, fn);
+        // don't return
+      }
+
+
+      const symbols = document.querySelectorAll('#icon-sprite symbol');
+      const iconNames = map(symbols, s => s.getAttribute('id'));
+      const iconMount = document.querySelector('.icon-mount');
+      iconNames.forEach(iconName => {
+        var svg = document.createElement('svg',
+
+          { 'style': '--local-primary: black', 'href': 'asdf' }
+        );
+
+        svg.setAttribute('style', '--local-primary: var(--won-primary-color);');
+
+        var use = document.createElement('use')
+        use.setAttribute('href', `#${iconName}`);
+        use.setAttribute('xlink:href', `#${iconName}`);
+
+        svg.appendChild(use);
+        iconMount.appendChild(svg)
+      })
+
+    })();
+  </script>
+
+</body>
+
+</html>

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -679,8 +679,7 @@
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-      "dev": true
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -2069,8 +2068,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -2381,8 +2379,7 @@
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-      "dev": true
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2911,7 +2908,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -5268,8 +5264,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9444,8 +9439,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -9638,7 +9632,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10112,8 +10105,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-loader": {
       "version": "7.1.0",
@@ -10475,8 +10467,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -10724,7 +10715,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }


### PR DESCRIPTION
You can now enter data in "professional » search job", that's tailored to be matched with the hokify job-offers.

Doesn't include yet:

* icons
* sparql-queries
* manually entered job-offers

test:

1. post job search with all details
2. compare the generated RDF against the following json-ld pseudo-code (taken from our modelling document):

```
```json
{
  "won:is" : {
    "@type": "s:Person",
  }

  "won:seeks": {
    "@type": "s:JobPosting",

    "s:employmentType": "Full-time", // full-time/vollzeit, part-time,... - use a dropdown
    "s:industry": ["Computer Software", "Design"], // match by checking for intersection + text-similarity and translations

    //"s:baseSalary": {...}, // free-form-text in hokify json; can't match :|
    
    "s:hiringOrganization": { // for ppl who only want offers from a specific organization (rather niche tho)
      "@type": "s:Organization",
      "s:name": "Google", // JSON - company
    },
 
    "s:jobLocation": [
      {
        "@type": "s:Place",
        "s:geo": {
          "@id": "https://satvm05.researchstudio.at/won/resource/need/rsiiungn085u/location/6l7plycz2g", // unique id; i assume it's necessary for the geo-service
          "@type": "s:GeoCoordinates",
          "s:latitude": "48.216931",
          "s:longitude": "16.361197"
        },
        "s:address": { // couldn't match that atm either + using nominatim guarantees that addresses are resolvable
          "@type": "s:PostalAddress",
          "s:addressCountry": "AT",
          "s:addressLocality": "Vienna"
        }
      },
      {
        "@type": "s:Place",
        //...
        "s:address": {
          //...
          "s:addressLocality": "Graz"
        }
      }
    ],
    
  }
}
```