### PR TITLE
Made connection list and connection content scale symmetrically.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connections.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connections.scss
@@ -17,14 +17,13 @@
     flex-grow: 1;
     max-width: $maxContentWidth / 2;
 
-    @media (min-width: $responsivenessBreakPoint) {
-      min-width: 28rem;
-    }
+    flex-basis: 0;
   }
 
   .conn__content {
     display: flex;
     flex-grow: 1;
+    flex-basis: 0;
     height: 100%;
     justify-content: center;
     align-content: center;


### PR DESCRIPTION
Fixes #2335 

Setting `flex-basis: 0` on both elements makes them scale exactly equally. This is a fix for the squished right side, but it is not perfect visibility-wise, as seen in this screenshot:
![image](https://user-images.githubusercontent.com/1326334/47213922-b92ea180-d39c-11e8-8c27-a51b839a7871.png)

To fix this, we need to change how we do responsiveness. A single "breakpoint" isn't going to cut it there.