### PR TITLE
Refac adhocstruct #2505

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -92,7 +92,7 @@ export function createWhatsNew() {
     dispatch({ type: actionTypes.needs.whatsNew });
 
     const whatsNewObject = {
-      content: { whatsNew: true },
+      content: { whatsNew: true }, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       seeks: {},
       matchingContext: defaultContext,
     };
@@ -139,7 +139,7 @@ export function createWhatsAround() {
                 dispatch(actionCreators.needs__close(need.get("uri"))); //TODO action creators should not call other action creators, according to Moru
               });
             const whatsAroundObject = {
-              content: { whatsAround: true },
+              content: { whatsAround: true }, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
               seeks: { location: location },
               matchingContext: defaultContext,
             };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -72,7 +72,7 @@ async function connectReview(
 ) {
   const getFacet = persona => {
     const reviewFacet = persona
-      .get("hasFacets")
+      .get("facets")
       .filter(facetType => facetType == "won:ReviewFacet")
       .keySeq()
       .first();
@@ -86,7 +86,7 @@ async function connectReview(
   };
 
   const cnctMsg = buildConnectMessage({
-    ownNeedUri: ownPersona.get("uri"),
+    ownedNeedUri: ownPersona.get("uri"),
     theirNeedUri: foreignPersona.get("uri"),
     ownNodeUri: ownPersona.get("nodeUri"),
     theirNodeUri: foreignPersona.get("nodeUri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -10,6 +10,7 @@ import { actionCreators } from "../actions/actions.js";
 import { labels, relativeTime } from "../won-label-utils.js";
 import { attach } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
+import { isDirectResponseNeed } from "../need-utils.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
 import {
   selectLastUpdateTime,
@@ -38,11 +39,14 @@ function genComponentConf() {
       </div>
       <div class="ch__right" ng-if="!self.isLoading()">
         <div class="ch__right__topline">
-          <div class="ch__right__topline__title" ng-if="self.theirNeed.get('humanReadable')" title="{{ self.theirNeed.get('humanReadable') }}">
+          <div class="ch__right__topline__title" ng-if="!self.isDirectResponseFromRemote && self.theirNeed.get('humanReadable')" title="{{ self.theirNeed.get('humanReadable') }}">
             {{ self.theirNeed.get('humanReadable') }}
           </div>
-          <div class="ch__right__topline__notitle" ng-if="!self.theirNeed.get('humanReadable')" title="no title">
+          <div class="ch__right__topline__notitle" ng-if="!self.isDirectResponseFromRemote && !self.theirNeed.get('humanReadable')" title="no title">
             no title
+          </div>
+          <div class="ch__right__topline__notitle" ng-if="self.isDirectResponseFromRemote" title="Direct Response">
+            Direct Response
           </div>
         </div>
         <div class="ch__right__subtitle">
@@ -130,6 +134,7 @@ function genComponentConf() {
           connection,
           ownedNeed,
           theirNeed,
+          isDirectResponseFromRemote: isDirectResponseNeed(theirNeed),
           latestMessageHumanReadableString,
           latestMessageUnread,
           unreadMessageCount:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -14,6 +14,17 @@ export function isWhatsAroundNeed(need) {
 }
 
 /**
+ * Determines if a given need is a DirectResponse-Need
+ * @param msg
+ * @returns {*|boolean}
+ */
+export function isDirectResponseNeed(need) {
+  return (
+    need && need.get("flags") && need.get("flags").contains("won:responseToUri")
+  );
+}
+
+/**
  * Determines if a given need is a WhatsNew-Need
  * @param msg
  * @returns {*|boolean}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -20,7 +20,9 @@ export function isWhatsAroundNeed(need) {
  */
 export function isDirectResponseNeed(need) {
   return (
-    need && need.get("flags") && need.get("flags").contains("won:responseToUri")
+    need &&
+    need.get("flags") &&
+    need.get("flags").contains("won:DirectResponse")
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -319,7 +319,33 @@ export default function(allNeedsInState = initialState, action = {}) {
           usingTemporaryUri: true,
           state: won.WON.RequestSent,
           remoteNeedUri: theirNeedUri,
+          remoteConnectionUri: undefined,
           unread: true,
+          facet: won.WON.ChatFacetCompacted, //TODO: INSERT CORRECT FACET FROM NEEDS
+          agreementData: {
+            agreementUris: Immutable.Set(),
+            pendingProposalUris: Immutable.Set(),
+            pendingCancellationProposalUris: Immutable.Set(),
+            cancellationPendingAgreementUris: Immutable.Set(),
+            acceptedCancellationProposalUris: Immutable.Set(),
+            cancelledAgreementUris: Immutable.Set(),
+            rejectedMessageUris: Immutable.Set(),
+            retractedMessageUris: Immutable.Set(),
+            proposedMessageUris: Immutable.Set(),
+            claimedMessageUris: Immutable.Set(),
+            isLoaded: false,
+          },
+          petriNetData: Immutable.Map(),
+          creationDate: undefined,
+          lastUpdateDate: undefined,
+          isRated: false,
+          isLoadingMessages: false,
+          isLoadingAgreementData: false,
+          isLoadingPetriNetData: false,
+          isLoading: false,
+          showAgreementData: false,
+          showPetriNetData: false,
+          multiSelectType: undefined,
           messages: {
             [eventUri]: {
               uri: eventUri,
@@ -520,7 +546,7 @@ export default function(allNeedsInState = initialState, action = {}) {
           "messages",
           eventUri,
         ];
-        if (allNeedsInState.getIn[path]) {
+        if (allNeedsInState.getIn(path)) {
           allNeedsInState = allNeedsInState.setIn(
             [...path, "isReceivedByOwn"],
             true
@@ -549,13 +575,13 @@ export default function(allNeedsInState = initialState, action = {}) {
           );
 
           if (
-            allNeedsInState.getIn[
-              (needByConnectionUri.get("uri"),
+            allNeedsInState.getIn([
+              needByConnectionUri.get("uri"),
               "connections",
               connectionUri,
               "messages",
-              eventUri)
-            ]
+              eventUri,
+            ])
           ) {
             allNeedsInState = allNeedsInState.setIn(
               [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -1,11 +1,7 @@
 import Immutable from "immutable";
 import won from "../../won-es6.js";
 import { getAllDetails } from "../../won-utils.js";
-import {
-  isWhatsNewNeed,
-  isWhatsAroundNeed,
-  isDirectResponseNeed,
-} from "../../need-utils.js";
+import { isWhatsNewNeed, isWhatsAroundNeed } from "../../need-utils.js";
 
 export function parseNeed(jsonldNeed, isOwned) {
   const jsonldNeedImm = Immutable.fromJS(jsonldNeed);
@@ -189,10 +185,6 @@ function getHumanReadableStringFromNeed(need, detailsToParse) {
           includeLabel: false,
         })
       );
-    }
-
-    if (isDirectResponseNeed(Immutable.fromJS(need))) {
-      return "Direct Response Need (formerly known as Re: Need)"; //TODO: FIGURE OUT A BETTER NAMING INCLUDE THE HUMANREADABLE OF THE RELATED POST MAYBE
     }
 
     if (title && seeksTitle) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -1,7 +1,11 @@
 import Immutable from "immutable";
 import won from "../../won-es6.js";
 import { getAllDetails } from "../../won-utils.js";
-import { isWhatsNewNeed, isWhatsAroundNeed } from "../../need-utils.js";
+import {
+  isWhatsNewNeed,
+  isWhatsAroundNeed,
+  isDirectResponseNeed,
+} from "../../need-utils.js";
 
 export function parseNeed(jsonldNeed, isOwned) {
   const jsonldNeedImm = Immutable.fromJS(jsonldNeed);
@@ -185,6 +189,10 @@ function getHumanReadableStringFromNeed(need, detailsToParse) {
           includeLabel: false,
         })
       );
+    }
+
+    if (isDirectResponseNeed(Immutable.fromJS(need))) {
+      return "Direct Response Need (formerly known as Re: Need)"; //TODO: FIGURE OUT A BETTER NAMING INCLUDE THE HUMANREADABLE OF THE RELATED POST MAYBE
     }
 
     if (title && seeksTitle) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -16,6 +16,7 @@ export default function(allToasts = initialState, action = {}) {
     case actionTypes.logout:
       return initialState;
 
+    case actionTypes.messages.connect.failure:
     case actionTypes.connections.sendChatMessageFailed: {
       const msg = getIn(action, ["payload", "message"]);
       return pushNewToast(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -160,28 +160,34 @@ import { Generator } from "sparqljs";
     const matchingContext = args.matchingContext;
 
     // TODO: if both is and seeks are present, the seeks content gets ignored here
-    const isWhatsAround = args.content
+    const isDirectResponse = args.content //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+      ? args.content.directResponseNeed
+      : args.seeks
+        ? args.seeks.directResponseNeed
+        : undefined;
+    const isWhatsAround = args.content //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       ? args.content.whatsAround
       : args.seeks
         ? args.seeks.whatsAround
         : undefined;
-    const isWhatsNew = args.content
+    const isWhatsNew = args.content //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       ? args.content.whatsNew
       : args.seeks
         ? args.seeks.whatsNew
         : undefined;
-    const noHints = args.content
+    const noHints = args.content //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       ? args.content.noHints
       : args.seeks
         ? args.seeks.noHints
         : undefined;
-    const noHintForCounterpart = isWhatsAround
+    const noHintForCounterpart = isWhatsAround //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       ? true
       : isWhatsNew
         ? true
         : args.useCase === "search" //hack: no hint for counterpart if it's a pure search
           ? true
           : false;
+
     let seeksContentUri;
     if (isWhatsAround) {
       seeksContentUri = won.WON.contentNodeBlankUri.whatsAround;
@@ -259,14 +265,15 @@ import { Generator } from "sparqljs";
         ? args.facet
         : { "@id": "#chatFacet", "@type": "won:ChatFacet" },
       "won:hasFlag": new Set([
-        won.debugmode ? "won:UsedForTesting" : undefined,
+        won.debugmode ? "won:UsedForTesting" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
 
-        isWhatsAround ? "won:WhatsAround" : undefined,
-        isWhatsNew ? "won:WhatsNew" : undefined,
-        noHintForCounterpart ? "won:NoHintForCounterpart" : undefined,
+        isWhatsAround ? "won:WhatsAround" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+        isWhatsNew ? "won:WhatsNew" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+        isDirectResponse ? "won:DirectResponse" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+        noHintForCounterpart ? "won:NoHintForCounterpart" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
 
-        noHints ? "won:NoHintForMe" : undefined,
-        noHints ? "won:NoHintForCounterpart" : undefined,
+        noHints ? "won:NoHintForMe" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+        noHints ? "won:NoHintForCounterpart" : undefined, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
       ]), ///.toArray().filter(f => f),
       "won:doNotMatchAfter": doNotMatchAfter
         ? { "@value": doNotMatchAfter, "@type": "xsd:dateTime" }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -371,7 +371,6 @@ won.WONMSG.uriPlaceholder = Object.freeze({
 });
 
 won.WON.contentNodeBlankUri = Object.freeze({
-  is: "_:isNeedContent",
   seeks: "_:seeksNeedContent",
   whatsAround: "_:needContent",
   whatsNew: "_:needContent",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -606,20 +606,6 @@ export function clone(obj) {
 }
 
 /**
- * Returns a mutable object (or undefined if undefined was passed)
- * @param obj immutable or mutable object, or undefined
- */
-export function cloneAsMutable(obj) {
-  if (!obj) {
-    return obj;
-  } else if (obj.toJS) {
-    return obj.toJS();
-  } else {
-    return clone(obj);
-  }
-}
-
-/**
  * Returns a property of a given object, no matter whether
  * it's a normal or an immutable-js object.
  * @param obj

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -37,6 +37,7 @@ export const details = {
   pricerange: priceDetails.pricerange,
   price: priceDetails.price,
   review: reviewDetails.review,
+  responseToUri: basicDetails.responseToUri,
 };
 
 export const messageDetails = {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -140,3 +140,35 @@ export const suggestPost = {
     return undefined;
   },
 };
+
+export const responseToUri = {
+  identifier: "responseToUri",
+  label: "Response To Post",
+  icon: "#ico36_detail_title", //TODO: CORRECT ICON
+  placeholder: "Insert PostUri and Accept",
+  component: "won-suggestpost-picker",
+  viewerComponent: "won-suggestpost-viewer",
+  messageEnabled: false,
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+
+    if (val) {
+      return {
+        "won:responseToUri": { "@id": val },
+      };
+    } else {
+      return { "won:responseToUri": undefined };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    const responseToUriJsonLDImm =
+      jsonLDImm && jsonLDImm.get("won:responseToUri");
+    return responseToUriJsonLDImm && responseToUriJsonLDImm.get("@id");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};


### PR DESCRIPTION
Fixes adhoc need creation and connect with a remoteNeed (with or without persona -> was broken)

fixes #2505 (-> by removing all the Re content and replacing it with another flag won:DirectResponse and a won:responseToUri detail that contains the needUri that the adhoc need is going to connect to)

Also reimplemented the headerTitles for post-header and connection-header for adhoc needs

The need that is set in the responseToUri is (currently) visible via the won-suggest-post-viewer (since it became a new detail) however i am aware that there are some issues (as seen in #2525) they will be handled with a sep. PR as some issues (e.g. #2446 build upon the changes made in this PR)
