### PR TITLE
Feat sparql score

### DIFF
--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
@@ -281,7 +281,12 @@ public class SparqlMatcherActor extends UntypedActor {
                 }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
 
         BulkHintEvent bulkHintEvent = new BulkHintEvent();
-
+        
+        Optional<Double> maxScore = filteredNeeds.values().stream().flatMap(value -> value.stream()).map(n -> n.score).max((x, y) -> (int) Math.signum(x - y));
+        if (!maxScore.isPresent()) {
+            //this should not happen
+            return;
+        }
         filteredNeeds.forEach((hintTarget, hints) -> {
             hints
             .stream()
@@ -295,7 +300,7 @@ public class SparqlMatcherActor extends UntypedActor {
                                 hint.need.getWonNodeUri(), 
                                 hint.need.getNeedUri(), 
                                 config.getMatcherUri(), 
-                                hint.score));
+                                hint.score/maxScore.get()));
             });
         });
         

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -582,7 +582,8 @@ export function generateWhatsAroundQuery(latitude, longitude) {
           PREFIX s: <http://schema.org/>
           PREFIX geo: <http://www.bigdata.com/rdf/geospatial#>
           PREFIX geoliteral: <http://www.bigdata.com/rdf/geospatial/literals/v1#>
-          SELECT DISTINCT ?result if(?location_geoDistance = 0, 1, 1/?location_geoDistance) WHERE {
+          SELECT DISTINCT ?result ?score WHERE {
+            bind (if(?location_geoDistance = 0, 1, 1/?location_geoDistance) as ?score)
             {
               SELECT DISTINCT ?result ?location_geoDistance WHERE {
                   ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -636,14 +636,14 @@ export function generateWhatsNewQuery() {
   return `PREFIX won: <http://purl.org/webofneeds/model#>
         PREFIX s: <http://schema.org/>
         PREFIX dct: <http://purl.org/dc/terms/>
-        SELECT DISTINCT ?result ?score
-            BIND ((YEAR(?created) - 1970) * 315360000
+        SELECT DISTINCT ?result ?score WHERE {
+          BIND ((YEAR(?created) - 1970) * 315360000
                + MONTH(?created) * 26280000
                + DAY(?created) * 86400
                + HOURS(?created) * 3600
                + MINUTES(?created) * 60
                + SECONDS(?created)
-                as ?score) WHERE {
+                as ?score)
           ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.
           ?result won:isInState  won:Active .
           ?result dct:created ?created.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -636,8 +636,8 @@ export function generateWhatsNewQuery() {
   return `PREFIX won: <http://purl.org/webofneeds/model#>
         PREFIX s: <http://schema.org/>
         PREFIX dct: <http://purl.org/dc/terms/>
-        SELECT DISTINCT ?result 
-            ((YEAR(?created) - 1970) * 315360000
+        SELECT DISTINCT ?result ?score
+            BIND ((YEAR(?created) - 1970) * 315360000
                + MONTH(?created) * 26280000
                + DAY(?created) * 86400
                + HOURS(?created) * 3600

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -582,7 +582,7 @@ export function generateWhatsAroundQuery(latitude, longitude) {
           PREFIX s: <http://schema.org/>
           PREFIX geo: <http://www.bigdata.com/rdf/geospatial#>
           PREFIX geoliteral: <http://www.bigdata.com/rdf/geospatial/literals/v1#>
-          SELECT DISTINCT ?result WHERE {
+          SELECT DISTINCT ?result if(?location_geoDistance = 0, 1, 1/?location_geoDistance) WHERE {
             {
               SELECT DISTINCT ?result ?location_geoDistance WHERE {
                   ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.
@@ -628,7 +628,7 @@ export function generateWhatsAroundQuery(latitude, longitude) {
               }
             }
           }
-          ORDER BY (?location_geoDistance)`
+          ORDER BY desc(?score)`
   );
 }
 
@@ -636,11 +636,18 @@ export function generateWhatsNewQuery() {
   return `PREFIX won: <http://purl.org/webofneeds/model#>
         PREFIX s: <http://schema.org/>
         PREFIX dct: <http://purl.org/dc/terms/>
-        SELECT DISTINCT ?result WHERE {
+        SELECT DISTINCT ?result 
+            ((YEAR(?created) - 1970) * 315360000
+               + MONTH(?created) * 26280000
+               + DAY(?created) * 86400
+               + HOURS(?created) * 3600
+               + MINUTES(?created) * 60
+               + SECONDS(?created)
+                as ?score) WHERE {
           ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.
           ?result won:isInState  won:Active .
           ?result dct:created ?created.
           FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
         }
-        ORDER BY DESC(?created)`;
+        ORDER BY DESC(?score)`;
 }


### PR DESCRIPTION
Sparql queries used by the sparql matcher can now project a `?score` variable. The matcher will use that for descending ordering and normalize by the maximum score to produce values between 1 and 0