### PR TITLE
Feat detail petrinet update

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -158,6 +158,7 @@ $ngRedux.getState();
                    retractedMessageUris: Immutable.Set(),
                    isLoaded: true|false, //default is false, whether or not the agreementData has been loaded already
                },
+               petriNetData: Immutable.Map, //default is empty Map
                isLoadingMessages: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
                isLoadingAgreementData: true|false, //default is false, whether or not the agreementData has been loaded,
                isLoading: true|false, //default is false, whether or not this connection is currently loading itself (similar to the isLoading in the need)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -113,6 +113,7 @@ const actionHierarchy = {
     showAgreementData: INJ_DEFAULT,
     setMultiSelectType: INJ_DEFAULT,
     updateAgreementData: INJ_DEFAULT, //cnct.loadAgreementData,
+    updatePetriNetData: INJ_DEFAULT,
   },
   needs: {
     received: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
@@ -14,21 +14,21 @@ function genComponentConf() {
           <span class="petrinetv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
         </div>
         <div class="petrinetv__content">
-          <a class="petrinetv__content__download" ng-show="self.content"
-            ng-href="data:{{self.content.get('type')}};base64,{{self.content.get('data')}}"
-            download="{{ self.content.get('name') }}">
-            <div class="petrinetv__content__download__label clickable">
-              {{ self.content.get('name') }}
-            </div>
-            <svg class="petrinetv__content__download__typeicon">
-              <use xlink:href="#ico36_uc_transport_demand" href="#ico36_uc_transport_demand"></use>
-            </svg>
-          </a>
           <won-petrinet-state
             class="petrinetv__content__state"
             ng-if="self.content && self.content.get('processURI')"
             process-uri="self.content.get('processURI')">
           </won-petrinet-state>
+          <a class="petrinetv__content__download" ng-show="self.content"
+            ng-href="data:{{self.content.get('type')}};base64,{{self.content.get('data')}}"
+            download="{{ self.content.get('name') }}">
+            <svg class="petrinetv__content__download__typeicon">
+              <use xlink:href="#ico36_uc_transport_demand" href="#ico36_uc_transport_demand"></use>
+            </svg>
+            <div class="petrinetv__content__download__label clickable">
+              Download '{{ self.content.get('name') }}'
+            </div>
+          </a>
         </div>
       </div>
     `;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
@@ -1,5 +1,6 @@
 import angular from "angular";
 import { attach } from "../../../utils.js";
+import petrinetStateModule from "../../petrinet-state.js";
 
 import "style/_petrinet-viewer.scss";
 
@@ -23,12 +24,11 @@ function genComponentConf() {
               <use xlink:href="#ico36_uc_transport_demand" href="#ico36_uc_transport_demand"></use>
             </svg>
           </a>
-          <div class="petrinetv__content__state" ng-if="false && self.content">
-            <! -- TODO: PetriNet State could also be displayed here -->
-            <div class="petrinetv__content__state__processUri">
-              {{ self.content.get('processURI') }}
-            </div>
-          </div>
+          <won-petrinet-state
+            class="petrinetv__content__state"
+            ng-if="self.content && self.content.get('processURI')"
+            process-uri="self.content.get('processURI')">
+          </won-petrinet-state>
         </div>
       </div>
     `;
@@ -73,5 +73,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.petrinetViewer", [])
+  .module("won.owner.components.petrinetViewer", [petrinetStateModule])
   .directive("wonPetrinetViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.js
@@ -26,7 +26,7 @@ function genComponentConf() {
           <div class="petrinetv__content__state" ng-if="false && self.content">
             <! -- TODO: PetriNet State could also be displayed here -->
             <div class="petrinetv__content__state__processUri">
-              {{ self.content.get('processUri') }}
+              {{ self.content.get('processURI') }}
             </div>
           </div>
         </div>
@@ -53,7 +53,6 @@ function genComponentConf() {
     }
     updatedContent(newContent, prevContent) {
       if (newContent && newContent != prevContent) {
-        console.log("updating content");
         this.content = newContent;
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
@@ -1,0 +1,73 @@
+/**
+ * Component for rendering the connection state as an svg
+ * Created by fsuda on 10.04.2017.
+ */
+import angular from "angular";
+import "ng-redux";
+import { actionCreators } from "../actions/actions.js";
+
+import { attach } from "../utils.js";
+import {
+  selectNeedByConnectionUri,
+  selectOpenConnectionUri,
+} from "../selectors.js";
+import { connect2Redux } from "../won-utils.js";
+
+import "style/_petrinet-state.scss";
+
+const serviceDependencies = ["$ngRedux", "$scope"];
+function genComponentConf() {
+  let template = `
+        <div class="ps__active" ng-if="self.process && !self.isLoading">
+            {{ self.process.toJS() }}
+        </div>
+        <div class="ps__inactive" ng-if="!self.process && !self.isLoading">
+            This PetriNet, is not active (yet).
+        </div>
+        <div class="ps__loading" ng-if="!self.process && self.isLoading">
+            The PetriNet-State, is currently loading
+        </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+
+      const selectFromState = state => {
+        const connectionUri = selectOpenConnectionUri(state); //TODO: create selector that returns the correct connectionUri without looking up the open one
+        const need =
+          connectionUri && selectNeedByConnectionUri(state, connectionUri);
+        const connection = need && need.getIn(["connections", connectionUri]);
+
+        const process =
+          this.processUri &&
+          connection &&
+          connection.getIn(["petriNetData", this.processUri]);
+
+        const isLoading = false; //TODO: Implement Loading in state first
+
+        return {
+          process: process,
+          isLoading: isLoading,
+        };
+      };
+
+      connect2Redux(selectFromState, actionCreators, ["self.processUri"], this);
+    }
+  }
+  Controller.$inject = serviceDependencies;
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      processUri: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.petrinetState", [])
+  .directive("wonPetrinetState", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -353,16 +353,30 @@ function genComponentConf() {
       });
     }
 
-    //TODO: THIS IS SOLELY FOR TESTING PURPOSES
-    loadPetriNetUris4Dbg() {
+    loadPetriNetUris() {
+      //TODO: THIS IS NEEDS TO BE CALLED
       const connectionUri = this.connection && this.connection.get("uri");
       if (connectionUri) {
         fetchPetriNetUris(connectionUri)
           .then(response => {
-            console.log("Response: ", response);
+            const petriNetData = {};
+
+            response.forEach(entry => {
+              if (entry.processURI) {
+                petriNetData[entry.processURI] = entry;
+              }
+            });
+
+            const petriNetDataImm = Immutable.fromJS(petriNetData);
+
+            this.connections__updatePetriNetData({
+              connectionUri: this.connectionUri,
+              petriNetData: petriNetDataImm,
+            });
           })
           .catch(error => {
             console.error("Error: ", error);
+            //TODO: ERROR HANDLING
           });
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -38,6 +38,7 @@ import {
   changeConnectionStateByFun,
   storeConnectionsData,
   updateAgreementStateData,
+  updatePetriNetStateData,
   setShowAgreementData,
   setMultiSelectType,
 } from "./reduce-connections.js";
@@ -541,7 +542,12 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.connectionUri,
         action.payload.isLoadingMessages
       );
-
+    case actionTypes.connections.updatePetriNetData:
+      return updatePetriNetStateData(
+        allNeedsInState,
+        action.payload.connectionUri,
+        action.payload.petriNetData
+      );
     case actionTypes.connections.updateAgreementData:
       return updateAgreementStateData(
         allNeedsInState,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
@@ -24,6 +24,7 @@ export function parseConnection(jsonldConnection) {
         retractedMessageUris: Immutable.Set(),
         isLoaded: false,
       },
+      petriNetData: Immutable.Map(),
       remoteNeedUri: undefined,
       remoteConnectionUri: undefined,
       creationDate: undefined,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -221,11 +221,35 @@ export function changeConnectionStateByFun(state, connectionUri, fun) {
   return changeConnectionState(state, connectionUri, fun(connectionState));
 }
 
+export function updatePetriNetStateData(state, connectionUri, petriNetData) {
+  const need = selectNeedByConnectionUri(state, connectionUri);
+
+  if (!need || !petriNetData) {
+    console.error(
+      "no need found for connectionUri",
+      connectionUri,
+      " or no petriNetData present"
+    );
+    return state;
+  }
+
+  const needUri = need.get("uri");
+
+  return state.setIn(
+    [needUri, "connections", connectionUri, "petriNetData"],
+    petriNetData
+  );
+}
+
 export function updateAgreementStateData(state, connectionUri, agreementData) {
   const need = selectNeedByConnectionUri(state, connectionUri);
 
   if (!need || !agreementData) {
-    console.error("no need found for connectionUri", connectionUri);
+    console.error(
+      "no need found for connectionUri",
+      connectionUri,
+      " or no petriNetData present"
+    );
     return state;
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/workflow.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/workflow.js
@@ -83,7 +83,7 @@ export const petriNetWorkflow = {
     const wflw = jsonLDImm && jsonLDImm.get("won:hasPetriNet");
 
     let workflow = {
-      processUri: get(wflw, "@id"),
+      processURI: get(wflw, "@id"),
       name: get(wflw, "s:name"),
       type: get(wflw, "s:type"),
       data: get(wflw, "wf:hasInlinePetriNetDefinition"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
@@ -1,0 +1,17 @@
+@import "won-config";
+@import "flex-layout";
+@import "sizing-utils";
+
+won-petrinet-state {
+  .ps__active {
+    color: $won-primary-text-color;
+  }
+
+  .ps__inactive {
+    color: $won-line-gray;
+  }
+
+  .ps__loading {
+    color: $won-subtitle-gray;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
@@ -3,8 +3,48 @@
 @import "sizing-utils";
 
 won-petrinet-state {
+  display: grid;
+  grid-gap: 0.25rem;
+
   .ps__active {
-    color: $won-primary-text-color;
+    display: grid;
+    grid-gap: 0.5rem;
+
+    .ps__active__header {
+      font-weight: bold;
+      padding-bottom: 0.25rem;
+      border-bottom: $thinGrayBorder;
+    }
+
+    .ps__active__markedPlace {
+      background-color: white;
+      border: $thinGrayBorder;
+      padding: 0.5rem;
+    }
+
+    .ps__active__noMarkedPlace {
+      color: $won-subtitle-gray;
+      padding: 0.5rem 0;
+    }
+
+    .ps__active__enabledTransition {
+      display: grid;
+      grid-gap: 0.25rem;
+      grid-template-columns: 1fr min-content;
+      align-items: center;
+
+      .ps__active__enabledTransition__label {
+      }
+
+      .ps__active__enabledTransition__button {
+        font-size: $smallFontSize;
+      }
+    }
+
+    .ps__active__noEnabledTransition {
+      color: $won-subtitle-gray;
+      padding: 0.5rem 0;
+    }
   }
 
   .ps__inactive {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-viewer.scss
@@ -9,32 +9,28 @@ won-petrinet-viewer {
     grid-gap: 0.25rem;
 
     .petrinetv__content__download {
-      width: 100%;
       display: grid;
-      grid-template-rows: min-content 1fr;
+      grid-template-columns: min-content 1fr;
       border: $thinGrayBorder;
       border-radius: 0.19rem;
       background: $won-lighter-gray;
       grid-gap: 0.25rem;
       padding: 0.25rem;
       justify-items: center;
-
-      .petrinetv__content__download__typeicon {
-        grid-row: 2 / span 1;
-        height: 5rem;
-        max-width: 100%;
-        width: 100%;
-        --local-primary: #{$won-line-gray};
-      }
+      align-items: center;
 
       .petrinetv__content__download__label {
-        grid-row: 1 / span 1;
         font-size: $smallFontSize;
-        color: $won-primary-text-color;
+        color: $won-line-gray;
         text-overflow: ellipsis;
         overflow: hidden;
-        max-width: 100%;
         white-space: nowrap;
+      }
+
+      .petrinetv__content__download__typeicon {
+        height: 2rem;
+        width: 2rem;
+        --local-primary: #{$won-line-gray};
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-viewer.scss
@@ -39,8 +39,6 @@ won-petrinet-viewer {
     }
 
     .petrinetv__content__state {
-      .petrinetv__content__state__processUri {
-      }
     }
   }
 }


### PR DESCRIPTION
First Implementation Iteration of Active PetriNet instances

What has been done?
- Created petrinet-state component to view the currently markedPlaces and enabledTransitions, add the ability to send the transitionmessage from within this component
- Updated the PetriNetViewer: smaller Download Button, inclusion of petriNetData-component (if present)
- Created a method in post-messages.js that retrieves the petriNetData for the connection that is currently viewed (execute: pm4dbg.loadPetriNetUris() to retrieve the data
- Updated the connection in the state and reducers/actions to store the received data in the reduxstate

ToDo:
- Implement inital and recurring fetch of petriNetData
- Implement a View for all petriNet instances (similar to the agreementData-View)
- Error handling for petrinetdata fetch
- send transitionmessage with an immediately following claim message so we dont have to execute two actions for the transition
- Update/Refactor/Refine UI accordingly
- update transition picker from two inputfields to two connected dropdowns (nice to have i guess)

How to load petriNetData: (if you are in need of a valid petrinet xml ask @fkleedorfer )
1) go to any given chat and send a message with a petrinetdetail
2) propose this message
3) accept the proposal (or let debugbot accept it)
4) pm4dbg.loadPetriNetUris() in the console to retrieve the current state

How to see changes and test:
1) intially do all of the above
2) "send" an enabled transition visible within the message containing the petrinetdetail
3) propose or claim the sent message
4) if propose was made ask the counterpart need to accept the propsal (if claim was chosen you do not have to wait for the other one to accept the claim)
5) reload petrinetdata within the console
6) see state changes wirh the petrinetmessage
repeat steps 2-6 as many times as you want, maybe also try to retract claims or cancel accepted proposals instead of step 2) --> unknown states or changes might lie in the backend impl of the petriNetData calculation, and would be seen as unrelated issues

the pr can be merged in my opinion since it does not break anything and we can just exclude the petrinets if the finished or satisfactory implementation would not be done in due time for the code freeze