### PR TITLE
Feat  jobsearch sparql

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -200,7 +200,10 @@ export function filterInVicinity(rootSubject, location, radius = 10) {
 }
 
 /**
- * @param {String} rootSubject: a variable name that the score judges, e.g. `?need`
+ * Subquery that generates a score [1,0] (1 for exact location matches, 0 for anything
+ * further away than the `radius`, linearly degrading inbetween)
+ *
+ * @param {String} resultName: a variable name that the score judges, e.g. `?need`
  * @param {String} bindScoreAs: the variable name for the score (use the same name for
  *   sorting/aggregating in the parent query)
  * @param {String} pathToLocation: the predicates to be traversed to get to the root
@@ -241,6 +244,19 @@ export function vicinityScoreSubQuery(
   });
 }
 
+/**
+ * Calculates the jaccard-index (i.e. normalized set-overlap) between own and a
+ * potential match's set of tags. Full overlap means 1, having no shared tags
+ * means 0.
+ *
+ * @param {String} resultName: a variable name that the score judges, e.g. `?need`
+ * @param {String} bindScoreAs: the variable name for the score (use the same name for
+ *   sorting/aggregating in the parent query)
+ * @param {String} pathToTags: the predicates to be traversed to get to the tags
+ *   in the RDF-graph.
+ * @param {Array<String>} tagLikes: an array of own tags to intersect matches' tags with
+ * @returns see `sparqlQuery`
+ */
 export function tagOverlapScoreSubQuery(
   resultName,
   bindScoreAs,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -19,7 +19,7 @@ import { Parser as SparqlParser } from "sparqljs";
  * @param {Array<String>} where any operations to add to the `WHERE`-block
  * @param {*} orderBy Array of objects like `{order: "ASC", variable: "?geoDistance"}`
  */
-export function sparqlQuery({ prefixes, selectDistinct, where, orderBy }) {
+export function sparqlQuery({ prefixes, variables, distinct, where, orderBy }) {
   let orderByStr;
   if (orderBy && is("Array", orderBy)) {
     const orderClauses = orderBy
@@ -27,10 +27,11 @@ export function sparqlQuery({ prefixes, selectDistinct, where, orderBy }) {
       .join(" ");
     orderByStr = orderClauses ? "ORDER BY " + orderClauses : "";
   }
+  const distinctStr = distinct ? "DISTINCT" : "";
 
   const queryTemplate = `
 ${prefixesString(prefixes)}
-SELECT DISTINCT ${selectDistinct}
+SELECT ${distinctStr} ${variables.join(" ")}
 WHERE {
   ${where ? where.join(" ") : ""}
 } ${orderByStr ? orderByStr : ""}`;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -19,22 +19,35 @@ import { Parser as SparqlParser } from "sparqljs";
  * @param {Array<String>} where any operations to add to the `WHERE`-block
  * @param {*} orderBy Array of objects like `{order: "ASC", variable: "?geoDistance"}`
  */
-export function sparqlQuery({ prefixes, variables, distinct, where, orderBy }) {
-  let orderByStr;
+export function sparqlQuery({
+  prefixes,
+  variables,
+  distinct,
+  where,
+  orderBy,
+  groupBy,
+}) {
+  const distinctStr = distinct ? "DISTINCT" : "";
+
+  let orderByStr = "";
   if (orderBy && is("Array", orderBy)) {
     const orderClauses = orderBy
       .map(o => `${o.order}(${o.variable})`)
       .join(" ");
     orderByStr = orderClauses ? "ORDER BY " + orderClauses : "";
   }
-  const distinctStr = distinct ? "DISTINCT" : "";
+
+  let groupByStr = "";
+  if (groupBy) {
+    groupByStr = `GROUP BY (${groupBy})`;
+  }
 
   const queryTemplate = `
 ${prefixesString(prefixes)}
 SELECT ${distinctStr} ${variables.join(" ")}
 WHERE {
   ${where ? where.join(" ") : ""}
-} ${orderByStr ? orderByStr : ""}`;
+} ${orderByStr} ${groupByStr}`;
 
   return new SparqlParser().parse(queryTemplate);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -201,7 +201,7 @@ export function filterInVicinity(rootSubject, location, radius = 10) {
 
 /**
  * @param {String} rootSubject: a variable name that the score judges, e.g. `?need`
- * @param {String} scoreName: the variable name for the score (use the same name for
+ * @param {String} bindScoreAs: the variable name for the score (use the same name for
  *   sorting/aggregating in the parent query)
  * @param {String} pathToLocation: the predicates to be traversed to get to the root
  *   of the location (i.e. the `s:Place`) in the RDF-graph.
@@ -211,7 +211,7 @@ export function filterInVicinity(rootSubject, location, radius = 10) {
  */
 export function vicinityScoreSubQuery(
   resultName,
-  scoreName,
+  bindScoreAs,
   pathToLocation,
   location,
   radius = 10
@@ -224,7 +224,7 @@ export function vicinityScoreSubQuery(
       geo: "http://www.bigdata.com/rdf/geospatial#",
       geoliteral: "http://www.bigdata.com/rdf/geospatial/literals/v1#",
     },
-    variables: [resultName, scoreName],
+    variables: [resultName, bindScoreAs],
     where: [
       `${resultName} ${pathToLocation}/s:geo ?geo`,
       `SERVICE geo:search {
@@ -236,14 +236,14 @@ export function vicinityScoreSubQuery(
             ?geo geo:distanceValue ?geoDistance .
           }`,
       `BIND((${radius} - ?geoDistance) / ${radius} as ?geoScoreRaw)`, // 100 is the spatialCircleRadius / maxDistance in km
-      `BIND(IF(?geoScoreRaw > 0, ?geoScoreRaw , 0 ) as ${scoreName})`,
+      `BIND(IF(?geoScoreRaw > 0, ?geoScoreRaw , 0 ) as ${bindScoreAs})`,
     ],
   });
 }
 
 export function tagOverlapScoreSubQuery(
   resultName,
-  scoreName,
+  bindScoreAs,
   pathToTags,
   tagLikes
 ) {
@@ -296,8 +296,8 @@ export function tagOverlapScoreSubQuery(
     where: [
       `bind (?targetOverlap / ( ?targetTotal + ${
         tagLikes.length
-      } - ?targetOverlap ) as ${scoreName} )`, // intersection over union, see https://en.wikipedia.org/wiki/Jaccard_index
-      `filter(${scoreName} > 0)`, // filter out posts without any common tag-likes
+      } - ?targetOverlap ) as ${bindScoreAs} )`, // intersection over union, see https://en.wikipedia.org/wiki/Jaccard_index
+      `filter(${bindScoreAs} > 0)`, // filter out posts without any common tag-likes
     ],
     subQueries: [subQuery],
   });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -32,8 +32,8 @@ export function sparqlQuery({ prefixes, selectDistinct, where, orderBy }) {
 ${prefixesString(prefixes)}
 SELECT DISTINCT ${selectDistinct}
 WHERE {
-  ${where.join(" ")}
-} ${orderByStr}`;
+  ${where ? where.join(" ") : ""}
+} ${orderByStr ? orderByStr : ""}`;
 
   return new SparqlParser().parse(queryTemplate);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/jobs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/jobs.js
@@ -7,7 +7,7 @@ export const industryDetail = {
   identifier: "industry",
   label: "Industries and Fields",
   placeholder: "e.g. construction, graphic design, metal industry, etc",
-  icon: "#TODO", //TODO proper icon
+  icon: "#ico36_detail_tags", //TODO proper icon
   parseToRDF: function({ value }) {
     if (!value) {
       return { "s:industry": undefined };
@@ -25,8 +25,7 @@ export const employmentTypesDetail = {
   identifier: "employmentTypes",
   label: "Employment Types",
   placeholder: "e.g. full-time, part-time, internship, self-employed, etc",
-  // icon: "#ico36_detail_tags", //TODO proper icon
-  icon: "#TODO", //TODO proper icon
+  icon: "#ico36_detail_tags", //TODO proper icon
   parseToRDF: function({ value }) {
     if (!value) {
       return { "s:employmentType": undefined };
@@ -45,8 +44,7 @@ export const organizationNamesDetail = {
   label: "Organization Name(s)",
   placeholder:
     "e.g. Shiawase Corp., Simmerling Constructions, Daily Bugle, etc",
-  // icon: "#ico36_detail_tags", //TODO proper icon
-  icon: "#TODO", //TODO proper icon
+  icon: "#ico36_detail_tags", //TODO proper icon
   parseToRDF: function({ value }) {
     if (!value) {
       return { "s:hiringOrganization": undefined };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -4,7 +4,7 @@ import { realEstateGroup } from "./usecases/real-estate.js";
 import { transportGroup } from "./usecases/transport.js";
 import { complainGroup } from "./usecases/complain.js";
 import { socialGroup } from "./usecases/social.js";
-import { professionalGroup } from "./usecases/professional.js";
+import { professionalGroup } from "./usecases/professional/professional.js";
 import { mobilityGroup } from "./usecases/mobility.js";
 import { musicianGroup } from "./usecases/musician.js";
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/mobility.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/mobility.js
@@ -108,7 +108,8 @@ const mobilityUseCases = {
 
       return sparqlQuery({
         prefixes: concatenatedFilter.prefixes,
-        selectDistinct: resultName,
+        distinct: true,
+        variables: [resultName],
         where: concatenatedFilter.operations,
         orderBy: [
           {
@@ -155,7 +156,8 @@ const mobilityUseCases = {
 
       return sparqlQuery({
         prefixes: concatenatedFilter.prefixes,
-        selectDistinct: resultName,
+        distinct: true,
+        variables: [resultName],
         where: concatenatedFilter.operations,
         orderBy: [
           {
@@ -217,7 +219,8 @@ const mobilityUseCases = {
 
       return sparqlQuery({
         prefixes: concatenatedFilter.prefixes,
-        selectDistinct: resultName,
+        distinct: true,
+        variables: [resultName],
         where: concatenatedFilter.operations,
         orderBy: [
           {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
@@ -16,11 +16,11 @@ export const jobOffer = {
   draft: {
     ...emptyDraft,
     is: {
-      "@type": "s:JobPosting",
+      type: "s:JobPosting",
       tags: ["offer-job"],
     },
     seeks: {
-      "@type": "s:Person",
+      type: "s:Person",
     },
     searchString: ["search-job"],
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
@@ -11,7 +11,7 @@ import { jobLocation } from "../../details/location.js";
 export const jobOffer = {
   identifier: "jobOffer",
   label: "Find people for a Job",
-  // icon: "#ico36_uc_find_people", TODO
+  icon: "#ico36_uc_consortium-offer", //TODO proper icon
   doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
   draft: {
     ...emptyDraft,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
@@ -1,0 +1,40 @@
+import { details, emptyDraft } from "../../detail-definitions.js";
+import { interestsDetail, skillsDetail } from "../../details/person.js";
+import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../../app/won-utils.js";
+import {
+  industryDetail,
+  employmentTypesDetail,
+  organizationNamesDetail,
+} from "../../details/jobs.js";
+import { jobLocation } from "../../details/location.js";
+
+export const jobOffer = {
+  identifier: "jobOffer",
+  label: "Find people for a Job",
+  // icon: "#ico36_uc_find_people", TODO
+  doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+  draft: {
+    ...emptyDraft,
+    is: {
+      "@type": "s:JobPosting",
+      tags: ["offer-job"],
+    },
+    seeks: {
+      "@type": "s:Person",
+    },
+    searchString: ["search-job"],
+  },
+  isDetails: {
+    title: { ...details.title },
+    description: { ...details.description },
+    jobLocation: { ...jobLocation },
+    industry: { ...industryDetail },
+    employmentTypes: { ...employmentTypesDetail },
+    organizationNames: { ...organizationNamesDetail },
+  },
+  seeksDetails: {
+    description: { ...details.description },
+    skills: { ...skillsDetail },
+    interests: { ...interestsDetail },
+  },
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -39,4 +39,77 @@ export const jobSearch = {
     employmentTypes: { ...employmentTypesDetail },
     organizationNames: { ...organizationNamesDetail },
   },
+
+  generateQuery: (draft, resultName) => {
+    console.log(draft, resultName, "deleteme");
+
+    //
+    // # index for industries using binds
+    // prefix s: <http://schema.org/>
+    // prefix won:   <http://purl.org/webofneeds/model#>
+    // select distinct * where {
+    //   {
+    //     select ?need (sum(?var1) + sum(?var2) as ?targetOverlap) (count(?need) as ?targetTotal) where {
+    //       ?need a won:Need;
+    //             won:is ?is.
+    //             ?is s:industry ?value .
+    //       bind(if(str(?value) = "foo",1,0) as ?var1)
+    //       bind(if(str(?value) = "bar",1,0) as ?var2)
+    //     } group by (?need)
+    //   }
+    //   bind (?targetOverlap / ( ?targetTotal + 2 - ?targetOverlap ) as ?jaccardIndex )
+    // } order by desc(?jaccardIndex)
+    // limit 100
+    //
+    //
+    //     const seeksBranch = draft && draft.seeks;
+    //     const rentRange = seeksBranch && seeksBranch.rentRange;
+    //     const floorSizeRange = seeksBranch && seeksBranch.floorSizeRange;
+    //     const numberOfRoomsRange =
+    //       seeksBranch && seeksBranch.numberOfRoomsRange;
+    //     const location = seeksBranch && seeksBranch.location;
+    //     const filters = [
+    //       {
+    //         // to select is-branch
+    //         prefixes: {
+    //           won: won.defaultContext["won"],
+    //         },
+    //         operations: [
+    //           `${resultName} a won:Need.`,
+    //           `${resultName} won:is ?is.`,
+    //           location && "?is won:hasLocation ?location.",
+    //         ],
+    //       },
+    //       rentRange &&
+    //         filterRentRange(
+    //           "?is",
+    //           rentRange.min,
+    //           rentRange.max,
+    //           rentRange.currency
+    //         ),
+    //       floorSizeRange &&
+    //         filterFloorSizeRange("?is", floorSizeRange.min, floorSizeRange.max),
+    //       numberOfRoomsRange &&
+    //         filterNumOfRoomsRange(
+    //           "?is",
+    //           numberOfRoomsRange.min,
+    //           numberOfRoomsRange.max
+    //         ),
+    //       filterInVicinity("?location", location),
+    //     ];
+    //     const concatenatedFilter = concatenateFilters(filters);
+    //     return sparqlQuery({
+    //       prefixes: concatenatedFilter.prefixes,
+    //       selectDistinct: resultName,
+    //       where: concatenatedFilter.operations,
+    //       orderBy: [
+    //         {
+    //           order: "ASC",
+    //           variable: "?location_geoDistance",
+    //         },
+    //       ],
+    //     });
+    //   },
+    // },
+  },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -28,11 +28,11 @@ export const jobSearch = {
   draft: {
     ...emptyDraft,
     is: {
-      "@type": "s:Person",
+      type: "s:Person",
       tags: ["search-job"],
     },
     seeks: {
-      "@type": "s:JobPosting",
+      type: "s:JobPosting",
     },
     searchString: ["offer-job"],
   },
@@ -154,13 +154,15 @@ export const jobSearch = {
     const query = sparqlQuery({
       prefixes: {
         won: won.defaultContext["won"],
-        rdfs: won.defaultContext["rdfs"],
+        rdf: won.defaultContext["rdf"],
+        s: won.defaultContext["s"],
       },
       distinct: true,
       variables: [resultName],
       subQueries: subQueries,
       where: [
-        `${resultName} a won:Need.`,
+        `${resultName} rdf:type won:Need.`,
+        `${resultName} won:is/rdf:type s:JobPosting.`,
 
         // calculate average of scores; can be weighed if necessary
         `BIND( ( 
@@ -170,7 +172,7 @@ export const jobSearch = {
           COALESCE(?employmentTypes_jaccardIndex, 0) + 
           COALESCE(?jobLocation_geoScore, 0) 
         ) / 5  as ?aggregatedScore)`,
-        `FILTER(?aggregatedScore > 0)`,
+        // `FILTER(?aggregatedScore > 0)`, // not necessary atm to filter; there are parts of job-postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
       ],
       orderBy: [{ order: "DESC", variable: "?aggregatedScore" }],
       limit: 20,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -108,7 +108,38 @@ export const jobSearch = {
         `${resultName} ${sparqlPredicatePath} ${sparqlVarName} .`,
         ...bindOps,
       ],
+      groupBy: resultName,
     });
+
+    // const query = sparqlQuery({
+    //   prefixes: { /* get prefixes from inner query */}
+    // })
+    /*
+   *
+   * e.g.: with just industries:
+   * ```
+   * # index for industries using binds
+   * prefix s: <http://schema.org/>
+   * prefix won:   <http://purl.org/webofneeds/model#>
+   * select distinct * where {
+   *   {
+   *     select
+   *       ?needUri 
+   *       (sum(?var1) + sum(?var2) as ?targetOverlap)
+   *       (count(?needUri as ?targetTotal)
+   *     where {
+   *       needUria won:Need;
+   *             won:is ?is.
+   *             ?is s:industry ?industry .
+   *       bind(if(str(?industry) = "design",1,0) as ?var1)
+   *       bind(if(str(?industry) = "computer science",1,0) as ?var2)
+   *     } group by (?needUri)
+   *   }
+   *   bind (?targetOverlap / ( ?targetTotal + 2 - ?targetOverlap ) as ?jaccardIndex )
+   * } order by desc(?jaccardIndex)
+   * limit 100
+   * ```
+   */
 
     console.log(
       draft,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -9,7 +9,7 @@ import {
 import { jobLocation } from "../../details/location.js";
 import {
   sparqlQuery,
-  filterInVicinity,
+  vicinityScoreSubQuery,
 } from "../../../app/sparql-builder-utils.js";
 
 import won from "../../../app/won-es6.js";
@@ -165,8 +165,14 @@ export const jobSearch = {
       },
     });
 
-    const locationFilter = filterInVicinity("?jobLocation", jobLocation);
-    console.log("job location filter deleteme 2: ", locationFilter);
+    const vicinity = vicinityScoreSubQuery(
+      resultName,
+      "?jobLocation_geoScore",
+      "won:is/s:jobLocation",
+      jobLocation
+    );
+
+    console.log("job location filter deleteme 2: ", vicinity);
 
     // console.log(draft, resultName, subQuery, tagLikes, query, "deleteme");
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -107,7 +107,7 @@ export const jobSearch = {
     const employmentTypesSQ = tagOverlapScoreSubQuery({
       resultName: resultName,
       bindScoreAs: "?employmentTypes_jaccardIndex",
-      pathToTags: "won:is/s:employmentTypes",
+      pathToTags: "won:is/s:employmentType",
       prefixesInPath: {
         s: won.defaultContext["s"],
         won: won.defaultContext["won"],
@@ -141,6 +141,7 @@ export const jobSearch = {
     const query = sparqlQuery({
       prefixes: {
         won: won.defaultContext["won"],
+        rdfs: won.defaultContext["rdfs"],
       },
       distinct: true,
       variables: [resultName],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -71,6 +71,22 @@ export const jobSearch = {
    * ```
    */
   generateQuery: (draft, resultName) => {
+    // skills
+    // const pathInDraft = ["is", "skills"];
+    // const sparqlPredicatePath = "won:seeks/s:knowsAbout";
+    // const sparqlVarName = "?skills";
+
+    // hiringOrganizationName
+    // const pathInDraft = ["seeks", "organizationNames"];
+    // const sparqlPredicatePath = "won:is/s:hiringOrganization/s:name";
+    // const sparqlVarName = "?organizationName";
+
+    // employmentType
+    // const pathInDraft = ["seeks", "employmentTypes"];
+    // const sparqlPredicatePath = "won:is/s:employmentType";
+    // const sparqlVarName = "?employmentType";
+
+    // industry:
     const pathInDraft = ["seeks", "industry"];
     const sparqlPredicatePath = "won:is/s:industry";
     const sparqlVarName = "?industry";

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -127,60 +127,8 @@ export const jobSearch = {
       },
     });
 
-    console.log(draft, resultName, subQuery, tagLikes, query, "deleteme");
+    // console.log(draft, resultName, subQuery, tagLikes, query, "deleteme");
 
     return query;
-    //
-    //
-    //
-    //     const seeksBranch = draft && draft.seeks;
-    //     const rentRange = seeksBranch && seeksBranch.rentRange;
-    //     const floorSizeRange = seeksBranch && seeksBranch.floorSizeRange;
-    //     const numberOfRoomsRange =
-    //       seeksBranch && seeksBranch.numberOfRoomsRange;
-    //     const location = seeksBranch && seeksBranch.location;
-    //     const filters = [
-    //       {
-    //         // to select is-branch
-    //         prefixes: {
-    //           won: won.defaultContext["won"],
-    //         },
-    //         operations: [
-    //           `${resultName} a won:Need.`,
-    //           `${resultName} won:is ?is.`,
-    //           location && "?is won:hasLocation ?location.",
-    //         ],
-    //       },
-    //       rentRange &&
-    //         filterRentRange(
-    //           "?is",
-    //           rentRange.min,
-    //           rentRange.max,
-    //           rentRange.currency
-    //         ),
-    //       floorSizeRange &&
-    //         filterFloorSizeRange("?is", floorSizeRange.min, floorSizeRange.max),
-    //       numberOfRoomsRange &&
-    //         filterNumOfRoomsRange(
-    //           "?is",
-    //           numberOfRoomsRange.min,
-    //           numberOfRoomsRange.max
-    //         ),
-    //       filterInVicinity("?location", location),
-    //     ];
-    //     const concatenatedFilter = concatenateFilters(filters);
-    //     return sparqlQuery({
-    //       prefixes: concatenatedFilter.prefixes,
-    //       selectDistinct: resultName,
-    //       where: concatenatedFilter.operations,
-    //       orderBy: [
-    //         {
-    //           order: "ASC",
-    //           variable: "?location_geoDistance",
-    //         },
-    //       ],
-    //     });
-    //   },
-    // },
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -136,19 +136,6 @@ export const jobSearch = {
       limit: 20,
     });
 
-    console.log(
-      "job location filter deleteme 2: ",
-      vicinityScoreSQ,
-      industryScoreSQ,
-      query
-    );
-
-    // console.log(draft, resultName, subQuery, tagLikes, query, "deleteme");
-
-    //TODO: STOPPED HERE
-    // use `subQueries` field of args to `sparqlQuery` to combine the queries
-
     return query;
-    // throw new Error("NOT IMPLEMENTED YET");
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -23,7 +23,7 @@ window.SparqlGenerator4dbg = Generator;
 export const jobSearch = {
   identifier: "jobSearch",
   label: "Search a Job",
-  // icon: "#ico36_uc_find_people", TODO
+  icon: "#ico36_uc_consortium-search", //TODO proper icon
   doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
   draft: {
     ...emptyDraft,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -53,7 +53,11 @@ export const jobSearch = {
    * prefix won:   <http://purl.org/webofneeds/model#>
    * select distinct * where {
    *   {
-   *     select ${resultName} (sum(?var1) + sum(?var2) as ?targetOverlap) (count(${resultName}) as ?targetTotal) where {
+   *     select
+   *       ${resultName}
+   *       (sum(?var1) + sum(?var2) as ?targetOverlap)
+   *       (count(${resultName}) as ?targetTotal)
+   *     where {
    *       ${resultName} a won:Need;
    *             won:is ?is.
    *             ?is s:industry ?industry .
@@ -97,7 +101,7 @@ export const jobSearch = {
         s: won.defaultContext["s"], // TODO needs to be moved to outermost query
         won: won.defaultContext["won"],
       },
-      selectDistinct: `${resultName} ${targetOverlapSelect} ${targetTotalSelect}`,
+      variables: [resultName, targetOverlapSelect, targetTotalSelect],
       //  ${resultName} (sum(?var1) + sum(?var2) as ?targetOverlap) (count(${resultName}) as ?targetTotal) {
       where: [
         `${resultName} a won:Need .`,
@@ -106,7 +110,14 @@ export const jobSearch = {
       ],
     });
 
-    console.log(draft, resultName, innerQuery, tagLikes, "deleteme");
+    console.log(
+      draft,
+      resultName,
+      innerQuery,
+      innerQuery.prefixes,
+      tagLikes,
+      "deleteme"
+    );
     //
     //
     //

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -1,0 +1,42 @@
+import { details, emptyDraft } from "../../detail-definitions.js";
+import { interestsDetail, skillsDetail } from "../../details/person.js";
+import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../../app/won-utils.js";
+import {
+  industryDetail,
+  employmentTypesDetail,
+  organizationNamesDetail,
+} from "../../details/jobs.js";
+import { jobLocation } from "../../details/location.js";
+
+export const jobSearch = {
+  identifier: "jobSearch",
+  label: "Search a Job",
+  // icon: "#ico36_uc_find_people", TODO
+  doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+  draft: {
+    ...emptyDraft,
+    is: {
+      "@type": "s:Person",
+      tags: ["search-job"],
+    },
+    seeks: {
+      "@type": "s:JobPosting",
+    },
+    searchString: ["offer-job"],
+  },
+  isDetails: {
+    title: { ...details.title },
+    description: { ...details.description },
+    // location: { ...details.location }, // why would your current location of residency matter?
+    // person: { ...details.person }, // has current company fields, that are weird for a search
+    skills: { ...skillsDetail },
+    interests: { ...interestsDetail },
+  },
+  seeksDetails: {
+    description: { ...details.description },
+    jobLocation: { ...jobLocation },
+    industry: { ...industryDetail },
+    employmentTypes: { ...employmentTypesDetail },
+    organizationNames: { ...organizationNamesDetail },
+  },
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -95,7 +95,6 @@ export const jobSearch = {
     // const sparqlVarName = "?employmentType";
 
     // industry:
-    const industries = getIn(draft, ["seeks", "industry"]);
     const industryScoreSQ = tagOverlapScoreSubQuery({
       resultName: resultName,
       bindScoreAs: "?industry_jaccardIndex",
@@ -104,10 +103,9 @@ export const jobSearch = {
         s: won.defaultContext["s"],
         won: won.defaultContext["won"],
       },
-      tagLikes: industries,
+      tagLikes: getIn(draft, ["seeks", "industry"]),
     });
 
-    const jobLocation = getIn(draft, ["seeks", "jobLocation"]); // TODO move to better place
     const vicinityScoreSQ = vicinityScoreSubQuery({
       resultName: resultName,
       bindScoreAs: "?jobLocation_geoScore",
@@ -116,7 +114,7 @@ export const jobSearch = {
         s: won.defaultContext["s"],
         won: won.defaultContext["won"],
       },
-      geoCoordinates: jobLocation,
+      geoCoordinates: getIn(draft, ["seeks", "jobLocation"]),
     });
 
     const query = sparqlQuery({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/professional.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/professional.js
@@ -1,83 +1,19 @@
 /**
  * Created by fsuda on 18.09.2018.
  */
-import { details, emptyDraft } from "../detail-definitions.js";
-import { interestsDetail, skillsDetail } from "../details/person.js";
-import { jobLocation } from "../details/location.js";
-import {
-  industryDetail,
-  employmentTypesDetail,
-  organizationNamesDetail,
-} from "../details/jobs.js";
-import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
+import { details, emptyDraft } from "../../detail-definitions.js";
+import { interestsDetail, skillsDetail } from "../../details/person.js";
+import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../../app/won-utils.js";
+import { jobSearch } from "./job-search.js";
+import { jobOffer } from "./job-offer.js";
 
 export const professionalGroup = {
   identifier: "professionalgroup",
   label: "Professional Networking",
   icon: undefined,
   useCases: {
-    jobSearch: {
-      identifier: "jobSearch",
-      label: "Search a Job",
-      // icon: "#ico36_uc_find_people", TODO
-      doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
-      draft: {
-        ...emptyDraft,
-        is: {
-          "@type": "s:Person",
-          tags: ["search-job"],
-        },
-        seeks: {
-          "@type": "s:JobPosting",
-        },
-        searchString: ["offer-job"],
-      },
-      isDetails: {
-        title: { ...details.title },
-        description: { ...details.description },
-        // location: { ...details.location }, // why would your current location of residency matter?
-        // person: { ...details.person }, // has current company fields, that are weird for a search
-        skills: { ...skillsDetail },
-        interests: { ...interestsDetail },
-      },
-      seeksDetails: {
-        description: { ...details.description },
-        jobLocation: { ...jobLocation },
-        industry: { ...industryDetail },
-        employmentTypes: { ...employmentTypesDetail },
-        organizationNames: { ...organizationNamesDetail },
-      },
-    },
-    jobOffer: {
-      identifier: "jobOffer",
-      label: "Find people for a Job",
-      // icon: "#ico36_uc_find_people", TODO
-      doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
-      draft: {
-        ...emptyDraft,
-        is: {
-          "@type": "s:JobPosting",
-          tags: ["offer-job"],
-        },
-        seeks: {
-          "@type": "s:Person",
-        },
-        searchString: ["search-job"],
-      },
-      isDetails: {
-        title: { ...details.title },
-        description: { ...details.description },
-        jobLocation: { ...jobLocation },
-        industry: { ...industryDetail },
-        employmentTypes: { ...employmentTypesDetail },
-        organizationNames: { ...organizationNamesDetail },
-      },
-      seeksDetails: {
-        description: { ...details.description },
-        skills: { ...skillsDetail },
-        interests: { ...interestsDetail },
-      },
-    },
+    jobSearch: jobSearch,
+    jobOffer: jobOffer,
     getToKnow: {
       identifier: "getToKnow",
       label: "Find people",

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/real-estate.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/real-estate.js
@@ -100,7 +100,8 @@ export const realEstateGroup = {
 
         return sparqlQuery({
           prefixes: concatenatedFilter.prefixes,
-          selectDistinct: resultName,
+          distinct: true,
+          variables: [resultName],
           where: concatenatedFilter.operations,
           orderBy: [
             {
@@ -188,7 +189,8 @@ export const realEstateGroup = {
 
         return sparqlQuery({
           prefixes: concatenatedFilter.prefixes,
-          selectDistinct: resultName,
+          distinct: true,
+          variables: [resultName],
           where: concatenatedFilter.operations,
           orderBy: [
             {


### PR DESCRIPTION
1. Generate some job-offers with varying locations, tags, skills, etc
2. with a different account generate job-searches with intersecting tags, skills, etc and/or nearby locations
3. you should get matches.

if something doesn't work (e.g. because the matcher isn't running), copy-paste the SPARQL-query attached to the job-searches into your nodes Blazegraph (for integration-testing it's <http://satvm05.researchstudio.at:9999/blazegraph/#query>) and change the outer select to `select * from`, to see all (sub-)scores)

Also changes the icons for the job-search/offer use-cases and details to placeholders (until we have better designs)