### PR TITLE
Feat petrinetdata refresh

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -161,6 +161,7 @@ $ngRedux.getState();
                petriNetData: {
                     data: Immutable.Map(),
                     isLoaded: true|false //default is false, whether or not the petriNetData has been loaded already
+                    isDirty: true|false //default is false, whether or not the currently stored petriNetData is (assumed to be) not correct anymore
                },
                isLoadingMessages: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
                isLoadingAgreementData: true|false, //default is false, whether or not the agreementData has been loaded,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -105,6 +105,7 @@ const actionHierarchy = {
     rate: cnct.connectionsRate,
     sendChatMessage: cnct.connectionsChatMessage,
     sendChatMessageClaimOnSuccess: cnct.connectionsChatMessageClaimOnSuccess,
+    sendChatMessageRefreshDataOnSuccess: INJ_DEFAULT,
     sendChatMessageFailed: INJ_DEFAULT,
     showLatestMessages: cnct.showLatestMessages,
     showMoreMessages: cnct.showMoreMessages,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -105,7 +105,7 @@ const actionHierarchy = {
     rate: cnct.connectionsRate,
     sendChatMessage: cnct.connectionsChatMessage,
     sendChatMessageClaimOnSuccess: cnct.connectionsChatMessageClaimOnSuccess,
-    sendChatMessageRefreshDataOnSuccess: INJ_DEFAULT,
+    sendChatMessageRefreshDataOnSuccess: INJ_DEFAULT, //will be dispatched solely within sendChatMessage (only if chatMessage that is sent contains References)
     sendChatMessageFailed: INJ_DEFAULT,
     showLatestMessages: cnct.showLatestMessages,
     showMoreMessages: cnct.showMoreMessages,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -211,7 +211,7 @@ export function connectionsChatMessage(
         // dispatch(actionCreators.messages__send(messageData));
         dispatch({
           type: referencedContentUris
-            ? actionTypes.connections.sendChatMessageRefreshDataOnSuccess
+            ? actionTypes.connections.sendChatMessageRefreshDataOnSuccess //If there are references in the message we need to Refresh the Data from the backend on msg success
             : actionTypes.connections.sendChatMessage,
           payload: {
             eventUri: optimisticEvent.getMessageUri(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -210,7 +210,9 @@ export function connectionsChatMessage(
       .then(([optimisticEvent, jsonldMessage]) => {
         // dispatch(actionCreators.messages__send(messageData));
         dispatch({
-          type: actionTypes.connections.sendChatMessage,
+          type: referencedContentUris
+            ? actionTypes.connections.sendChatMessageRefreshDataOnSuccess
+            : actionTypes.connections.sendChatMessage,
           payload: {
             eventUri: optimisticEvent.getMessageUri(),
             message: jsonldMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -828,9 +828,8 @@ export function dispatchActionOnSuccessRemote(event) {
           ])
         )
         .then(([optimisticEvent, jsonldMessage]) => {
-          // dispatch(actionCreators.messages__send(messageData));
           dispatch({
-            type: actionTypes.connections.sendChatMessage,
+            type: actionTypes.connections.sendChatMessageRefreshDataOnSuccess,
             payload: {
               eventUri: optimisticEvent.getMessageUri(),
               message: jsonldMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
@@ -18,7 +18,7 @@ import "style/_petrinet-state.scss";
 const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
   let template = `
-        <div class="ps__active" ng-if="self.process && !self.isLoading">
+        <div class="ps__active" ng-if="self.process && (self.isLoaded || !self.isLoading)">
           <div class="ps__active__header">
             Marked Places
           </div>
@@ -50,11 +50,14 @@ function genComponentConf() {
             No Enabled Transitions in PetriNet
           </div>
         </div>
-        <div class="ps__inactive" ng-if="!self.process && !self.isLoading">
+        <div class="ps__inactive" ng-if="!self.process && !self.isLoading && self.isLoaded">
             This PetriNet, is not active (yet).
         </div>
-        <div class="ps__loading" ng-if="!self.process && self.isLoading">
-            The PetriNet-State, is currently loading
+        <div class="ps__loading" ng-if="self.isLoaded && (self.isLoading || self.isDirty)">
+            <svg class="ps__loading__spinner">
+              <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
+            </svg>
+            <div class="ps__loading__label">The PetriNet-State, is currently being calculated</div>
         </div>
     `;
 
@@ -77,6 +80,7 @@ function genComponentConf() {
           petriNetData.getIn(["data", this.processUri]);
 
         const isLoading = connection && connection.get("isLoadingPetriNetData");
+        const isLoaded = petriNetData && petriNetData.get("isLoaded");
         const isDirty = petriNetData && petriNetData.get("isDirty");
         const markedPlaces = process && process.get("markedPlaces");
         const enabledTransitions = process && process.get("enabledTransitions");
@@ -89,6 +93,7 @@ function genComponentConf() {
         return {
           connectionUri: connectionUri,
           multiSelectType: connection && connection.get("multiSelectType"),
+          petriNetData: petriNetData,
           process: process,
           hasEnabledTransitions: enabledTransitionsSize > 0,
           hasMarkedPlaces: markedPlacesSize > 0,
@@ -97,6 +102,7 @@ function genComponentConf() {
           markedPlacesArray: markedPlaces && markedPlaces.toArray(),
           isDirty: isDirty,
           isLoading: isLoading,
+          isLoaded: isLoaded,
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.js
@@ -41,7 +41,7 @@ function genComponentConf() {
               </div>
               <!-- The button is labelled 'send' at the moment because we jsut send the transition but not claim it right away -->
               <button class="ps__active__enabledTransition__button won-button--filled thin red"
-                ng-disabled="self.multiSelectType"
+                ng-disabled="self.multiSelectType || self.isDirty"
                 ng-click="self.sendClaim(enabledTransition)">
                   Claim
               </button>
@@ -69,12 +69,15 @@ function genComponentConf() {
           connectionUri && selectNeedByConnectionUri(state, connectionUri);
         const connection = need && need.getIn(["connections", connectionUri]);
 
+        const petriNetData = connection && connection.get("petriNetData");
+
         const process =
           this.processUri &&
-          connection &&
-          connection.getIn(["petriNetData", "data", this.processUri]);
+          petriNetData &&
+          petriNetData.getIn(["data", this.processUri]);
 
-        const isLoading = false; //TODO: Implement Loading in state first
+        const isLoading = connection && connection.get("isLoadingPetriNetData");
+        const isDirty = petriNetData && petriNetData.get("isDirty");
         const markedPlaces = process && process.get("markedPlaces");
         const enabledTransitions = process && process.get("enabledTransitions");
 
@@ -92,6 +95,7 @@ function genComponentConf() {
           enabledTransitionsArray:
             enabledTransitions && enabledTransitions.toArray(),
           markedPlacesArray: markedPlaces && markedPlaces.toArray(),
+          isDirty: isDirty,
           isLoading: isLoading,
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -97,15 +97,15 @@ function genComponentConf() {
               post-uri="self.theirNeedUri">
             </won-post-content-message>
             <div class="pm__content__loadspinner"
-                ng-if="self.isLoadingMessages || (self.showAgreementData && self.isLoadingAgreementData) || (self.showPetriNetData && self.isLoadingPetriNetData)">
+                ng-if="self.isLoadingMessages || (self.showAgreementData && self.isLoadingAgreementData) || (self.showPetriNetData && self.isLoadingPetriNetData && !self.hasPetriNetData)">
                 <svg class="hspinner">
                   <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
-              </svg>
+                </svg>
             </div>
             <div class="pm__content__agreement__loadingtext"  ng-if="self.showAgreementData && self.isLoadingAgreementData">
               Calculating Agreement Status
             </div>
-            <div class="pm__content__petrinet__loadingtext"  ng-if="self.showPetriNetData && self.isLoadingPetriNetData">
+            <div class="pm__content__petrinet__loadingtext"  ng-if="self.showPetriNetData && self.isLoadingPetriNetData && !self.hasPetriNetData">
               Calculating PetriNet Status
             </div>
             <button class="pm__content__loadbutton won-button--outlined thin red"
@@ -165,7 +165,7 @@ function genComponentConf() {
               No PetriNet Data within this Conversation
             </div>
             <div class="pm__content__petrinet__process"
-              ng-if="self.showPetriNetData && !self.isLoadingPetriNetData && self.hasPetriNetData && process.get('processURI')"
+              ng-if="self.showPetriNetData && (!self.isLoadingPetriNetData || self.hasPetriNetData) && process.get('processURI')"
               ng-repeat="process in self.petriNetDataArray">
               <div class="pm__content__petrinet__process__header">
                 ProcessURI: {{ process.get('processURI') }}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -14,6 +14,7 @@ const initialState = Immutable.fromJS({
   enqueued: {},
   waitingForAnswer: {},
   claimOnSuccess: {},
+  refreshDataOnSuccess: {},
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
@@ -52,6 +53,14 @@ export function messagesReducer(messages = initialState, action = {}) {
         ["enqueued", action.payload.eventUri],
         action.payload.message
       );
+
+    case actionTypes.connections.sendChatMessageRefreshDataOnSuccess:
+      return messages
+        .setIn(["enqueued", action.payload.eventUri], action.payload.message)
+        .setIn(
+          ["refreshDataOnSuccess", action.payload.eventUri],
+          action.payload.message
+        );
 
     case actionTypes.connections.sendChatMessageClaimOnSuccess:
       return messages
@@ -183,6 +192,7 @@ export function messagesReducer(messages = initialState, action = {}) {
     case actionTypes.messages.dispatchActionOn.successRemote:
       return messages
         .removeIn(["claimOnSuccess", action.payload.eventUri])
+        .removeIn(["refreshDataOnSuccess", action.payload.eventUri])
         .removeIn(["dispatchOnSuccessRemote", action.payload.eventUri])
         .removeIn(["dispatchOnFailureRemote", action.payload.eventUri]);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -42,6 +42,7 @@ import {
   updatePetriNetStateData,
   setShowAgreementData,
   setShowPetriNetData,
+  setPetriNetDataDirty,
   setMultiSelectType,
 } from "./reduce-connections.js";
 
@@ -596,6 +597,18 @@ export default function(allNeedsInState = initialState, action = {}) {
       return addMessage(allNeedsInState, action.payload);
 
     case actionTypes.connections.sendChatMessageClaimOnSuccess:
+    case actionTypes.connections.sendChatMessageRefreshDataOnSuccess: {
+      const allNeedsInStateWithDirtyPetriNetData = setPetriNetDataDirty(
+        allNeedsInState,
+        action.payload.optimisticEvent.getSender(),
+        true
+      );
+      return addMessage(
+        allNeedsInStateWithDirtyPetriNetData,
+        action.payload.optimisticEvent
+      );
+    }
+
     case actionTypes.connections.sendChatMessage:
       // ADD SENT TEXT MESSAGE
       /*

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -168,9 +168,40 @@ export function setConnectionLoadingPetriNetData(
     return state;
   }
 
+  return state
+    .setIn(
+      [needUri, "connections", connectionUri, "petriNetData", "isDirty"],
+      isLoadingPetriNetData //Assuming that there is currently a load of petriNetData in progress we flag it dirty just in case
+    )
+    .setIn(
+      [needUri, "connections", connectionUri, "isLoadingPetriNetData"],
+      isLoadingPetriNetData
+    );
+}
+
+export function setPetriNetDataDirty(
+  state,
+  connectionUri,
+  isPetriNetDataDirty
+) {
+  const need = connectionUri && selectNeedByConnectionUri(state, connectionUri);
+  const needUri = need && need.get("uri");
+  const connection = need && need.getIn(["connections", connectionUri]);
+
+  if (!connection) {
+    console.error(
+      "no connection with connectionUri: <",
+      connectionUri,
+      "> found within needUri: <",
+      needUri,
+      ">"
+    );
+    return state;
+  }
+
   return state.setIn(
-    [needUri, "connections", connectionUri, "isLoadingPetriNetData"],
-    isLoadingPetriNetData
+    [needUri, "connections", connectionUri, "petriNetData", "isDirty"],
+    isPetriNetDataDirty
   );
 }
 
@@ -269,6 +300,10 @@ export function updatePetriNetStateData(state, connectionUri, petriNetData) {
     .setIn(
       [needUri, "connections", connectionUri, "petriNetData", "isLoaded"],
       true
+    )
+    .setIn(
+      [needUri, "connections", connectionUri, "petriNetData", "isDirty"],
+      false
     )
     .setIn(
       [needUri, "connections", connectionUri, "isLoadingPetriNetData"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_petrinet-state.scss
@@ -52,6 +52,21 @@ won-petrinet-state {
   }
 
   .ps__loading {
-    color: $won-subtitle-gray;
+    display: grid;
+    grid-template-columns: min-content 1fr;
+    grid-gap: 0.5rem;
+    margin: 0 auto;
+    align-items: center;
+
+    &__spinner {
+      max-width: 2.25rem;
+      max-height: 2.25rem;
+      --local-primary: #{$won-primary-color};
+      --local-secondary: #{$won-secondary-color};
+    }
+
+    &__label {
+      color: $won-subtitle-gray;
+    }
   }
 }


### PR DESCRIPTION
Implements Better "loading/dirty" styling of petriNetData

We introduce a isDirty state for the petriNetData, which disables all the petriNetData-Transition buttons, until the state has been refreshed and marked "isDirty"=false

Also if there is already data present we do not display the generic loadingPetriNetData spinner, but show a loading spinner underneath the markedplaces and enabledTransition (which are not-clickable during the load because they are marked as isDirty)

This should allow us to fetch the correct petriNetData whenever we send a message containing references