### PR TITLE
Feat minify messages

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -148,6 +148,15 @@ $ngRedux.getState();
                            isSelected: true|false //whether or not the message is Selected in the MultiSelect view
                            isCollapsed: true|false //default is false, whether or not the message should be displayed in a minimized fashion
                            showActions: true|false //default is false, whether or not the actionButtons of a message are visible
+                           expandedReferences: {
+                             forwards: true,
+                             claims: false,
+                             proposes: false,
+                             proposesToCancel: false,
+                             accepts: false,
+                             rejects: false,
+                             retracts: false,
+                           }
                        },
                        uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -133,12 +133,14 @@ $ngRedux.getState();
                        isParsable: true|false //true if hasReferences or hasContent is true
                        isMessageStatusUpToDate: true|false //true if the agreementData has been checked to define the status of the message
                        messageStatus: {
+                           isProposed: true|false //if the message was proposed
+                           isClaimed: true|false //if the message was claimed
                            isRetracted: true|false //if the message was retracted
                            isRejected: true|false //if the message was rejected
                            isAccepted: true|false //if the message was accepted
                            isCancellationPending: true|false //if the message is pending to be cancelled
                            isCancelled: true|false //if the message was cancelled
-                       }
+                       },
                        uri: string //unique identifier of this message
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
                        isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -147,6 +147,7 @@ $ngRedux.getState();
                            //TODO: everything in this state should be extracted into its own (view/ui)-state, this is only here so we do not have a huge (fail prone refactoring shortly before the codefreeze)
                            isSelected: true|false //whether or not the message is Selected in the MultiSelect view
                            isCollapsed: true|false //default is false, whether or not the message should be displayed in a minimized fashion
+                           showActions: true|false //default is false, whether or not the actionButtons of a message are visible
                        },
                        uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -163,6 +163,8 @@ $ngRedux.getState();
                    cancellationPendingAgreementUris: Immutable.Set(),
                    acceptedCancellationProposalUris: Immutable.Set(),
                    cancelledAgreementUris: Immutable.Set(),
+                   proposedMessageUris: Immutable.Set(),
+                   claimedMessageUris: Immutable.Set(),
                    rejectedMessageUris: Immutable.Set(),
                    retractedMessageUris: Immutable.Set(),
                    isLoaded: true|false, //default is false, whether or not the agreementData has been loaded already

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -147,7 +147,7 @@ $ngRedux.getState();
                            //TODO: everything in this state should be extracted into its own (view/ui)-state, this is only here so we do not have a huge (fail prone refactoring shortly before the codefreeze)
                            isSelected: true|false //whether or not the message is Selected in the MultiSelect view
                            isCollapsed: true|false //default is false, whether or not the message should be displayed in a minimized fashion
-                       }
+                       },
                        uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
                        isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -109,12 +109,14 @@ $ngRedux.getState();
                        messageType: //no default but is always set to the specific message type of the received/sent wonMessage
                        date: date, //creation Date of this message
                        unread: true|false, //whether or not this message is new (or already seen if you will)
+                       forwardMessage: true|false, //default is false, flag to indicate if this is a message coming from another connection, and is referenced in the references->forwards of another message (this is a flag to indicate if the message is visible or not)
                        outgoingMessage: true|false, //flag to indicate if this was an outgoing or incoming message
                        systemMessage: true|false, //flag to indicate if this message came from the system (e.g. hint messages) !wonMessage.isFromOwner() && !wonMessage.getSenderNeed() && wonMessage.getSenderNode(),
                        senderUri: uri //to indicate which need or node sent the message itself, wonMessage.getSenderNeed() || wonMessage.getSenderNode(),
                        content: {
                            text: wonMessage.getTextMessage(),
                            matchScore: wonMessage.getMatchScore(),
+                           [and other details which are parsed from the detail-definitions are stored here]
                        },
                        references: {
                            //These references are parsed in a way that it will always be a list no matter if there is only a single element or an array
@@ -141,7 +143,7 @@ $ngRedux.getState();
                            isCancellationPending: true|false //if the message is pending to be cancelled
                            isCancelled: true|false //if the message was cancelled
                        },
-                       uri: string //unique identifier of this message
+                       uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
                        isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)
                        isSelected: true|false //whether or not the message is Selected in the MultiSelect view

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -143,10 +143,13 @@ $ngRedux.getState();
                            isCancellationPending: true|false //if the message is pending to be cancelled
                            isCancelled: true|false //if the message was cancelled
                        },
+                       viewState: {
+                           //TODO: everything in this state should be extracted into its own (view/ui)-state, this is only here so we do not have a huge (fail prone refactoring shortly before the codefreeze)
+                           isSelected: true|false //whether or not the message is Selected in the MultiSelect view
+                       }
                        uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)
                        isReceivedByRemote: true|false //whether the sent request/message is received by the remote server or not (default: false, if its not an outgoingMessage the default is true)
-                       isSelected: true|false //whether or not the message is Selected in the MultiSelect view
                        failedToSend: true|false //whether the sent message failed for whatever reason (default: false, only relevant in outgoingMessages)
                    }
                    ...

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -146,6 +146,7 @@ $ngRedux.getState();
                        viewState: {
                            //TODO: everything in this state should be extracted into its own (view/ui)-state, this is only here so we do not have a huge (fail prone refactoring shortly before the codefreeze)
                            isSelected: true|false //whether or not the message is Selected in the MultiSelect view
+                           isCollapsed: true|false //default is false, whether or not the message should be displayed in a minimized fashion
                        }
                        uri: string //unique identifier of this message (same as messageUri)
                        isReceivedByOwn: true|false //whether the sent request/message is received by the own server or not (default: false, if its not an outgoingMessage the default is true)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -206,7 +206,6 @@ const actionHierarchy = {
       failure: messages.failedReopenNeed,
     },
     markAsRead: INJ_DEFAULT,
