### PR TITLE
Feat detail suggestneed

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -52,7 +52,11 @@ import {
   createWhatsAround,
 } from "./create-need-action.js";
 
-import { needsConnect, fetchUnloadedNeeds } from "./needs-actions.js";
+import {
+  needsConnect,
+  fetchUnloadedNeeds,
+  fetchSuggested,
+} from "./needs-actions.js";
 
 import {
   stateBack,
@@ -123,7 +127,7 @@ const actionHierarchy = {
     failed: INJ_DEFAULT,
     connect: needsConnect,
     fetchUnloadedNeeds: fetchUnloadedNeeds,
-    fetchSuggested: INJ_DEFAULT,
+    fetchSuggested: fetchSuggested,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -123,6 +123,7 @@ const actionHierarchy = {
     failed: INJ_DEFAULT,
     connect: needsConnect,
     fetchUnloadedNeeds: fetchUnloadedNeeds,
+    fetchSuggested: INJ_DEFAULT,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -3,12 +3,14 @@
  */
 
 import won from "../won-es6.js";
+import Immutable from "immutable";
 
 import { actionTypes } from "./actions.js";
 
 import {
   buildConnectMessage,
   fetchUnloadedData,
+  fetchDataForNonOwnedNeedOnly,
 } from "../won-message-utils.js";
 
 export function fetchUnloadedNeeds() {
@@ -20,6 +22,25 @@ export function fetchUnloadedNeeds() {
       });
     };
     fetchUnloadedData(curriedDispatch);
+  };
+}
+
+export function fetchSuggested(needUri) {
+  return async dispatch => {
+    fetchDataForNonOwnedNeedOnly(needUri).then(response => {
+      const suggestedPosts = response && response.get("theirNeeds");
+
+      if (suggestedPosts && suggestedPosts.size > 0) {
+        const payload = Immutable.fromJS({
+          suggestedPosts: suggestedPosts,
+        });
+
+        dispatch({
+          type: actionTypes.needs.fetchSuggestedNeed,
+          payload: payload,
+        });
+      }
+    });
   };
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -36,7 +36,7 @@ export function fetchSuggested(needUri) {
         });
 
         dispatch({
-          type: actionTypes.needs.fetchSuggestedNeed,
+          type: actionTypes.needs.fetchSuggested,
           payload: payload,
         });
       }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -167,7 +167,7 @@ function genComponentConf() {
             <div class="cts__details__input__content"
               message-detail-element="{{self.selectedDetailComponent}}"
               on-update="::self.updateDetail(identifier, value)"
-              initial-value="::self.additionalContent.get(self.selectedDetail.identifier)"
+              initial-value="self.additionalContent.get(self.selectedDetail.identifier)"
               identifier="self.selectedDetail.identifier"
               detail="self.selectedDetail">
             </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
@@ -16,6 +16,7 @@ import filePickerModule from "./file-picker.js";
 import workflowPickerModule from "./workflow-picker.js";
 import petrinetPickerModule from "./petrinet-picker.js";
 import reviewPickerModule from "./review-picker.js";
+import suggestPostPickerModule from "./suggestpost-picker.js";
 
 /**
  * module names for angular's module system
@@ -39,4 +40,5 @@ export default [
   workflowPickerModule,
   petrinetPickerModule,
   reviewPickerModule,
+  suggestPostPickerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -18,7 +18,6 @@ function genComponentConf() {
           <input
               type="text"
               class="suggestpostp__input__inner"
-              placeholder="{{self.detail.placeholder}}"
               won-input="::self.updateTitle()" />
       </div>
     `;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -1,0 +1,110 @@
+import angular from "angular";
+import { attach, delay } from "../../../utils.js";
+import { DomCache } from "../../../cstm-ng-utils.js";
+import wonInput from "../../../directives/input.js";
+
+import "style/_suggestpostpicker.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <div class="suggestpostp__input">
+         <svg class="suggestpostp__input__icon clickable"
+            style="--local-primary:var(--won-primary-color);"
+            ng-if="self.showResetButton"
+            ng-click="self.resetTitle()">
+            <use xlink:href="#ico36_close" href="#ico36_close"></use>
+          </svg>
+          <input
+              type="text"
+              class="suggestpostp__input__inner"
+              placeholder="{{self.detail.placeholder}}"
+              won-input="::self.updateTitle()" />
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.domCache = new DomCache(this.$element);
+
+      window.suggestpostp4dbg = this;
+
+      this.addedTitle = this.initialValue;
+      this.showResetButton = false;
+
+      delay(0).then(() => this.showInitialTitle());
+    }
+
+    /**
+     * Checks validity and uses callback method
+     */
+    update(title) {
+      if (title && title.trim().length > 0) {
+        this.onUpdate({ value: title });
+      } else {
+        this.onUpdate({ value: undefined });
+      }
+    }
+
+    showInitialTitle() {
+      this.addedTitle = this.initialValue;
+
+      if (this.initialValue && this.initialValue.trim().length > 0) {
+        this.textfield().value = this.initialValue.trim();
+        this.showResetButton = true;
+      }
+
+      this.$scope.$apply();
+    }
+
+    updateTitle() {
+      const text = this.textfield().value;
+
+      if (text && text.trim().length > 0) {
+        this.addedTitle = text.trim();
+        this.update(this.addedTitle);
+        this.showResetButton = true;
+      } else {
+        this.resetTitle();
+      }
+    }
+
+    resetTitle() {
+      this.addedTitle = undefined;
+      this.textfield().value = "";
+      this.update(undefined);
+      this.showResetButton = false;
+    }
+
+    textfieldNg() {
+      return angular.element(this.textfield());
+    }
+    textfield() {
+      if (!this._titleInput) {
+        this._titleInput = this.$element[0].querySelector(
+          ".suggestpostp__input__inner"
+        );
+      }
+      return this._titleInput;
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      onUpdate: "&",
+      initialValue: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.suggestpostPicker", [wonInput])
+  .directive("wonSuggestpostPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -1,0 +1,59 @@
+import angular from "angular";
+import { attach } from "../../../utils.js";
+
+import "style/_suggestpost-viewer.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+        <div class="suggestpostv__header">
+          <svg class="suggestpostv__header__icon" ng-if="self.detail.icon">
+              <use xlink:href={{self.detail.icon}} href={{self.detail.icon}}></use>
+          </svg>
+          <span class="suggestpostv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
+        </div>
+        <div class="suggestpostv__content">{{ self.content }}</div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      window.suggestpostv4dbg = this;
+
+      this.$scope.$watch("self.content", (newContent, prevContent) =>
+        this.updatedContent(newContent, prevContent)
+      );
+      this.$scope.$watch("self.details", (newDetails, prevDetails) =>
+        this.updatedDetails(newDetails, prevDetails)
+      );
+    }
+
+    updatedDetails(newDetails, prevDetails) {
+      if (newDetails && newDetails != prevDetails) {
+        this.details = newDetails;
+      }
+    }
+    updatedContent(newContent, prevContent) {
+      if (newContent && newContent != prevContent) {
+        this.content = newContent;
+      }
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      content: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.suggestpostViewer", [])
+  .directive("wonSuggestpostViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -1,6 +1,5 @@
 import angular from "angular";
 import "ng-redux";
-import Immutable from "immutable";
 import { actionCreators } from "../../../actions/actions.js";
 import postHeaderModule from "../../post-header.js";
 import { attach } from "../../../utils.js";
@@ -9,7 +8,6 @@ import {
   selectOpenConnectionUri,
   selectNeedByConnectionUri,
 } from "../../../selectors.js";
-import { fetchDataForNonOwnedNeedOnly } from "../../../won-message-utils.js";
 
 import "style/_suggestpost-viewer.scss";
 
@@ -100,20 +98,10 @@ function genComponentConf() {
     }
 
     loadPost() {
-      console.log("Trying to retrieve Post: ", this.content);
-      const suggestedPostUri = this.content;
-      fetchDataForNonOwnedNeedOnly(suggestedPostUri).then(response => {
-        console.log("response after fetchDataForNonOwnedNeedOnly: ", response);
-        const suggestedPosts = response && response.get("theirNeeds");
-
-        if (suggestedPosts && suggestedPosts.size > 0) {
-          this.needs__fetchSuggested(
-            Immutable.fromJS({
-              suggestedPosts: suggestedPosts,
-            })
-          );
-        }
-      });
+      if (this.content) {
+        //this.content is the suggestedPostUri
+        this.needs__fetchSuggested(this.content);
+      }
     }
 
     connectWithPost() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -127,7 +127,7 @@ function genComponentConf() {
           this.openedOwnPost.get("uri"),
           undefined,
           this.suggestedPost.get("uri"),
-          "THIS IS FROM A SUGGEST NEED"
+          "Hey a Friend told me about you, let's chat!"
         );
       } else {
         console.warn(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -23,10 +23,10 @@ function genComponentConf() {
         <div class="suggestpostv__content">
           <div class="suggestpostv__content__post" ng-if="self.suggestedPost">
             <won-post-header
-                class="clickable"
+               
                 need-uri="self.suggestedPost.get('uri')"
                 timestamp="self.suggestedPost.get('creationDate')"
-                ng-click="!self.multiSelectType && self.router__stateGoCurrent({postUri: self.suggestedPost.get('uri')})"
+             
                 hide-image="::false">
             </won-post-header>
           </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -54,10 +54,9 @@ function genComponentConf() {
 
       const selectFromState = state => {
         const openedConnectionUri = selectOpenConnectionUri(state);
-        const openedOwnPost = selectNeedByConnectionUri(
-          state,
-          openedConnectionUri
-        );
+        const openedOwnPost =
+          openedConnectionUri &&
+          selectNeedByConnectionUri(state, openedConnectionUri);
         const connection =
           openedOwnPost &&
           openedOwnPost.getIn(["connections", openedConnectionUri]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -1,9 +1,19 @@
 import angular from "angular";
+import "ng-redux";
+import Immutable from "immutable";
+import { actionCreators } from "../../../actions/actions.js";
+import postHeaderModule from "../../post-header.js";
 import { attach } from "../../../utils.js";
+import { connect2Redux } from "../../../won-utils.js";
+import {
+  selectOpenConnectionUri,
+  selectNeedByConnectionUri,
+} from "../../../selectors.js";
+import { fetchDataForNonOwnedNeedOnly } from "../../../won-message-utils.js";
 
 import "style/_suggestpost-viewer.scss";
 
-const serviceDependencies = ["$scope", "$element"];
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
         <div class="suggestpostv__header">
@@ -12,7 +22,31 @@ function genComponentConf() {
           </svg>
           <span class="suggestpostv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
         </div>
-        <div class="suggestpostv__content">{{ self.content }}</div>
+        <div class="suggestpostv__content">
+          <div class="suggestpostv__content__post" ng-if="self.suggestedPost">
+            <won-post-header
+                class="clickable"
+                need-uri="self.suggestedPost.get('uri')"
+                timestamp="self.suggestedPost.get('creationDate')"
+                ng-click="!self.multiSelectType && self.router__stateGoCurrent({postUri: self.suggestedPost.get('uri')})"
+                hide-image="::false">
+            </won-post-header>
+          </div>
+          <div class="suggestpostv__content__notloaded" ng-if="!self.suggestedPost">
+              Suggestion not loaded yet. Click the Button below to retrieve the Suggested Post.
+          </div>
+          <button class="suggestpostv__content__action won-button--outlined thin red"
+              ng-if="!self.suggestedPost"
+              ng-click="self.loadPost()">
+              Load Post
+          </button>
+          <button class="suggestpostv__content__action won-button--outlined thin red"
+              ng-if="self.suggestedPost && !self.suggestedPost.get('ownNeed') && self.openedOwnPost"
+              ng-disabled="self.hasConnectionBetweenPosts"
+              ng-click="self.connectWithPost()">
+              {{ self.getConnectButtonLabel() }}
+          </button>
+        </div>
     `;
 
   class Controller {
@@ -20,22 +54,97 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
       window.suggestpostv4dbg = this;
 
-      this.$scope.$watch("self.content", (newContent, prevContent) =>
-        this.updatedContent(newContent, prevContent)
-      );
-      this.$scope.$watch("self.details", (newDetails, prevDetails) =>
-        this.updatedDetails(newDetails, prevDetails)
+      const selectFromState = state => {
+        const openedConnectionUri = selectOpenConnectionUri(state);
+        const openedOwnPost = selectNeedByConnectionUri(
+          state,
+          openedConnectionUri
+        );
+        const connection =
+          openedOwnPost &&
+          openedOwnPost.getIn(["connections", openedConnectionUri]);
+
+        const suggestedPost = state.getIn(["needs", this.content]);
+        const suggestedPostUri = suggestedPost && suggestedPost.get("uri");
+
+        const connectionsOfOpenedOwnPost =
+          openedOwnPost && openedOwnPost.get("connections");
+        const connectionsBetweenPosts =
+          suggestedPostUri &&
+          connectionsOfOpenedOwnPost &&
+          connectionsOfOpenedOwnPost.filter(
+            conn => conn.get("remoteNeedUri") === suggestedPostUri
+          );
+
+        return {
+          suggestedPost,
+          openedOwnPost,
+          multiSelectType: connection && connection.get("multiSelectType"),
+          hasConnectionBetweenPosts:
+            connectionsBetweenPosts && connectionsBetweenPosts.size > 0,
+        };
+      };
+
+      connect2Redux(
+        selectFromState,
+        actionCreators,
+        ["self.content", "self.detail"],
+        this
       );
     }
 
-    updatedDetails(newDetails, prevDetails) {
-      if (newDetails && newDetails != prevDetails) {
-        this.details = newDetails;
-      }
+    getConnectButtonLabel() {
+      return this.hasConnectionBetweenPosts
+        ? "Already Connected With Post"
+        : "Connect with Post";
     }
-    updatedContent(newContent, prevContent) {
-      if (newContent && newContent != prevContent) {
-        this.content = newContent;
+
+    loadPost() {
+      console.log("Trying to retrieve Post: ", this.content);
+      const suggestedPostUri = this.content;
+      fetchDataForNonOwnedNeedOnly(suggestedPostUri).then(response => {
+        console.log("response after fetchDataForNonOwnedNeedOnly: ", response);
+        const suggestedPosts = response && response.get("theirNeeds");
+
+        if (suggestedPosts && suggestedPosts.size > 0) {
+          this.needs__fetchSuggested(
+            Immutable.fromJS({
+              suggestedPosts: suggestedPosts,
+            })
+          );
+        }
+      });
+    }
+
+    connectWithPost() {
+      console.log(
+        "Trying to connect with Post: ",
+        this.content,
+        " postData: ",
+        this.suggestedPost
+      );
+      console.log(
+        "Connect openedOwnPost: ",
+        this.openedOwnPost,
+        " with suggestedPost: ",
+        this.suggestedPost
+      );
+      const openedOwnPostUri =
+        this.openedOwnPost && this.openedOwnPost.get("uri");
+      const suggestedPostUri =
+        this.suggestedPost && this.suggestedPost.get("uri");
+
+      if (openedOwnPostUri && suggestedPostUri) {
+        this.needs__connect(
+          this.openedOwnPost.get("uri"),
+          undefined,
+          this.suggestedPost.get("uri"),
+          "THIS IS FROM A SUGGEST NEED"
+        );
+      } else {
+        console.warn(
+          "No Connect, either openedOwnPost(Uri) or suggestedPost(Uri) not present"
+        );
       }
     }
   }
@@ -55,5 +164,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.suggestpostViewer", [])
+  .module("won.owner.components.suggestpostViewer", [postHeaderModule])
   .directive("wonSuggestpostViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
@@ -14,6 +14,7 @@ import fileViewerModule from "./file-viewer.js";
 import workflowViewerModule from "./workflow-viewer.js";
 import petrinetViewerModule from "./petrinet-viewer.js";
 import reviewViewerModule from "./review-viewer.js";
+import suggestPostViewerModule from "./suggestpost-viewer.js";
 
 /**
  * module names for angular's module system
@@ -35,4 +36,5 @@ export default [
   workflowViewerModule,
   petrinetViewerModule,
   reviewViewerModule,
+  suggestPostViewerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -49,14 +49,14 @@ function genComponentConf() {
                         </svg>
                         <span>{{self.shouldShowRdf? "Hide raw RDF data" : "Show raw RDF data"}}</span>
                     </button>
+                    <button class="won-button--outlined thin red"
+                        ng-click="self.exportPdf()">
+                        Export as PDF
+                    </button>
                     <button class="won-button--filled red"
                         ng-if="self.isOwnPost && self.isInactive"
                         ng-click="self.reOpenPost()">
                         Reopen Post
-                    </button>
-                    <button class="won-button--filled red"
-                        ng-click="self.exportPdf()">
-                        Export as PDF
                     </button>
                     <button class="won-button--filled red"
                         ng-if="self.isOwnPost && self.isActive"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -58,6 +58,19 @@ export default function(allNeedsInState = initialState, action = {}) {
         need.set("ownNeed", false).set("connections", Immutable.Map())
       );
 
+    case actionTypes.needs.fetchSuggested: {
+      console.log("action: ", action);
+      let suggestedPosts = action.payload.get("suggestedPosts");
+      suggestedPosts = suggestedPosts ? suggestedPosts : Immutable.Set();
+
+      const stateWithSuggestedPosts = suggestedPosts.reduce(
+        (updatedState, suggestedPost) =>
+          addNeed(updatedState, suggestedPost, false),
+        allNeedsInState
+      );
+
+      return stateWithSuggestedPosts;
+    }
     case actionTypes.initialPageLoad:
     case actionTypes.needs.fetchUnloadedNeeds:
     case actionTypes.login: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -57,9 +57,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       return allNeedsInState.map(need =>
         need.set("ownNeed", false).set("connections", Immutable.Map())
       );
-
     case actionTypes.needs.fetchSuggested: {
-      console.log("action: ", action);
       let suggestedPosts = action.payload.get("suggestedPosts");
       suggestedPosts = suggestedPosts ? suggestedPosts : Immutable.Set();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -24,6 +24,15 @@ export function selectOpenNeeds(state) {
     allOwnNeeds.filter(post => post.get("state") === won.WON.ActiveCompacted)
   );
 }
+
+export function selectAllOpenNeeds(state) {
+  const allNeeds = selectAllNeeds(state);
+  return (
+    allNeeds &&
+    allNeeds.filter(post => post.get("state") === won.WON.ActiveCompacted)
+  );
+}
+
 export function selectClosedNeeds(state) {
   const allOwnNeeds = selectAllOwnNeeds(state);
   return (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -1146,6 +1146,36 @@ export function sortByDate(
   return sortedElements;
 }
 
+/**
+ * Sorts the elements by Selector (default order is ascending)
+ * @param elementsImm elements from state that need to be returned as a sorted array
+ * @param selector selector for the date that will be used to sort the elements (default is "lastUpdateDate")
+ * @param order if "ASC" then the order will be ascending, everything else resorts to the default sort of descending order
+ * @returns {*} sorted Elements array
+ */
+export function sortBy(elementsImm, selector = "humanReadable", order = "ASC") {
+  let sortedElements = elementsImm && elementsImm.toArray();
+
+  if (sortedElements) {
+    sortedElements.sort(function(a, b) {
+      const bValue = b && b.get(selector);
+      const aValue = a && a.get(selector);
+
+      if (order === "ASC") {
+        if (aValue < bValue) return -1;
+        if (aValue > bValue) return 1;
+        return 0;
+      } else {
+        if (bValue < aValue) return -1;
+        if (bValue > aValue) return 1;
+        return 0;
+      }
+    });
+  }
+
+  return sortedElements;
+}
+
 export function clamp(value, lower, upper) {
   if (lower > value) return lower;
   if (upper < value) return upper;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -38,6 +38,7 @@ export const details = {
 };
 
 export const messageDetails = {
+  suggestPost: basicDetails.suggestPost,
   bpmnWorkflow: fileDetails.bpmnWorkflow,
   petrinetWorkflow: fileDetails.petrinetWorkflow,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -90,6 +90,7 @@ export const suggestPost = {
   identifier: "suggestPost",
   label: "Suggest Post",
   icon: "#ico36_detail_title", //TODO: CORRECT ICON
+  placeholder: "Insert PostUri and Accept",
   component: "won-suggestpost-picker",
   viewerComponent: "won-suggestpost-viewer",
   parseToRDF: function({ value }) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -85,3 +85,34 @@ export const tags = {
     }
   },
 };
+
+export const suggestPost = {
+  identifier: "suggestPost",
+  label: "Suggest Post",
+  icon: "#ico36_detail_title", //TODO: CORRECT ICON
+  placeholder: "What? (Short title shown in lists)",
+  component: "won-suggestpost-picker",
+  viewerComponent: "won-suggestpost-viewer",
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+
+    if (val) {
+      return {
+        "won:suggestPostUri": { "@id": val },
+      };
+    } else {
+      return { "won:suggestPostUri": undefined };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    const suggestUriJsonLDImm =
+      jsonLDImm && jsonLDImm.get("won:suggestPostUri");
+    return suggestUriJsonLDImm && suggestUriJsonLDImm.get("@id");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -90,7 +90,6 @@ export const suggestPost = {
   identifier: "suggestPost",
   label: "Suggest Post",
   icon: "#ico36_detail_title", //TODO: CORRECT ICON
-  placeholder: "What? (Short title shown in lists)",
   component: "won-suggestpost-picker",
   viewerComponent: "won-suggestpost-viewer",
   parseToRDF: function({ value }) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_button.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_button.scss
@@ -14,6 +14,7 @@
     by every button that is set to disabled*/
     color: white;
     background: lightgrey;
+    cursor: default;
   }
 }
 
@@ -37,6 +38,7 @@
     by every button that is set to disabled*/
     color: white;
     background: $won-disabled-color;
+    cursor: default;
   }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
@@ -1,0 +1,5 @@
+@import "sizing-utils";
+
+won-suggestpost-viewer {
+  @include won-detail-viewer("suggestpostv");
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
@@ -1,5 +1,26 @@
 @import "sizing-utils";
+@import "won-config";
 
 won-suggestpost-viewer {
   @include won-detail-viewer("suggestpostv");
+
+  .suggestpostv__content {
+    display: grid;
+    grid-gap: 0.25rem;
+
+    &__post {
+      border: $thinGrayBorder;
+      padding: 0.25rem;
+      background: white;
+    }
+
+    &__notloaded {
+      font-size: $smallFontSize;
+    }
+
+    &__action {
+      width: 100%;
+      font-size: $smallFontSize;
+    }
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
@@ -3,6 +3,28 @@
 @import "sizing-utils";
 
 won-suggestpost-picker {
+  display: grid;
+  grid-gap: 0.5rem;
+
+  .suggestpostp__posts {
+    display: grid;
+    grid-gap: 0.25rem;
+
+    &__post {
+      border: $thinGrayBorder;
+      padding: 0.25rem;
+      background: white;
+
+      &.won--selected {
+        background: $won-line-gray;
+      }
+    }
+  }
+
+  .suggestpostp__noposts {
+    font-size: $normalFontSize;
+  }
+
   .suggestpostp__input {
     position: relative;
     display: grid;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
@@ -1,0 +1,40 @@
+@import "won-config";
+@import "textfield";
+@import "sizing-utils";
+
+won-suggestpost-picker {
+  .suggestpostp__input {
+    position: relative;
+    display: grid;
+
+    .suggestpostp__input__icon {
+      @include fixed-square($bigiconSize);
+      position: absolute;
+      right: 0.5rem;
+      top: $formInputHeight / 2 - $bigiconSize / 2;
+      z-index: 1;
+    }
+
+    .suggestpostp__input__inner {
+      @extend .won-txt;
+      border: $thinGrayBorder;
+      min-height: $formInputHeight;
+      min-height: $formInputHeight;
+      word-wrap: break-word;
+
+      $verticalPadding: calcVerticalPaddingToHeight(
+        $normalFontSize,
+        22/16,
+        $thinBorderWidth,
+        $formInputHeight
+      );
+      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+        0.438rem;
+    }
+
+    .suggestpostp__input__inner::-ms-clear {
+      width: 0;
+      height: 0;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
@@ -25,6 +25,15 @@ won-suggestpost-picker {
     font-size: $normalFontSize;
   }
 
+  .suggestpostp__labelledhr {
+    .wlh__label {
+      .wlh__label__text {
+        background: $won-light-gray;
+        white-space: nowrap;
+      }
+    }
+  }
+
   .suggestpostp__input {
     position: relative;
     display: grid;


### PR DESCRIPTION
Adds the ability to send "Suggestions" of Needs within a chat
Displays the suggested Post (if present) -> if not one can invoke an action to load the post

Detail Picker works as follows:
-Shows a List of all Open and Loaded Needs to select from (except both of the needs in the currently open connection)
- Also includes a input type=url that includes the abilty to load any need into the state (input validation is currently only based on default url-validation) -> there is no way to check if the url was actually a postUri that has been fetched correctly (no error will be displayed) -> however a succesful fetch should add a need in the suggestionlist to select from... unless the need is already loaded, or is a need that is either part of the currently opened chat-connection