### PR TITLE
Fixes #2480: Creation of Search Needs

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
@@ -213,6 +213,7 @@ function genComponentConf() {
 
         this.needs__create(
           this.draftObject,
+          undefined,
           this.$ngRedux.getState().getIn(["config", "defaultNodeUri"])
         );
       }


### PR DESCRIPTION
We called the needCreation with one parameter less than expected (due to refac. needed for personas) this wouldnt have been an issue if the new param was the last param of the function but since the persona param was in between the pre-existing params we needed to update all method invocations and simply forgot to do so for a search-need -> thus resulting in handling the nodeUri as the persona which could obciously not been found and therefore resulted in an error while trying to create the search need

tl;dr

this PR fixes this error
fixes #2480