-    setMessageSelected: INJ_DEFAULT,
     messageStatus: {
       markAsProposed: messages.markAsProposed,
       markAsClaimed: messages.markAsClaimed,
@@ -215,6 +214,10 @@ const actionHierarchy = {
       markAsAccepted: messages.markAsAccepted,
       markAsCancelled: messages.markAsCancelled,
       markAsCancellationPending: messages.markAsCancellationPending,
+    },
+    viewState: {
+      markAsCollapsed: INJ_DEFAULT,
+      markAsSelected: INJ_DEFAULT,
     },
     updateMessageStatus: messages.updateMessageStatus,
     processConnectionMessage: messages.processConnectionMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -208,6 +208,8 @@ const actionHierarchy = {
     markAsRead: INJ_DEFAULT,
     setMessageSelected: INJ_DEFAULT,
     messageStatus: {
+      markAsProposed: messages.markAsProposed,
+      markAsClaimed: messages.markAsClaimed,
       markAsRetracted: messages.markAsRetracted,
       markAsRejected: messages.markAsRejected,
       markAsAccepted: messages.markAsAccepted,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -219,6 +219,7 @@ const actionHierarchy = {
       markAsCollapsed: INJ_DEFAULT,
       markAsSelected: INJ_DEFAULT,
       markShowActions: INJ_DEFAULT,
+      markExpandReference: INJ_DEFAULT,
     },
     updateMessageStatus: messages.updateMessageStatus,
     processConnectionMessage: messages.processConnectionMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -218,6 +218,7 @@ const actionHierarchy = {
     viewState: {
       markAsCollapsed: INJ_DEFAULT,
       markAsSelected: INJ_DEFAULT,
+      markShowActions: INJ_DEFAULT,
     },
     updateMessageStatus: messages.updateMessageStatus,
     processConnectionMessage: messages.processConnectionMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -178,7 +178,26 @@ export function connectionsChatMessage(
               });
               break;
             case "claims":
+              dispatch({
+                type: actionTypes.messages.messageStatus.markAsClaimed,
+                payload: {
+                  messageUri: msg.get("uri"),
+                  connectionUri: connectionUri,
+                  needUri: ownNeed.get("uri"),
+                  claimed: true,
+                },
+              });
+              break;
             case "proposes":
+              dispatch({
+                type: actionTypes.messages.messageStatus.markAsProposed,
+                payload: {
+                  messageUri: msg.get("uri"),
+                  connectionUri: connectionUri,
+                  needUri: ownNeed.get("uri"),
+                  proposed: true,
+                },
+              });
               break;
             default:
               console.error("referenced key/type is not valid: ", key);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -122,6 +122,9 @@ export function connectionsChatMessage(
     ]);
 
     let referencedContentUris = undefined;
+    /*TODO: Since we set messages to be (successfully) claimed/proposed/accepted... before we even know if the transition was successful we might
+     need to rethink this implementation in favor of a dirtyState somehow, and remove the dirty state on successRemote of the message -> handling is in
+     messages-actions.js (dispatchActionOnSuccessRemote part if(toRefreshData) ... but for now this will do*/
     if (referencedContent) {
       referencedContentUris = new Map();
       referencedContent.forEach((referencedMessages, key) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -902,6 +902,29 @@ export function dispatchActionOnSuccessRemote(event) {
         { "@id": event.getIsRemoteResponseTo() },
       ]);
 
+      /*
+      This Dispatch is similar to the one we use in connection-actions.js ->
+        function connectionsChatMessage(...)
+        The part where we iterate over all the references and send the dispatches to mark the
+        message appropriately. usually we need to check whether the messageUri to be marked is
+        the remoteMessageUri or the ownMessageUri, but since the autoClaim will only be executed
+        on ownMessages we do not need this check here
+       */
+      /*TODO:
+       Since we set a messageToBe (successfully) claimed before we even know if the transition was successful
+       we might need to rethink this implementation in favor of a dirtyState somehow, and remove the dirty state on success
+       of the message(if(toRefreshData)-part above)... but for now and because
+       connectionsChateMessage does not do this either it will do...*/
+      dispatch({
+        type: actionTypes.messages.messageStatus.markAsClaimed,
+        payload: {
+          messageUri: event.getIsRemoteResponseTo(),
+          connectionUri: connectionUri,
+          needUri: ownNeedUri,
+          claimed: true,
+        },
+      });
+
       buildChatMessage({
         chatMessage: undefined,
         additionalContent: undefined,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -268,6 +268,7 @@ export function processConnectionMessage(event) {
       //PETRINET DATA PART END **************************
       fetchMessageEffects(connectionUri, event.getMessageUri()).then(
         response => {
+          //TODO: ADD CLAIM AND PROPOSE MESSAGE STATE HANDLING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           if (response && response.length > 0) {
             console.log("agreement response : ", response);
           }
@@ -521,6 +522,56 @@ export function markAsRejected(event) {
 
     dispatch({
       type: actionTypes.messages.messageStatus.markAsRejected,
+      payload: payload,
+    });
+  };
+}
+
+export function markAsProposed(event) {
+  return (dispatch, getState) => {
+    const messages = getState().getIn([
+      "needs",
+      event.needUri,
+      "connections",
+      event.connectionUri,
+      "messages",
+    ]);
+    const messageUri = getCorrectMessageUri(messages, event.messageUri);
+
+    const payload = {
+      messageUri: messageUri,
+      connectionUri: event.connectionUri,
+      needUri: event.needUri,
+      proposed: event.proposed,
+    };
+
+    dispatch({
+      type: actionTypes.messages.messageStatus.markAsProposed,
+      payload: payload,
+    });
+  };
+}
+
+export function markAsClaimed(event) {
+  return (dispatch, getState) => {
+    const messages = getState().getIn([
+      "needs",
+      event.needUri,
+      "connections",
+      event.connectionUri,
+      "messages",
+    ]);
+    const messageUri = getCorrectMessageUri(messages, event.messageUri);
+
+    const payload = {
+      messageUri: messageUri,
+      connectionUri: event.connectionUri,
+      needUri: event.needUri,
+      claimed: event.claimed,
+    };
+
+    dispatch({
+      type: actionTypes.messages.messageStatus.markAsClaimed,
       payload: payload,
     });
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -233,9 +233,6 @@ export function processConnectionMessage(event) {
 
       fetchPetriNetUris(connectionUri)
         .then(response => {
-          console.log(
-            "FETCH PETRINETURIS FOR INCOMING MESSAGE THAT MADE THAT NECESSARY"
-          );
           const petriNetData = {};
 
           response.forEach(entry => {
@@ -268,7 +265,6 @@ export function processConnectionMessage(event) {
       //PETRINET DATA PART END **************************
       fetchMessageEffects(connectionUri, event.getMessageUri()).then(
         response => {
-          //TODO: ADD CLAIM AND PROPOSE MESSAGE STATE HANDLING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           if (response && response.length > 0) {
             console.log("agreement response : ", response);
           }
@@ -299,7 +295,53 @@ export function processConnectionMessage(event) {
                   });
                 }
                 break;
+              case "CLAIMS":
+                if (effect.claims) {
+                  let claimedMessageUris = Array.isArray(effect.claims)
+                    ? effect.claims
+                    : [effect.claims];
+
+                  claimedMessageUris.forEach(claimedMessageUris => {
+                    let messageUri = getCorrectMessageUri(
+                      messages,
+                      claimedMessageUris
+                    );
+                    dispatch({
+                      type: actionTypes.messages.messageStatus.markAsClaimed,
+                      payload: {
+                        messageUri: messageUri,
+                        connectionUri: connectionUri,
+                        needUri: needUri,
+                        claimed: true,
+                      },
+                    });
+                  });
+                }
+                break;
+
               case "PROPOSES":
+                if (effect.proposes) {
+                  let proposedMessageUris = Array.isArray(effect.proposes)
+                    ? effect.proposes
+                    : [effect.proposes];
+
+                  proposedMessageUris.forEach(proposedMessageUri => {
+                    let messageUri = getCorrectMessageUri(
+                      messages,
+                      proposedMessageUri
+                    );
+                    dispatch({
+                      type: actionTypes.messages.messageStatus.markAsProposed,
+                      payload: {
+                        messageUri: messageUri,
+                        connectionUri: connectionUri,
+                        needUri: needUri,
+                        proposed: true,
+                      },
+                    });
+                  });
+                }
+
                 if (effect.proposalType === "CANCELS") {
                   let proposesToCancelUris = Array.isArray(
                     effect.proposesToCancel

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -514,7 +514,7 @@ function genComponentConf() {
         this.referencedContent && this.referencedContent.get(type);
       if (referencedContent) {
         referencedContent.forEach(msg => {
-          this.messages__setMessageSelected({
+          this.messages__viewState__markAsSelected({
             messageUri: msg.get("uri"),
             connectionUri: this.connectionUri,
             needUri: this.post.get("uri"),
@@ -565,7 +565,7 @@ function genComponentConf() {
     }
 
     removeMessageFromSelection(msg) {
-      this.messages__setMessageSelected({
+      this.messages__viewState__markAsSelected({
         messageUri: msg.get("uri"),
         connectionUri: this.connectionUri,
         needUri: this.post.get("uri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -23,7 +23,7 @@ function genComponentConf() {
       <div class="msg__header" ng-if="!self.isConnectionMessage && !self.hasNotBeenLoaded">
           <div class="msg__header__type">{{ self.getTypeHeaderLabel() }}</div>
       </div>
-      <div class="msg__header msg__header--agreement" ng-if="self.isConnectionMessage && (this.hasClaims || this.hasProposes) && !self.hasNotBeenLoaded">
+      <div class="msg__header msg__header--agreement" ng-if="self.isConnectionMessage && (self.hasClaims || self.hasProposes) && !self.hasNotBeenLoaded">
           <div class="msg__header__type">{{ self.getAgreementHeaderLabel() }}</div>
       </div>
       <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
@@ -122,7 +122,7 @@ function genComponentConf() {
           this.hasNotBeenLoaded ||
           this.hasClaims ||
           this.hasProposes ||
-          self.originatorUri,
+          this.originatorUri,
         this
       );
       classOnComponentRoot(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -21,7 +21,10 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
       <div class="msg__header" ng-if="!self.isConnectionMessage && !self.hasNotBeenLoaded">
-          <div class="msg__header__type">{{ self.getHeaderLabel() }}</div>
+          <div class="msg__header__type">{{ self.getTypeHeaderLabel() }}</div>
+      </div>
+      <div class="msg__header msg__header--agreement" ng-if="self.isConnectionMessage && (this.hasClaims || this.hasProposes) && !self.hasNotBeenLoaded">
+          <div class="msg__header__type">{{ self.getAgreementHeaderLabel() }}</div>
       </div>
       <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
           <div class="msg__header__type">Forwarded from:</div>
@@ -76,6 +79,11 @@ function genComponentConf() {
         const messageType = message && message.get("messageType");
         const injectInto = message && message.get("injectInto");
 
+        const hasReferences = message && message.get("hasReferences");
+        const references = message && message.get("references");
+        const referencesProposes = references && references.get("proposes");
+        const referencesClaims = references && references.get("claims");
+
         const allConnections = selectAllConnections(state);
         const allNeeds = selectAllNeeds(state);
 
@@ -87,7 +95,10 @@ function genComponentConf() {
           shouldShowRdf: state.get("showRdf"),
           hasContent: message && message.get("hasContent"),
           hasNotBeenLoaded: !message,
-          hasReferences: message && message.get("hasReferences"),
+          hasReferences,
+          hasClaims: referencesClaims && referencesClaims.size > 0,
+          hasProposes: referencesProposes && referencesProposes.size > 0,
+          messageStatus: message && message.get("messageStatus"),
           isInjectIntoMessage: injectInto && injectInto.size > 0, //contains the remoteConnectionUris
           originatorUri: message && message.get("originatorUri"),
           injectIntoArray: injectInto && Array.from(injectInto.toSet()),
@@ -106,7 +117,12 @@ function genComponentConf() {
       classOnComponentRoot(
         "won-has-non-ref-content",
         () =>
-          !this.isConnectionMessage || this.hasContent || this.hasNotBeenLoaded,
+          !this.isConnectionMessage ||
+          this.hasContent ||
+          this.hasNotBeenLoaded ||
+          this.hasClaims ||
+          this.hasProposes ||
+          self.originatorUri,
         this
       );
       classOnComponentRoot(
@@ -116,9 +132,52 @@ function genComponentConf() {
       );
     }
 
-    getHeaderLabel() {
+    getTypeHeaderLabel() {
       const headerLabel = labels.messageType[this.messageType];
       return headerLabel || this.messageType;
+    }
+
+    getAgreementHeaderLabel() {
+      if (this.hasClaims && this.hasProposes) {
+        if (this.messageStatus) {
+          if (this.messageStatus.get("isCancelled"))
+            return "Agreement/Claim - Cancelled";
+          if (this.messageStatus.get("isCancellationPending"))
+            return "Agreement/Claim - Accepted(Pending Cancellation)";
+          if (this.messageStatus.get("isAccepted"))
+            return "Agreement/Claim - Accepted";
+          if (this.messageStatus.get("isRetracted"))
+            return "Proposal/Claim - Retracted";
+          if (this.messageStatus.get("isRejected"))
+            return "Proposal/Claim - Rejected";
+        }
+        return "Proposal/Claim";
+      } else if (this.hasClaims) {
+        if (this.messageStatus) {
+          if (this.messageStatus.get("isCancelled")) return "Claim - Cancelled";
+          if (this.messageStatus.get("isCancellationPending"))
+            return "Claim - Accepted(Pending Cancellation)";
+          if (this.messageStatus.get("isAccepted")) return "Claim - Accepted";
+          if (this.messageStatus.get("isRetracted")) return "Claim - Retracted";
+          if (this.messageStatus.get("isRejected")) return "Claim - Rejected";
+        }
+        return "Claim";
+      } else if (this.hasProposes) {
+        if (this.messageStatus) {
+          if (this.messageStatus.get("isCancelled"))
+            return "Agreement - Cancelled";
+          if (this.messageStatus.get("isCancellationPending"))
+            return "Agreement - Pending Cancellation";
+          if (this.messageStatus.get("isAccepted")) return "Agreement";
+          if (this.messageStatus.get("isRetracted"))
+            return "Proposal - Retracted";
+          if (this.messageStatus.get("isRejected"))
+            return "Proposal - Rejected";
+        }
+        return "Proposal";
+      }
+      //should never happen
+      return undefined;
     }
 
     getInjectIntoNeedUri(connectionUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.js
@@ -13,6 +13,8 @@ import {
   isMessageRejectable,
   isMessageRetractable,
   isMessageAcceptable,
+  isMessageProposed,
+  isMessageClaimed,
   isMessageRejected,
   isMessageAccepted,
   isMessageRetracted,
@@ -31,7 +33,7 @@ function genComponentConf() {
           ng-if="self.isProposable"
           ng-disabled="self.multiSelectType || self.clicked"
           ng-click="self.sendActionMessage('proposes')">
-          Propose
+          {{ self.getProposeLabel() }}
       </button>
       <button class="won-button--filled thin black"
           ng-if="self.isClaimable"
@@ -105,6 +107,8 @@ function genComponentConf() {
           ownNeed,
           message,
           multiSelectType: connection && connection.get("multiSelectType"),
+          isProposed: isMessageProposed(this.message),
+          isClaimed: isMessageClaimed(this.message),
           isAccepted: isMessageAccepted(this.message),
           isRejected: isMessageRejected(this.message),
           isRetracted: isMessageRetracted(this.message),
@@ -148,6 +152,10 @@ function genComponentConf() {
         this.connectionUri,
         false
       );
+    }
+
+    getProposeLabel() {
+      return this.isProposed ? "Propose (again)" : "Propose";
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.js
@@ -107,13 +107,13 @@ function genComponentConf() {
           ownNeed,
           message,
           multiSelectType: connection && connection.get("multiSelectType"),
-          isProposed: isMessageProposed(this.message),
-          isClaimed: isMessageClaimed(this.message),
-          isAccepted: isMessageAccepted(this.message),
-          isRejected: isMessageRejected(this.message),
-          isRetracted: isMessageRetracted(this.message),
-          isCancellationPending: isMessageCancellationPending(this.message),
-          isCancelled: isMessageCancelled(this.message),
+          isProposed: isMessageProposed(message),
+          isClaimed: isMessageClaimed(message),
+          isAccepted: isMessageAccepted(message),
+          isRejected: isMessageRejected(message),
+          isRetracted: isMessageRetracted(message),
+          isCancellationPending: isMessageCancellationPending(message),
+          isCancelled: isMessageCancelled(message),
           isProposable:
             connection &&
             connection.get("state") === won.WON.Connected &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -87,11 +87,11 @@ function genComponentConf() {
     			      </div>
                 <div class="won-cm__center__bubble__carret clickable"
                     ng-if="!self.isCollapsed && (self.isProposable || self.isClaimable) && !self.multiSelectType"
-                    ng-click="self.showDetail = !self.showDetail">
-                    <svg ng-show="!self.showDetail">
+                    ng-click="self.toggleActions()">
+                    <svg ng-show="!self.showActions">
                         <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
                     </svg>
-                    <svg ng-show="self.showDetail">
+                    <svg ng-show="self.showActions">
                         <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
                     </svg>
                 </div>
@@ -111,8 +111,6 @@ function genComponentConf() {
   class Controller {
     constructor(/* arguments = dependency injections */) {
       attach(this, serviceDependencies, arguments);
-      this.clicked = false;
-      this.showDetail = false;
       this.won = won;
 
       const selectFromState = state => {
@@ -169,6 +167,7 @@ function genComponentConf() {
             message.get("messageType") === won.WONMSG.connectionMessage,
           isSelected: message && message.getIn(["viewState", "isSelected"]),
           isCollapsed: message && message.getIn(["viewState", "isCollapsed"]),
+          showActions: message && message.getIn(["viewState", "showActions"]),
           multiSelectType: connection && connection.get("multiSelectType"),
           shouldShowRdf,
           rdfLinkURL,
@@ -252,6 +251,15 @@ function genComponentConf() {
       }
     }
 
+    toggleActions() {
+      this.messages__viewState__markShowActions({
+        messageUri: this.message.get("uri"),
+        connectionUri: this.connectionUri,
+        needUri: this.ownNeed.get("uri"),
+        showActions: !this.showActions,
+      });
+    }
+
     generateCollapsedLabel() {
       if (this.message) {
         let label;
@@ -292,7 +300,7 @@ function genComponentConf() {
 
     showActionButtons() {
       return (
-        this.showDetail ||
+        this.showActions ||
         hasProposesReferences(this.message) ||
         hasClaimsReferences(this.message) ||
         hasProposesToCancelReferences(this.message)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -21,6 +21,8 @@ import {
   isMessageRejectable,
   isMessageRetractable,
   isMessageAcceptable,
+  isMessageProposed,
+  isMessageClaimed,
   isMessageRejected,
   isMessageAccepted,
   isMessageRetracted,
@@ -164,6 +166,8 @@ function genComponentConf() {
           shouldShowRdf,
           rdfLinkURL,
           isParsable: message.get("isParsable"),
+          isClaimed: isMessageClaimed(this.message),
+          isProposed: isMessageProposed(this.message),
           isAccepted: isMessageAccepted(this.message),
           isRejected: isMessageRejected(this.message),
           isRetracted: isMessageRetracted(this.message),
@@ -214,6 +218,8 @@ function genComponentConf() {
         this
       );
       classOnComponentRoot("won-is-selected", () => this.isSelected, this);
+      classOnComponentRoot("won-is-proposed", () => this.isProposed, this);
+      classOnComponentRoot("won-is-claimed", () => this.isClaimed, this);
       classOnComponentRoot("won-is-rejected", () => this.isRejected, this);
       classOnComponentRoot("won-is-retracted", () => this.isRetracted, this);
       classOnComponentRoot("won-is-accepted", () => this.isAccepted, this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -161,7 +161,7 @@ function genComponentConf() {
           isConnectionMessage:
             message &&
             message.get("messageType") === won.WONMSG.connectionMessage,
-          isSelected: message && message.get("isSelected"),
+          isSelected: message && message.getIn(["viewState", "isSelected"]),
           multiSelectType: connection && connection.get("multiSelectType"),
           shouldShowRdf,
           rdfLinkURL,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -18,7 +18,7 @@ function genComponentConf() {
   let template = `
       <div class="refmsgcontent__fragment" ng-if="self.hasClaimUris">
         <div class="refmsgcontent__fragment__header">Claims {{ self.getCountString(self.claimUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('claims')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.claimUrisArray"
@@ -33,7 +33,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeUris">
         <div class="refmsgcontent__fragment__header">Proposes {{ self.getCountString(self.proposeUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('proposes')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.proposeUrisArray"
@@ -48,7 +48,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRetractUris">
         <div class="refmsgcontent__fragment__header">Retracts {{ self.getCountString(self.retractUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('retracts')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.retractUrisArray"
@@ -63,7 +63,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasAcceptUris">
         <div class="refmsgcontent__fragment__header">Accepts {{ self.getCountString(self.acceptUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('accepts')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.acceptUrisArray"
@@ -78,7 +78,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeToCancelUris">
         <div class="refmsgcontent__fragment__header">Propose to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('proposesToCancel')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.proposeToCancelUrisArray"
@@ -93,7 +93,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRejectUris">
         <div class="refmsgcontent__fragment__header">Rejects {{ self.getCountString(self.rejectUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('rejects')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.rejectUrisArray"
@@ -108,7 +108,7 @@ function genComponentConf() {
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasForwardUris">
         <div class="refmsgcontent__fragment__header">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
-        <div class="refmsgcontent__fragment__body">
+        <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('forwards')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
             ng-repeat="msgUri in self.forwardUrisArray"
@@ -137,6 +137,9 @@ function genComponentConf() {
             ? getIn(connection, ["messages", this.messageUri])
             : Immutable.Map();
 
+        const expandedReferences =
+          message && message.getIn(["viewState", "expandedReferences"]);
+
         const chatMessages = connection && connection.get("messages");
 
         const references = message && message.get("references");
@@ -162,6 +165,7 @@ function genComponentConf() {
 
         return {
           ownNeedUri: ownNeed && ownNeed.get("uri"),
+          message,
           chatMessages: chatMessages,
           connection,
           acceptUrisSize,
@@ -171,6 +175,7 @@ function genComponentConf() {
           retractUrisSize,
           forwardUrisSize,
           claimUrisSize,
+          expandedReferences,
           hasProposeUris: proposeUrisSize > 0,
           hasAcceptUris: acceptUrisSize > 0,
           hasProposeToCancelUris: proposeToCancelUrisSize > 0,
@@ -220,6 +225,25 @@ function genComponentConf() {
           return undefined;
         }
       }
+    }
+
+    toggleReferenceExpansion(reference) {
+      const currentExpansionState =
+        this.expandedReferences && this.expandedReferences.get(reference);
+
+      if (this.message && !this.multiSelectType) {
+        this.messages__viewState__markExpandReference({
+          messageUri: this.messageUri,
+          connectionUri: this.connectionUri,
+          needUri: this.ownNeedUri,
+          isExpanded: !currentExpansionState,
+          reference: reference,
+        });
+      }
+    }
+
+    isReferenceExpanded(reference) {
+      return this.expandedReferences && this.expandedReferences.get(reference);
     }
 
     getCountString(elements) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -17,7 +17,17 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
       <div class="refmsgcontent__fragment" ng-if="self.hasClaimUris">
-        <div class="refmsgcontent__fragment__header">Claims {{ self.getCountString(self.claimUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('claims')">
+          <div class="refmsgcontent__fragment__header__label">Claims {{ self.getCountString(self.claimUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('claims')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('claims')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('claims')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -32,7 +42,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeUris">
-        <div class="refmsgcontent__fragment__header">Proposes {{ self.getCountString(self.proposeUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('proposes')">
+          <div class="refmsgcontent__fragment__header__label">Proposes {{ self.getCountString(self.proposeUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('proposes')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('proposes')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('proposes')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -47,7 +67,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRetractUris">
-        <div class="refmsgcontent__fragment__header">Retracts {{ self.getCountString(self.retractUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('retracts')">
+          <div class="refmsgcontent__fragment__header__label">Retracts {{ self.getCountString(self.retractUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret clickable">
+              <svg ng-show="!self.isReferenceExpanded('retracts')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('retracts')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('retracts')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -62,7 +92,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasAcceptUris">
-        <div class="refmsgcontent__fragment__header">Accepts {{ self.getCountString(self.acceptUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('accepts')">
+          <div class="refmsgcontent__fragment__header__label">Accepts {{ self.getCountString(self.acceptUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('accepts')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('accepts')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('accepts')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -77,7 +117,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeToCancelUris">
-        <div class="refmsgcontent__fragment__header">Propose to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('proposesToCancel')">
+          <div class="refmsgcontent__fragment__header__label">Propose to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('proposesToCancel')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('proposesToCancel')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('proposesToCancel')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -92,7 +142,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRejectUris">
-        <div class="refmsgcontent__fragment__header">Rejects {{ self.getCountString(self.rejectUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('rejects')">
+          <div class="refmsgcontent__fragment__header__label">Rejects {{ self.getCountString(self.rejectUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('rejects')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('rejects')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('rejects')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"
@@ -107,7 +167,17 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasForwardUris">
-        <div class="refmsgcontent__fragment__header">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
+        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('forwards')">
+          <div class="refmsgcontent__fragment__header__label">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__carret">
+              <svg ng-show="!self.isReferenceExpanded('forwards')">
+                  <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+              </svg>
+              <svg ng-show="self.isReferenceExpanded('forwards')">
+                  <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+              </svg>
+          </div>
+        </div>
         <div class="refmsgcontent__fragment__body" ng-if="self.isReferenceExpanded('forwards')">
           <won-combined-message-content
             ng-click="self.loadMessage(msgUri)"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -20,7 +20,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('claims')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('claims')}">
-          <div class="refmsgcontent__fragment__header__label">Claims {{ self.getCountString(self.claimUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Claiming {{ self.getCountString(self.claimUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('claims')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -47,7 +47,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('proposes')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('proposes')}">
-          <div class="refmsgcontent__fragment__header__label">Proposes {{ self.getCountString(self.proposeUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Proposing {{ self.getCountString(self.proposeUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('proposes')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -74,7 +74,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('retracts')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('retracts')}">
-          <div class="refmsgcontent__fragment__header__label">Retracts {{ self.getCountString(self.retractUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Retracting {{ self.getCountString(self.retractUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret clickable">
               <svg ng-show="!self.isReferenceExpanded('retracts')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -101,7 +101,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('accepts')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('accepts')}">
-          <div class="refmsgcontent__fragment__header__label">Accepts {{ self.getCountString(self.acceptUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Accepting {{ self.getCountString(self.acceptUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('accepts')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -128,7 +128,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('proposesToCancel')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('proposesToCancel')}">
-          <div class="refmsgcontent__fragment__header__label">Propose to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Proposing to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('proposesToCancel')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -155,7 +155,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('rejects')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('rejects')}">
-          <div class="refmsgcontent__fragment__header__label">Rejects {{ self.getCountString(self.rejectUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Rejecting {{ self.getCountString(self.rejectUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('rejects')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
@@ -182,7 +182,7 @@ function genComponentConf() {
         <div class="refmsgcontent__fragment__header"
           ng-click="self.toggleReferenceExpansion('forwards')"
           ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('forwards')}">
-          <div class="refmsgcontent__fragment__header__label">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
+          <div class="refmsgcontent__fragment__header__label">Forwarding {{ self.getCountString(self.forwardUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('forwards')">
                   <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.js
@@ -17,7 +17,9 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
       <div class="refmsgcontent__fragment" ng-if="self.hasClaimUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('claims')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('claims')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('claims')}">
           <div class="refmsgcontent__fragment__header__label">Claims {{ self.getCountString(self.claimUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('claims')">
@@ -42,7 +44,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('proposes')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('proposes')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('proposes')}">
           <div class="refmsgcontent__fragment__header__label">Proposes {{ self.getCountString(self.proposeUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('proposes')">
@@ -67,7 +71,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRetractUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('retracts')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('retracts')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('retracts')}">
           <div class="refmsgcontent__fragment__header__label">Retracts {{ self.getCountString(self.retractUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret clickable">
               <svg ng-show="!self.isReferenceExpanded('retracts')">
@@ -92,7 +98,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasAcceptUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('accepts')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('accepts')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('accepts')}">
           <div class="refmsgcontent__fragment__header__label">Accepts {{ self.getCountString(self.acceptUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('accepts')">
@@ -117,7 +125,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasProposeToCancelUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('proposesToCancel')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('proposesToCancel')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('proposesToCancel')}">
           <div class="refmsgcontent__fragment__header__label">Propose to cancel {{ self.getCountString(self.proposeToCancelUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('proposesToCancel')">
@@ -142,7 +152,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasRejectUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('rejects')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('rejects')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('rejects')}">
           <div class="refmsgcontent__fragment__header__label">Rejects {{ self.getCountString(self.rejectUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('rejects')">
@@ -167,7 +179,9 @@ function genComponentConf() {
         </div>
       </div>
       <div class="refmsgcontent__fragment" ng-if="self.hasForwardUris">
-        <div class="refmsgcontent__fragment__header" ng-click="self.toggleReferenceExpansion('forwards')">
+        <div class="refmsgcontent__fragment__header"
+          ng-click="self.toggleReferenceExpansion('forwards')"
+          ng-class="{'refmsgcontent__fragment__header--collapsed': !self.isReferenceExpanded('forwards')}">
           <div class="refmsgcontent__fragment__header__label">Forwarded {{ self.getCountString(self.forwardUrisSize)}}</div>
           <div class="refmsgcontent__fragment__header__carret">
               <svg ng-show="!self.isReferenceExpanded('forwards')">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -810,7 +810,7 @@ function genComponentConf() {
     selectMessage(msg) {
       const selected = msg.getIn(["viewState", "isSelected"]);
 
-      this.messages__setMessageSelected({
+      this.messages__viewState__markAsSelected({
         messageUri: msg.get("uri"),
         connectionUri: this.connection.get("uri"),
         needUri: this.ownNeed.get("uri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -480,6 +480,20 @@ function genComponentConf() {
           fetchAgreementProtocolUris(this.connection.get("uri"))
             .then(response => {
               console.log("retrieved agreement Protocol Uris: ", response);
+
+              let proposedMessageUris = [];
+              const pendingProposals = response.pendingProposals;
+
+              if (pendingProposals) {
+                pendingProposals.forEach(prop => {
+                  if (prop.proposes) {
+                    proposedMessageUris = proposedMessageUris.concat(
+                      prop.proposes
+                    );
+                  }
+                });
+              }
+
               const agreementData = Immutable.fromJS({
                 agreementUris: Immutable.Set(response.agreementUris),
                 pendingProposalUris: Immutable.Set(
@@ -503,6 +517,8 @@ function genComponentConf() {
                 retractedMessageUris: Immutable.Set(
                   response.retractedMessageUris
                 ),
+                proposedMessageUris: Immutable.Set(proposedMessageUris),
+                claimedMessageUris: Immutable.Set(response.claimedMessageUris),
               });
 
               this.connections__updateAgreementData({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -808,7 +808,7 @@ function genComponentConf() {
     }
 
     selectMessage(msg) {
-      const selected = msg.get("isSelected");
+      const selected = msg.getIn(["viewState", "isSelected"]);
 
       this.messages__setMessageSelected({
         messageUri: msg.get("uri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -476,7 +476,7 @@ function genComponentConf() {
             connectionUri: this.connectionUri,
             isLoadingAgreementData: true,
           });
-
+          //TODO: WE PROBABLY NEED A DIFFERENT APPROACH FOR AGREEMENTDATA INCLUDE THE MESSAGES THAT HAVE BEEN PROPOSED OR CLAIMED WITHIN TOO
           fetchAgreementProtocolUris(this.connection.get("uri"))
             .then(response => {
               console.log("retrieved agreement Protocol Uris: ", response);
@@ -542,6 +542,7 @@ function genComponentConf() {
             " Messages"
           );
           this.chatMessagesWithUnknownState.forEach(msg => {
+            //TODO: WE PROBABLY NEED A DIFFERENT APPROACH FOR AGREEMENTDATA AS IS ENSURE THAT isProposed and isClaimed is handled in here as well
             let messageStatus = msg && msg.get("messageStatus");
             const msgUri = msg.get("uri");
             const remoteMsgUri = msg.get("remoteUri");
@@ -560,7 +561,15 @@ function genComponentConf() {
             const cancellationPendingUris =
               this.agreementData &&
               this.agreementData.get("cancellationPendingAgreementUris");
+            const claimedUris =
+              this.agreementData &&
+              this.agreementData.get("claimedMessageUris"); //TODO not sure if this is correct
+            const proposedUris =
+              this.agreementData &&
+              this.agreementData.get("proposedMessageUris"); //TODO not sure if this is correct
 
+            const isProposed = messageStatus && messageStatus.get("isProposed");
+            const isClaimed = messageStatus && messageStatus.get("isClaimed");
             const isAccepted = messageStatus && messageStatus.get("isAccepted");
             const isRejected = messageStatus && messageStatus.get("isRejected");
             const isRetracted =
@@ -570,24 +579,32 @@ function genComponentConf() {
             const isCancellationPending =
               messageStatus && messageStatus.get("isCancellationPending");
 
+            const isOldProposed =
+              proposedUris &&
+              (proposedUris.get(msgUri) || proposedUris.get(remoteMsgUri));
+            const isOldClaimed =
+              claimedUris &&
+              (claimedUris.get(msgUri) || claimedUris.get(remoteMsgUri));
             const isOldAccepted =
-              (acceptedUris && acceptedUris.get(msgUri)) ||
-              acceptedUris.get(remoteMsgUri);
+              acceptedUris &&
+              (acceptedUris.get(msgUri) || acceptedUris.get(remoteMsgUri));
             const isOldRejected =
-              (rejectedUris && rejectedUris.get(msgUri)) ||
-              rejectedUris.get(remoteMsgUri);
+              rejectedUris &&
+              (rejectedUris.get(msgUri) || rejectedUris.get(remoteMsgUri));
             const isOldRetracted =
-              (retractedUris && retractedUris.get(msgUri)) ||
-              retractedUris.get(remoteMsgUri);
+              retractedUris &&
+              (retractedUris.get(msgUri) || retractedUris.get(remoteMsgUri));
             const isOldCancelled =
-              (cancelledUris && cancelledUris.get(msgUri)) ||
-              cancelledUris.get(remoteMsgUri);
+              cancelledUris &&
+              (cancelledUris.get(msgUri) || cancelledUris.get(remoteMsgUri));
             const isOldCancellationPending =
-              (cancellationPendingUris &&
-                cancellationPendingUris.get(msgUri)) ||
-              cancellationPendingUris.get(remoteMsgUri);
+              cancellationPendingUris &&
+              (cancellationPendingUris.get(msgUri) ||
+                cancellationPendingUris.get(remoteMsgUri));
 
             messageStatus = messageStatus
+              .set("isProposed", isProposed || isOldProposed)
+              .set("isClaimed", isClaimed || isOldClaimed)
               .set("isAccepted", isAccepted || isOldAccepted)
               .set("isRejected", isRejected || isOldRejected)
               .set("isRetracted", isRetracted || isOldRetracted)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -476,7 +476,6 @@ function genComponentConf() {
             connectionUri: this.connectionUri,
             isLoadingAgreementData: true,
           });
-          //TODO: WE PROBABLY NEED A DIFFERENT APPROACH FOR AGREEMENTDATA INCLUDE THE MESSAGES THAT HAVE BEEN PROPOSED OR CLAIMED WITHIN TOO
           fetchAgreementProtocolUris(this.connection.get("uri"))
             .then(response => {
               console.log("retrieved agreement Protocol Uris: ", response);
@@ -558,7 +557,6 @@ function genComponentConf() {
             " Messages"
           );
           this.chatMessagesWithUnknownState.forEach(msg => {
-            //TODO: WE PROBABLY NEED A DIFFERENT APPROACH FOR AGREEMENTDATA AS IS ENSURE THAT isProposed and isClaimed is handled in here as well
             let messageStatus = msg && msg.get("messageStatus");
             const msgUri = msg.get("uri");
             const remoteMsgUri = msg.get("remoteUri");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -630,15 +630,12 @@ function genComponentConf() {
                 isCancellationPending || isOldCancellationPending
               );
 
-            //Only update messageState if the state was actually different
-            if (!Immutable.is(msg.get("messageStatus"), messageStatus)) {
-              this.messages__updateMessageStatus({
-                messageUri: msgUri,
-                connectionUri: this.connectionUri,
-                needUri: this.ownNeed.get("uri"),
-                messageStatus: messageStatus,
-              });
-            }
+            this.messages__updateMessageStatus({
+              messageUri: msgUri,
+              connectionUri: this.connectionUri,
+              needUri: this.ownNeed.get("uri"),
+              messageStatus: messageStatus,
+            });
           });
         }
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -597,26 +597,28 @@ function genComponentConf() {
 
             const isOldProposed =
               proposedUris &&
-              (proposedUris.get(msgUri) || proposedUris.get(remoteMsgUri));
+              !!(proposedUris.get(msgUri) || proposedUris.get(remoteMsgUri));
             const isOldClaimed =
               claimedUris &&
-              (claimedUris.get(msgUri) || claimedUris.get(remoteMsgUri));
+              !!(claimedUris.get(msgUri) || claimedUris.get(remoteMsgUri));
             const isOldAccepted =
               acceptedUris &&
-              (acceptedUris.get(msgUri) || acceptedUris.get(remoteMsgUri));
+              !!(acceptedUris.get(msgUri) || acceptedUris.get(remoteMsgUri));
             const isOldRejected =
               rejectedUris &&
-              (rejectedUris.get(msgUri) || rejectedUris.get(remoteMsgUri));
+              !!(rejectedUris.get(msgUri) || rejectedUris.get(remoteMsgUri));
             const isOldRetracted =
               retractedUris &&
-              (retractedUris.get(msgUri) || retractedUris.get(remoteMsgUri));
+              !!(retractedUris.get(msgUri) || retractedUris.get(remoteMsgUri));
             const isOldCancelled =
               cancelledUris &&
-              (cancelledUris.get(msgUri) || cancelledUris.get(remoteMsgUri));
+              !!(cancelledUris.get(msgUri) || cancelledUris.get(remoteMsgUri));
             const isOldCancellationPending =
               cancellationPendingUris &&
-              (cancellationPendingUris.get(msgUri) ||
-                cancellationPendingUris.get(remoteMsgUri));
+              !!(
+                cancellationPendingUris.get(msgUri) ||
+                cancellationPendingUris.get(remoteMsgUri)
+              );
 
             messageStatus = messageStatus
               .set("isProposed", isProposed || isOldProposed)
@@ -630,12 +632,15 @@ function genComponentConf() {
                 isCancellationPending || isOldCancellationPending
               );
 
-            this.messages__updateMessageStatus({
-              messageUri: msgUri,
-              connectionUri: this.connectionUri,
-              needUri: this.ownNeed.get("uri"),
-              messageStatus: messageStatus,
-            });
+            //Only update messageState if the state was actually different
+            if (!Immutable.is(msg.get("messageStatus"), messageStatus)) {
+              this.messages__updateMessageStatus({
+                messageUri: msgUri,
+                connectionUri: this.connectionUri,
+                needUri: this.ownNeed.get("uri"),
+                messageStatus: messageStatus,
+              });
+            }
           });
         }
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -502,22 +502,18 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.connectionUri,
         action.payload.needUri
       );
-    case actionTypes.messages.updateMessageStatus: {
-      const messageStatus = action.payload.messageStatus;
 
-      const allNeedsInStateWithUpdatedStatus = updateMessageStatus(
+    case actionTypes.messages.updateMessageStatus:
+      return updateMessageStatus(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
-        messageStatus
+        action.payload.messageStatus
       );
 
-      return allNeedsInStateWithUpdatedStatus;
-    }
-
-    case actionTypes.messages.messageStatus.markAsProposed: {
-      const allNeedsInStateMarkedProposed = markMessageAsProposed(
+    case actionTypes.messages.messageStatus.markAsProposed:
+      return markMessageAsProposed(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -525,20 +521,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.proposed
       );
 
-      if (action.payload.proposed) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedProposed,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedProposed;
-    }
-
-    case actionTypes.messages.messageStatus.markAsClaimed: {
-      const allNeedsInStateMarkedClaimed = markMessageAsClaimed(
+    case actionTypes.messages.messageStatus.markAsClaimed:
+      return markMessageAsClaimed(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -546,20 +530,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.claimed
       );
 
-      if (action.payload.claimed) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedClaimed,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedClaimed;
-    }
-
-    case actionTypes.messages.messageStatus.markAsRejected: {
-      const allNeedsInStateMarkedRejected = markMessageAsRejected(
+    case actionTypes.messages.messageStatus.markAsRejected:
+      return markMessageAsRejected(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -567,20 +539,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.rejected
       );
 
-      if (action.payload.rejected) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedRejected,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedRejected;
-    }
-
-    case actionTypes.messages.messageStatus.markAsRetracted: {
-      const allNeedsInStateMarkedRetracted = markMessageAsRetracted(
+    case actionTypes.messages.messageStatus.markAsRetracted:
+      return markMessageAsRetracted(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -588,20 +548,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.retracted
       );
 
-      if (action.payload.retracted) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedRetracted,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedRetracted;
-    }
-
-    case actionTypes.messages.messageStatus.markAsAccepted: {
-      const allNeedsInStateMarkedAccepted = markMessageAsAccepted(
+    case actionTypes.messages.messageStatus.markAsAccepted:
+      return markMessageAsAccepted(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -609,20 +557,8 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.accepted
       );
 
-      if (action.payload.accepted) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedAccepted,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedAccepted;
-    }
-
-    case actionTypes.messages.messageStatus.markAsCancelled: {
-      const allNeedsInStateMarkedCancelled = markMessageAsCancelled(
+    case actionTypes.messages.messageStatus.markAsCancelled:
+      return markMessageAsCancelled(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
@@ -630,38 +566,14 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.cancelled
       );
 
-      if (action.payload.cancelled) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedCancelled,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedCancelled;
-    }
-
-    case actionTypes.messages.messageStatus.markAsCancellationPending: {
-      const allNeedsInStateMarkedCancellationPending = markMessageAsCancellationPending(
+    case actionTypes.messages.messageStatus.markAsCancellationPending:
+      return markMessageAsCancellationPending(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.cancellationPending
       );
-
-      if (action.payload.cancellationPending) {
-        return markMessageAsCollapsed(
-          allNeedsInStateMarkedCancellationPending,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-      return allNeedsInStateMarkedCancellationPending;
-    }
 
     case actionTypes.connections.markAsRead:
       return markConnectionAsRead(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -472,7 +472,7 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.getReceiver(),
         won.WON.Closed
       );
-    case actionTypes.messages.viewState.markExpandReferences:
+    case actionTypes.messages.viewState.markExpandReference:
       return markMessageExpandReferences(
         allNeedsInState,
         action.payload.messageUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -501,62 +501,153 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.needUri,
         action.payload.messageStatus
       );
-    case actionTypes.messages.messageStatus.markAsProposed:
-      return markMessageAsProposed(
+    case actionTypes.messages.messageStatus.markAsProposed: {
+      const allNeedsInStateMarkedProposed = markMessageAsProposed(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.proposed
       );
-    case actionTypes.messages.messageStatus.markAsClaimed:
-      return markMessageAsClaimed(
+
+      if (action.payload.proposed) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedProposed,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.proposed
+        );
+      }
+      return allNeedsInStateMarkedProposed;
+    }
+
+    case actionTypes.messages.messageStatus.markAsClaimed: {
+      const allNeedsInStateMarkedClaimed = markMessageAsClaimed(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.claimed
       );
-    case actionTypes.messages.messageStatus.markAsRejected:
-      return markMessageAsRejected(
+
+      if (action.payload.claimed) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedClaimed,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.claimed
+        );
+      }
+      return allNeedsInStateMarkedClaimed;
+    }
+
+    case actionTypes.messages.messageStatus.markAsRejected: {
+      const allNeedsInStateMarkedRejected = markMessageAsRejected(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.rejected
       );
-    case actionTypes.messages.messageStatus.markAsRetracted:
-      return markMessageAsRetracted(
+
+      if (action.payload.rejected) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedRejected,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.rejected
+        );
+      }
+      return allNeedsInStateMarkedRejected;
+    }
+
+    case actionTypes.messages.messageStatus.markAsRetracted: {
+      const allNeedsInStateMarkedRetracted = markMessageAsRetracted(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.retracted
       );
-    case actionTypes.messages.messageStatus.markAsAccepted:
-      return markMessageAsAccepted(
+
+      if (action.payload.retracted) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedRetracted,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.retracted
+        );
+      }
+      return allNeedsInStateMarkedRetracted;
+    }
+
+    case actionTypes.messages.messageStatus.markAsAccepted: {
+      const allNeedsInStateMarkedAccepted = markMessageAsAccepted(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.accepted
       );
-    case actionTypes.messages.messageStatus.markAsCancelled:
-      return markMessageAsCancelled(
+
+      if (action.payload.accepted) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedAccepted,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.accepted
+        );
+      }
+      return allNeedsInStateMarkedAccepted;
+    }
+
+    case actionTypes.messages.messageStatus.markAsCancelled: {
+      const allNeedsInStateMarkedCancelled = markMessageAsCancelled(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.cancelled
       );
-    case actionTypes.messages.messageStatus.markAsCancellationPending:
-      return markMessageAsCancellationPending(
+
+      if (action.payload.cancelled) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedCancelled,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.cancelled
+        );
+      }
+      return allNeedsInStateMarkedCancelled;
+    }
+
+    case actionTypes.messages.messageStatus.markAsCancellationPending: {
+      const allNeedsInStateMarkedCancellationPending = markMessageAsCancellationPending(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.cancellationPending
       );
+
+      if (action.payload.cancellationPending) {
+        return markMessageAsCollapsed(
+          allNeedsInStateMarkedCancellationPending,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          action.payload.cancellationPending
+        );
+      }
+      return allNeedsInStateMarkedCancellationPending;
+    }
+
     case actionTypes.connections.markAsRead:
       return markConnectionAsRead(
         allNeedsInState,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -18,7 +18,8 @@ import {
   addMessage,
   addExistingMessages,
   updateMessageStatus,
-  setMessageSelected,
+  markMessageAsSelected,
+  markMessageAsCollapsed,
   markMessageAsRead,
   markMessageAsClaimed,
   markMessageAsProposed,
@@ -469,13 +470,21 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.getReceiver(),
         won.WON.Closed
       );
-    case actionTypes.messages.setMessageSelected:
-      return setMessageSelected(
+    case actionTypes.messages.viewState.markAsSelected:
+      return markMessageAsSelected(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.isSelected
+      );
+    case actionTypes.messages.viewState.markAsCollapsed:
+      return markMessageAsCollapsed(
+        allNeedsInState,
+        action.payload.messageUri,
+        action.payload.connectionUri,
+        action.payload.needUri,
+        action.payload.isCollapsed
       );
     case actionTypes.messages.markAsRead:
       return markMessageAsRead(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -513,23 +513,6 @@ export default function(allNeedsInState = initialState, action = {}) {
         messageStatus
       );
 
-      if (
-        messageStatus.isProposed ||
-        messageStatus.isClaimed ||
-        messageStatus.isAccepted ||
-        messageStatus.isRejected ||
-        messageStatus.isCancelled ||
-        messageStatus.isCancellationPending
-      ) {
-        return markMessageAsCollapsed(
-          allNeedsInStateWithUpdatedStatus,
-          action.payload.messageUri,
-          action.payload.connectionUri,
-          action.payload.needUri,
-          true
-        );
-      }
-
       return allNeedsInStateWithUpdatedStatus;
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -292,6 +292,8 @@ export default function(allNeedsInState = initialState, action = {}) {
               unread: true,
               messageType: won.WONMSG.connectMessage,
               messageStatus: {
+                isProposed: false,
+                isClaimed: false,
                 isRetracted: false,
                 isRejected: false,
                 isAccepted: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -20,6 +20,7 @@ import {
   updateMessageStatus,
   markMessageAsSelected,
   markMessageAsCollapsed,
+  markMessageShowActions,
   markMessageAsRead,
   markMessageAsClaimed,
   markMessageAsProposed,
@@ -485,6 +486,14 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.isCollapsed
+      );
+    case actionTypes.messages.viewState.markShowActions:
+      return markMessageShowActions(
+        allNeedsInState,
+        action.payload.messageUri,
+        action.payload.connectionUri,
+        action.payload.needUri,
+        action.payload.showActions
       );
     case actionTypes.messages.markAsRead:
       return markMessageAsRead(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -20,6 +20,8 @@ import {
   updateMessageStatus,
   setMessageSelected,
   markMessageAsRead,
+  markMessageAsClaimed,
+  markMessageAsProposed,
   markMessageAsRejected,
   markMessageAsRetracted,
   markMessageAsAccepted,
@@ -487,6 +489,22 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.connectionUri,
         action.payload.needUri,
         action.payload.messageStatus
+      );
+    case actionTypes.messages.messageStatus.markAsProposed:
+      return markMessageAsProposed(
+        allNeedsInState,
+        action.payload.messageUri,
+        action.payload.connectionUri,
+        action.payload.needUri,
+        action.payload.proposed
+      );
+    case actionTypes.messages.messageStatus.markAsClaimed:
+      return markMessageAsClaimed(
+        allNeedsInState,
+        action.payload.messageUri,
+        action.payload.connectionUri,
+        action.payload.needUri,
+        action.payload.claimed
       );
     case actionTypes.messages.messageStatus.markAsRejected:
       return markMessageAsRejected(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -493,14 +493,37 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.connectionUri,
         action.payload.needUri
       );
-    case actionTypes.messages.updateMessageStatus:
-      return updateMessageStatus(
+    case actionTypes.messages.updateMessageStatus: {
+      const messageStatus = action.payload.messageStatus;
+
+      const allNeedsInStateWithUpdatedStatus = updateMessageStatus(
         allNeedsInState,
         action.payload.messageUri,
         action.payload.connectionUri,
         action.payload.needUri,
-        action.payload.messageStatus
+        messageStatus
       );
+
+      if (
+        messageStatus.isProposed ||
+        messageStatus.isClaimed ||
+        messageStatus.isAccepted ||
+        messageStatus.isRejected ||
+        messageStatus.isCancelled ||
+        messageStatus.isCancellationPending
+      ) {
+        return markMessageAsCollapsed(
+          allNeedsInStateWithUpdatedStatus,
+          action.payload.messageUri,
+          action.payload.connectionUri,
+          action.payload.needUri,
+          true
+        );
+      }
+
+      return allNeedsInStateWithUpdatedStatus;
+    }
+
     case actionTypes.messages.messageStatus.markAsProposed: {
       const allNeedsInStateMarkedProposed = markMessageAsProposed(
         allNeedsInState,
@@ -516,7 +539,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.proposed
+          true
         );
       }
       return allNeedsInStateMarkedProposed;
@@ -537,7 +560,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.claimed
+          true
         );
       }
       return allNeedsInStateMarkedClaimed;
@@ -558,7 +581,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.rejected
+          true
         );
       }
       return allNeedsInStateMarkedRejected;
@@ -579,7 +602,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.retracted
+          true
         );
       }
       return allNeedsInStateMarkedRetracted;
@@ -600,7 +623,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.accepted
+          true
         );
       }
       return allNeedsInStateMarkedAccepted;
@@ -621,7 +644,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.cancelled
+          true
         );
       }
       return allNeedsInStateMarkedCancelled;
@@ -642,7 +665,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           action.payload.messageUri,
           action.payload.connectionUri,
           action.payload.needUri,
-          action.payload.cancellationPending
+          true
         );
       }
       return allNeedsInStateMarkedCancellationPending;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -29,6 +29,7 @@ import {
   markMessageAsAccepted,
   markMessageAsCancelled,
   markMessageAsCancellationPending,
+  markMessageExpandReferences,
 } from "./reduce-messages.js";
 import {
   addConnectionFull,
@@ -470,6 +471,15 @@ export default function(allNeedsInState = initialState, action = {}) {
         allNeedsInState,
         action.payload.getReceiver(),
         won.WON.Closed
+      );
+    case actionTypes.messages.viewState.markExpandReferences:
+      return markMessageExpandReferences(
+        allNeedsInState,
+        action.payload.messageUri,
+        action.payload.connectionUri,
+        action.payload.needUri,
+        action.payload.isExpanded,
+        action.payload.reference
       );
     case actionTypes.messages.viewState.markAsSelected:
       return markMessageAsSelected(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
@@ -22,6 +22,8 @@ export function parseConnection(jsonldConnection) {
         cancelledAgreementUris: Immutable.Set(),
         rejectedMessageUris: Immutable.Set(),
         retractedMessageUris: Immutable.Set(),
+        proposedMessageUris: Immutable.Set(),
+        claimedMessageUris: Immutable.Set(),
         isLoaded: false,
       },
       petriNetData: Immutable.Map(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -75,6 +75,8 @@ export function parseMessage(
       senderUri: wonMessage.getSenderNeed() || wonMessage.getSenderNode(),
       messageType: wonMessage.getMessageType(),
       messageStatus: {
+        isProposed: false,
+        isClaimed: false,
         isRetracted: false,
         isRejected: false,
         isAccepted: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -86,6 +86,15 @@ export function parseMessage(
       viewState: {
         isSelected: false,
         isCollapsed: false,
+        expandedReferences: {
+          forwards: true,
+          claims: false,
+          proposes: false,
+          proposesToCancel: false,
+          accepts: false,
+          rejects: false,
+          retracts: false,
+        },
       },
       isMessageStatusUpToDate: false,
       contentGraphTrig: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -83,6 +83,9 @@ export function parseMessage(
         isCancellationPending: false,
         isCancelled: false,
       },
+      viewState: {
+        isSelected: false,
+      },
       isMessageStatusUpToDate: false,
       contentGraphTrig: {
         prefixes: trigPrefixes,
@@ -97,7 +100,6 @@ export function parseMessage(
       //Send Status Flags
       isReceivedByOwn: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway
       isReceivedByRemote: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway
-      isSelected: false,
       failedToSend: false,
     },
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -88,8 +88,8 @@ export function parseMessage(
         isCollapsed: false,
         expandedReferences: {
           forwards: true,
-          claims: false,
-          proposes: false,
+          claims: true,
+          proposes: true,
           proposesToCancel: false,
           accepts: false,
           rejects: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -85,6 +85,7 @@ export function parseMessage(
       },
       viewState: {
         isSelected: false,
+        isCollapsed: false,
       },
       isMessageStatusUpToDate: false,
       contentGraphTrig: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -395,7 +395,7 @@ export function setMultiSelectType(
 
   if (!multiSelectType) {
     messages = messages.map(msg => {
-      msg = msg.set("isSelected", false);
+      msg = msg.setIn(["viewState", "isSelected"], false);
       return msg;
     });
     state = state.setIn(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -185,6 +185,16 @@ export function markMessageAsCollapsed(
     return state;
   }
 
+  if (isCollapsed) {
+    state = markMessageShowActions(
+      state,
+      messageUri,
+      connectionUri,
+      needUri,
+      false
+    );
+  }
+
   return state.setIn(
     [
       needUri,
@@ -196,6 +206,46 @@ export function markMessageAsCollapsed(
       "isCollapsed",
     ],
     isCollapsed
+  );
+}
+
+export function markMessageShowActions(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  showActions
+) {
+  const need = state.get(needUri);
+  const connection = need && need.getIn(["connections", connectionUri]);
+  const message = connection && connection.getIn(["messages", messageUri]);
+
+  markUriAsRead(messageUri);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  }
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "viewState",
+      "showActions",
+    ],
+    showActions
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -598,64 +598,30 @@ export function markMessageAsAccepted(
       ">"
     );
     return state;
-  } else {
-    const proposedToCancelReferences = message.getIn([
-      "references",
-      "proposesToCancel",
-    ]);
+  }
+  const proposedToCancelReferences = message.getIn([
+    "references",
+    "proposesToCancel",
+  ]);
 
-    if (proposedToCancelReferences) {
-      proposedToCancelReferences.forEach(proposedToCancelRef => {
-        const correctMessageUri = getCorrectMessageUri(
-          messages,
-          proposedToCancelRef
-        );
-        state = markMessageAsCancelled(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          true
-        );
-        state = markMessageAsCollapsed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          true
-        );
-      });
-    }
-
-    if (accepted) {
-      state = state.setIn(
-        [
-          needUri,
-          "connections",
-          connectionUri,
-          "messages",
-          messageUri,
-          "messageStatus",
-          "isCancelled",
-        ],
-        false
+  if (proposedToCancelReferences) {
+    proposedToCancelReferences.forEach(proposedToCancelRef => {
+      const correctMessageUri = getCorrectMessageUri(
+        messages,
+        proposedToCancelRef
       );
-
-      state = state.setIn(
-        [
-          needUri,
-          "connections",
-          connectionUri,
-          "messages",
-          messageUri,
-          "messageStatus",
-          "isCancellationPending",
-        ],
-        false
+      state = markMessageAsCancelled(
+        state,
+        correctMessageUri,
+        connectionUri,
+        needUri,
+        true
       );
-    }
+    });
+  }
 
-    return state.setIn(
+  if (accepted) {
+    state = state.setIn(
       [
         needUri,
         "connections",
@@ -663,11 +629,45 @@ export function markMessageAsAccepted(
         "messages",
         messageUri,
         "messageStatus",
-        "isAccepted",
+        "isCancelled",
       ],
-      accepted
+      false
+    );
+
+    state = state.setIn(
+      [
+        needUri,
+        "connections",
+        connectionUri,
+        "messages",
+        messageUri,
+        "messageStatus",
+        "isCancellationPending",
+      ],
+      false
     );
   }
+
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    accepted
+  );
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isAccepted",
+    ],
+    accepted
+  );
 }
 
 export function markMessageAsCancelled(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -209,6 +209,46 @@ export function markMessageAsCollapsed(
   );
 }
 
+export function markMessageExpandReferences(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  isExpanded,
+  reference
+) {
+  const need = state.get(needUri);
+  const connection = need && need.getIn(["connections", connectionUri]);
+  const message = connection && connection.getIn(["messages", messageUri]);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  }
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "viewState",
+      "expandedReferences",
+      reference,
+    ],
+    isExpanded
+  );
+}
+
 export function markMessageShowActions(
   state,
   messageUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -328,6 +328,19 @@ export function markMessageAsRead(state, messageUri, connectionUri, needUri) {
   );
 }
 
+/**
+ * Sets the given messageUri messageStatus->isRejected to the given parameter (rejected).
+ * Additionally calls markMessageAsCollapsed to the given parameter (rejected) as well
+ * Additionally calls markMessageAsCancellationPending to the referencedMessages with the parameter false
+ * Additionally calls markMessageAsProposed to the referencedMessages with the parameter false
+ * Additionally calls markMessageAsClaimed to the referencedMessages with the parameter false
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param rejected
+ * @returns {*}
+ */
 export function markMessageAsRejected(
   state,
   messageUri,
@@ -425,6 +438,19 @@ export function markMessageAsRejected(
   );
 }
 
+/**
+ * Sets the given messageUri messageStatus->isRetracted to the given parameter (retracted).
+ * Additionally calls markMessageAsCollapsed to the given parameter (retracted) as well
+ * Additionally calls markMessageAsCancellationPending to the referencedMessages with the parameter false
+ * Additionally calls markMessageAsProposed to the referencedMessages with the parameter false
+ * Additionally calls markMessageAsClaimed to the referencedMessages with the parameter false
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param retracted
+ * @returns {*}
+ */
 export function markMessageAsRetracted(
   state,
   messageUri,
@@ -522,6 +548,16 @@ export function markMessageAsRetracted(
   );
 }
 
+/**
+ * Sets the given messageUri messageStatus->isClaimed to the given parameter (claimed).
+ * Additionally calls markMessageAsCollapsed to the given parameter (claimed) as well
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param claimed
+ * @returns {*}
+ */
 export function markMessageAsClaimed(
   state,
   messageUri,
@@ -567,7 +603,16 @@ export function markMessageAsClaimed(
     claimed
   );
 }
-
+/**
+ * Sets the given messageUri messageStatus->isProposed to the given parameter (proposed).
+ * Additionally calls markMessageAsCollapsed to the given parameter (proposed) as well
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param proposed
+ * @returns {*}
+ */
 export function markMessageAsProposed(
   state,
   messageUri,
@@ -688,14 +733,6 @@ export function markMessageAsAccepted(
     );
   }
 
-  state = markMessageAsCollapsed(
-    state,
-    messageUri,
-    connectionUri,
-    needUri,
-    accepted
-  );
-
   return state.setIn(
     [
       needUri,
@@ -734,13 +771,6 @@ export function markMessageAsCancelled(
     );
     return state;
   }
-  state = markMessageAsCollapsed(
-    state,
-    messageUri,
-    connectionUri,
-    needUri,
-    cancelled
-  );
 
   state = state.setIn(
     [
@@ -806,14 +836,6 @@ export function markMessageAsCancellationPending(
     return state;
   }
 
-  state = markMessageAsCollapsed(
-    state,
-    messageUri,
-    connectionUri,
-    needUri,
-    cancellationPending
-  );
-
   return state.setIn(
     [
       needUri,
@@ -827,7 +849,16 @@ export function markMessageAsCancellationPending(
     cancellationPending
   );
 }
-
+/**
+ * Sets the given messageUri messageStatus to the given parameter (messageStatus).
+ * Additionally calls markMessageAsCollapsed to the bool-exp from messageStatus data => (isProposed || isClaimed ||isRejected || isRetracted)
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param messageStatus
+ * @returns {*}
+ */
 export function updateMessageStatus(
   state,
   messageUri,
@@ -856,10 +887,8 @@ export function updateMessageStatus(
   const hasCollapsedMessageState =
     messageStatus.get("isProposed") ||
     messageStatus.get("isClaimed") ||
-    messageStatus.get("isAccepted") ||
     messageStatus.get("isRejected") ||
-    messageStatus.get("isCancelled") ||
-    messageStatus.get("isCancellationPending");
+    messageStatus.get("isRetracted");
 
   state = markMessageAsCollapsed(
     state,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -365,6 +365,84 @@ export function markMessageAsRetracted(
   }
 }
 
+export function markMessageAsClaimed(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  claimed
+) {
+  let need = state.get(needUri);
+  let connection = need && need.getIn(["connections", connectionUri]);
+  let messages = connection && connection.get("messages");
+  let message = messages && messages.get(messageUri);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  } else {
+    return state.setIn(
+      [
+        needUri,
+        "connections",
+        connectionUri,
+        "messages",
+        messageUri,
+        "messageStatus",
+        "isClaimed",
+      ],
+      claimed
+    );
+  }
+}
+
+export function markMessageAsProposed(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  proposed
+) {
+  let need = state.get(needUri);
+  let connection = need && need.getIn(["connections", connectionUri]);
+  let messages = connection && connection.get("messages");
+  let message = messages && messages.get(messageUri);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  } else {
+    return state.setIn(
+      [
+        needUri,
+        "connections",
+        connectionUri,
+        "messages",
+        messageUri,
+        "messageStatus",
+        "isProposed",
+      ],
+      proposed
+    );
+  }
+}
+
 export function markMessageAsAccepted(
   state,
   messageUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -152,6 +152,7 @@ export function setMessageSelected(
       connectionUri,
       "messages",
       messageUri,
+      "viewState",
       "isSelected",
     ],
     isSelected

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -693,46 +693,53 @@ export function markMessageAsCancelled(
       ">"
     );
     return state;
-  } else {
-    state = state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isCancelled",
-      ],
-      cancelled
-    );
-
-    state = state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isAccepted",
-      ],
-      false
-    );
-
-    return state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isCancellationPending",
-      ],
-      false
-    );
   }
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    cancelled
+  );
+
+  state = state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isCancelled",
+    ],
+    cancelled
+  );
+
+  state = state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isAccepted",
+    ],
+    false
+  );
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isCancellationPending",
+    ],
+    false
+  );
 }
 
 export function markMessageAsCancellationPending(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -280,6 +280,57 @@ export function markMessageAsRejected(
           needUri,
           false
         );
+        state = markMessageAsCollapsed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+      });
+    }
+
+    const proposesReferences = message.getIn(["references", "proposes"]);
+
+    if (proposesReferences) {
+      proposesReferences.forEach(proposesRef => {
+        const correctMessageUri = getCorrectMessageUri(messages, proposesRef);
+        state = markMessageAsProposed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+        state = markMessageAsCollapsed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+      });
+    }
+
+    const claimsReferences = message.getIn(["references", "claims"]);
+
+    if (claimsReferences) {
+      claimsReferences.forEach(claimsRef => {
+        const correctMessageUri = getCorrectMessageUri(messages, claimsRef);
+        state = markMessageAsClaimed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+        state = markMessageAsCollapsed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
       });
     }
 
@@ -382,6 +433,57 @@ export function markMessageAsRetracted(
           proposedToCancelRef
         );
         state = markMessageAsCancellationPending(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+        state = markMessageAsCollapsed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+      });
+    }
+
+    const proposesReferences = message.getIn(["references", "proposes"]);
+
+    if (proposesReferences) {
+      proposesReferences.forEach(proposesRef => {
+        const correctMessageUri = getCorrectMessageUri(messages, proposesRef);
+        state = markMessageAsProposed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+        state = markMessageAsCollapsed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+      });
+    }
+
+    const claimsReferences = message.getIn(["references", "claims"]);
+
+    if (claimsReferences) {
+      claimsReferences.forEach(claimsRef => {
+        const correctMessageUri = getCorrectMessageUri(messages, claimsRef);
+        state = markMessageAsClaimed(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          false
+        );
+        state = markMessageAsCollapsed(
           state,
           correctMessageUri,
           connectionUri,
@@ -520,6 +622,13 @@ export function markMessageAsAccepted(
           proposedToCancelRef
         );
         state = markMessageAsCancelled(
+          state,
+          correctMessageUri,
+          connectionUri,
+          needUri,
+          true
+        );
+        state = markMessageAsCollapsed(
           state,
           correctMessageUri,
           connectionUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -311,92 +311,78 @@ export function markMessageAsRejected(
       ">"
     );
     return state;
-  } else {
-    const proposedToCancelReferences = message.getIn([
-      "references",
-      "proposesToCancel",
-    ]);
-
-    if (proposedToCancelReferences) {
-      proposedToCancelReferences.forEach(proposedToCancelRef => {
-        const correctMessageUri = getCorrectMessageUri(
-          messages,
-          proposedToCancelRef
-        );
-        state = markMessageAsCancellationPending(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-        state = markMessageAsCollapsed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-      });
-    }
-
-    const proposesReferences = message.getIn(["references", "proposes"]);
-
-    if (proposesReferences) {
-      proposesReferences.forEach(proposesRef => {
-        const correctMessageUri = getCorrectMessageUri(messages, proposesRef);
-        state = markMessageAsProposed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-        state = markMessageAsCollapsed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-      });
-    }
-
-    const claimsReferences = message.getIn(["references", "claims"]);
-
-    if (claimsReferences) {
-      claimsReferences.forEach(claimsRef => {
-        const correctMessageUri = getCorrectMessageUri(messages, claimsRef);
-        state = markMessageAsClaimed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-        state = markMessageAsCollapsed(
-          state,
-          correctMessageUri,
-          connectionUri,
-          needUri,
-          false
-        );
-      });
-    }
-
-    return state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isRejected",
-      ],
-      rejected
-    );
   }
+  const proposedToCancelReferences = message.getIn([
+    "references",
+    "proposesToCancel",
+  ]);
+
+  if (proposedToCancelReferences) {
+    proposedToCancelReferences.forEach(proposedToCancelRef => {
+      const correctMessageUri = getCorrectMessageUri(
+        messages,
+        proposedToCancelRef
+      );
+      state = markMessageAsCancellationPending(
+        state,
+        correctMessageUri,
+        connectionUri,
+        needUri,
+        false
+      );
+    });
+  }
+
+  const proposesReferences = message.getIn(["references", "proposes"]);
+
+  if (proposesReferences) {
+    proposesReferences.forEach(proposesRef => {
+      const correctMessageUri = getCorrectMessageUri(messages, proposesRef);
+      state = markMessageAsProposed(
+        state,
+        correctMessageUri,
+        connectionUri,
+        needUri,
+        false
+      );
+    });
+  }
+
+  const claimsReferences = message.getIn(["references", "claims"]);
+
+  if (claimsReferences) {
+    claimsReferences.forEach(claimsRef => {
+      const correctMessageUri = getCorrectMessageUri(messages, claimsRef);
+      state = markMessageAsClaimed(
+        state,
+        correctMessageUri,
+        connectionUri,
+        needUri,
+        false
+      );
+    });
+  }
+
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    rejected
+  );
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isRejected",
+    ],
+    rejected
+  );
 }
 
 export function markMessageAsRetracted(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -422,6 +422,24 @@ export function updateMessageStatus(
     );
     return state;
   }
+
+  //Check if there is any "positive" messageStatus, we assume that we do not want to display this message "fully"
+  const hasCollapsedMessageState =
+    messageStatus.get("isProposed") ||
+    messageStatus.get("isClaimed") ||
+    messageStatus.get("isAccepted") ||
+    messageStatus.get("isRejected") ||
+    messageStatus.get("isCancelled") ||
+    messageStatus.get("isCancellationPending");
+
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    hasCollapsedMessageState
+  );
+
   return state
     .setIn(
       [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -119,7 +119,7 @@ export function addExistingMessages(state, wonMessages) {
   return state;
 }
 
-export function setMessageSelected(
+export function markMessageAsSelected(
   state,
   messageUri,
   connectionUri,
@@ -156,6 +156,46 @@ export function setMessageSelected(
       "isSelected",
     ],
     isSelected
+  );
+}
+
+export function markMessageAsCollapsed(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  isCollapsed
+) {
+  const need = state.get(needUri);
+  const connection = need && need.getIn(["connections", connectionUri]);
+  const message = connection && connection.getIn(["messages", messageUri]);
+
+  markUriAsRead(messageUri);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  }
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "viewState",
+      "isCollapsed",
+    ],
+    isCollapsed
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -599,20 +599,27 @@ export function markMessageAsClaimed(
       ">"
     );
     return state;
-  } else {
-    return state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isClaimed",
-      ],
-      claimed
-    );
   }
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    claimed
+  );
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isClaimed",
+    ],
+    claimed
+  );
 }
 
 export function markMessageAsProposed(
@@ -638,20 +645,28 @@ export function markMessageAsProposed(
       ">"
     );
     return state;
-  } else {
-    return state.setIn(
-      [
-        needUri,
-        "connections",
-        connectionUri,
-        "messages",
-        messageUri,
-        "messageStatus",
-        "isProposed",
-      ],
-      proposed
-    );
   }
+
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    proposed
+  );
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "messageStatus",
+      "isProposed",
+    ],
+    proposed
+  );
 }
 
 export function markMessageAsAccepted(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -765,6 +765,15 @@ export function markMessageAsCancellationPending(
     );
     return state;
   }
+
+  state = markMessageAsCollapsed(
+    state,
+    messageUri,
+    connectionUri,
+    needUri,
+    cancellationPending
+  );
+
   return state.setIn(
     [
       needUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -193,6 +193,14 @@ export function markMessageAsCollapsed(
       needUri,
       false
     );
+
+    state = markMessageExpandAllReferences(
+      state,
+      messageUri,
+      connectionUri,
+      needUri,
+      false
+    );
   }
 
   return state.setIn(
@@ -209,6 +217,87 @@ export function markMessageAsCollapsed(
   );
 }
 
+/**
+ * Collapses/Expands all available references within the viewState of a message based on the isExpanded value
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param isExpanded
+ * @param reference
+ * @returns {*}
+ */
+export function markMessageExpandAllReferences(
+  state,
+  messageUri,
+  connectionUri,
+  needUri,
+  isExpanded
+) {
+  const need = state.get(needUri);
+  const connection = need && need.getIn(["connections", connectionUri]);
+  const message = connection && connection.getIn(["messages", messageUri]);
+
+  if (!message) {
+    console.error(
+      "no message with messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  }
+
+  const expandedReferences = state.getIn([
+    needUri,
+    "connections",
+    connectionUri,
+    "messages",
+    messageUri,
+    "viewState",
+    "expandedReferences",
+  ]);
+
+  if (!expandedReferences) {
+    console.error(
+      "no expandedReferences found within messageUri: <",
+      messageUri,
+      "> found within needUri: <",
+      needUri,
+      "> connectionUri: <",
+      connectionUri,
+      ">"
+    );
+    return state;
+  }
+
+  return state.setIn(
+    [
+      needUri,
+      "connections",
+      connectionUri,
+      "messages",
+      messageUri,
+      "viewState",
+      "expandedReferences",
+    ],
+    expandedReferences.map(() => isExpanded)
+  );
+}
+
+/**
+ * Collapses/Expands the given reference within the viewState of a message based on the isExpanded value
+ * @param state
+ * @param messageUri
+ * @param connectionUri
+ * @param needUri
+ * @param isExpanded
+ * @param reference
+ * @returns {*}
+ */
 export function markMessageExpandReferences(
   state,
   messageUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -422,7 +422,9 @@ export function selectClaimableMessagesByConnectionUri(state, connectionUri) {
 
 export function selectSelectedMessagesByConnectionUri(state, connectionUri) {
   const messages = selectAllMessagesByConnectionUri(state, connectionUri);
-  return messages && messages.filter(msg => msg.get("isSelected"));
+  return (
+    messages && messages.filter(msg => msg.getIn(["viewState", "isSelected"]))
+  );
 }
 
 export function selectAgreementMessagesByConnectionUri(state, connectionUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors.js
@@ -227,6 +227,7 @@ export function isPrivateUser(state) {
 }
 
 export function isMessageProposable(msg) {
+  //TODO: should a message be proposable if it was already proposed? or even accepted? and what if the ref are only forwardedMessages?
   return (
     msg &&
     msg.get("hasContent") &&
@@ -236,6 +237,7 @@ export function isMessageProposable(msg) {
 }
 
 export function isMessageClaimable(msg) {
+  //TODO: should a message be claimable if it was already claimed or proposed or even accepted? what if the ref are only forwardedMessages?
   return (
     msg &&
     msg.get("hasContent") &&
@@ -321,6 +323,16 @@ export function hasProposesToCancelReferences(msg) {
     references.get("proposesToCancel") &&
     references.get("proposesToCancel").size > 0
   );
+}
+
+export function isMessageProposed(msg) {
+  const messageStatus = msg && msg.get("messageStatus");
+  return messageStatus && messageStatus.get("isProposed");
+}
+
+export function isMessageClaimed(msg) {
+  const messageStatus = msg && msg.get("messageStatus");
+  return messageStatus && messageStatus.get("isClaimed");
 }
 
 export function isMessageRejected(msg) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -684,8 +684,7 @@
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha1-9HPdR+AnegjijpvsWu6wR1HwuMk=",
-      "dev": true
+      "integrity": "sha1-9HPdR+AnegjijpvsWu6wR1HwuMk="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -2083,8 +2082,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
-      "dev": true
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -2126,7 +2124,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha1-s0b27PapX1qBXFg5/HzbIlAvHtc="
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "binwrap": {
       "version": "0.1.4",
@@ -2426,8 +2424,7 @@
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha1-TLiDLSNhJYmwQG6eKVbBfwb99TE=",
-      "dev": true
+      "integrity": "sha1-TLiDLSNhJYmwQG6eKVbBfwb99TE="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2915,7 +2912,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -3014,7 +3011,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -5421,8 +5417,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -7255,7 +7250,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -7525,7 +7520,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -8165,7 +8160,7 @@
     "node-forge": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-      "integrity": "sha1-bBUsNFzhHFL0ZcKr2VfoY5zWdN8="
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -8522,7 +8517,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -9708,8 +9703,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
-      "dev": true
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "progress": {
       "version": "2.0.0",
@@ -9918,7 +9912,7 @@
     "rdf-canonize": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-0.2.4.tgz",
-      "integrity": "sha1-G0brAVALaAA0isX+CVPBviJrFEY=",
+      "integrity": "sha512-xwAEHJt8FTe4hP9CjFgwQPFdszu4iwEintk31+9eh0rljC28vm9EhoaIlC1rQx5LaCB5oHom4+yoei4+DTdRjQ==",
       "requires": {
         "bindings": "^1.3.0",
         "nan": "^2.10.0",
@@ -10001,7 +9995,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10496,8 +10489,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "dev": true
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sass-loader": {
       "version": "7.1.0",
@@ -10909,8 +10901,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -11164,7 +11155,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -13036,7 +13026,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -13069,7 +13059,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -13108,7 +13098,7 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_combined-message-content.scss
@@ -25,6 +25,13 @@ won-combined-message-content {
       color: $won-subtitle-gray;
     }
 
+    &--agreement {
+      .msg__header__type {
+        font-size: $normalFontSize;
+        color: black;
+      }
+    }
+
     &--forwarded-from,
     &--inject-into {
       display: grid;
@@ -33,7 +40,7 @@ won-combined-message-content {
       grid-gap: 0.25rem;
       align-items: center;
 
-      .msg_header_type {
+      .msg__header__type {
         grid-area: auto;
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -27,6 +27,11 @@ won-connection-message {
     background-color: $won-unread;
   }
 
+  &.won-is-collapsed {
+    filter: opacity(25%);
+    @include square-image($postIconSizeCollapsed, 0 0.5rem 0 0);
+  }
+
   &.won-is-loading {
     @include animateOpacityHeartBeat();
 
@@ -96,13 +101,13 @@ won-connection-message {
   &.won-is-accepted {
     //TODO: STYLING
   }
-  &.won-is-rejected,
-  &.won-is-cancellationPending,
-  &.won-is-cancelled {
+  &.won-is-rejected:not(.won-is-collapsed),
+  &.won-is-cancellationPending:not(.won-is-collapsed),
+  &.won-is-cancelled:not(.won-is-collapsed) {
     pointer-events: none;
   }
 
-  &.won-is-retracted {
+  &.won-is-retracted:not(.won-is-collapsed) {
     opacity: 0.35;
     pointer-events: none;
     .won-cm__center__bubble {
@@ -126,6 +131,10 @@ won-connection-message {
       box-sizing: border-box; // background: $won-light-gray;
       background-color: $won-light-gray; // like the error toast-notifications
       color: black;
+
+      &__collapsed {
+        padding: 0.25rem 0.5rem;
+      }
 
       &__carret {
         padding: 0.5rem;
@@ -166,6 +175,7 @@ won-connection-message {
         //TODO: FAILURE MESSAGE STYLING
       }
     }
+
     &.won-cm__center--system,
     &.won-cm__center--nondisplayable {
       // hsla(57, 100%, 95%, 1);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -101,15 +101,9 @@ won-connection-message {
   &.won-is-accepted {
     //TODO: STYLING
   }
-  &.won-is-rejected:not(.won-is-collapsed),
-  &.won-is-cancellationPending:not(.won-is-collapsed),
-  &.won-is-cancelled:not(.won-is-collapsed) {
-    pointer-events: none;
-  }
 
   &.won-is-retracted:not(.won-is-collapsed) {
     opacity: 0.35;
-    pointer-events: none;
     .won-cm__center__bubble {
       won-combined-message-content {
         text-decoration: line-through;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
@@ -22,9 +22,23 @@ won-referenced-message-content {
     background-color: white;
 
     &__header {
-      font-weight: bold;
+      display: grid;
+      grid-template-columns: 1fr min-content;
       border-bottom: $thinGrayBorder;
+      grid-gap: 0.25rem;
       padding: 0.5rem;
+      align-items: center;
+      cursor: pointer;
+
+      &__label {
+        font-weight: bold;
+      }
+
+      &__carret {
+        svg {
+          @include fixed-square(1rem); // visually center icon on line
+        }
+      }
     }
 
     &__body {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_referenced-message-content.scss
@@ -30,6 +30,10 @@ won-referenced-message-content {
       align-items: center;
       cursor: pointer;
 
+      &.refmsgcontent__fragment__header--collapsed {
+        border-bottom: $thinBorderWidth solid white;
+      }
+
       &__label {
         font-weight: bold;
       }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -30,6 +30,7 @@ $contentInfoHeaderIconSize: 1.25rem;
 $toastIconCloseSize: 1rem;
 $toastIconSize: 2rem;
 $postIconSize: 2.5rem;
+$postIconSizeCollapsed: 1.6rem;
 $postIconSizeMobile: 1.5rem;
 $feedIconSize: 3rem;
 $backIconSize: 2.25rem;


### PR DESCRIPTION
In Order To make our chat-views more useful we try to minify/collapse messages or their respective content so that the view is not cluttered with cascading and duplicate entries

This PR changes the following in the chat-view (aka open connection view)

Any message that has been proposed/claimed/rejected/retracted will be minified in the chat view (see screenshot below
![collapsedmessage](https://user-images.githubusercontent.com/8503486/47419533-b78a2280-d77c-11e8-9857-6a7d71f425ab.PNG)
)

The referenced-content of a message will be collapsible/expandable now, the references have the following inital collapsed State:
- forwards -> not collapsed by default
- proposes -> not collapsed by default
- claims -> not collapsed by default
- accepts -> collapsed by default
- proposeToCancel -> collapsed by default
- rejects -> collapsed by default
- retracts -> collapsed by default

If a message containing references is going to be collapsed (e.g if the message was rejected) the contained references of the message are also all collapsed -> this will ensure that upon displaying (click on the collapsed message) the message we will not get bombarded with the whole content right away 

