### PR TITLE
Feat enable forward

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
@@ -85,7 +85,7 @@ public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAct
     Pattern PATTERN_PROPOSE = Pattern.compile("^propose(\\s+((my)|(any))?\\s*([1-9])?)?$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_ACCEPT = Pattern.compile("^accept$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_CANCEL = Pattern.compile("^cancel$", Pattern.CASE_INSENSITIVE);
-    Pattern PATTERN_FORWARD = Pattern.compile("^forward$", Pattern.CASE_INSENSITIVE);
+    Pattern PATTERN_INJECT = Pattern.compile("^inject$", Pattern.CASE_INSENSITIVE);
 
     public static void main(String[] args) {
     	Pattern p = Pattern.compile("^reject(\\s+(yours))?$", Pattern.CASE_INSENSITIVE);
@@ -132,21 +132,21 @@ public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAct
     public static final String[] USAGE_MESSAGES = {
             "You are connected to the debug bot. You can issue commands that will cause interactions with your need.\n\n" +
             "Usage:\n" +
-            "    'hint':            create a new need and send hint to it\n" +
-            "    'connect':         create a new need and send connection request to it\n" +
-            "    'close':           close the current connection\n" +
-            "    'deactivate':      deactivate remote need of the current connection\n" +
-            "    'chatty on|off':   send chat messages spontaneously every now and then? (default: on)\n" +
-            "    'send N':          send N messages, one per second. N must be an integer between 1 and 9\n" +
-            "    'validate':        download the connection data and validate it\n" +
-            "    'propose (my|any) (N)':  propose one (N, max 9) of my(/your/any) messages for an agreement\n" +
-            "    'accept':          accept the last proposal made (including cancellation proposals)\n" +
-            "    'cancel:           propose to cancel the newest agreement (that wasn't only a cancellation)\n" +
-            "    'retract (mine|proposal)':  retract the last (proposal) message you sent, or the last message I sent\n" +
-            "    'reject (yours)':  reject the last rejectable message I (you) sent\n" +
-            "    'cache eager|lazy: use lazy or eager RDF cache\n" +
-            "    'forward'          send a message in this connection that will be forwarded to all other connections we have\n" +
-            "    'usage':           display this message\n"
+            "    `hint`:            create a new need and send hint to it\n" +
+            "    `connect`:         create a new need and send connection request to it\n" +
+            "    `close`:           close the current connection\n" +
+            "    `deactivate`:      deactivate remote need of the current connection\n" +
+            "    `chatty on|off`:   send chat messages spontaneously every now and then? (default: on)\n" +
+            "    `send N`:          send N messages, one per second. N must be an integer between 1 and 9\n" +
+            "    `validate'`:        download the connection data and validate it\n" +
+            "    `propose (my|any) (N)`:  propose one (N, max 9) of my(/your/any) messages for an agreement\n" +
+            "    `accept`:          accept the last proposal made (including cancellation proposals)\n" +
+            "    `cancel`:           propose to cancel the newest agreement (that wasn't only a cancellation)\n" +
+            "    `retract (mine|proposal)`:  retract the last (proposal) message you sent, or the last message I sent\n" +
+            "    `reject (yours)`:  reject the last rejectable message I (you) sent\n" +
+            "    `cache eager|lazy`: use lazy or eager RDF cache\n" +
+            "    `inject`           send a message in this connection that will be forwarded to all other connections we have\n" +
+            "    `usage`:           display this message\n"
     };
 
     public static final String[] N_MESSAGES = {
@@ -262,8 +262,8 @@ public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAct
                 	accept(ctx, bus, con);
                 } else if (PATTERN_CANCEL.matcher(message).matches()) {
                 	cancel(ctx, bus, con);
-                } else if (PATTERN_FORWARD.matcher(message).matches()) {
-                    forward(ctx, bus, con);
+                } else if (PATTERN_INJECT.matcher(message).matches()) {
+                    inject(ctx, bus, con);
                 } else {
                     //default: answer with eliza.
                     bus.publish(new MessageToElizaEvent(con, message));
@@ -278,7 +278,7 @@ public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAct
     
     
 
-    private void forward(EventListenerContext ctx, EventBus bus, Connection con) {
+    private void inject(EventListenerContext ctx, EventBus bus, Connection con) {
         Model messageModel = WonRdfUtils.MessageUtils.textMessage("Ok, I'll send you one message that will be injected into our other connections by your WoN node if the inject permission is granted");
         bus.publish(new ConnectionMessageCommandEvent(con, messageModel));
         //build a message to be injected into all connections of the receiver need (not controlled by us)

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/AbstractCreateNeedAction.java
@@ -103,7 +103,7 @@ public abstract class AbstractCreateNeedAction extends BaseEventBotAction {
       needModelWrapper.addFlag( WON.USED_FOR_TESTING);
     }
 
-        RdfUtils.replaceBaseURI(needDataset, needURI.toString());
+        RdfUtils.replaceBaseURI(needDataset, needURI.toString(), true);
 
         return WonMessageBuilder.setMessagePropertiesForCreate(
             wonNodeInformationService.generateEventURI(wonNodeURI),

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateNeedWithFacetsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/needlifecycle/CreateNeedWithFacetsAction.java
@@ -67,9 +67,9 @@ public class CreateNeedWithFacetsAction extends AbstractCreateNeedAction {
         Resource needResource = WonRdfUtils.NeedUtils.getNeedResource(needDataset);
         if (needResource.isURIResource()) {
             needUriFromProducer = URI.create(needResource.getURI().toString());
-            RdfUtils.replaceBaseURI(needDataset, needResource.getURI());
+            RdfUtils.replaceBaseURI(needDataset, needResource.getURI(), true);
         } else {
-            RdfUtils.replaceBaseResource(needDataset, needResource);
+            RdfUtils.replaceBaseResource(needDataset, needResource, true);
         }
         final URI needUriBeforeCreation = needUriFromProducer;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteConnectionMessageCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteConnectionMessageCommandAction.java
@@ -83,9 +83,9 @@ public class ExecuteConnectionMessageCommandAction extends ExecuteSendMessageCom
                         remoteNeed,
                         WonRdfUtils.NeedUtils.getWonNodeURIFromNeed(remoteNeedRDF, remoteNeed),
                         localMessageModel);
-        Set<URI> forwardToReceivers = messageCommandEvent.getForwardToReceivers();
-        if (!forwardToReceivers.isEmpty()) {
-            wmb.setForwardToReceiverURIs(forwardToReceivers);
+        Set<URI> injectionTargets = messageCommandEvent.getInjectIntoConnections();
+        if (!injectionTargets.isEmpty()) {
+            wmb.setInjectIntoConnections(injectionTargets);
         }
         return wmb.build();
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteConnectionMessageCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteConnectionMessageCommandAction.java
@@ -1,12 +1,15 @@
 package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
+import java.net.URI;
+import java.util.Set;
+
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
+
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandFailureEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandNotSentEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandSuccessEvent;
-import won.bot.framework.eventbot.event.impl.command.close.CloseCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.connectionmessage.ConnectionMessageCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.connectionmessage.ConnectionMessageCommandFailureEvent;
 import won.bot.framework.eventbot.event.impl.command.connectionmessage.ConnectionMessageCommandSuccessEvent;
@@ -18,8 +21,6 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
-
-import java.net.URI;
 
 /**
  * Action executing a ConnectionMessageCommandEvent, creating a connection message for sending in the specified connection, adding the specified model as the content of the message.
@@ -71,8 +72,9 @@ public class ExecuteConnectionMessageCommandAction extends ExecuteSendMessageCom
         URI messageURI = wonNodeInformationService.generateEventURI(wonNode);
         RdfUtils.replaceBaseURI(localMessageModel, messageURI.toString());
 
-        return WonMessageBuilder
-                .setMessagePropertiesForConnectionMessage(
+        WonMessageBuilder wmb =  
+                WonMessageBuilder
+                    .setMessagePropertiesForConnectionMessage(
                         messageURI,
                         messageCommandEvent.getConnectionURI(),
                         localNeed,
@@ -80,7 +82,11 @@ public class ExecuteConnectionMessageCommandAction extends ExecuteSendMessageCom
                         WonRdfUtils.ConnectionUtils.getRemoteConnectionURIFromConnection(connectionRDF, messageCommandEvent.getConnectionURI()),
                         remoteNeed,
                         WonRdfUtils.NeedUtils.getWonNodeURIFromNeed(remoteNeedRDF, remoteNeed),
-                        localMessageModel)
-                .build();
+                        localMessageModel);
+        Set<URI> forwardToReceivers = messageCommandEvent.getForwardToReceivers();
+        if (!forwardToReceivers.isEmpty()) {
+            wmb.setForwardToReceiverURIs(forwardToReceivers);
+        }
+        return wmb.build();
     }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateNeedCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateNeedCommandAction.java
@@ -68,9 +68,9 @@ public class ExecuteCreateNeedCommandAction extends BaseEventBotAction {
         Resource needResource = WonRdfUtils.NeedUtils.getNeedResource(needDataset);
         if (needResource.isURIResource()) {
             needUriFromProducer = URI.create(needResource.getURI().toString());
-            RdfUtils.replaceBaseURI(needDataset, needResource.getURI());
+            RdfUtils.replaceBaseURI(needDataset, needResource.getURI(), true);
         } else {
-            RdfUtils.replaceBaseResource(needDataset, needResource);
+            RdfUtils.replaceBaseResource(needDataset, needResource, true);
         }
 
         final URI needUriBeforeCreation = needUriFromProducer;
@@ -125,7 +125,7 @@ public class ExecuteCreateNeedCommandAction extends BaseEventBotAction {
             WonNodeInformationService wonNodeInformationService, URI needURI, URI wonNodeURI, Dataset needDataset,
             final boolean usedForTesting, final boolean doNotMatch) throws WonMessageBuilderException {
 
-        RdfUtils.replaceBaseURI(needDataset, needURI.toString());
+        RdfUtils.replaceBaseURI(needDataset, needURI.toString(), true);
 
         NeedModelWrapper needModelWrapper = new NeedModelWrapper(needDataset);
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/LogMessageCommandFailureAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/LogMessageCommandFailureAction.java
@@ -41,9 +41,9 @@ public class LogMessageCommandFailureAction extends BaseEventBotAction{
         String command = failureEvent.getOriginalCommandEvent().getClass().getSimpleName();
         String message = failureEvent.getMessage();
         if (message != null) {
-            logger.info("Message command {} failed", command);
+            logger.error("Message command {} failed", command);
         } else {
-            logger.info("Message command {} failed. Message: ", command, message);
+            logger.error("Message command {} failed. Message: ", command, message);
         }
     }
 }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/connectionmessage/ConnectionMessageCommandEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/connectionmessage/ConnectionMessageCommandEvent.java
@@ -1,20 +1,32 @@
 package won.bot.framework.eventbot.event.impl.command.connectionmessage;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.jena.rdf.model.Model;
+
 import won.bot.framework.eventbot.event.BaseNeedAndConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandEvent;
 import won.protocol.message.WonMessageType;
 import won.protocol.model.Connection;
 
-import java.net.URI;
-
 public class ConnectionMessageCommandEvent extends BaseNeedAndConnectionSpecificEvent implements MessageCommandEvent, ConnectionSpecificEvent {
     private Model messageModel;
+    private Set<URI> forwardToReceivers = new HashSet<>();
 
-    public ConnectionMessageCommandEvent(Connection con, Model messageModel) {
+    public ConnectionMessageCommandEvent(Connection con, Model messageModel, Collection<URI> forwardToReceivers) {
         super(con);
         this.messageModel = messageModel;
+        if (forwardToReceivers != null) {
+            this.forwardToReceivers.addAll(forwardToReceivers);
+        }
+    }
+    
+    public ConnectionMessageCommandEvent(Connection con, Model messageModel) {
+        this(con, messageModel, null);
     }
 
     @Override
@@ -25,6 +37,10 @@ public class ConnectionMessageCommandEvent extends BaseNeedAndConnectionSpecific
     @Override
     public WonMessageType getWonMessageType() {
         return WonMessageType.CONNECTION_MESSAGE;
+    }
+    
+    public Set<URI> getForwardToReceivers() {
+        return forwardToReceivers;
     }
 
     public Model getMessageModel() {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/connectionmessage/ConnectionMessageCommandEvent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/event/impl/command/connectionmessage/ConnectionMessageCommandEvent.java
@@ -15,13 +15,13 @@ import won.protocol.model.Connection;
 
 public class ConnectionMessageCommandEvent extends BaseNeedAndConnectionSpecificEvent implements MessageCommandEvent, ConnectionSpecificEvent {
     private Model messageModel;
-    private Set<URI> forwardToReceivers = new HashSet<>();
+    private Set<URI> injectIntoConnections = new HashSet<>();
 
-    public ConnectionMessageCommandEvent(Connection con, Model messageModel, Collection<URI> forwardToReceivers) {
+    public ConnectionMessageCommandEvent(Connection con, Model messageModel, Collection<URI> injectionTargets) {
         super(con);
         this.messageModel = messageModel;
-        if (forwardToReceivers != null) {
-            this.forwardToReceivers.addAll(forwardToReceivers);
+        if (injectionTargets != null) {
+            this.injectIntoConnections.addAll(injectionTargets);
         }
     }
     
@@ -39,8 +39,8 @@ public class ConnectionMessageCommandEvent extends BaseNeedAndConnectionSpecific
         return WonMessageType.CONNECTION_MESSAGE;
     }
     
-    public Set<URI> getForwardToReceivers() {
-        return forwardToReceivers;
+    public Set<URI> getInjectIntoConnections() {
+        return injectIntoConnections;
     }
 
     public Model getMessageModel() {

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessage.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessage.java
@@ -47,8 +47,9 @@ public class WonMessage implements Serializable {
     private URI receiverNeedURI;
     private URI receiverNodeURI;
     private URI receiverFacetURI;
-    private List<URI> refersTo = new ArrayList<>();
-    private List<URI> previousMessages = new ArrayList<>();
+    private List<URI> refersTo = null;
+    private List<URI> previousMessages = null;
+    private List<URI> forwardToReceiverURI = null;    
     private URI isResponseToMessageURI;
     private URI isRemoteResponseToMessageURI;
     private List<String> contentGraphNames;
@@ -443,8 +444,8 @@ public class WonMessage implements Serializable {
         }
         return this.receiverURI;
     }
-
-
+    
+   
     public synchronized URI getReceiverNeedURI() {
         if (this.receiverNeedURI == null) {
             this.receiverNeedURI = getEnvelopePropertyURIValue(WONMSG.RECEIVER_NEED_PROPERTY);
@@ -472,8 +473,16 @@ public class WonMessage implements Serializable {
             this.refersTo = getEnvelopePropertyURIValues(WONMSG.REFERS_TO_PROPERTY);
         }
         return this.refersTo;
-
     }
+    
+    public synchronized List<URI> getForwardToReceiverURIs() {
+        if (this.forwardToReceiverURI == null) {
+            this.forwardToReceiverURI = getEnvelopePropertyURIValues(WONMSG.HAS_FORWARD_TO_RECEIVER);
+        }
+        return this.forwardToReceiverURI;
+    }
+
+
     
     public synchronized List<URI> getPreviousMessageURIs() {
         if (this.previousMessages == null) {

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessage.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessage.java
@@ -49,7 +49,7 @@ public class WonMessage implements Serializable {
     private URI receiverFacetURI;
     private List<URI> refersTo = null;
     private List<URI> previousMessages = null;
-    private List<URI> forwardToReceiverURI = null;    
+    private List<URI> injectIntoConnections = null;    
     private URI isResponseToMessageURI;
     private URI isRemoteResponseToMessageURI;
     private List<String> contentGraphNames;
@@ -475,11 +475,11 @@ public class WonMessage implements Serializable {
         return this.refersTo;
     }
     
-    public synchronized List<URI> getForwardToReceiverURIs() {
-        if (this.forwardToReceiverURI == null) {
-            this.forwardToReceiverURI = getEnvelopePropertyURIValues(WONMSG.HAS_FORWARD_TO_RECEIVER);
+    public synchronized List<URI> getInjectIntoConnectionURIs() {
+        if (this.injectIntoConnections == null) {
+            this.injectIntoConnections = getEnvelopePropertyURIValues(WONMSG.HAS_INJECT_INTO_CONNECTION);
         }
-        return this.forwardToReceiverURI;
+        return this.injectIntoConnections;
     }
 
 

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
@@ -1,6 +1,7 @@
 package won.protocol.message;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -920,7 +921,6 @@ public class WonMessageBuilder
     return this;
   }
 
-
   public WonMessageBuilder setCorrespondingRemoteMessageURI(URI correspondingRemoteMessageURI){
     this.correspondingRemoteMessageURI = correspondingRemoteMessageURI;
     return this;
@@ -929,6 +929,11 @@ public class WonMessageBuilder
   public WonMessageBuilder setForwardedMessageURI(URI forwardedMessageURI) {
     this.forwardedMessageURI = forwardedMessageURI;
     return this;
+  }
+  
+  public WonMessageBuilder setForwardToReceiverURIs(Collection<URI> forwardToReceiverUris) {
+      this.forwardToReceiverURIs.addAll(forwardToReceiverUris);
+      return this;
   }
 
   public WonMessageBuilder setSentTimestamp(final long sentTimestamp) {

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageBuilder.java
@@ -47,7 +47,7 @@ public class WonMessageBuilder
   private URI receiverNeedURI;
   private URI receiverNodeURI;
   private URI receiverFacetURI;
-  private Set<URI> forwardToReceiverURIs = new HashSet<>();
+  private Set<URI> injectIntoConnections = new HashSet<>();
 
   private WonMessageType wonMessageType;
   private WonMessageDirection wonMessageDirection;
@@ -179,8 +179,8 @@ public class WonMessageBuilder
     }
     
     // add forwards
-    if (!forwardToReceiverURIs.isEmpty()) {
-        forwardToReceiverURIs.forEach(receiver -> messageEventResource.addProperty(WONMSG.HAS_FORWARD_TO_RECEIVER,
+    if (!injectIntoConnections.isEmpty()) {
+        injectIntoConnections.forEach(receiver -> messageEventResource.addProperty(WONMSG.HAS_INJECT_INTO_CONNECTION,
                 envelopeGraph.getResource(receiver.toString())));
     }
     
@@ -931,8 +931,8 @@ public class WonMessageBuilder
     return this;
   }
   
-  public WonMessageBuilder setForwardToReceiverURIs(Collection<URI> forwardToReceiverUris) {
-      this.forwardToReceiverURIs.addAll(forwardToReceiverUris);
+  public WonMessageBuilder setInjectIntoConnections(Collection<URI> forwardToReceiverUris) {
+      this.injectIntoConnections.addAll(forwardToReceiverUris);
       return this;
   }
 

--- a/webofneeds/won-core/src/main/java/won/protocol/util/NeedModelWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/NeedModelWrapper.java
@@ -48,17 +48,15 @@ public class NeedModelWrapper {
      */
     public NeedModelWrapper(String needUri) {
 
-        needDataset = DatasetFactory.create();
+        needDataset = DatasetFactory.createGeneral();
         Model needModel = ModelFactory.createDefaultModel();
         DefaultPrefixUtils.setDefaultPrefixes(needModel);
         needModel.createResource(needUri, WON.NEED);
         Model sysInfoModel = ModelFactory.createDefaultModel();
         DefaultPrefixUtils.setDefaultPrefixes(sysInfoModel);
         sysInfoModel.createResource(needUri, WON.NEED);
-        this.needModelGraphName = "dummy#need";
+        this.needModelGraphName = needUri + "#need";
         needDataset.addNamedModel(this.needModelGraphName, needModel);
-        this.sysInfoGraphName = "dummy#sysinfo";
-        needDataset.addNamedModel(this.sysInfoGraphName, sysInfoModel);
     }
 
     /**
@@ -67,7 +65,7 @@ public class NeedModelWrapper {
      * @param ds need dataset to load
      */
     public NeedModelWrapper(Dataset ds) {
-        this(ds, true);
+        this(ds, false);
     }
 
     /**
@@ -111,7 +109,7 @@ public class NeedModelWrapper {
      */
     public NeedModelWrapper(Model needModel, Model sysInfoModel) {
 
-        needDataset = DatasetFactory.create();
+        needDataset = DatasetFactory.createGeneral();
         String needUri = null;
 
         if (sysInfoModel != null) {
@@ -172,7 +170,10 @@ public class NeedModelWrapper {
         while(modelNameIter.hasNext()) {
             String tempModelName = modelNameIter.next();
             Model model = needDataset.getNamedModel(tempModelName);
-
+            if (tempModelName.equals("dummy#sysinfo")) {
+                continue;  
+            }
+            
             if(model.listSubjectsWithProperty(RDF.type, WON.NEED).hasNext() && ! model.listSubjectsWithProperty(WON.IS_IN_STATE).hasNext()) {
                 this.needModelGraphName = tempModelName;
                 return model;
@@ -194,6 +195,9 @@ public class NeedModelWrapper {
 
         while(modelNameIter.hasNext()) {
             String tempModelName = modelNameIter.next();
+            if (tempModelName.equals("dummy#need")) {
+                continue;  
+            }
             Model model = needDataset.getNamedModel(tempModelName);
 
             if(model.listSubjectsWithProperty(RDF.type, WON.NEED).hasNext() && model.listSubjectsWithProperty(WON.IS_IN_STATE).hasNext()){
@@ -318,11 +322,11 @@ public class NeedModelWrapper {
     }
     
     public void addMatchingContext(String context) {
-    	getNeedNode(NeedGraphType.NEED).addProperty(WON.HAS_MATCHING_CONTEXT, context);
+        getNeedNode(NeedGraphType.NEED).addProperty(WON.HAS_MATCHING_CONTEXT, context);
     }
     
     public boolean hasMatchingContext(String context) {
-    	return getNeedNode(NeedGraphType.NEED).hasProperty(WON.HAS_MATCHING_CONTEXT, context);
+        return getNeedNode(NeedGraphType.NEED).hasProperty(WON.HAS_MATCHING_CONTEXT, context);
     }
     
     public void addQuery(String query) {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -1196,9 +1196,4 @@ public class WonRdfUtils
     
   }
   
-  
-  public static void main (String...strings) {
-      NeedUtils.getRemoteConnectionURIsForRemoteNeeds(null, Arrays.asList(URI.create("http://ex.com/1")));
-      NeedUtils.getRemoteConnectionURIsForRemoteNeeds(null, Arrays.asList(URI.create("http://ex.com/1"), URI.create("http://ex.com/2"), URI.create("http://ex.com/3")));
-  }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -4,17 +4,21 @@ import static won.protocol.util.RdfUtils.findOnePropertyFromResource;
 import static won.protocol.util.RdfUtils.findOrCreateBaseResource;
 import static won.protocol.util.RdfUtils.visit;
 
-import java.awt.TrayIcon.MessageType;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -35,6 +39,16 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.rdf.model.impl.PropertyImpl;
 import org.apache.jena.rdf.model.impl.ResourceImpl;
 import org.apache.jena.riot.Lang;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpAsQuery;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpGraph;
+import org.apache.jena.sparql.algebra.op.OpProject;
+import org.apache.jena.sparql.algebra.op.OpUnion;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathParser;
 import org.apache.jena.tdb.TDB;
@@ -43,10 +57,11 @@ import org.hibernate.cfg.NotYetImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.andrewoma.dexx.collection.Sets;
+
 import won.protocol.exception.IncorrectPropertyCountException;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
-import won.protocol.message.WonMessageType;
 import won.protocol.message.WonSignatureData;
 import won.protocol.model.ConnectionState;
 import won.protocol.model.Match;
@@ -1119,6 +1134,71 @@ public class WonRdfUtils
       return URI.create(findOnePropertyFromResource(
         dataset, needURI, WON.HAS_WON_NODE).asResource().getURI());
     }
+    
+    /**
+     * 
+     */
+    public static Iterator<URI> getConnectedNeeds(Dataset dataset, final URI needURI) {
+        PrefixMapping pmap = new PrefixMappingImpl();
+        pmap.withDefaultMappings(PrefixMapping.Standard);
+        pmap.setNsPrefix("won", WON.getURI());
+        pmap.setNsPrefix("msg", WONMSG.getURI());
+        Path path = PathParser.parse("won:hasConnectionContainer/rdfs:member/won:hasRemoteNeed", pmap);
+        return RdfUtils.getURIsForPropertyPath(dataset, needURI, path);
+    }
+    
+    /**
+     * Assumes that the dataset contains a need's connection information, looks for the specified remote needs and returns the remote connection uris.
+     * Optionally the result can be filtered by connection state. 
+     */
+    public static Set<URI> getRemoteConnectionURIsForRemoteNeeds(Dataset dataset, final Collection<URI> remoteNeeds, final Optional<ConnectionState> state) {
+        Optional<Object> unions = 
+            remoteNeeds.stream()
+                .map(uri -> {
+                    BasicPattern pattern = new BasicPattern();
+                    pattern.add(Triple.create(Var.alloc("localCon"), NodeFactory.createURI("http://purl.org/webofneeds/model#hasRemoteNeed"), NodeFactory.createURI(uri.toString())));
+                    pattern.add(Triple.create(Var.alloc("localCon"), NodeFactory.createURI("http://purl.org/webofneeds/model#hasRemoteConnection"), Var.alloc("remoteCon")));
+                    if (state.isPresent()) {
+                        pattern.add(Triple.create(Var.alloc("localCon"), NodeFactory.createURI("http://purl.org/webofneeds/model#hasConnectionState"), NodeFactory.createURI(state.get().getURI().toString())));
+                    }
+                    return pattern;
+                })
+                .map(pattern -> new OpBGP(pattern))
+                .map(bgp -> new OpGraph(Var.alloc("g"), bgp))
+                .reduce(
+                    Optional.empty(), 
+                    (union, pattern) -> {
+                        if (!union.isPresent()) {
+                            return Optional.of(pattern);
+                        } 
+                        return Optional.of(new OpUnion((Op) union.get(), pattern));
+                    }, (union1, union2) -> {
+                       if (!union1.isPresent()) return union2;
+                       if (!union2.isPresent()) return union1;
+                       return Optional.of(new OpUnion((Op)union1.get(), (Op)union2.get()));
+                    });
+        if (!unions.isPresent()) {
+            return Collections.EMPTY_SET;
+        }
+        Op op = new OpProject((Op) unions.get(), Arrays.asList(Var.alloc("remoteCon"))); 
+        Query q = OpAsQuery.asQuery(op);                       
+        q.setQuerySelectType();                                
+        Set<URI> result = new HashSet();
+        try (QueryExecution qexec = QueryExecutionFactory.create(q, dataset)){
+            ResultSet resultSet = qexec.execSelect();
+            while(resultSet.hasNext()) {
+                QuerySolution solution = resultSet.next();
+                result.add(URI.create(solution.get("remoteCon").asResource().getURI()));
+            }
+        }
+        return result;
+    }
+    
   }
-
+  
+  
+  public static void main (String...strings) {
+      NeedUtils.getRemoteConnectionURIsForRemoteNeeds(null, Arrays.asList(URI.create("http://ex.com/1")));
+      NeedUtils.getRemoteConnectionURIsForRemoteNeeds(null, Arrays.asList(URI.create("http://ex.com/1"), URI.create("http://ex.com/2"), URI.create("http://ex.com/3")));
+  }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
@@ -302,6 +302,9 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
 		DatasetResponseWithStatusCodeAndHeaders responseData = fetchWithEtagValidation(resource, requesterWebID,
 				linkedDataCacheEntry, headers);
 		Date expires = parseCacheControlMaxAgeValue(resource, responseData);
+		if (responseData.getDataset() == null ) {
+		    throw new IllegalStateException("Could not load dataset for URI " + resource + " and requesterWebID " + requesterWebID);
+		}
 		if (expires == null) {
 			expires = parseExpiresHeader(resource, responseData);
 			if (expires != null && expires.getTime() == 0) {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
@@ -264,6 +264,24 @@ public class WonLinkedDataUtils
   }
 
   /**
+   * Crawls all connections of the specified need without messages. 
+   * 
+   */
+  public static Dataset getConnectionNetwork(URI needURI, LinkedDataSource linkedDataSource) {
+      assert linkedDataSource != null : "linkedDataSource must not be null";
+      int depth = 5; 
+      int maxRequests = 1000;
+      List<Path> propertyPaths = new ArrayList<>();
+      PrefixMapping pmap = new PrefixMappingImpl();
+      pmap.withDefaultMappings(PrefixMapping.Standard);
+      pmap.setNsPrefix("won", WON.getURI());
+      pmap.setNsPrefix("msg", WONMSG.getURI());
+      propertyPaths.add(PathParser.parse("won:hasConnections", pmap));
+      propertyPaths.add(PathParser.parse("won:hasConnections/rdfs:member", pmap));
+      return linkedDataSource.getDataForResourceWithPropertyPath(needURI, needURI, propertyPaths, maxRequests, depth);
+  }
+  
+  /**
    * Iterator implementation that fetches linked data lazily for the specified iterator of URIs.
    */
   private static class ModelFetchingIterator implements Iterator<Dataset> {

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WONMSG.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WONMSG.java
@@ -143,7 +143,7 @@ public class WONMSG
   public static final Property HAS_CORRESPONDING_REMOTE_MESSAGE = m.createProperty(BASE_URI, "hasCorrespondingRemoteMessage");
   public static final Property HAS_FORWARDED_MESSAGE = m.createProperty(BASE_URI, "hasForwardedMessage");
   
-  public static final Property HAS_FORWARD_TO_RECEIVER = m.createProperty(BASE_URI, "hasForwardToReceiver");
+  public static final Property HAS_INJECT_INTO_CONNECTION = m.createProperty(BASE_URI, "hasInjectIntoConnection");
 
   public static final Property HAS_PREVIOUS_MESSAGE_PROPERTY = m.createProperty(BASE_URI + "hasPreviousMessage");
   public static final Property NEW_NEED_STATE_PROPERTY = m.createProperty(BASE_URI, "newNeedState");

--- a/webofneeds/won-core/src/main/resources/validation/message/02_prop/invalid_forward_to_receiver.rq
+++ b/webofneeds/won-core/src/main/resources/validation/message/02_prop/invalid_forward_to_receiver.rq
@@ -1,0 +1,25 @@
+prefix dc:    <http://purl.org/dc/elements/1.1/>
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+prefix geo:   <http://www.w3.org/2003/01/geo/wgs84_pos#>
+prefix conn:  <http://localhost:8080/won/resource/connection/>
+prefix event: <http://localhost:8080/won/resource/event/>
+prefix woncrypt: <http://purl.org/webofneeds/woncrypt#>
+prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix local: <http://localhost:8080/won/resource/>
+prefix won:   <http://purl.org/webofneeds/model#>
+prefix msg:   <http://purl.org/webofneeds/message#>
+prefix signature: <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#>
+prefix ldp:   <http://www.w3.org/ns/ldp#>
+
+# The msg:hasForwardToReceiver property is only allowed in msg:ConnectionMessage envelopes.
+SELECT * WHERE {
+  GRAPH ?graph
+  {
+      ?offendingMessage msg:hasMessageType ?type .
+      optional {
+          ?offendingMessage msg:hasForwardToReceiver ?forwardReceiver .
+      }
+      bind(if (bound(?forwardReceiver) && ?type != msg:ConnectionMessage, "FAIL", "OK") as ?check)
+  }
+}

--- a/webofneeds/won-core/src/test/java/won/protocol/message/WonMessageValidatorTest.java
+++ b/webofneeds/won-core/src/test/java/won/protocol/message/WonMessageValidatorTest.java
@@ -168,6 +168,21 @@ public class WonMessageValidatorTest
     Assert.assertTrue("validation is expected not to fail at " + message, valid);
   }
 
+  @Test
+  public void testValidForwardToReceiverMessage() throws IOException {
+    WonMessageValidator validator = new WonMessageValidator();
+    StringBuilder message = new StringBuilder();
+    boolean valid = validator.validate(Utils.createTestDataset("/validation/valid/conversation_msg_with_forward.trig"), message);
+    Assert.assertTrue("validation is expected not to fail at " + message, valid);
+  }
+
+  @Test
+  public void testInvalidForwardToReceiverMessage() throws IOException {
+    WonMessageValidator validator = new WonMessageValidator();
+    StringBuilder message = new StringBuilder();
+    boolean valid = validator.validate(Utils.createTestDataset("/validation/invalid/create_msg_with_forward.trig"), message);
+    Assert.assertFalse("validation is expected to fail at " + message, valid);
+  }
   
   @Test
   public void testInvalidDefaultGraph() throws IOException {

--- a/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWrapperTest.java
+++ b/webofneeds/won-core/src/test/java/won/protocol/util/NeedModelWrapperTest.java
@@ -1,21 +1,23 @@
 package won.protocol.util;
 
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+
 import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
 import org.junit.Assert;
 import org.junit.Test;
+
 import won.protocol.message.Utils;
 import won.protocol.model.NeedContentPropertyType;
 import won.protocol.model.NeedGraphType;
 import won.protocol.model.NeedState;
 import won.protocol.vocabulary.WON;
-
-import java.io.IOException;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Collection;
 
 /**
  * Created by hfriedrich on 16.03.2017.
@@ -114,42 +116,7 @@ public class NeedModelWrapperTest {
         Assert.assertTrue("did not expect to find matching contexts", needModelWrapper.getMatchingContexts().isEmpty());
     }
 
-    @Test
-    public void createSysInfoModel() {
-
-        // create a empty wrapper with a need uri, check that the need and sysinfo models are there
-        NeedModelWrapper needModelWrapper = new NeedModelWrapper(NEED_URI);
-        Assert.assertNotNull(needModelWrapper.copyNeedModel(NeedGraphType.SYSINFO));
-        Assert.assertEquals(NEED_URI, needModelWrapper.getNeedUri());
-
-        // check that wrapper is empty
-        Assert.assertFalse(needModelWrapper.hasFlag(WON.USED_FOR_TESTING));
-        Assert.assertEquals(0, needModelWrapper.getContentNodes(NeedContentPropertyType.ALL).size());
-        Assert.assertEquals(0, needModelWrapper.getContentNodes(NeedContentPropertyType.ALL).size());
-        Assert.assertEquals(0, needModelWrapper.getFacetUris().size());
-
-        // set some values to the sysinfo model and check them
-        needModelWrapper.setNeedState(NeedState.INACTIVE);
-        needModelWrapper.setNeedState(NeedState.ACTIVE);
-        Assert.assertEquals(NeedState.ACTIVE, needModelWrapper.getNeedState());
-        needModelWrapper.addFlag(WON.USED_FOR_TESTING);
-        needModelWrapper.addFlag(WON.GOOD);
-        Assert.assertTrue(needModelWrapper.hasFlag(WON.USED_FOR_TESTING));
-        Assert.assertTrue(needModelWrapper.hasFlag(WON.GOOD));
-        needModelWrapper.setConnectionContainerUri("https://connnection1");
-        needModelWrapper.setConnectionContainerUri("https://connnection2");
-        Assert.assertEquals("https://connnection2", needModelWrapper.getConnectionContainerUri());
-        needModelWrapper.addFacet("#facet1", WON.CHAT_FACET_STRING);
-        needModelWrapper.addFacet("#facet2", WON.GROUP_FACET_STRING);
-        Assert.assertEquals(2, needModelWrapper.getFacetUris().size());
-        needModelWrapper.setWonNodeUri("https://wonnode1");
-        needModelWrapper.setWonNodeUri("https://wonnode2");
-        Assert.assertEquals("https://wonnode2", needModelWrapper.getWonNodeUri());
-
-        //make sure we don't find a matching context:
-        Assert.assertTrue("did not expect to find matching contexts", needModelWrapper.getMatchingContexts().isEmpty());
-    }
-
+    
     @Test
     public void createNeedWithShapesModel() throws IOException{
         Dataset ds = Utils.createTestDataset("/needmodel/needwithshapes.trig");

--- a/webofneeds/won-core/src/test/resources/validation/invalid/create_msg_with_forward.trig
+++ b/webofneeds/won-core/src/test/resources/validation/invalid/create_msg_with_forward.trig
@@ -1,0 +1,72 @@
+@prefix msg:   <http://purl.org/webofneeds/message#> .
+@prefix woncrypt: <http://purl.org/webofneeds/woncrypt#> .
+@prefix rdfg:  <http://www.w3.org/2004/03/trix/rdfg-1/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix cnt:   <http://www.w3.org/2011/content#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix cert:  <http://www.w3.org/ns/auth/cert#> .
+@prefix gr:    <http://purl.org/goodrelations/v1#> .
+@prefix agr:   <http://purl.org/webofneeds/agreement#> .
+@prefix geo:   <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix sig:   <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#> .
+@prefix webID: <http://www.example.com/webids/> .
+@prefix s:     <http://schema.org/> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix won:   <http://purl.org/webofneeds/model#> .
+@prefix ldp:   <http://www.w3.org/ns/ldp#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix sioc:  <http://rdfs.org/sioc/ns#> .
+
+<https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#envelope-sig> {
+    <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#envelope-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGUCMQDeR98fsXaIff43svGgSQYstSuJ6/EPoHUVuZi3km1tLYgiUDg3rsxV/ELWT9LFdLsCMCC6SJ+5yzjsEthPZDAO/hCn9/RkTJ5rA1rgVNR7K/B30FWJ1lQdBqnLfatdjrLdMQ==" ;
+            sig:hasVerificationCertificate  <https://satvm05.researchstudio.at/won/resource/need/fw1tqsz1grkz> ;
+            msg:hasHash                     "MTEbibThObfznigsKrNSRSt+lU8jAKB0E4typt+eSYsno7hCZLu9wzs5q542lS4Fx7C58OdyicrUgH8Y9z10VnlXhd9A2N0Mzv8oKxvdJp9qghq8cMotrFLXKCChjCEISEvwoUJfRI1D4RzTe5zToLw5dZqvICHvmY8LTNEjzM8=" ;
+            msg:hasPublicKeyFingerprint     "MJXK51S3WommnANGwyLCxWaLoXHpIwcaMKSTFFA/6qo=" ;
+            msg:hasSignedGraph              <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#envelope> .
+}
+
+<https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#need> {
+    <https://satvm05.researchstudio.at/won/resource/need/fw1tqsz1grkz>
+            a                    won:Need ;
+            won:doNotMatchAfter  "2018-09-18T07:14:57.185Z"^^xsd:dateTime ;
+            won:hasFacet         won:ChatFacet ;
+            won:is               [ dc:title    "Title" ;
+                                   won:hasTag  "Tag"
+                                 ] ;
+            cert:key             [ cert:PublicKey  [ a                       woncrypt:ECCPublicKey ;
+                                                     woncrypt:ecc_algorithm  "EC" ;
+                                                     woncrypt:ecc_curveId    "secp384r1" ;
+                                                     woncrypt:ecc_qx         "515fedf001434db5ff89c8b3e3269c1b49ebb4488fddf0b9d8b0a33ab92139fbdc82d7e530f96885b5152754ba9b0f9c" ;
+                                                     woncrypt:ecc_qy         "e49a63de34031c549c1bb2c0fee60a0b3421bbc0edbff40b07552759ca1c1098a68a85a02b00723b5340725ccad04fd9"
+                                                   ] ] .
+}
+
+<https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#envelope> {
+    <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#need-sig>
+            a                               sig:Signature ;
+            sig:hasSignatureValue           "MGQCMAO6rYzZyW5B058RaRO3tX96fXQfoerOcB8RjAA4SEH8jF41ZpgW2CufZ8yv1Huu1wIwcPDoQFqywOivhTdbKqasSmAuL0jhmFqnXBEDzoMmHRZzVTY2SS7Qg9wY6jaEhol2" ;
+            sig:hasVerificationCertificate  <https://satvm05.researchstudio.at/won/resource/need/fw1tqsz1grkz> ;
+            msg:hasHash                     "PuN4qpHJCciJoqnkE+5rq1ICXFb4/9INzTa78VDL+flDo19lvd4mejH98hHNeN1O3gfzHy4Xnim8387eZvexEAo9fFz4lhu67zjc3dhq7haq/NDd4PBj325QsBWwCxf2l/OjvblpGgiw1AftHEEt6T0t+NptM2axp2i4PVfPueA=" ;
+            msg:hasPublicKeyFingerprint     "MJXK51S3WommnANGwyLCxWaLoXHpIwcaMKSTFFA/6qo=" ;
+            msg:hasSignedGraph              <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#need> .
+
+    <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#envelope>
+            a                      msg:EnvelopeGraph ;
+            msg:containsSignature  <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#need-sig> ;
+            rdfg:subGraphOf        <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu> .
+
+    <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu>
+            a                     msg:FromOwner ;
+            msg:hasContent        <https://satvm05.researchstudio.at/won/resource/event/wh698cvrukwu#need> ;
+            msg:hasMessageType    msg:CreateMessage ;
+            msg:hasForwardToReceiver <https://satvm05.researchstudio.at/won/resource/connection/jalwkert080wetnwergf> ;
+            msg:hasReceiverNode   <https://satvm05.researchstudio.at/won/resource> ;
+            msg:hasSenderNeed     <https://satvm05.researchstudio.at/won/resource/need/fw1tqsz1grkz> ;
+            msg:hasSenderNode     <https://satvm05.researchstudio.at/won/resource> ;
+            msg:hasSentTimestamp  1537253097185 .
+}

--- a/webofneeds/won-core/src/test/resources/validation/valid/conversation_msg_with_forward.trig
+++ b/webofneeds/won-core/src/test/resources/validation/valid/conversation_msg_with_forward.trig
@@ -1,0 +1,66 @@
+<https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#envelope-cla6-sig> {
+    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#envelope-cla6-sig>
+            a       <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#Signature> ;
+            <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#hasSignatureValue>
+                    "MGQCMEjjppP7wlL0rPP15xneU7Y+gcV4wKMulwUCLdV2jRMpFK83IN9CXnp6NNpNUls0fAIwW+1XbNIQunuO9X1cNIi74shr3Ph5aDE62qm7kWbYG0qJuSym0QNI4gMhsQ04Hv/G" ;
+            <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#hasVerificationCertificate>
+                    <https://satvm05.researchstudio.at/won/resource/need/bxh7r6yz5u5s7u4s8ru5> ;
+            <http://purl.org/webofneeds/message#hasHash>
+                    "AJQqAWUCpPEwuY5TFnprrLxAX680BdFSYziKJ3QedizSw28iHChbRtRMxh9/ASLFHoVyM3x9l8JoYlD45FljBTvrpEvY9nrbqLtybmDSTefGk9ryJYYzoh02F1I2YD1odrzbQzZ0e02SxmbyXo+mC3X10qVQXbi8arcPe6/T6HTM" ;
+            <http://purl.org/webofneeds/message#hasPublicKeyFingerprint>
+                    "P855D3zfYF8O09qp/efHWixjquCHpGTNDHSkWG/51sI=" ;
+            <http://purl.org/webofneeds/message#hasSignedGraph>
+                    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#envelope-cla6> .
+}
+
+<https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#envelope-cla6> {
+    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#envelope-cla6>
+            a       <http://purl.org/webofneeds/message#EnvelopeGraph> ;
+            <http://purl.org/webofneeds/message#containsSignature>
+                    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#content-eof7-sig> ;
+            <http://www.w3.org/2004/03/trix/rdfg-1/subGraphOf>
+                    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil> .
+
+    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#content-eof7-sig>
+            a       <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#Signature> ;
+            <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#hasSignatureValue>
+                    "MGQCMF61cbLcCvBS7zOg/1YL6MN0fEfzW52eMx7H/DhA3ZEpc2UEfQ7afvRJl+6iMPQl3wIwcjxHJnQUs6fJQtIPOHQ9rFuwdT/lu2pbSpdWgfpArXXq/zGuZ4bEgqVc9em0u6fJ" ;
+            <http://icp.it-risk.iwvi.uni-koblenz.de/ontologies/signature.owl#hasVerificationCertificate>
+                    <https://satvm05.researchstudio.at/won/resource/need/bxh7r6yz5u5s7u4s8ru5> ;
+            <http://purl.org/webofneeds/message#hasHash>
+                    "YEosEbNXJZ5Otvyzlf6Jq8f0BUuXXUSEzhZo4MMo43dtgC2rIOX8qPjN10RFV5ueyOOU2WxjOGEt8J86WAW1HykwART0x+0jGoGVT5qZUmnds8gpAaZG94lxSKMWV7uqp5uw/HSbgFJYb/TiLsKquhs5ZtZopnZBz0KA3l1nzLY=" ;
+            <http://purl.org/webofneeds/message#hasPublicKeyFingerprint>
+                    "P855D3zfYF8O09qp/efHWixjquCHpGTNDHSkWG/51sI=" ;
+            <http://purl.org/webofneeds/message#hasSignedGraph>
+                    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#content-eof7> .
+
+    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil>
+            a       <http://purl.org/webofneeds/message#FromOwner> ;
+            <http://purl.org/webofneeds/message#hasContent>
+                    <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#content-eof7> ;
+            <http://purl.org/webofneeds/message#hasMessageType>
+                    <http://purl.org/webofneeds/message#ConnectionMessage> ;
+            <http://purl.org/webofneeds/message#hasReceiver>
+                    <https://satvm05.researchstudio.at/won/resource/connection/hmbej2exnskvzt6glh73> ;
+            <http://purl.org/webofneeds/message#hasForwardToReceiver>
+                    <https://satvm05.researchstudio.at/won/resource/connection/ertwjbn456l3546h4357> ;
+            <http://purl.org/webofneeds/message#hasReceiverNeed>
+                    <https://satvm05.researchstudio.at/won/resource/need/gp2xiapmiw18> ;
+            <http://purl.org/webofneeds/message#hasReceiverNode>
+                    <https://satvm05.researchstudio.at/won/resource> ;
+            <http://purl.org/webofneeds/message#hasSender>
+                    <https://satvm05.researchstudio.at/won/resource/connection/q5a4b3vszf2henxchmgn> ;
+            <http://purl.org/webofneeds/message#hasSenderNeed>
+                    <https://satvm05.researchstudio.at/won/resource/need/bxh7r6yz5u5s7u4s8ru5> ;
+            <http://purl.org/webofneeds/message#hasSenderNode>
+                    <https://satvm05.researchstudio.at/won/resource> ;
+            <http://purl.org/webofneeds/message#hasSentTimestamp>
+                    "1536133735069"^^<http://www.w3.org/2001/XMLSchema#long> ;
+            <http://purl.org/webofneeds/message#protocolVersion>
+                    "1.0" .
+}
+
+<https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil#content-eof7> {
+  <https://satvm05.researchstudio.at/won/resource/event/k5g40aj5p9akbum5olil> <http://purl.org/webofneeds/model#hasTextMessage> "Hello World!" .  
+}
+

--- a/webofneeds/won-node/src/main/java/won/node/camel/predicate/IsSystemMessageToOwnerPredicate.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/predicate/IsSystemMessageToOwnerPredicate.java
@@ -21,6 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Predicate;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
+import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.camel.WonCamelConstants;
 
 /**
@@ -32,6 +33,8 @@ public class IsSystemMessageToOwnerPredicate implements Predicate {
     public boolean matches(Exchange exchange) {
         WonMessage message = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.ORIGINAL_MESSAGE_HEADER);
         if (message == null) return false;
+        if (message.getMessageType() == WonMessageType.SUCCESS_RESPONSE) return false;
+        if (message.getMessageType() == WonMessageType.FAILURE_RESPONSE) return false;
         if (message.getEnvelopeType() != WonMessageDirection.FROM_SYSTEM) return false;
         return true;
     }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/groupFacet/SendMessageFromNodeGroupFacetImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/facet/groupFacet/SendMessageFromNodeGroupFacetImpl.java
@@ -94,8 +94,7 @@ public class SendMessageFromNodeGroupFacetImpl extends AbstractFromOwnerCamelPro
                         logger.debug("forwarding message {} received from need {} in group {} to group member {}", new Object[]{wonMessage.getMessageURI(), wonMessage.getSenderNeedURI(), wonMessage.getReceiverNeedURI(),  conToSendTo.getRemoteNeedURI()});
                     }
                     URI forwardedMessageURI = wonNodeInformationService.generateEventURI(wonMessage.getReceiverNodeURI());
-                    URI remoteWonNodeUri = WonLinkedDataUtils.getWonNodeURIForNeedOrConnectionURI(conOfIncomingMessage.getRemoteConnectionURI(),
-                            linkedDataSource);
+                    URI remoteWonNodeUri = WonLinkedDataUtils.getWonNodeURIForNeedOrConnectionURI(conToSendTo.getRemoteConnectionURI(),linkedDataSource);
                     WonMessage newWonMessage = WonMessageBuilder.forwardReceivedNodeToNodeMessageAsNodeToNodeMessage(
                             forwardedMessageURI, wonMessage,
                             conToSendTo.getConnectionURI(), conToSendTo.getNeedURI(), wonMessage.getReceiverNodeURI(),

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectMessageFromOwnerProcessor.java
@@ -76,7 +76,7 @@ public class ConnectMessageFromOwnerProcessor extends AbstractFromOwnerCamelProc
         
         Facet actualFacet = dataService.getFacet(senderNeedURI, userDefinedFacetURI);
         Optional<URI> actualFacetURI = Optional.of(actualFacet.getFacetURI());
-        Optional<URI> actualRemoteFacetURI = Optional.of(userDefinedRemoteFacetURI.orElse(lookupDefaultFacet(senderNeedURI)));
+        Optional<URI> actualRemoteFacetURI = Optional.of(userDefinedRemoteFacetURI.orElse(lookupDefaultFacet(receiverNeedURI)));
             
         con = connectionRepository.findOneByNeedURIAndRemoteNeedURIAndFacetURIAndRemoteFacetURIForUpdate(senderNeedURI, receiverNeedURI, actualFacetURI.get(), actualRemoteFacetURI.get());
         if (con.isPresent()) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateNeedMessageProcessor.java
@@ -101,6 +101,9 @@ public class CreateNeedMessageProcessor extends AbstractCamelProcessor
         f.setNeedURI(needURI);
         f.setFacetURI(URI.create(facetUri));
         f.setTypeURI(URI.create(facetType.get()));
+        if (facetUri.equals(defaultFacet)) {
+            f.setDefaultFacet(true);
+        }
         return f;
     }).collect(Collectors.toSet());
     

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
@@ -11,6 +11,7 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.MissingMessagePropertyException;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionState;
+import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.WONMSG;
 
 import java.net.URI;
@@ -24,6 +25,8 @@ import java.net.URI;
 public class SendMessageFromNodeProcessor extends AbstractCamelProcessor
 {
 
+    
+    
   public void process(final Exchange exchange) throws Exception {
     Message message = exchange.getIn();
     WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
@@ -34,6 +37,12 @@ public class SendMessageFromNodeProcessor extends AbstractCamelProcessor
     Connection con = connectionRepository.findOneByConnectionURIForUpdate(connectionUri).get();
     if (con.getState() != ConnectionState.CONNECTED) {
       throw new IllegalMessageForConnectionStateException(connectionUri, "CONNECTION_MESSAGE", con.getState());
+    }
+    if (logger.isDebugEnabled()) {
+        logger.debug("received this ConnectioMessage FromExternal:\n{}", RdfUtils.toString(wonMessage.getCompleteDataset()));
+        if (wonMessage.getForwardedMessageURI() != null) {
+            logger.debug("This message contains the forwarded message {}", wonMessage.getForwardedMessageURI());
+        }
     }
   }
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
@@ -1,0 +1,84 @@
+package won.node.camel.processor.fixed;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import won.node.camel.processor.AbstractCamelProcessor;
+import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
+import won.protocol.message.WonMessage;
+import won.protocol.message.WonMessageBuilder;
+import won.protocol.message.processor.camel.WonCamelConstants;
+import won.protocol.model.Connection;
+import won.protocol.model.ConnectionState;
+import won.protocol.util.linkeddata.WonLinkedDataUtils;
+import won.protocol.vocabulary.WONMSG;
+
+@Component
+@FixedMessageReactionProcessor(direction = WONMSG.TYPE_FROM_EXTERNAL_STRING, messageType = WONMSG.TYPE_CONNECTION_MESSAGE_STRING)
+/**
+ * If the message has a msg:hasForwardToReceiver property, try to forward it.
+ */
+public class SendMessageFromNodeReactionProcessor extends AbstractCamelProcessor {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message message = exchange.getIn();
+        Objects.nonNull(message);
+        WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);
+        Objects.nonNull(wonMessage);
+        logger.debug("reacting to ConnectionMessage {}", wonMessage.getMessageURI());        
+        List<URI> forwardToReceivers = wonMessage.getForwardToReceiverURIs();
+        if (forwardToReceivers.isEmpty()) {
+            logger.debug("no forwarding attempted - nothing to do for us here");            
+            return;
+        }
+        forwardToReceivers.forEach(forwardTo -> {
+            try {
+                // don't forward to the connection we're currently on.
+                if (forwardTo.equals(wonMessage.getReceiverURI())) {
+                    return;
+                }
+                // only forward to those connections that belong to the receiver need of this
+                // message
+                Connection con = connectionRepository.findOneByConnectionURI(forwardTo);
+                if (con.getNeedURI().equals(wonMessage.getReceiverNeedURI())) {
+                    forward(wonMessage, con);
+                }
+            } catch (Exception e) {
+                logger.info("could not forward message {}: {} (more info on loglevel 'debug'",
+                        wonMessage.getMessageURI(), e.getMessage());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("caught exception", e);
+                }
+            }
+        });
+    }
+
+    public void forward(WonMessage wonMessage, Connection conToSendTo) {
+        if (conToSendTo.getState() != ConnectionState.CONNECTED) {
+            return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("forwarding message {} received from need {} to receiver {}",
+                    new Object[] { wonMessage.getMessageURI(), wonMessage.getSenderNeedURI(), conToSendTo.getConnectionURI() });
+        }
+        URI forwardedMessageURI = wonNodeInformationService.generateEventURI(wonMessage.getReceiverNodeURI());
+        URI remoteWonNodeUri = WonLinkedDataUtils
+                .getWonNodeURIForNeedOrConnectionURI(conToSendTo.getRemoteConnectionURI(), linkedDataSource);
+        WonMessage newWonMessage = WonMessageBuilder.forwardReceivedNodeToNodeMessageAsNodeToNodeMessage(
+                forwardedMessageURI, wonMessage, conToSendTo.getConnectionURI(), conToSendTo.getNeedURI(),
+                wonMessage.getReceiverNodeURI(), conToSendTo.getRemoteConnectionURI(), conToSendTo.getRemoteNeedURI(),
+                remoteWonNodeUri);
+        sendSystemMessage(newWonMessage);
+    }
+
+}

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
@@ -17,6 +17,7 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionState;
+import won.protocol.util.RdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 
@@ -78,6 +79,9 @@ public class SendMessageFromNodeReactionProcessor extends AbstractCamelProcessor
                 injectedMessageURI, wonMessage, conToSendTo.getConnectionURI(), conToSendTo.getNeedURI(),
                 wonMessage.getReceiverNodeURI(), conToSendTo.getRemoteConnectionURI(), conToSendTo.getRemoteNeedURI(),
                 remoteWonNodeUri);
+        if (logger.isDebugEnabled()) {
+            logger.debug("injecting this message: {} ", RdfUtils.toString(newWonMessage.getCompleteDataset()));
+        }
         sendSystemMessage(newWonMessage);
     }
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToOwnerEchoer.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ToOwnerEchoer.java
@@ -14,25 +14,22 @@
  *    limitations under the License.
  */
 
-package won.node.camel.predicate;
-
+package won.node.camel.processor.general;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Predicate;
+import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
-import won.protocol.message.WonMessageDirection;
 import won.protocol.message.processor.camel.WonCamelConstants;
 
 /**
- * Ture if the WonMessage in the wonOriginalMessage header is FROM_SYSTEM.
+ * Sends the WonMessage found in the exchange's in (in the 'wonMessage' header) to
+ * the respective owner application(s).
  */
-public class IsSystemMessageToOwnerPredicate implements Predicate {
-
-    @Override
-    public boolean matches(Exchange exchange) {
-        WonMessage message = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.ORIGINAL_MESSAGE_HEADER);
-        if (message == null) return false;
-        if (message.getEnvelopeType() != WonMessageDirection.FROM_SYSTEM) return false;
-        return true;
-    }
+public class ToOwnerEchoer extends AbstractCamelProcessor
+{
+  @Override
+  public void process(final Exchange exchange) throws Exception {
+    WonMessage message = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
+    sendMessageToOwner(message, message.getSenderNeedURI(), (String) exchange.getIn().getHeader(WonCamelConstants.OWNER_APPLICATION_ID));
+  }
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
@@ -201,7 +201,7 @@ public class WonMessageRoutes extends RouteBuilder
             // e.g. when client's public keys changed and hence their queuenames did, too. Added the onException part to deal
             // with that.
             .onException(Exception.class)
-              .log("failure during seda:OwnerProtocolOut, ignoring. Exception message: ${exception.message}")
+              .log("failure during seda:OwnerProtocolOut, ignoring. Exception message: ${exception.messsage}")
               .handled(true)
               .stop()
               .end()
@@ -268,7 +268,9 @@ public class WonMessageRoutes extends RouteBuilder
                         .when(
                             // we want to send a FROM_SYSTEM message to the owner if it is addressed at the owner.
                             // this is the case if senderURI equals receiverURI and both are non-null.
-                            header(WonCamelConstants.ORIGINAL_MESSAGE_HEADER).isNotNull())
+                            PredicateBuilder.and(
+                                    header(WonCamelConstants.ORIGINAL_MESSAGE_HEADER).isNotNull(),
+                                    new IsSystemMessageToOwnerPredicate()))
                             //swap back: original into MESSAGE_HEADER
                             .setHeader(WonCamelConstants.MESSAGE_HEADER, header(WonCamelConstants.ORIGINAL_MESSAGE_HEADER))
                             // here, we use the echo functionality so a message always gets delivered to the owner, even if

--- a/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/camel/node-camel.xml
@@ -129,6 +129,8 @@
           class="won.node.camel.processor.general.ToNodeSender" />
     <bean id="toOwnerSender"
           class="won.node.camel.processor.general.ToOwnerSender" />
+    <bean id="toOwnerEchoer"
+          class="won.node.camel.processor.general.ToOwnerEchoer" />          
     <bean id="wonMessageCloner"
           class="won.node.camel.processor.general.WonMessageCloner" />
     <bean id="facetExtractor"

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -120,13 +120,14 @@ $ngRedux.getState();
                            //These references are parsed in a way that it will always be a list no matter if there is only a single element or an array
                            proposes: wonMessage.getProposedMessages(),
                            proposesToCancel: wonMessage.getProposedToCancelMessages(),
-                           accepts: wonMessage.getAcceptedMessages(),
+                           accepts: wonMessage.getAcceptsMessages(),
                            rejects: wonMessage.getRejectsMessages(),
-                           retracts: wonMessage.getRetractMessages(),
+                           retracts: wonMessage.getRetractsMessages(),
                        }
                        hasReferences: true|false //whether it contains any non-null/non-undefined references within the references block of the message
                        hasContent: true|false //whether it contains any non-null/non-undefined content within the content block of the message
                        injectInto: undefined or an array of connectionUris this message is injected into
+                       originatorUri: undefined or the uri of the post/need which initiated the forwardMessage (the one who injected the msg)
                        isParsable: true|false //true if hasReferences or hasContent is true
                        isMessageStatusUpToDate: true|false //true if the agreementData has been checked to define the status of the message
                        messageStatus: {

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -126,6 +126,7 @@ $ngRedux.getState();
                        }
                        hasReferences: true|false //whether it contains any non-null/non-undefined references within the references block of the message
                        hasContent: true|false //whether it contains any non-null/non-undefined content within the content block of the message
+                       injectInto: undefined or an array of connectionUris this message is injected into
                        isParsable: true|false //true if hasReferences or hasContent is true
                        isMessageStatusUpToDate: true|false //true if the agreementData has been checked to define the status of the message
                        messageStatus: {

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -164,6 +164,7 @@ $ngRedux.getState();
                unread: true|false, //whether or not this connection is new (or already seen if you will)
                isRated: true|false, //whether or not this connection has been rated yet
                remoteNeedUri: string, //corresponding remote Need identifier
+               remoteConnectionUri: string, //corresponding remote Connection uri
                state: string, //state of the connection
                uri: string //unique identifier of this connection
            }

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -118,11 +118,12 @@ $ngRedux.getState();
                        },
                        references: {
                            //These references are parsed in a way that it will always be a list no matter if there is only a single element or an array
-                           proposes: wonMessage.getProposedMessages(),
-                           proposesToCancel: wonMessage.getProposedToCancelMessages(),
-                           accepts: wonMessage.getAcceptsMessages(),
-                           rejects: wonMessage.getRejectsMessages(),
-                           retracts: wonMessage.getRetractsMessages(),
+                           forwards: wonMessage.getForwardMessageUris(),
+                           proposes: wonMessage.getProposedMessageUris(),
+                           proposesToCancel: wonMessage.getProposedToCancelMessageUris(),
+                           accepts: wonMessage.getAcceptsMessageUris(),
+                           rejects: wonMessage.getRejectsMessageUris(),
+                           retracts: wonMessage.getRetractsMessageUris(),
                        }
                        hasReferences: true|false //whether it contains any non-null/non-undefined references within the references block of the message
                        hasContent: true|false //whether it contains any non-null/non-undefined content within the content block of the message

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -472,7 +472,10 @@ export async function loadLatestMessagesOfConnection({
   if (actionTypesToDispatch.start) {
     dispatch({
       type: actionTypesToDispatch.start,
-      payload: Immutable.fromJS({ connectionUri_, isLoadingMessages: true }),
+      payload: Immutable.fromJS({
+        connectionUri: connectionUri_,
+        isLoadingMessages: true,
+      }),
     });
   }
 
@@ -557,7 +560,7 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
     const connection = need && need.getIn(["connections", connectionUri]);
     const connectionMessages = connection && connection.get("messages");
 
-    if (connection.get("isLoadingMessages")) return; // only start loading once.
+    if (!connection || connection.get("isLoadingMessages")) return; // only start loading once, or not if no connection was found
 
     // determine the oldest loaded event
     const sortedConnectionMessages = connectionMessages

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -107,7 +107,13 @@ function genComponentConf() {
         const sortedMessages = allMessages && allMessages.toArray();
         if (sortedMessages) {
           sortedMessages.sort(function(a, b) {
-            return b.get("date").getTime() - a.get("date").getTime();
+            const aDate = a.get("date");
+            const bDate = b.get("date");
+
+            const aTime = aDate && aDate.getTime();
+            const bTime = bDate && bDate.getTime();
+
+            return bTime - aTime;
           });
         }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -277,7 +277,9 @@ function genComponentConf() {
 
           if (messageCount == 0) {
             console.log(
-              "DISPATCH connections__showLatestMessages -> NO messages have already been loaded in the connection: ",
+              "DISPATCH connections__showLatestMessages for connUri:",
+              conn.get("uri"),
+              " -> NO messages have already been loaded in the connection: ",
               conn
             );
             this.connections__showLatestMessages(conn.get("uri"), MESSAGECOUNT);
@@ -290,7 +292,9 @@ function genComponentConf() {
 
             if (!receivedMessagesReadPresent) {
               console.log(
-                "DISPATCH connections__showMoreMessages -> ONLY unread messages are currently present:",
+                "DISPATCH connections__showMoreMessages for connUri:",
+                conn.get("uri"),
+                " -> ONLY unread messages are currently present:",
                 conn
               );
               this.connections__showMoreMessages(conn.get("uri"), MESSAGECOUNT);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -228,8 +228,8 @@ function genComponentConf() {
         const needUriImpliedInRoute =
           needImpliedInRoute && needImpliedInRoute.get("uri");
 
-        const sortedOpenNeeds = sortByDate(openNeeds);
-        const sortedClosedNeeds = sortByDate(closedNeeds);
+        const sortedOpenNeeds = sortByDate(openNeeds, "creationDate");
+        const sortedClosedNeeds = sortByDate(closedNeeds, "creationDate");
 
         const unloadedNeeds = closedNeeds.filter(need => need.get("toLoad"));
 
@@ -400,7 +400,8 @@ function genComponentConf() {
           return (
             remoteNeedActiveOrLoading && conn.get("state") !== won.WON.Closed
           );
-        })
+        }),
+        "creationDate"
       );
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -276,6 +276,10 @@ function genComponentConf() {
           const messageCount = messages ? messages.size : 0;
 
           if (messageCount == 0) {
+            console.log(
+              "DISPATCH connections__showLatestMessages -> NO messages have already been loaded in the connection: ",
+              conn
+            );
             this.connections__showLatestMessages(conn.get("uri"), MESSAGECOUNT);
           } else {
             const receivedMessages = messages.filter(
@@ -285,6 +289,10 @@ function genComponentConf() {
               receivedMessages.filter(msg => !msg.get("unread")).size > 0;
 
             if (!receivedMessagesReadPresent) {
+              console.log(
+                "DISPATCH connections__showMoreMessages -> ONLY unread messages are currently present:",
+                conn
+              );
               this.connections__showMoreMessages(conn.get("uri"), MESSAGECOUNT);
             }
           }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -24,17 +24,22 @@ function genComponentConf() {
           <div class="msg__header__type">{{ self.getHeaderLabel() }}</div>
       </div>
       <div class="msg__header msg__header--inject-into" ng-if="self.isConnectionMessage && self.isInjectIntoMessage && !self.hasNotBeenLoaded">
-          <div class="msg__header__type">Inject this message into:</div>
-          <div class="msg__header__inject">
-            <won-square-image
-              class="msg__header__inject__connection"
-              ng-class="{'clickable': self.isConnectionPresent(connUri)}"
-              ng-repeat="connUri in self.injectIntoArray"
-              title="self.getRemoteNeedTitle(connUri)"
-              uri="self.getRemoteNeedUri(connUri)"
-              ng-click="!self.multiSelectType && self.isConnectionPresent(connUri) && self.router__stateGoCurrent({connectionUri: connUri})">
-            </won-square-image>
-          </div>
+          <div class="msg__header__type">Forward to:</div>
+          <won-square-image
+            class="msg__header__inject"
+            ng-class="{'clickable': self.isConnectionPresent(connUri)}"
+            ng-repeat="connUri in self.injectIntoArray"
+            title="self.getRemoteNeedTitle(connUri)"
+            uri="self.getRemoteNeedUri(connUri)"
+            ng-click="!self.multiSelectType && self.isConnectionPresent(connUri) && self.router__stateGoCurrent({connectionUri: connUri})">
+          </won-square-image>
+      </div>
+      <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
+          <div class="msg__header__type">Forwarded from:</div>
+          <won-square-image
+            class="msg__header__originator"
+            uri="self.originatorUri">
+          </won-square-image>
       </div>
       <won-message-content
           ng-if="self.hasContent || self.hasNotBeenLoaded"
@@ -84,6 +89,7 @@ function genComponentConf() {
           hasNotBeenLoaded: !message,
           hasReferences: message && message.get("hasReferences"),
           isInjectIntoMessage: injectInto && injectInto.size > 0,
+          originatorUri: message && message.get("originatorUri"),
           injectIntoArray: injectInto && Array.from(injectInto.toSet()),
           messageType,
           isConnectionMessage: messageType === won.WONMSG.connectionMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -23,6 +23,13 @@ function genComponentConf() {
       <div class="msg__header" ng-if="!self.isConnectionMessage && !self.hasNotBeenLoaded">
           <div class="msg__header__type">{{ self.getHeaderLabel() }}</div>
       </div>
+      <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
+          <div class="msg__header__type">Forwarded from:</div>
+          <won-square-image
+            class="msg__header__originator"
+            uri="self.originatorUri">
+          </won-square-image>
+      </div>
       <div class="msg__header msg__header--inject-into" ng-if="self.isConnectionMessage && self.isInjectIntoMessage && !self.hasNotBeenLoaded">
           <div class="msg__header__type">Forward to:</div>
           <won-square-image
@@ -32,13 +39,6 @@ function genComponentConf() {
             title="self.getInjectIntoNeedTitle(connUri)"
             uri="self.getInjectIntoNeedUri(connUri)"
             ng-click="!self.multiSelectType && self.isInjectIntoConnectionPresent(connUri) && self.router__stateGoCurrent({connectionUri: connUri})">
-          </won-square-image>
-      </div>
-      <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
-          <div class="msg__header__type">Forwarded from:</div>
-          <won-square-image
-            class="msg__header__originator"
-            uri="self.originatorUri">
           </won-square-image>
       </div>
       <won-message-content

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -60,7 +60,8 @@ function genComponentConf() {
         <div class="won-cm__center"
                 ng-class="{
                   'won-cm__center--nondisplayable': self.isConnectionMessage && !self.isParsable,
-                  'won-cm__center--system': self.isFromSystem
+                  'won-cm__center--system': self.isFromSystem,
+                  'won-cm__center--inject-into': self.isInjectIntoMessage
                 }"
                 in-view="$inview && self.markAsRead()">
             <div class="won-cm__center__bubble"
@@ -146,6 +147,8 @@ function genComponentConf() {
           (!(isReceivedByOwn && isReceivedByRemote) &&
             (isReceivedByOwn || isReceivedByRemote));
 
+        const injectInto = message && message.get("injectInto");
+
         return {
           ownNeed,
           theirNeed,
@@ -173,6 +176,8 @@ function genComponentConf() {
           isRejectable: isMessageRejectable(message),
           isAcceptable: isMessageAcceptable(message),
           isUnread: isMessageUnread(message),
+          isInjectIntoMessage: injectInto && injectInto.size > 0,
+          injectInto: injectInto,
           isReceived,
           isSent,
           isFailedToSend,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -91,6 +91,21 @@ function genComponentConf() {
           </won-combined-message-content>
         </div>
       </div>
+      <div class="refmsgcontent__fragment" ng-if="self.hasForwardUris">
+        <div class="refmsgcontent__fragment__header">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__body">
+          <won-combined-message-content
+            ng-click="self.loadMessage(msgUri)"
+            ng-repeat="msgUri in self.forwardUrisArray"
+            ng-class="{
+              'won-cm--left' : self.getReferencedMessage(msgUri) && !self.getReferencedMessage(msgUri).get('outgoingMessage'),
+              'won-cm--right' : self.getReferencedMessage(msgUri) && self.getReferencedMessage(msgUri).get('outgoingMessage'),
+            }"
+            message-uri="self.getReferencedMessage(msgUri).get('uri')"
+            connection-uri="self.connection.get('uri')">
+          </won-combined-message-content>
+        </div>
+      </div>
     `;
 
   class Controller {
@@ -120,6 +135,7 @@ function genComponentConf() {
         const proposeToCancelUris =
           references && references.get("proposesToCancel");
         const acceptUris = references && references.get("accepts");
+        const forwardUris = references && references.get("forwards");
 
         const acceptUrisSize = acceptUris ? acceptUris.size : 0;
         const proposeUrisSize = proposeUris ? proposeUris.size : 0;
@@ -128,6 +144,7 @@ function genComponentConf() {
           : 0;
         const rejectUrisSize = rejectUris ? rejectUris.size : 0;
         const retractUrisSize = retractUris ? retractUris.size : 0;
+        const forwardUrisSize = forwardUris ? forwardUris.size : 0;
 
         return {
           ownNeedUri: ownNeed && ownNeed.get("uri"),
@@ -138,14 +155,17 @@ function genComponentConf() {
           proposeToCancelUrisSize,
           rejectUrisSize,
           retractUrisSize,
+          forwardUrisSize,
           hasProposeUris: proposeUrisSize > 0,
           hasAcceptUris: acceptUrisSize > 0,
           hasProposeToCancelUris: proposeToCancelUrisSize > 0,
           hasRetractUris: retractUrisSize > 0,
           hasRejectUris: rejectUrisSize > 0,
+          hasForwardUris: forwardUrisSize > 0,
           proposeUrisArray: proposeUris && Array.from(proposeUris.toSet()),
           retractUrisArray: retractUris && Array.from(retractUris.toSet()),
           rejectUrisArray: rejectUris && Array.from(rejectUris.toSet()),
+          forwardUrisArray: forwardUris && Array.from(forwardUris.toSet()),
           proposeToCancelUrisArray:
             proposeToCancelUris && Array.from(proposeToCancelUris.toSet()),
           acceptUrisArray: acceptUris && Array.from(acceptUris.toSet()),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -97,10 +97,7 @@ function genComponentConf() {
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.forwardUrisArray"
-            ng-class="{
-              'won-cm--left' : self.getReferencedMessage(msgUri) && !self.getReferencedMessage(msgUri).get('outgoingMessage'),
-              'won-cm--right' : self.getReferencedMessage(msgUri) && self.getReferencedMessage(msgUri).get('outgoingMessage'),
-            }"
+            class="won-cm--forward"
             message-uri="self.getReferencedMessage(msgUri).get('uri')"
             connection-uri="self.connection.get('uri')">
           </won-combined-message-content>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -212,7 +212,10 @@ function genComponentConf() {
 
         const theirNeedUri = connection && connection.get("remoteNeedUri");
         const theirNeed = theirNeedUri && state.getIn(["needs", theirNeedUri]);
-        const chatMessages = connection && connection.get("messages");
+        const chatMessages =
+          connection &&
+          connection.get("messages") &&
+          connection.get("messages").filter(msg => !msg.get("forwardMessage"));
         const allMessagesLoaded =
           chatMessages &&
           chatMessages.filter(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -237,7 +237,13 @@ function genComponentConf() {
         let sortedMessages = chatMessages && chatMessages.toArray();
         sortedMessages &&
           sortedMessages.sort(function(a, b) {
-            return a.get("date").getTime() - b.get("date").getTime();
+            const aDate = a.get("date");
+            const bDate = b.get("date");
+
+            const aTime = aDate && aDate.getTime();
+            const bTime = bDate && bDate.getTime();
+
+            return aTime - bTime;
           });
 
         const unreadMessages = selectUnreadMessagesByConnectionUri(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -65,7 +65,10 @@ export function runMessagingAgent(redux) {
         );
         return true;
       } else if (message.isConnectionMessage()) {
-        console.log("Message received over ws that is an outgoing message");
+        console.log(
+          "Message received over ws that is an outgoing message",
+          message
+        );
         redux.dispatch(
           actionCreators.messages__processConnectionMessage(message)
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -60,6 +60,13 @@ export function runMessagingAgent(redux) {
     },
     function(message) {
       if (message.isFromExternal() && message.isConnectionMessage()) {
+        console.log("Message received over ws that is not an outgoing message");
+        redux.dispatch(
+          actionCreators.messages__processConnectionMessage(message)
+        );
+        return true;
+      } else if (message.isConnectionMessage()) {
+        console.log("Message received over ws that is an outgoing message");
         redux.dispatch(
           actionCreators.messages__processConnectionMessage(message)
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -60,7 +60,6 @@ export function runMessagingAgent(redux) {
     },
     function(message) {
       if (message.isFromExternal() && message.isConnectionMessage()) {
-        console.log("Message received over ws that is not an outgoing message");
         redux.dispatch(
           actionCreators.messages__processConnectionMessage(message)
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -384,19 +384,26 @@ export default function(allNeedsInState = initialState, action = {}) {
             [needUri, "connections", connectionUri],
             properConnection
           );
-
-        allNeedsInState = allNeedsInState.setIn(
-          [
-            needUri,
-            "connections",
-            connectionUri,
-            "messages",
-            eventUri,
-            "isReceivedByOwn",
-          ],
-          true
-        );
-
+        const path = [
+          needUri,
+          "connections",
+          connectionUri,
+          "messages",
+          eventUri,
+        ];
+        if (allNeedsInState.getIn[path]) {
+          allNeedsInState = allNeedsInState.setIn(
+            [...path, "isReceivedByOwn"],
+            true
+          );
+        } else {
+          console.error(
+            "connect.successOwn for message that was not sent(or was not loaded in the state yet, wonMessage: ",
+            wonMessage,
+            "messageUri: ",
+            eventUri
+          );
+        }
         return allNeedsInState;
       } else {
         // connection has been stored as match first
@@ -412,19 +419,27 @@ export default function(allNeedsInState = initialState, action = {}) {
         );
 
         if (needFromConnection) {
-          allNeedsInState = allNeedsInState.setIn(
-            [
-              needFromConnection.get("uri"),
-              "connections",
-              connectionUri,
-              "messages",
-              eventUri,
-              "isReceivedByOwn",
-            ],
-            true
-          );
+          const path = [
+            needFromConnection.get("uri"),
+            "connections",
+            connectionUri,
+            "messages",
+            eventUri,
+          ];
+          if (allNeedsInState.getIn[path]) {
+            allNeedsInState = allNeedsInState.setIn(
+              [...path, "isReceivedByOwn"],
+              true
+            );
+          } else {
+            console.error(
+              "connect.successOwn for message that was not sent(or was not loaded in the state yet, wonMessage: ",
+              wonMessage,
+              "messageUri: ",
+              eventUri
+            );
+          }
         }
-
         return allNeedsInState;
       }
     }
@@ -623,18 +638,26 @@ export default function(allNeedsInState = initialState, action = {}) {
       const eventUri = wonMessage.getIsRemoteResponseTo();
       const needUri = wonMessage.getReceiverNeed();
       const connectionUri = wonMessage.getReceiver();
-
-      allNeedsInState = allNeedsInState.setIn(
-        [
-          needUri,
-          "connections",
-          connectionUri,
-          "messages",
-          eventUri,
-          "isReceivedByRemote",
-        ],
-        true
-      );
+      const path = [
+        needUri,
+        "connections",
+        connectionUri,
+        "messages",
+        eventUri,
+      ];
+      if (allNeedsInState.getIn(path)) {
+        allNeedsInState = allNeedsInState.setIn(
+          [...path, "isReceivedByRemote"],
+          true
+        );
+      } else {
+        console.error(
+          "chatMessage.successRemote for message that was not sent(or was not loaded in the state yet, wonMessage: ",
+          wonMessage,
+          "messageUri: ",
+          eventUri
+        );
+      }
       return allNeedsInState;
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -13,14 +13,14 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
     wonMessage.contentGraphTrig
   );
 
-  const injectInto = wonMessage.getInjectIntoConnections();
-  const forwardedMessages = wonMessage.getForwardedMessages();
+  const injectInto = wonMessage.getInjectIntoConnectionUris();
+  const forwardedMessages = wonMessage.getForwardedMessageUris();
 
-  const proposedMessages = wonMessage.getProposedMessages();
-  const proposedToCancelMessages = wonMessage.getProposedToCancelMessages();
-  const acceptsMessages = wonMessage.getAcceptsMessages();
-  const rejectsMessages = wonMessage.getRejectsMessages();
-  const retractsMessages = wonMessage.getRetractsMessages();
+  const proposedMessages = wonMessage.getProposedMessageUris();
+  const proposedToCancelMessages = wonMessage.getProposedToCancelMessageUris();
+  const acceptsMessages = wonMessage.getAcceptsMessageUris();
+  const rejectsMessages = wonMessage.getRejectsMessageUris();
+  const retractsMessages = wonMessage.getRetractsMessageUris();
 
   const matchScoreFloat = parseFloat(wonMessage.getMatchScore());
 
@@ -43,6 +43,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
       },
       injectInto: injectInto,
       references: {
+        forwards: forwardedMessages,
         proposes: proposedMessages,
         proposesToCancel: proposedToCancelMessages,
         accepts: acceptsMessages,
@@ -95,12 +96,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
   }
 
   //PARSE MESSAGE CONTENT
-  if (forwardedMessages && forwardedMessages.length == 1) {
-    /*
-    TODO: FORWARDED MESSAGE ONLY WORKS IF THERE IS ONLY ONE FORWARD MESSAGE NOW, not sure if that is per definition
-    also does not handle any references that are stored within the forwarded message itself (e.g. proposes etc.)
-    not sure if these are a necessity or if these can be ommitted
-    */
+  /*if (forwardedMessages && forwardedMessages.length == 1) {
     const forwardedMessageContent = wonMessage.getCompactFramedForwardedMessageContent();
 
     if (forwardedMessageContent) {
@@ -147,6 +143,14 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
         parsedMessage.data.content
       );
     }
+  }*/
+
+  if (wonMessage.getCompactFramedMessageContent()) {
+    parsedMessage.data.content = generateContent(
+      Immutable.fromJS(wonMessage.getCompactFramedMessageContent()),
+      detailsToParse,
+      parsedMessage.data.content
+    );
   }
 
   parsedMessage.data.hasContent = hasContent(parsedMessage.data.content);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -164,16 +164,6 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
     );
     return undefined;
   } else {
-    if (forwardedMessages) {
-      console.log(
-        "RECEIVED A FORWARDED MESSAGE!!!\nwonMessage:\n",
-        wonMessage,
-        "\nparsedMessage:\n",
-        parsedMessage,
-        "\nForwarded Message Content:\n",
-        wonMessage.getCompactFramedForwardedMessageContent()
-      );
-    }
     return Immutable.fromJS(parsedMessage);
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -20,7 +20,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
   const acceptedMessages = wonMessage.getAcceptedMessages();
   const rejectedMessages = wonMessage.getRejectsMessages();
   const retractedMessages = wonMessage.getRetractMessages();
-  //const forwardedMessages = wonMessage.getForwardedMessage();
+  const forwardedMessages = wonMessage.getForwardedMessage();
 
   const matchScoreFloat = parseFloat(wonMessage.getMatchScore());
 
@@ -115,6 +115,14 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
       detailsToParse,
       parsedMessage.data.content
     );
+  }
+
+  if (forwardedMessages) {
+    const forwardedMessagesArray = Array.isArray(forwardedMessages)
+      ? forwardedMessages
+      : [forwardedMessages];
+    parsedMessage.data.content.text =
+      "Forwarded Messages: " + forwardedMessagesArray;
   }
 
   parsedMessage.data.hasContent = hasContent(parsedMessage.data.content);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -101,7 +101,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
 
     if (forwardedMessageContent) {
       parsedMessage.data.originatorUri =
-        forwardedMessageContent["msg:hasSenderNeed"];
+        forwardedMessageContent["msg:hasSenderNeed"]["@id"];
       parsedMessage.data.content.text =
         forwardedMessageContent["won:hasTextMessage"];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -13,6 +13,8 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
     wonMessage.contentGraphTrig
   );
 
+  const injectInto = wonMessage.getInjectIntoConnection();
+
   const proposedMessages = wonMessage.getProposedMessages();
   const proposedToCancelMessages = wonMessage.getProposedToCancelMessages();
   const acceptedMessages = wonMessage.getAcceptedMessages();
@@ -37,6 +39,8 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
             ? matchScoreFloat
             : undefined,
       },
+      injectInto:
+        !injectInto || Array.isArray(injectInto) ? injectInto : [injectInto],
       references: {
         proposes:
           !proposedMessages || Array.isArray(proposedMessages)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -67,7 +67,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
       hasContent: false, //will be determined by the hasContent function
       isParsable: false, //will be determined by the clause (hasReferences || hasContent) function
       date: msStringToDate(wonMessage.getTimestamp()),
-      outgoingMessage: wonMessage.isFromOwner(),
+      outgoingMessage: wonMessage.isOutgoingMessage(),
       systemMessage:
         !wonMessage.isFromOwner() &&
         !wonMessage.getSenderNeed() &&
@@ -101,6 +101,8 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
   };
 
   if (wonMessage.isFromOwner()) {
+    parsedMessage.belongsToUri = wonMessage.getSender();
+  } else if (wonMessage.isFromSystem()) {
     parsedMessage.belongsToUri = wonMessage.getSender();
   } else {
     parsedMessage.belongsToUri = wonMessage.getReceiver();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -20,6 +20,7 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
   const acceptedMessages = wonMessage.getAcceptedMessages();
   const rejectedMessages = wonMessage.getRejectsMessages();
   const retractedMessages = wonMessage.getRetractMessages();
+  //const forwardedMessages = wonMessage.getForwardedMessage();
 
   const matchScoreFloat = parseFloat(wonMessage.getMatchScore());
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -7,6 +7,12 @@ import {
 import { isUriRead } from "../../won-localstorage.js";
 import { getAllDetails } from "../../won-utils.js";
 
+/*
+  "alreadyProcessed" flag sets the sentOwn/Remote flags to true
+   "forwardMessage" flag is used to set an originatorUri (uri of the need that the forwardedMessage was sent from)
+   and a flag to indicate that the message should not be displayed in the chat as it is used purely used for reference
+   purposes
+*/
 export function parseMessage(
   wonMessage,
   alreadyProcessed = false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -7,7 +7,11 @@ import {
 import { isUriRead } from "../../won-localstorage.js";
 import { getAllDetails } from "../../won-utils.js";
 
-export function parseMessage(wonMessage, alreadyProcessed = false) {
+export function parseMessage(
+  wonMessage,
+  alreadyProcessed = false,
+  forwardMessage = false
+) {
   //seperating off header/@prefix-statements, so they can be folded in
   const { trigPrefixes, trigBody } = trigPrefixesAndBody(
     wonMessage.contentGraphTrig
@@ -33,7 +37,8 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
       remoteUri: !wonMessage.isFromOwner() //THIS HAS TO STAY UNDEFINED If the message is not a received message
         ? wonMessage.getRemoteMessageUri()
         : undefined,
-      originatorUri: undefined,
+      forwardMessage: forwardMessage,
+      originatorUri: forwardMessage ? wonMessage.getSenderNeed() : undefined,
       content: {
         text: wonMessage.getTextMessage(),
         matchScore:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -96,7 +96,11 @@ export function parseMessage(wonMessage, alreadyProcessed = false) {
 
   //PARSE MESSAGE CONTENT
   if (forwardedMessages && forwardedMessages.length == 1) {
-    //FORWARDED MESSAGE ONLY WORKS IF THERE IS ONLY ONE FORWARD MESSAGE NOW
+    /*
+    TODO: FORWARDED MESSAGE ONLY WORKS IF THERE IS ONLY ONE FORWARD MESSAGE NOW, not sure if that is per definition
+    also does not handle any references that are stored within the forwarded message itself (e.g. proposes etc.)
+    not sure if these are a necessity or if these can be ommitted
+    */
     const forwardedMessageContent = wonMessage.getCompactFramedForwardedMessageContent();
 
     if (forwardedMessageContent) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -7,7 +7,13 @@ import { getCorrectMessageUri } from "../../selectors.js";
  "alreadyProcessed" flag, which indicates that we do not care about the
  sent status anymore and assume that it has been successfully sent to each server (incl. the remote)
  */
-export function addMessage(state, wonMessage, alreadyProcessed = false) {
+export function addMessage(
+  state,
+  wonMessage,
+  alreadyProcessed = false,
+  insertIntoConnUri = undefined,
+  insertIntoNeedUri = undefined
+) {
   // we used to exclude messages without content here, using
   // if (wonMessage.getContentGraphs().length > 0) as the condition
   // however, after moving the facet info of connect/open messages from
@@ -21,14 +27,20 @@ export function addMessage(state, wonMessage, alreadyProcessed = false) {
   // throwing off the message rendering.
   // New solution: parse anything that is not a response, but allow responses with content
   if (!wonMessage.isResponse() || wonMessage.getContentGraphs().length > 0) {
-    let parsedMessage = parseMessage(wonMessage, alreadyProcessed);
+    let parsedMessage = parseMessage(
+      wonMessage,
+      alreadyProcessed,
+      insertIntoConnUri && insertIntoNeedUri
+    );
     if (parsedMessage) {
-      const connectionUri = parsedMessage.get("belongsToUri");
-      let needUri = null;
-      if (parsedMessage.getIn(["data", "outgoingMessage"])) {
+      const connectionUri =
+        insertIntoConnUri || parsedMessage.get("belongsToUri");
+
+      let needUri = insertIntoNeedUri;
+      if (!needUri && parsedMessage.getIn(["data", "outgoingMessage"])) {
         // needUri is the message's hasSenderNeed
         needUri = wonMessage.getSenderNeed();
-      } else {
+      } else if (!needUri) {
         // needUri is the remote message's hasReceiverNeed
         needUri = wonMessage.getReceiverNeed();
         if (parsedMessage.getIn(["data", "unread"])) {
@@ -47,8 +59,35 @@ export function addMessage(state, wonMessage, alreadyProcessed = false) {
             true
           );
         }
+      } else {
+        console.log(
+          "needUri was already set by method call as seen the params: insertIntoConnUri: ",
+          insertIntoConnUri,
+          "insertIntoNeedUri: ",
+          insertIntoNeedUri
+        );
       }
+
       if (needUri) {
+        if (wonMessage.hasContainedForwardedWonMessages()) {
+          const containedForwardedWonMessages = wonMessage.getContainedForwardedWonMessages();
+          console.log(
+            "containedForwardedWonMessages: ",
+            containedForwardedWonMessages
+          );
+          containedForwardedWonMessages.map(forwardedWonMessage => {
+            console.log("forwardedWonMessage: ", forwardedWonMessage);
+            state = addMessage(
+              state,
+              forwardedWonMessage,
+              true,
+              connectionUri,
+              needUri
+            );
+            //PARSE MESSAGE DIFFERENTLY FOR FORWARDED MESSAGES
+          });
+        }
+
         let messages = state.getIn([
           needUri,
           "connections",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -6,6 +6,9 @@ import { getCorrectMessageUri } from "../../selectors.js";
 /*
  "alreadyProcessed" flag, which indicates that we do not care about the
  sent status anymore and assume that it has been successfully sent to each server (incl. the remote)
+ "insertIntoConnUri" and "insertIntoNeedUri" are used for forwardedMessages so that the message is
+ stored within the given connection/need and not in the original need or connection as we might not
+ have these stored in the state
  */
 export function addMessage(
   state,
@@ -59,24 +62,12 @@ export function addMessage(
             true
           );
         }
-      } else {
-        console.log(
-          "needUri was already set by method call as seen the params: insertIntoConnUri: ",
-          insertIntoConnUri,
-          "insertIntoNeedUri: ",
-          insertIntoNeedUri
-        );
       }
 
       if (needUri) {
         if (wonMessage.hasContainedForwardedWonMessages()) {
           const containedForwardedWonMessages = wonMessage.getContainedForwardedWonMessages();
-          console.log(
-            "containedForwardedWonMessages: ",
-            containedForwardedWonMessages
-          );
           containedForwardedWonMessages.map(forwardedWonMessage => {
-            console.log("forwardedWonMessage: ", forwardedWonMessage);
             state = addMessage(
               state,
               forwardedWonMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -721,49 +721,6 @@ import won from "./won.js";
                           }
                           `
           );
-          if (!queryResult || queryResult.length == 0) {
-            console.log(
-              "QueryResult was null for docUri: ",
-              docUri,
-              "executing old query"
-            );
-            const correspondingRemoteMessageUri = getIn(
-              await executeQueryOnRdfStore(
-                tmpstore,
-                `
-                        prefix event: <${baseUriForEvents}>
-                        prefix msg: <http://purl.org/webofneeds/message#>
-
-                        select distinct ?remoteUri where {
-                            { <${messageUri}> msg:hasCorrespondingRemoteMessage ?remoteUri } union
-                            { ?remoteUri msg:hasCorrespondingRemoteMessage <${messageUri}> }
-                        }
-                        `
-              ),
-              [0, "remoteUri", "value"] // the result is nested a bit, so we need to extract the uri here
-            );
-
-            const urisInStoreThatStartWith = uri =>
-              Array.from(
-                new Set(
-                  Object.values(tmpstore.engine.lexicon.OIDToUri).filter(u =>
-                    u.startsWith(uri)
-                  )
-                )
-              );
-
-            const graphUrisInEventDocOld = urisInStoreThatStartWith(
-              messageUri + "#"
-            ).concat(
-              urisInStoreThatStartWith(correspondingRemoteMessageUri + "#")
-            );
-
-            return {
-              uri: messageUri,
-              correspondingRemoteMessageUri,
-              containedGraphUris: graphUrisInEventDocOld,
-            };
-          }
 
           const graphUrisOfMessage = queryResult.map(result =>
             getIn(result, ["graphOfMessage", "value"])
@@ -782,7 +739,7 @@ import won from "./won.js";
           ).concat(
             graphUrisOfMessage
               .map(uri => urisInStoreThatStartWith(uri + "#"))
-              .reduce((arr1, arr2) => arr1.concat(arr2))
+              .reduce((arr1, arr2) => arr1.concat(arr2), []) //parse empty array of initial value to avoid exception
           );
           return {
             uri: messageUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -868,25 +868,6 @@ won.DomainObjectFactory.prototype = {
   jsonLdToWonDomainObjects: function(/*jsonLdContent*/) {},
 };
 
-/**
- * This function should take any of the different chat-message-structures flying around in this code-base
- * and return a WonMessage object.
- * @param message
- * @returns {*|Promise.<WonMessage>}
- */
-won.toWonMessage = function(message) {
-  if (message["@graph"]) {
-    return won.wonMessageFromJsonLd(message);
-  } else if (message instanceof WonMessage) {
-    return Promise.resolve(message);
-  } else {
-    throw new Error(
-      "Couldn't convert the following to a WonMessage: ",
-      message
-    );
-  }
-};
-
 won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD) {
   //console.log("converting this JSON-LD to WonMessage", wonMessageAsJsonLD)
   const expandedJsonLd = await jsonld.promises.expand(wonMessageAsJsonLD);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1217,6 +1217,11 @@ WonMessage.prototype = {
       "http://purl.org/webofneeds/message#hasMessageType"
     );
   },
+  getInjectIntoConnection: function() {
+    return this.getProperty(
+      "http://purl.org/webofneeds/message#hasInjectIntoConnection"
+    );
+  },
   getReceivedTimestamp: function() {
     return this.getPropertyFromLocalMessage(
       "http://purl.org/webofneeds/message#hasReceivedTimestamp"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1212,20 +1212,34 @@ WonMessage.prototype = {
       return this.compactFramedMessage["msg:hasCorrespondingRemoteMessage"];
     }
   },
+  getCompactFramedForwardedMessageContent: function() {
+    const forwardedMessage =
+      this.compactFramedMessage &&
+      this.compactFramedMessage["msg:hasForwardedMessage"];
+    const forwardedMessageContent =
+      forwardedMessage && forwardedMessage["msg:hasCorrespondingRemoteMessage"];
+    return forwardedMessageContent;
+  },
   getMessageType: function() {
     return this.getProperty(
       "http://purl.org/webofneeds/message#hasMessageType"
     );
   },
-  getInjectIntoConnection: function() {
-    return this.getProperty(
+  getInjectIntoConnections: function() {
+    const injectInto = this.getProperty(
       "http://purl.org/webofneeds/message#hasInjectIntoConnection"
     );
+
+    return !injectInto || Array.isArray(injectInto) ? injectInto : [injectInto];
   },
-  getForwardedMessage: function() {
-    return this.getProperty(
+  getForwardedMessages: function() {
+    const forwardedMessages = this.getProperty(
       "http://purl.org/webofneeds/message#hasForwardedMessage"
     );
+
+    return !forwardedMessages || Array.isArray(forwardedMessages)
+      ? forwardedMessages
+      : [forwardedMessages];
   },
   getReceivedTimestamp: function() {
     return this.getPropertyFromLocalMessage(
@@ -1297,22 +1311,46 @@ WonMessage.prototype = {
   },
 
   getProposedMessages: function() {
-    return this.getProperty("http://purl.org/webofneeds/agreement#proposes");
+    const proposedMessages = this.getProperty(
+      "http://purl.org/webofneeds/agreement#proposes"
+    );
+    return !proposedMessages || Array.isArray(proposedMessages)
+      ? proposedMessages
+      : [proposedMessages];
   },
 
-  getAcceptedMessages: function() {
-    return this.getProperty("http://purl.org/webofneeds/agreement#accepts");
+  getAcceptsMessages: function() {
+    const acceptsMessages = this.getProperty(
+      "http://purl.org/webofneeds/agreement#accepts"
+    );
+    return !acceptsMessages || Array.isArray(acceptsMessages)
+      ? acceptsMessages
+      : [acceptsMessages];
   },
   getProposedToCancelMessages: function() {
-    return this.getProperty(
+    const proposedToCancelMessages = this.getProperty(
       "http://purl.org/webofneeds/agreement#proposesToCancel"
     );
+
+    return !proposedToCancelMessages || Array.isArray(proposedToCancelMessages)
+      ? proposedToCancelMessages
+      : [proposedToCancelMessages];
   },
   getRejectsMessages: function() {
-    return this.getProperty("http://purl.org/webofneeds/agreement#rejects");
+    const rejectsMessages = this.getProperty(
+      "http://purl.org/webofneeds/agreement#rejects"
+    );
+    return !rejectsMessages || Array.isArray(rejectsMessages)
+      ? rejectsMessages
+      : [rejectsMessages];
   },
-  getRetractMessages: function() {
-    return this.getProperty("http://purl.org/webofneeds/modification#retracts");
+  getRetractsMessages: function() {
+    const retractsMessages = this.getProperty(
+      "http://purl.org/webofneeds/modification#retracts"
+    );
+    return !retractsMessages || Array.isArray(retractsMessages)
+      ? retractsMessages
+      : [retractsMessages];
   },
 
   isProposeMessage: function() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1336,7 +1336,12 @@ WonMessage.prototype = {
       "http://purl.org/webofneeds/modification#retracts"
     );
   },
-
+  isOutgoingMessage: function() {
+    return (
+      this.isFromOwner() ||
+      (this.isFromSystem() && this.getSender() !== this.getReceiver())
+    );
+  },
   isFromSystem: function() {
     let direction = this.getMessageDirection();
     return direction === "http://purl.org/webofneeds/message#FromSystem";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -18,7 +18,7 @@
  * Created by LEIH-NB on 19.08.2014.
  */
 "format es6" /* required to force babel to transpile this so the minifier is happy */;
-import { is, prefixOfUri, isArray, clone } from "../utils.js";
+import { is, prefixOfUri, isArray, clone, createArray } from "../utils.js";
 import {
   clearPrivateId,
   clearReadUris,
@@ -869,12 +869,29 @@ won.DomainObjectFactory.prototype = {
 };
 
 won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD) {
-  //console.log("converting this JSON-LD to WonMessage", wonMessageAsJsonLD)
   const expandedJsonLd = await jsonld.promises.expand(wonMessageAsJsonLD);
   const wonMessage = new WonMessage(expandedJsonLd);
   await wonMessage.frameInPromise();
   await wonMessage.generateContentGraphTrig();
   await wonMessage.generateCompactedFramedMessage();
+
+  const forwardedMessageUris = wonMessage.getForwardedMessageUris();
+  if (forwardedMessageUris) {
+    //TODO: RECURSIVELY CREATE wonMessageObjects from all the forwarded Messages within this message
+    //const forwardedMessages = wonMessage.compactFramedMessage["msg:hasForwardedMessage"];
+    console.log(
+      "WonMessage",
+      wonMessage,
+      " contains forwarded Messages:",
+      forwardedMessageUris
+    );
+    forwardedMessageUris.map(fwdMessageUri => {
+      console.log("fwdMessageUri: ", fwdMessageUri);
+      //const wonMessage = await won.wonMessageFromJsonLd(expandedJsonLd);
+      console.log(wonMessage);
+    });
+  }
+
   return wonMessage;
 };
 
@@ -1206,21 +1223,17 @@ WonMessage.prototype = {
       "http://purl.org/webofneeds/message#hasMessageType"
     );
   },
-  getInjectIntoConnections: function() {
-    const injectInto = this.getProperty(
-      "http://purl.org/webofneeds/message#hasInjectIntoConnection"
+  getInjectIntoConnectionUris: function() {
+    return createArray(
+      this.getProperty(
+        "http://purl.org/webofneeds/message#hasInjectIntoConnection"
+      )
     );
-
-    return !injectInto || Array.isArray(injectInto) ? injectInto : [injectInto];
   },
-  getForwardedMessages: function() {
-    const forwardedMessages = this.getProperty(
-      "http://purl.org/webofneeds/message#hasForwardedMessage"
+  getForwardedMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/message#hasForwardedMessage")
     );
-
-    return !forwardedMessages || Array.isArray(forwardedMessages)
-      ? forwardedMessages
-      : [forwardedMessages];
   },
   getReceivedTimestamp: function() {
     return this.getPropertyFromLocalMessage(
@@ -1291,47 +1304,31 @@ WonMessage.prototype = {
     return this.getProperty("http://purl.org/webofneeds/message#hasReceiver");
   },
 
-  getProposedMessages: function() {
-    const proposedMessages = this.getProperty(
-      "http://purl.org/webofneeds/agreement#proposes"
+  getProposedMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/agreement#proposes")
     );
-    return !proposedMessages || Array.isArray(proposedMessages)
-      ? proposedMessages
-      : [proposedMessages];
   },
 
-  getAcceptsMessages: function() {
-    const acceptsMessages = this.getProperty(
-      "http://purl.org/webofneeds/agreement#accepts"
+  getAcceptsMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/agreement#accepts")
     );
-    return !acceptsMessages || Array.isArray(acceptsMessages)
-      ? acceptsMessages
-      : [acceptsMessages];
   },
-  getProposedToCancelMessages: function() {
-    const proposedToCancelMessages = this.getProperty(
-      "http://purl.org/webofneeds/agreement#proposesToCancel"
+  getProposedToCancelMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/agreement#proposesToCancel")
     );
-
-    return !proposedToCancelMessages || Array.isArray(proposedToCancelMessages)
-      ? proposedToCancelMessages
-      : [proposedToCancelMessages];
   },
-  getRejectsMessages: function() {
-    const rejectsMessages = this.getProperty(
-      "http://purl.org/webofneeds/agreement#rejects"
+  getRejectsMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/agreement#rejects")
     );
-    return !rejectsMessages || Array.isArray(rejectsMessages)
-      ? rejectsMessages
-      : [rejectsMessages];
   },
-  getRetractsMessages: function() {
-    const retractsMessages = this.getProperty(
-      "http://purl.org/webofneeds/modification#retracts"
+  getRetractsMessageUris: function() {
+    return createArray(
+      this.getProperty("http://purl.org/webofneeds/modification#retracts")
     );
-    return !retractsMessages || Array.isArray(retractsMessages)
-      ? retractsMessages
-      : [retractsMessages];
   },
 
   isProposeMessage: function() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -879,29 +879,6 @@ won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD) {
   return wonMessage;
 };
 
-/*traverseMessageStructure: async function(rawMessage,structure){
-  const uris = [];
-  if (structure.containedContent) {
-    uris.concat(structure.containedContent);
-  }
-  if (!structure.containsEnvelopes) {
-    return {uris : uris};
-  } else {
-    structure.containsEnvelopes.forEach(env => {
-      const sub = traverseMessageStructure(rawMessage, env);
-      if (sub.uris) {
-        sub.concat(uris);
-      }
-    });
-    if (structure.messageDirection === "http://purl.org/webofneeds/message#FromExternal") {
-      const subRawMessage = rawMessage.filter(graph => uris.includes(graph['@id']));
-      const messages = sub.messages || [];
-      return {
-        uris,
-        messages: messages.push(won.wonMessageFromJsonLd(subRawMessage));
-    }
-  }
-}*/
 /**
  * Serializes the jsonldData into trig.
  *
@@ -1145,7 +1122,7 @@ WonMessage.prototype = {
   },
   generateContainedForwardedWonMessages: async function() {
     const forwardedMessageUris = this.getForwardedMessageUris();
-    if (forwardedMessageUris) {
+    if (forwardedMessageUris && forwardedMessageUris.length == 1) {
       //TODO: RECURSIVELY CREATE wonMessageObjects from all the forwarded Messages within this message
       //const forwardedMessages = wonMessage.compactFramedMessage["msg:hasForwardedMessage"];
       const encapsulatingMessageUri = this.messageStructure.messageUri;
@@ -1153,7 +1130,7 @@ WonMessage.prototype = {
         elem => !elem["@id"].startsWith(encapsulatingMessageUri)
       );
 
-      console.log(
+      /*console.log(
         "WonMessage\n",
         this,
         "\nforwardedMessageUris:\n",
@@ -1162,18 +1139,20 @@ WonMessage.prototype = {
         encapsulatingMessageUri,
         "\nrawMessageWithouthEncapsulatingUri\n",
         rawMessageWithoutEncapsulatingUri
-      );
+      );*/
 
       const fwdMessage = await won.wonMessageFromJsonLd(
         rawMessageWithoutEncapsulatingUri
       );
       this.containedForwardedWonMessages.push(fwdMessage);
 
-      /*forwardedMessageUris.map(fwdMessageUri => {
-        console.log("fwdMessageUri: ", fwdMessageUri);
-        //TODO: WORK WITH MULTIPLE FORWARDS IN MESSAGE
-      });*/
-      return Promise.resolve(this.containedForwardedWonMessages); //TODO: RESOLVE THE CORRECT PROMISE
+      return Promise.resolve(this.containedForwardedWonMessages);
+    } else if (forwardedMessageUris) {
+      console.warn(
+        "WonMessage contains more than one forwardedMessage on the same level: omitting forwardMessages, wonMessage:",
+        this
+      );
+      return Promise.resolve(this.containedForwardedWonMessages);
     } else {
       return Promise.resolve(this.containedForwardedWonMessages);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1222,6 +1222,11 @@ WonMessage.prototype = {
       "http://purl.org/webofneeds/message#hasInjectIntoConnection"
     );
   },
+  getForwardedMessage: function() {
+    return this.getProperty(
+      "http://purl.org/webofneeds/message#hasForwardedMessage"
+    );
+  },
   getReceivedTimestamp: function() {
     return this.getPropertyFromLocalMessage(
       "http://purl.org/webofneeds/message#hasReceivedTimestamp"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1438,4 +1438,14 @@ export function toLocalISODateString(dateTime) {
   return currentDatetime + timezoneString;
 }
 
+/**
+ * Method that checks if the given element is already an array, if so return it, if not
+ * return the element as a single element array, if element is undefined return undefined
+ * @param elements
+ * @returns {*}
+ */
+export function createArray(elements) {
+  return !elements || Array.isArray(elements) ? elements : [elements];
+}
+
 window.toLocalISODateString4dbg = toLocalISODateString;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1123,14 +1123,14 @@ export function prefixOfUri(uri) {
  * @param order if "ASC" then the order will be ascending, everything else resorts to the default sort of descending order
  * @returns {*} sorted Elements array
  */
-export function sortByDate(elementsImm, selector, order) {
+export function sortByDate(
+  elementsImm,
+  selector = "lastUpdateDate",
+  order = "DESC"
+) {
   let sortedElements = elementsImm && elementsImm.toArray();
 
   if (sortedElements) {
-    if (!selector) {
-      selector = "lastUpdateDate";
-    }
-
     sortedElements.sort(function(a, b) {
       const bDate = b.get(selector) && b.get(selector).getTime();
       const aDate = a.get(selector) && a.get(selector).getTime();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -34,9 +34,9 @@ export function messageHasReferences(wonMsg) {
   return (
     wonMsg &&
     (wonMsg.getProposedMessages() ||
-      wonMsg.getRetractMessages() ||
+      wonMsg.getRetractsMessages() ||
       wonMsg.getRejectsMessages() ||
-      wonMsg.getAcceptedMessages() ||
+      wonMsg.getAcceptsMessages() ||
       wonMsg.getProposedToCancelMessages())
   );
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -38,7 +38,7 @@ export function messageHasReferences(wonMsg) {
       wonMsg.getRejectsMessageUris() ||
       wonMsg.getAcceptsMessageUris() ||
       wonMsg.getProposedToCancelMessageUris() ||
-      wonMsg.getForwardMessageUris())
+      wonMsg.getForwardedMessageUris())
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -33,11 +33,12 @@ export function wellFormedPayload(payload) {
 export function messageHasReferences(wonMsg) {
   return (
     wonMsg &&
-    (wonMsg.getProposedMessages() ||
-      wonMsg.getRetractsMessages() ||
-      wonMsg.getRejectsMessages() ||
-      wonMsg.getAcceptsMessages() ||
-      wonMsg.getProposedToCancelMessages())
+    (wonMsg.getProposedMessageUris() ||
+      wonMsg.getRetractsMessageUris() ||
+      wonMsg.getRejectsMessageUris() ||
+      wonMsg.getAcceptsMessageUris() ||
+      wonMsg.getProposedToCancelMessageUris() ||
+      wonMsg.getForwardMessageUris())
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
@@ -25,25 +25,26 @@ won-combined-message-content {
       color: $won-subtitle-gray;
     }
 
+    &--forwarded-from,
     &--inject-into {
       display: grid;
-      grid-auto-flow: row;
+      grid-auto-columns: max-content;
+      grid-auto-flow: column;
       grid-gap: 0.25rem;
+      align-items: center;
 
+      .msg_header_type {
+        grid-area: auto;
+      }
+
+      .msg__header__originator,
       .msg__header__inject {
-        display: grid;
-        grid-auto-columns: min-content;
-        grid-auto-flow: column;
-        grid-gap: 0.25rem;
+        grid-area: auto;
+        margin: 0;
+        @include fixed-square(1.5rem);
 
-        .msg__header__inject__connection {
-          grid-area: auto;
-          margin: 0;
+        img {
           @include fixed-square(1.5rem);
-
-          img {
-            @include fixed-square(1.5rem);
-          }
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
@@ -24,5 +24,28 @@ won-combined-message-content {
     &__type {
       color: $won-subtitle-gray;
     }
+
+    &--inject-into {
+      display: grid;
+      grid-auto-flow: row;
+      grid-gap: 0.25rem;
+
+      .msg__header__inject {
+        display: grid;
+        grid-auto-columns: min-content;
+        grid-auto-flow: column;
+        grid-gap: 0.25rem;
+
+        .msg__header__inject__connection {
+          grid-area: auto;
+          margin: 0;
+          @include fixed-square(1.5rem);
+
+          img {
+            @include fixed-square(1.5rem);
+          }
+        }
+      }
+    }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -176,5 +176,12 @@ won-connection-message {
         color: #8f8f8f;
       }
     }
+
+    &.won-cm__center--inject-into {
+      .won-cm__center__bubble {
+        background-color: red; // TODO: CHANGE STYLING FOR INJECTINTO MESSAGE
+        color: white;
+      }
+    }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -179,8 +179,7 @@ won-connection-message {
 
     &.won-cm__center--inject-into {
       .won-cm__center__bubble {
-        background-color: red; // TODO: CHANGE STYLING FOR INJECTINTO MESSAGE
-        color: white;
+        // TODO: CHANGE STYLING FOR INJECTINTO MESSAGE
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
@@ -54,6 +54,10 @@ won-referenced-message-content {
             0.25rem
           );
         }
+        &.won-cm--forward {
+          background-color: $won-light-gray;
+          border: $thinGrayBorder;
+        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
@@ -1,7 +1,7 @@
 @import "sizing-utils";
 
 @mixin square-image($size, $margin: 0) {
-  won-square-image {
+  > won-square-image {
     display: block;
     user-select: none;
     margin: $margin;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -10,7 +10,6 @@ won-usecase-picker {
   grid-row-gap: $gridRowGap;
   width: 100%;
   max-width: $maxContentWidth;
-  height: 100%;
   box-sizing: border-box;
   padding: $gridRowGap;
 

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessage.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessage.java
@@ -45,6 +45,10 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 	URI correspondingRemoteMessageURI;
 	ConversationMessage correspondingRemoteMessageRef;
 	
+	Set<URI> forwarded = new HashSet<>();
+    Set<ConversationMessage> forwardedRefs = new HashSet<ConversationMessage>();
+    Set<ConversationMessage> forwardedInverseRefs = new HashSet<ConversationMessage>();
+	
 	URI isResponseTo;
 	Optional<ConversationMessage> isResponseToOption = Optional.empty();
 	ConversationMessage isResponseToInverseRef;
@@ -129,6 +133,14 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 	private void removeRetractsInverseRef(ConversationMessage other) {
 		this.proposesInverseRefs.remove(other);
 	}
+	
+	public boolean isForwardedMessage() {
+	    return ! this.forwardedInverseRefs.isEmpty();
+	}
+	
+	public boolean isForwardedOrRemoteMessageOfForwarded() {
+        return isForwardedMessage() || hasCorrespondingRemoteMessage() && correspondingRemoteMessageRef.isForwardedMessage();
+    }
 	
 	public ConversationMessage getRootOfDeliveryChain() {
 		return getDeliveryChain().getHead();
@@ -455,6 +467,21 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 		this.previousRefs.add(ref);
 	}
 	
+	public Set<URI> getForwarded() {
+        return forwarded;
+    }
+    public Set<ConversationMessage> getForwardedRefs(){
+        return forwardedRefs;
+    }
+    public void addForwarded(URI forwarded) {
+        this.forwarded.add(forwarded);
+    }
+    public void addForwardedRef(ConversationMessage ref) {
+        this.forwardedRefs.add(ref);
+    }
+
+	
+	
 	public Set<URI> getAccepts() {
 		return accepts;
 	}
@@ -557,6 +584,12 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 	public void addPreviousInverseRef(ConversationMessage ref) {
 		this.previousInverseRefs.add(ref);
 	}
+	public Set<ConversationMessage> getForwardedInverseRefs() {
+        return forwardedInverseRefs;
+    }
+    public void addForwardedInverseRef(ConversationMessage ref) {
+        this.forwardedInverseRefs.add(ref);
+    }
 	public Set<ConversationMessage> getAcceptsInverseRefs() {
 		return acceptsInverseRefs;
 	}
@@ -642,6 +675,7 @@ public class ConversationMessage implements Comparable<ConversationMessage>{
 				+ ", isRemoteResponseToRef:" + messageUriOrNullString(isRemoteResponseToRef)
 				+ ", isResponseToInverse: " + messageUriOrNullString(isResponseToInverseRef)
 				+ ", isRemoteResponseToInverse: " + messageUriOrNullString(isRemoteResponseToInverseRef)
+				+ ", isForwarded: " + isForwardedMessage()
 				+ "]";
 	}
 

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessagesReader.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/ConversationMessagesReader.java
@@ -62,6 +62,12 @@ public class ConversationMessagesReader {
 						Statement s) -> getOrCreateMessage(messages, getUri(s.getSubject()))
 								.setCorrespondingRemoteMessageURI(getUri(s.getObject())));
 
+		inithandlers.put(WONMSG.HAS_FORWARDED_MESSAGE,
+                (Map<URI, ConversationMessage> messages,
+                        Statement s) -> getOrCreateMessage(messages, getUri(s.getSubject()))
+                                .addForwarded(getUri(s.getObject())));
+
+		
 		inithandlers.put(WONMSG.HAS_PREVIOUS_MESSAGE_PROPERTY,
 				(Map<URI, ConversationMessage> messages,
 						Statement s) -> getOrCreateMessage(messages, getUri(s.getSubject()))


### PR DESCRIPTION
implements the ui for injected/forwarded messages, as well as the retrieval of these and parsing of forwardedMessages within other messages,
these are stored as "invisible" messages in the state so we can use our references implementation to display the forwarded messages (similar to the cascading message structure of propeses msgs)

the wonMessageFromJsonLd method also includes all the forwardedMessages that have been attached in a message and includes it as their own wonMessage objects -> thus making it possible for our reducer to include all these messages in the state

DebugBot changes: the debugBot has a new command "inject" now, which injects a message from the connection that the inject-command was requested in, to all the other open connections the debugbot has with the same need

fixes #2418 -> the problem was that the loadingMessages flag was never set in the connections and thus resulted in multiple redundant retrieve message calls on reload and login -> this should be significantly faster now, another benefit is that we see a loading indicator in the chat message view of a connection again if messages are currently loaded

fixes connection/need sorting in overview -> to reduce the "jumping" connections and needs in the overview we changed the sortBy attribute from lastUpdateDate to the creationDate of the need/connection