### PR TITLE
Refac wonhasflags

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -312,8 +312,11 @@ function connectAdHoc(theirNeedUri, textMessage, persona, dispatch, getState) {
     const adHocDraft = {
       content: {
         responseToUri: theirNeedUri,
-        directResponseNeed: true,
-        noHints: true,
+        flags: [
+          "won:DirectResponse",
+          "won:NoHintForCounterpart",
+          "won:NoHintForMe",
+        ],
       },
     };
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -92,7 +92,9 @@ export function createWhatsNew() {
     dispatch({ type: actionTypes.needs.whatsNew });
 
     const whatsNewObject = {
-      content: { whatsNew: true }, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+      content: {
+        flags: ["won:WhatsNew", "won:NoHintForCounterpart"],
+      },
       seeks: {},
       matchingContext: defaultContext,
     };
@@ -139,7 +141,9 @@ export function createWhatsAround() {
                 dispatch(actionCreators.needs__close(need.get("uri"))); //TODO action creators should not call other action creators, according to Moru
               });
             const whatsAroundObject = {
-              content: { whatsAround: true }, //TODO: refactor this and use a won:hasFlags-Detail in the content instead
+              content: {
+                flags: ["won:WhatsAround", "won:NoHintForCounterpart"],
+              },
               seeks: { location: location },
               matchingContext: defaultContext,
             };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -88,6 +88,7 @@ function genComponentConf() {
               ng-if="!self.multiSelectType && self.isConnected"></won-labelled-hr>
             <div class="cts__details__grid__detail"
               ng-repeat="detail in self.allMessageDetails"
+              ng-if="detail.component"
               ng-click="self.pickDetail(detail)">
               <svg class="cts__details__grid__detail__icon" ng-if="detail.icon">
                 <use xlink:href={{detail.icon}} href={{detail.icon}}></use>
@@ -179,6 +180,7 @@ function genComponentConf() {
             </div>
             <div class="cts__details__input__content"
               message-detail-element="{{self.selectedDetailComponent}}"
+              ng-if="self.selectedDetailComponent"
               on-update="::self.updateDetail(identifier, value)"
               initial-value="self.additionalContent.get(self.selectedDetail.identifier)"
               identifier="self.selectedDetail.identifier"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.js
@@ -18,6 +18,7 @@ function genComponentConf() {
     <!-- DETAIL TOGGLES -->
     <div class="cis__detail__items">
       <div class="cis__detail__items__item" ng-repeat="detail in self.detailList"
+          ng-if="detail.component"
           ng-class="{
             'cis__detail__items__item--won-expanded': self.openDetail === detail.identifier,
             'cis__detail__items__item--won-hasvalue': self.details.has(detail.identifier),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
@@ -117,7 +117,9 @@ function genComponentConf() {
       this.scrollContainer().addEventListener("scroll", e => this.onResize(e));
 
       this.draftObject = {
-        content: {},
+        content: {
+          flags: ["won:NoHintForCounterpart"],
+        },
         seeks: {},
         useCase: "search",
         matchingContext: undefined,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.js
@@ -17,7 +17,7 @@ function genComponentConf() {
       <div class="msg__text" ng-if="self.message && self.text" marked="self.text"></div>
       <div class="msg__content"
         ng-repeat="detail in self.allDetails"
-        ng-if="self.message && detail.identifier && self.getDetailContent(detail.identifier)"
+        ng-if="self.message && detail.identifier && detail.viewerComponent && self.getDetailContent(detail.identifier)"
         message-detail-viewer-element="{{detail.viewerComponent}}"
         detail="detail"
         content="self.getDetailContent(detail.identifier)">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -89,7 +89,7 @@ function genComponentConf() {
             : null;
 
         const post = this.postUri && state.getIn(["needs", this.postUri]);
-        const flags = post && post.get("flags");
+        const flags = post && post.getIn(["content", "flags"]);
 
         const persona = post
           ? state.getIn(["needs", post.get("heldBy")])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-or-seeks-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-is-or-seeks-info.js
@@ -24,7 +24,7 @@ function genComponentConf() {
       <!-- COMPONENT -->
         <div class="pis__component"
           ng-repeat="detail in self.allDetails"
-          ng-if="detail.identifier && self.getDetailContent(detail.identifier)"
+          ng-if="detail.identifier && detail.viewerComponent && self.getDetailContent(detail.identifier)"
           detail-viewer-element="{{detail.viewerComponent}}"
           detail="detail"
           content="self.getDetailContent(detail.identifier)">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -9,7 +9,9 @@
  */
 export function isWhatsAroundNeed(need) {
   return (
-    need && need.get("flags") && need.get("flags").contains("won:WhatsAround")
+    need &&
+    need.getIn(["content", "flags"]) &&
+    need.getIn(["content", "flags"]).contains("won:WhatsAround")
   );
 }
 
@@ -21,8 +23,8 @@ export function isWhatsAroundNeed(need) {
 export function isDirectResponseNeed(need) {
   return (
     need &&
-    need.get("flags") &&
-    need.get("flags").contains("won:DirectResponse")
+    need.getIn(["content", "flags"]) &&
+    need.getIn(["content", "flags"]).contains("won:DirectResponse")
   );
 }
 
@@ -33,7 +35,9 @@ export function isDirectResponseNeed(need) {
  */
 export function isWhatsNewNeed(need) {
   return (
-    need && need.get("flags") && need.get("flags").contains("won:WhatsNew")
+    need &&
+    need.getIn(["content", "flags"]) &&
+    need.getIn(["content", "flags"]).contains("won:WhatsNew")
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -14,7 +14,6 @@ export function parseNeed(jsonldNeed, isOwned) {
       nodeUri: jsonldNeedImm.getIn(["won:hasWonNode", "@id"]),
       types: extractTypes(jsonldNeedImm),
       facets: extractFacets(jsonldNeedImm.get("won:hasFacet")),
-      flags: extractFlags(jsonldNeedImm.get("won:hasFlag")),
       state: extractState(jsonldNeedImm),
       matchingContexts: extractMatchingContext(jsonldNeedImm),
       heldBy: won.parseFrom(jsonldNeedImm, ["won:heldBy"], "xsd:ID"),
@@ -123,21 +122,6 @@ function extractCreationDate(needJsonLd) {
     return new Date(creationDate);
   }
   return undefined;
-}
-
-function extractFlags(wonHasFlags) {
-  let flags = Immutable.List();
-
-  wonHasFlags &&
-    wonHasFlags.map(function(flag) {
-      if (flag instanceof Immutable.Map) {
-        flags = flags.push(flag.get("@id"));
-      } else {
-        flags = flags.push(flag);
-      }
-    });
-
-  return flags;
 }
 
 function extractFacets(wonHasFacets) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -372,8 +372,6 @@ won.WONMSG.uriPlaceholder = Object.freeze({
 
 won.WON.contentNodeBlankUri = Object.freeze({
   seeks: "_:seeksNeedContent",
-  whatsAround: "_:needContent",
-  whatsNew: "_:needContent",
 });
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -38,6 +38,7 @@ export const details = {
   price: priceDetails.price,
   review: reviewDetails.review,
   responseToUri: basicDetails.responseToUri,
+  flags: basicDetails.flags,
 };
 
 export const messageDetails = {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -181,6 +181,7 @@ export const flags = {
   label: "Flags",
   icon: "#ico36_detail_title", //TODO: CORRECT ICON
   viewerComponent: undefined, //this is so we do not display this with a detail-viewer,
+  component: undefined, //this is so we do not display the component as a detail-picker, but are still able to use the parseToRDF, parseFromRDF functions
   multiSelect: true,
   options: [
     { value: "won:WhatsNew", label: "WhatsNew" },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -1,6 +1,8 @@
 import won from "../../app/won-es6.js";
 import { is } from "../../app/utils.js";
 
+import { select } from "../details/abstract.js";
+
 export const title = {
   identifier: "title",
   label: "Title",
@@ -170,5 +172,46 @@ export const responseToUri = {
       return includeLabel ? this.label + ": " + value : value;
     }
     return undefined;
+  },
+};
+
+export const flags = {
+  ...select,
+  identifier: "flags",
+  label: "Flags",
+  icon: "#ico36_detail_title", //TODO: CORRECT ICON
+  viewerComponent: undefined, //this is so we do not display this with a detail-viewer,
+  multiSelect: true,
+  options: [
+    { value: "won:WhatsNew", label: "WhatsNew" },
+    { value: "won:WhatsAround", label: "WhatsAround" },
+    { value: "won:NoHintForMe", label: "NoHintForMe" },
+    { value: "won:NoHintForCounterpart", label: "NoHintForCounterpart" },
+    { value: "won:DirectResponse", label: "DirectResponse" },
+    { value: "won:UsedForTesting", label: "UsedForTesting" },
+  ],
+  parseToRDF: function({ value }) {
+    if (!value) {
+      return { "won:hasFlag": undefined };
+    } else if (is("Array", value)) {
+      const idFlags = value.map(item => {
+        return { "@id": item };
+      });
+      return { "won:hasFlag": idFlags };
+    } else {
+      return { "won:hasFlag": [{ "@id": value }] };
+    }
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseListFrom(jsonLDImm, ["won:hasFlag"], "xsd:ID");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    //TODO: Implement this so that the label shows instead of the value
+    if (value && is("Array", value) && value.length > 0) {
+      const prefix = includeLabel ? this.label + ": " : "";
+      return prefix + value.join(", ");
+    } else {
+      return undefined;
+    }
   },
 };


### PR DESCRIPTION
Created a non-pickable/non-viewable Detail for won:hasFlag, so we can set flags in the usecase content and not have x-boolean flags within the need-draft or special handling for pureSearch, whatsX, adHoc-needs

Note: If we would want to have the flags-picker for the custom-post creation then we can simply remove the `component: undefined` line from the flags-detail definition in basic.js -> it will automatically use the won-select-picker then.

Refactor all the need drafts (pureSearch, whatsX, adHoc) to use the flags-detail instead of the bool approach we had before