### PR TITLE
Fixes #2516 close conversation button for all connection states

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
@@ -66,7 +66,7 @@ function genComponentConf() {
                     <button
                         class="won-button--filled red"
                         ng-click="self.closeConnection()">
-                        self.generateCloseConnectionLabel()
+                        {{ self.generateCloseConnectionLabel() }}
                     </button>
                 </div>
             </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
@@ -64,16 +64,9 @@ function genComponentConf() {
                         Show PetriNet Data
                     </button>
                     <button
-                        ng-if="self.isConnected || self.isSuggested"
                         class="won-button--filled red"
                         ng-click="self.closeConnection()">
-                        Remove Connection
-                    </button>
-                    <button
-                        ng-if="self.isSentRequest"
-                        class="won-button--filled red"
-                        ng-click="self.closeConnection()">
-                        Cancel Request
+                        self.generateCloseConnectionLabel()
                     </button>
                 </div>
             </div>
@@ -137,6 +130,18 @@ function genComponentConf() {
 
     goToPost(postUri) {
       this.router__stateGoCurrent({ useCase: undefined, postUri: postUri });
+    }
+
+    generateCloseConnectionLabel() {
+      if (this.isConnected) {
+        return "Close Connection";
+      } else if (this.isSuggested) {
+        return "Remove Connection";
+      } else if (this.isSentRequest) {
+        return "Cancel Request";
+      } else if (this.isReceivedRequest) {
+        return "Deny Request";
+      }
     }
   }
   Controller.$inject = serviceDependencies;


### PR DESCRIPTION
Conversation/Connection Context Dropdown has a "remove connection" button regardless of the connection state:

Here are the displayed labels:
connected -> "Close Connection"
suggested -> "Remove Connection"
SentRequest -> "Cancel Request"
ReceivedRequest -> "Deny Request"

Maybe we should not use a different label since every button results in a closeConnection request, if that should be the case i will adapt this PR accordingly