### PR TITLE
Fix sparql query transform

### DIFF
--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
@@ -379,57 +379,12 @@ public class SparqlMatcherActor extends UntypedActor {
             if (log.isDebugEnabled()) {
                 log.debug("transforming query, adding 'no hint for counterpart' restriction: {}", q);
             }
-            Op noHintForCounterpartQuery = Transformer.transform(new TransformCopy() {
-                public Op transform(OpProject op, Op subOp) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("transforming: opProject:{}, subOp:{}", op, subOp);
-                    }
-                    return new OpSlice(
-                            op.copy(
-                                    OpJoin.create(
-                                            new OpTriple(
-                                                    new Triple(
-                                                            resultName,
-                                                            WON.HAS_FLAG.asNode(),
-                                                            WON.NO_HINT_FOR_COUNTERPART.asNode()
-                                                    )
-                                            ),
-                                            subOp
-                                    )
-                            ),
-                            0,
-                            config.getLimitResults() * 5);
-                }
-            }, q);
+            Op noHintForCounterpartQuery = SparqlMatcherUtils.noHintForCounterpartQuery(q, resultName, config.getLimitResults()*5);
             if (log.isDebugEnabled()) {
                 log.debug("transformed query: {}", noHintForCounterpartQuery);
                 log.debug("transforming query, adding 'wihout no hint for counterpart' restriction: {}", q);
             }
-            Op hintForCounterpartQuery = Transformer.transform(new TransformCopy() {
-                public Op transform(OpProject op, Op subOp) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("transforming: opProject:{}, subOp:{}", op, subOp);
-                    }
-                    return new OpSlice(
-                            op.copy(
-                                    OpFilter.filter(
-                                            new E_NotExists(
-                                                    new OpTriple(
-                                                            new Triple(
-                                                                    resultName,
-                                                                    WON.HAS_FLAG.asNode(),
-                                                                    WON.NO_HINT_FOR_COUNTERPART.asNode()
-                                                            )
-                                                    )
-                                            ),
-                                            subOp
-                                    )
-                            ),
-                            0,
-                            config.getLimitResults() * 2
-                    );
-                }
-            }, q);
+            Op hintForCounterpartQuery = SparqlMatcherUtils.hintForCounterpartQuery(q, resultName, config.getLimitResults() * 5);
             if (log.isDebugEnabled()) {
                 log.debug("transformed query: {}", hintForCounterpartQuery);
             }
@@ -442,6 +397,8 @@ public class SparqlMatcherActor extends UntypedActor {
 
         return needs;
     }
+
+   
 
     /**
      * Executes the query, optionally only searching in the datasetToQuery.

--- a/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
+++ b/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
@@ -21,6 +21,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.algebra.Algebra;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.OpAsQuery;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.tdb.TDB;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -55,26 +56,25 @@ public class SparqlQueryTest  {
     }
     
     @Test
-    @Ignore // useful for trying things out, does not make so much sense as a unit test
+    //@Ignore // useful for trying things out, does not make so much sense as a unit test
     public void testQuery() throws Exception {
         Dataset dataset = DatasetFactory.create();
         RDFDataMgr.read(dataset, getResourceAsStream("sparqlquerytest/need2.trig"), Lang.TRIG);
-        String queryString = getResourceAsString("sparqlquerytest/query2.rq");
+        String queryString = getResourceAsString("sparqlquerytest/jobquery-orig.rq");
         
         Query query = QueryFactory.create(queryString);
         Op queryOp = Algebra.compile(query);
         
-        Op queryWithGraphClause = SparqlMatcherUtils.addGraphOp(queryOp, Optional.of("urn:x-arq:UnionGraph"));
-        Op queryWithoutServiceClause = SparqlMatcherUtils.removeServiceOp(queryWithGraphClause, Optional.of("http://www.bigdata.com/rdf/geospatial#search"));
+        Op transformed = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, Var.alloc("result"), 10);
+        
         
         System.out.println("query algebra: " + queryOp);
-        System.out.println("transformed query algebra: " + queryWithGraphClause);
-        System.out.println("withoug service clause:" + queryWithoutServiceClause);
+        System.out.println("transformed query algebra: " + transformed);
         System.out.println("\nDataset:");
         RDFDataMgr.write(System.out, dataset, Lang.TRIG);
         System.out.println("\nQuery:");
 
-        query = OpAsQuery.asQuery(queryWithoutServiceClause);
+        query = OpAsQuery.asQuery(transformed);
         System.out.println(query);
         System.out.println("\nResult:");
         

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/jobquery-orig.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/jobquery-orig.rq
@@ -1,0 +1,41 @@
+PREFIX won: <http://purl.org/webofneeds/model#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX s: <http://schema.org/>
+PREFIX geo: <http://www.bigdata.com/rdf/geospatial#>
+PREFIX geoliteral: <http://www.bigdata.com/rdf/geospatial/literals/v1#>
+SELECT DISTINCT ?result WHERE {
+  OPTIONAL {
+    SELECT ?result ?jobLocation_geoScore WHERE {
+      ?result (won:is/s:jobLocation/s:geo) ?geo.
+      SERVICE geo:search {
+        ?geo geo:search "inCircle".
+        ?geo geo:searchDatatype geoliteral:lat-lon.
+        ?geo geo:predicate won:geoSpatial.
+        ?geo geo:spatialCircleCenter "48.2202097#16.3712159737999".
+        ?geo geo:spatialCircleRadius "10".
+        ?geo geo:distanceValue ?geoDistance.
+      }
+      BIND((10  - ?geoDistance) / 10  AS ?geoScoreRaw)
+      BIND(IF(?geoScoreRaw > 0 , ?geoScoreRaw, 0 ) AS ?jobLocation_geoScore)
+    }
+  }
+  OPTIONAL {
+    SELECT DISTINCT ?result ?skills_jaccardIndex WHERE {
+      {
+        SELECT ?result (SUM(?var0) AS ?targetOverlap) (COUNT(?result) AS ?targetTotal) WHERE {
+          ?result (won:seeks/s:knowsAbout) ?tag.
+          BIND(IF((STR(?tag)) = "Java", 1 , 0 ) AS ?var0)
+        }
+        GROUP BY ?result
+      }
+      BIND(?targetOverlap / ((?targetTotal + 1 ) - ?targetOverlap) AS ?skills_jaccardIndex)
+      FILTER(?skills_jaccardIndex > 0 )
+    }
+  }
+  ?result rdf:type won:Need.
+  ?result (won:is/rdf:type) s:JobPosting.
+  BIND((((((COALESCE(?industry_jaccardIndex, 0 )) + (COALESCE(?skills_jaccardIndex, 0 ))) + (COALESCE(?organizationName_jaccardIndex, 0 ))) + (COALESCE(?employmentTypes_jaccardIndex, 0 ))) + (COALESCE(?jobLocation_geoScore, 0 ))) / 5  AS ?aggregatedScore)
+}
+ORDER BY DESC (?aggregatedScore)
+LIMIT 20
+   


### PR DESCRIPTION
The embedded sparql query gets transformed by the matcher before
execution, adding checks for NoHintForCounterpart flags.
The problem is that this change was applied to each subquery instead of
just the toplevel one. When there is a subquery using 'group by' - the
transformation leads to
    ...
    GROUP BY ?result
    HAVING NOT EXISTS {
     ?result ...

Which blazegraph isn't able to execute, in contrast to jena