### PR TITLE
Fixed too-small input font size in elm application

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
@@ -323,7 +323,7 @@ view skin model =
     layout [] <|
         el
             [ padding 20
-            , Font.size 14
+            , Font.size 16
             , width <| maximum 600 fill
             , centerX
             ]

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -26,6 +26,7 @@ input[type="email"] {
   box-sizing: border-box;
   border-radius: 0.19rem;
   border: $thinGrayBorder;
+  font-size: 16px;
 }
 
 .clickable {


### PR DESCRIPTION
Fixes #2457 

Other parts of the ui seem to be mostly fine already, with an exception being our login menu. I tried making the font size there bigger, but it doesn't seem to change the behaviour on mobile. Maybe this is because the input elements are also too small? I think I will create a separate issue for this