### PR TITLE
Refac Reducer Dispatch

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -373,19 +373,6 @@ export function reconnect() {
 
       const state = getState();
 
-      /*
-      * -- check for new connections (i.e. matches and incoming requests) --
-      */
-      // await pageLoadAction()(dispatch, getState);
-      // const email = getIn(state, ["account", "email"]);
-      // await fetchOwnedData(email, payload => {
-      //   dispatch({
-      //     type: actionTypes.initialPageLoad, // TODO make this it's own type
-      //     payload: wellFormedPayload(payload),
-      //   });
-      // });
-      //TODO hard reload
-
       /* 
        * -- loading latest messages for all connections (we might have missed some during the dc) --
        */

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -177,7 +177,7 @@ export function accountLogin(credentials, options) {
       })
       .then((/*response*/) => {
         if (options_.fetchData) {
-          return fetchOwnedData(email, curriedDispatch, dispatch);
+          return fetchOwnedData(email, dispatch);
         } else {
           return Immutable.Map(); // only need to fetch data for non-new accounts
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -177,7 +177,7 @@ export function accountLogin(credentials, options) {
       })
       .then((/*response*/) => {
         if (options_.fetchData) {
-          return fetchOwnedData(email, curriedDispatch);
+          return fetchOwnedData(email, curriedDispatch, dispatch);
         } else {
           return Immutable.Map(); // only need to fetch data for non-new accounts
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -62,7 +62,6 @@ let _loginInProcessFor;
  *    signing in is new, there's no need to fetch this and `false` can be passed here
  *    * doRedirects(true): whether or not to do any redirects at all (e.g. if an invalid route was accessed)
  *    * redirectToFeed(false): whether or not to redirect to the feed after signing in (needs `redirects` to be true)
- *    * relogIfNecessary(true):  if there's a valid session or privateId, log out from that first.
  *
  * @param credentials either {email, password} or {privateId}
  * @returns {Function}
@@ -74,7 +73,6 @@ export function accountLogin(credentials, options) {
       fetchData: true,
       doRedirects: true,
       redirectToFeed: false,
-      relogIfNecessary: true, // if there's a valid session or privateId, log out from that first.
     },
     options
   );
@@ -169,7 +167,7 @@ export function accountLogin(credentials, options) {
           return checkAccessToCurrentRoute(dispatch, getState);
         }
       })
-      .then((/*response*/) => {
+      .then(() => {
         if (options_.fetchData) {
           return fetchOwnedData(email, dispatch);
         } else {
@@ -266,9 +264,7 @@ export function accountLogout() {
           }),
         })
       )
-      .then(() => {
-        won.clearStore();
-      })
+      .then(() => won.clearStore())
       .then(() => checkAccessToCurrentRoute(dispatch, getState))
       .then(() => {
         _logoutInProcess = false;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -177,10 +177,7 @@ export function accountLogin(credentials, options) {
           return Promise.resolve()
             .then(() => {
               if (wasLoggedIn) {
-                return dispatch({
-                  type: actionTypes.account.logout,
-                  payload: Immutable.fromJS({ loggedIn: false }),
-                });
+                return dispatch({ type: actionTypes.account.reset });
               }
             })
             .then(() => {
@@ -252,26 +249,14 @@ export function accountLogout() {
           return stateGoCurrent({ privateId: null })(dispatch, getState);
         }
       })
-      .then(() =>
-        dispatch({
-          type: actionTypes.account.logout,
-          payload: Immutable.fromJS({
-            loggedIn: false,
-            httpSessionDowngraded: true,
-          }),
-        })
-      )
+      .then(() => dispatch({ type: actionTypes.downgradeHttpSession }))
+      .then(() => dispatch({ type: actionTypes.account.reset }))
       .then(() => won.clearStore())
       .then(() => checkAccessToCurrentRoute(dispatch, getState))
       .then(() => {
         _logoutInProcess = false;
       })
-      .then(() =>
-        dispatch({
-          type: actionTypes.account.logout,
-          payload: Immutable.fromJS({ loggedIn: false, logoutFinished: true }),
-        })
-      );
+      .then(() => dispatch({ type: actionTypes.account.logoutFinished }));
   };
 }
 
@@ -422,8 +407,8 @@ export function reconnect() {
       );
     } catch (e) {
       if (e.message == "Unauthorized") {
-        //FIXME: this seems weird and unintentional to me, the actionTypes.account.logout closes the main menu (see view-reducer.js) and the dispatch after opens it again, is this wanted that way?
-        dispatch({ type: actionTypes.account.logout });
+        //FIXME: this seems weird and unintentional to me, the actionTypes.account.reset closes the main menu (see view-reducer.js) and the dispatch after opens it again, is this wanted that way?
+        dispatch({ type: actionTypes.account.reset });
         dispatch({ type: actionTypes.view.showMainMenu });
       } else {
         dispatch(actionCreators.lostConnection());

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -148,11 +148,8 @@ export function accountLogin(credentials, options) {
       .then(() => login(credentials))
       .then(data =>
         dispatch({
-          type: actionTypes.account.login,
-          payload: Immutable.fromJS(data).merge({
-            email: email,
-            loggedIn: true,
-          }),
+          type: actionTypes.account.store,
+          payload: Immutable.fromJS(data),
         })
       )
       .then(() => dispatch({ type: actionTypes.upgradeHttpSession }))

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -220,19 +220,12 @@ export function accountLogin(credentials, options) {
 }
 
 let _logoutInProcess;
+
 /**
- *
- * @param options
- *    * doRedirects(true): whether or not to do any redirects at all (e.g. if an invalid route was accessed)
- *
+ * Processes logout
  * @returns {Function}
  */
-export function accountLogout(options) {
-  const options_ = {
-    doRedirects: true,
-    ...options,
-  };
-
+export function accountLogout() {
   clearPrivateId();
 
   return (dispatch, getState) => {
@@ -260,10 +253,7 @@ export function accountLogout(options) {
       })
       .then(() => {
         // for the case that we've been logged in to an anonymous account, we need to remove the privateId here.
-        if (
-          options_.doRedirects &&
-          getIn(state, ["router", "currentParams", "privateId"])
-        ) {
+        if (getIn(state, ["router", "currentParams", "privateId"])) {
           return stateGoCurrent({ privateId: null })(dispatch, getState);
         }
       })
@@ -279,10 +269,7 @@ export function accountLogout(options) {
       .then(() => {
         won.clearStore();
       })
-      .then(
-        () =>
-          options_.doRedirects && checkAccessToCurrentRoute(dispatch, getState)
-      )
+      .then(() => checkAccessToCurrentRoute(dispatch, getState))
       .then(() => {
         _logoutInProcess = false;
       })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -119,12 +119,6 @@ export function accountLogin(credentials, options) {
       return;
     }
 
-    const curriedDispatch = data =>
-      dispatch({
-        type: actionTypes.account.login,
-        payload: Immutable.fromJS(data).merge({ email: email, loggedIn: true }),
-      });
-
     return Promise.resolve()
       .then(() => {
         _loginInProcessFor = email;
@@ -163,7 +157,7 @@ export function accountLogin(credentials, options) {
           }),
         })
       )
-      .then(() => curriedDispatch({ httpSessionUpgraded: true }))
+      .then(() => dispatch({ type: actionTypes.upgradeHttpSession }))
       .then(() => {
         if (!options_.doRedirects) {
           return;
@@ -182,7 +176,7 @@ export function accountLogin(credentials, options) {
           return Immutable.Map(); // only need to fetch data for non-new accounts
         }
       })
-      .then(() => curriedDispatch({ loginFinished: true }))
+      .then(() => dispatch({ type: actionTypes.loginFinished }))
       .catch(error =>
         error.response.json().then(loginError => {
           return Promise.resolve()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -303,7 +303,7 @@ export function accountRegister(credentials) {
   return (dispatch, getState) =>
     registerAccount(credentials)
       .then(() =>
-        /*response*/ accountLogin(credentials, {
+        accountLogin(credentials, {
           fetchData: false,
           redirectToFeed: true,
         })(dispatch, getState)
@@ -328,8 +328,7 @@ export function accountTransfer(credentials) {
     transferPrivateAccount(credentials)
       .then(() => {
         credentials.privateId = undefined;
-        /*response*/
-        accountLogin(credentials, {
+        return accountLogin(credentials, {
           fetchData: true,
           redirectToFeed: true,
         })(dispatch, getState);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -232,12 +232,7 @@ export function accountLogout() {
     _logoutInProcess = true;
 
     return Promise.resolve()
-      .then(() =>
-        dispatch({
-          type: actionTypes.account.logoutStarted,
-          payload: {},
-        })
-      )
+      .then(() => dispatch({ type: actionTypes.account.logoutStarted }))
       .then(() => logout())
       .catch(error => {
         //TODO: PRINT ERROR MESSAGE AND CHANGE STATE ACCORDINGLY

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -176,7 +176,7 @@ export function accountLogin(credentials, options) {
           return Immutable.Map(); // only need to fetch data for non-new accounts
         }
       })
-      .then(() => dispatch({ type: actionTypes.loginFinished }))
+      .then(() => dispatch({ type: actionTypes.account.loginFinished }))
       .catch(error =>
         error.response.json().then(loginError => {
           return Promise.resolve()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -266,9 +266,11 @@ const actionHierarchy = {
   },
   account: {
     login: accountLogin,
-    loginStarted: INJ_DEFAULT,
-    loginFinished: INJ_DEFAULT,
+    loginStarted: INJ_DEFAULT, //will only be dispatched on login not on page reload
+    loginFinished: INJ_DEFAULT, //will be dispatched when data has been loaded on login not on page reload
     loginFailed: INJ_DEFAULT,
+
+    store: INJ_DEFAULT, //stores the retrieved account in the state
 
     logout: accountLogout,
     logoutStarted: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -96,6 +96,7 @@ import { createPersona, reviewPersona } from "./persona-actions.js";
 const INJ_DEFAULT = "INJECT_DEFAULT_ACTION_CREATOR";
 const actionHierarchy = {
   initialPageLoad: pageLoadAction,
+  initialLoadFinished: INJ_DEFAULT,
   connections: {
     open: cnct.connectionsOpen,
     connectAdHoc: cnct.connectionsConnectAdHoc,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -118,6 +118,9 @@ const actionHierarchy = {
     setMultiSelectType: INJ_DEFAULT,
     updateAgreementData: INJ_DEFAULT, //cnct.loadAgreementData,
     updatePetriNetData: INJ_DEFAULT,
+
+    fetchActiveUrisLoading: INJ_DEFAULT,
+    fetchActive: INJ_DEFAULT,
   },
   needs: {
     received: INJ_DEFAULT,
@@ -139,11 +142,16 @@ const actionHierarchy = {
     fetchOwnedInactiveUrisLoading: INJ_DEFAULT,
     fetchOwnedActiveUris: INJ_DEFAULT,
     fetchTheirUrisLoading: INJ_DEFAULT,
+
+    fetchOwned: INJ_DEFAULT,
+    fetchTheirs: INJ_DEFAULT,
   },
   personas: {
     create: createPersona,
     createSuccessful: INJ_DEFAULT,
     review: reviewPersona,
+
+    fetchTheirs: INJ_DEFAULT,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -267,6 +267,7 @@ const actionHierarchy = {
   account: {
     login: accountLogin,
     loginStarted: INJ_DEFAULT,
+    loginFinished: INJ_DEFAULT,
     loginFailed: INJ_DEFAULT,
 
     logout: accountLogout,
@@ -298,6 +299,7 @@ const actionHierarchy = {
   geoLocationDenied: INJ_DEFAULT,
   lostConnection: INJ_DEFAULT,
   failedToGetLocation: INJ_DEFAULT,
+  upgradeHttpSession: INJ_DEFAULT,
 
   reconnect: {
     start: reconnect,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -138,20 +138,20 @@ const actionHierarchy = {
     fetchUnloadedNeeds: fetchUnloadedNeeds,
     fetchSuggested: fetchSuggested,
 
-    fetchOwnedInactiveUris: INJ_DEFAULT,
-    fetchOwnedInactiveUrisLoading: INJ_DEFAULT,
-    fetchOwnedActiveUris: INJ_DEFAULT,
-    fetchTheirUrisLoading: INJ_DEFAULT,
+    storeOwnedInactiveUris: INJ_DEFAULT,
+    storeOwnedInactiveUrisLoading: INJ_DEFAULT,
+    storeOwnedActiveUris: INJ_DEFAULT,
+    storeTheirUrisLoading: INJ_DEFAULT,
 
-    fetchOwned: INJ_DEFAULT,
-    fetchTheirs: INJ_DEFAULT,
+    storeOwned: INJ_DEFAULT,
+    storeTheirs: INJ_DEFAULT,
   },
   personas: {
     create: createPersona,
     createSuccessful: INJ_DEFAULT,
     review: reviewPersona,
 
-    fetchTheirs: INJ_DEFAULT,
+    storeTheirs: INJ_DEFAULT,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -119,8 +119,8 @@ const actionHierarchy = {
     updateAgreementData: INJ_DEFAULT, //cnct.loadAgreementData,
     updatePetriNetData: INJ_DEFAULT,
 
-    fetchActiveUrisLoading: INJ_DEFAULT,
-    fetchActive: INJ_DEFAULT,
+    storeActiveUrisLoading: INJ_DEFAULT,
+    storeActive: INJ_DEFAULT,
   },
   needs: {
     received: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -271,9 +271,11 @@ const actionHierarchy = {
     loginFailed: INJ_DEFAULT,
 
     store: INJ_DEFAULT, //stores the retrieved account in the state
+    reset: INJ_DEFAULT, //resets the retrieved account back to the initialState
 
     logout: accountLogout,
     logoutStarted: INJ_DEFAULT,
+    logoutFinished: INJ_DEFAULT,
 
     register: accountRegister,
     transfer: accountTransfer,
@@ -302,6 +304,7 @@ const actionHierarchy = {
   lostConnection: INJ_DEFAULT,
   failedToGetLocation: INJ_DEFAULT,
   upgradeHttpSession: INJ_DEFAULT,
+  downgradeHttpSession: INJ_DEFAULT,
 
   reconnect: {
     start: reconnect,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -134,6 +134,11 @@ const actionHierarchy = {
     connect: needsConnect,
     fetchUnloadedNeeds: fetchUnloadedNeeds,
     fetchSuggested: fetchSuggested,
+
+    fetchOwnedInactiveUris: INJ_DEFAULT,
+    fetchOwnedInactiveUrisLoading: INJ_DEFAULT,
+    fetchOwnedActiveUris: INJ_DEFAULT,
+    fetchTheirUrisLoading: INJ_DEFAULT,
   },
   personas: {
     create: createPersona,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -39,7 +39,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
 };
 
 function loadingWhileSignedIn(dispatch, getState, data) {
-  loginSuccess(data.username, true, dispatch, getState);
+  loginSuccess(dispatch, getState);
   fetchOwnedData(data.username, dispatch).then(() =>
     dispatch({
       type: actionTypes.initialLoadFinished,
@@ -47,18 +47,9 @@ function loadingWhileSignedIn(dispatch, getState, data) {
   );
 }
 
-function loginSuccess(username, loginStatus, dispatch, getState) {
+function loginSuccess(dispatch, getState) {
   // reset websocket to make sure it's using the logged-in session
   dispatch(actionCreators.reconnect__start());
-
-  /* quickly dispatch log-in status, even before loading data, to
-     * allow making correct access-control decisions
-     */
-  dispatch({
-    type: actionTypes.account.login,
-    payload: Immutable.fromJS({ email: username, loggedIn: loginStatus }),
-  });
-
   checkAccessToCurrentRoute(dispatch, getState);
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -43,6 +43,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
       return loadingWhileSignedIn(dispatch, getState, data);
     })
     .catch(() => {
+      //FIXME: I am actually not sure if we need that part here besides the else i feel like the loading of an anonymous account is being done before this already
       // as this is one of the first action-creators to be executed, we need to get the param directly from the url-bar instead of `state.getIn(['router','currentParams','privateId'])`
       const privateId =
         getParameterByName("privateId") || localStorage.getItem("privateId");
@@ -64,8 +65,7 @@ function loadingWhileSignedIn(dispatch, getState, data) {
   loginSuccess(data.username, true, dispatch, getState);
   fetchOwnedData(data.username, dispatch).then(() =>
     dispatch({
-      type: actionTypes.initialPageLoad,
-      payload: Immutable.fromJS({ initialLoadFinished: true }),
+      type: actionTypes.initialLoadFinished,
     })
   );
 }
@@ -85,8 +85,7 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
       .then(() => fetchOwnedData(email, dispatch))
       .then(() => {
         return dispatch({
-          type: actionTypes.initialPageLoad,
-          payload: Immutable.fromJS({ initialLoadFinished: true }),
+          type: actionTypes.initialLoadFinished,
         });
       })
       .catch(e => {
@@ -141,8 +140,13 @@ function loadingWhileSignedOut(dispatch, getState) {
   return dataPromise
     .then(publicData =>
       dispatch({
-        type: actionTypes.initialPageLoad,
-        payload: publicData.merge({ initialLoadFinished: true }),
+        type: actionTypes.needs.fetchTheirs,
+        payload: publicData,
+      })
+    )
+    .then(() =>
+      dispatch({
+        type: actionTypes.initialLoadFinished,
       })
     )
     .then(() => checkAccessToCurrentRoute(dispatch, getState));

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -26,8 +26,8 @@ export const pageLoadAction = () => (dispatch, getState) => {
     /* handle data, dispatch actions */
     .then(data =>
       dispatch({
-        type: actionTypes.account.login,
-        payload: Immutable.fromJS(data).merge({ loggedIn: true }),
+        type: actionTypes.account.store,
+        payload: Immutable.fromJS(data),
       })
     )
     .then(data => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -63,7 +63,11 @@ export const pageLoadAction = () => (dispatch, getState) => {
 
 function loadingWhileSignedIn(dispatch, getState, data) {
   loginSuccess(data.username, true, dispatch, getState);
-  fetchOwnedData(data.username, dispatchInitialPageLoad(dispatch)).then(() =>
+  fetchOwnedData(
+    data.username,
+    dispatchInitialPageLoad(dispatch),
+    dispatch
+  ).then(() =>
     dispatch({
       type: actionTypes.initialPageLoad,
       payload: Immutable.fromJS({ initialLoadFinished: true }),
@@ -83,7 +87,7 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
         loginSuccess(email, true, dispatch, getState);
         return response;
       })
-      .then(() => fetchOwnedData(email, dispatchInitialPageLoad(dispatch)))
+      .then(() => fetchOwnedData(dispatchInitialPageLoad(dispatch), dispatch))
       .then(() => {
         return dispatch({
           type: actionTypes.initialPageLoad,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -22,7 +22,6 @@ import { getParameterByName } from "../utils.js";
 import {
   fetchOwnedData,
   fetchDataForNonOwnedNeedOnly,
-  wellFormedPayload,
 } from "../won-message-utils.js";
 
 export const pageLoadAction = () => (dispatch, getState) => {
@@ -63,11 +62,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
 
 function loadingWhileSignedIn(dispatch, getState, data) {
   loginSuccess(data.username, true, dispatch, getState);
-  fetchOwnedData(
-    data.username,
-    dispatchInitialPageLoad(dispatch),
-    dispatch
-  ).then(() =>
+  fetchOwnedData(data.username, dispatch).then(() =>
     dispatch({
       type: actionTypes.initialPageLoad,
       payload: Immutable.fromJS({ initialLoadFinished: true }),
@@ -87,7 +82,7 @@ function loadingWithAnonymousAccount(dispatch, getState, privateId) {
         loginSuccess(email, true, dispatch, getState);
         return response;
       })
-      .then(() => fetchOwnedData(dispatchInitialPageLoad(dispatch), dispatch))
+      .then(() => fetchOwnedData(email, dispatch))
       .then(() => {
         return dispatch({
           type: actionTypes.initialPageLoad,
@@ -125,7 +120,10 @@ function loginSuccess(username, loginStatus, dispatch, getState) {
   /* quickly dispatch log-in status, even before loading data, to
      * allow making correct access-control decisions
      */
-  dispatchInitialPageLoad(dispatch)({ email: username, loggedIn: loginStatus });
+  dispatch({
+    type: actionTypes.account.login,
+    payload: Immutable.fromJS({ email: username, loggedIn: loginStatus }),
+  });
 
   checkAccessToCurrentRoute(dispatch, getState);
 }
@@ -148,14 +146,6 @@ function loadingWhileSignedOut(dispatch, getState) {
       })
     )
     .then(() => checkAccessToCurrentRoute(dispatch, getState));
-}
-
-function dispatchInitialPageLoad(dispatch) {
-  return payload =>
-    dispatch({
-      type: actionTypes.initialPageLoad,
-      payload: wellFormedPayload(payload),
-    });
 }
 
 /////////// THE ACTIONCREATORS BELOW SHOULD BE PART OF PAGELOAD

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -66,7 +66,7 @@ function loadingWhileSignedOut(dispatch, getState) {
   return dataPromise
     .then(publicData =>
       dispatch({
-        type: actionTypes.needs.fetchTheirs,
+        type: actionTypes.needs.storeTheirs,
         payload: publicData,
       })
     )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -3,21 +3,12 @@
  */
 
 import Immutable from "immutable";
-import won from "../won-es6.js";
 import { actionTypes, actionCreators } from "./actions.js";
 import { getPostUriFromRoute } from "../selectors/general-selectors.js";
 
 import { checkAccessToCurrentRoute } from "../configRouting.js";
 
-import { stateGoCurrent } from "./cstm-router-actions.js";
-
-import {
-  checkLoginStatus,
-  privateId2Credentials,
-  login,
-} from "../won-utils.js";
-
-import { getParameterByName } from "../utils.js";
+import { checkLoginStatus } from "../won-utils.js";
 
 import {
   fetchOwnedData,
@@ -43,21 +34,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
       return loadingWhileSignedIn(dispatch, getState, data);
     })
     .catch(() => {
-      //FIXME: I am actually not sure if we need that part here besides the else i feel like the loading of an anonymous account is being done before this already
-      // as this is one of the first action-creators to be executed, we need to get the param directly from the url-bar instead of `state.getIn(['router','currentParams','privateId'])`
-      const privateId =
-        getParameterByName("privateId") || localStorage.getItem("privateId");
-
-      if (privateId) {
-        return loadingWithAnonymousAccount(dispatch, getState, privateId).catch(
-          () => loadingWhileSignedOut(dispatch, getState)
-        );
-      } else {
-        /*
-         * ok, we're really not logged in -- thus we need to fetch any publicly visible, required data
-         */
-        return loadingWhileSignedOut(dispatch, getState);
-      }
+      return loadingWhileSignedOut(dispatch, getState);
     });
 };
 
@@ -68,48 +45,6 @@ function loadingWhileSignedIn(dispatch, getState, data) {
       type: actionTypes.initialLoadFinished,
     })
   );
-}
-
-function loadingWithAnonymousAccount(dispatch, getState, privateId) {
-  // using an anonymous account. need to log in.
-  const { email } = privateId2Credentials(privateId);
-  return (
-    login({ privateId })
-      /* quickly dispatch log-in status, even before loading data, to
-     * allow making correct access-control decisions
-     */
-      .then(response => {
-        loginSuccess(email, true, dispatch, getState);
-        return response;
-      })
-      .then(() => fetchOwnedData(email, dispatch))
-      .then(() => {
-        return dispatch({
-          type: actionTypes.initialLoadFinished,
-        });
-      })
-      .catch(e => {
-        console.error(
-          "failed to sign-in with privateId ",
-          privateId,
-          " because of: ",
-          e
-        );
-        dispatch({
-          type: actionTypes.account.loginFailed,
-          payload: {
-            loginError: Immutable.fromJS(won.PRIVATEID_NOT_FOUND_ERROR),
-            credentials: { privateId },
-          },
-        });
-        throw e;
-      })
-      .then(() => {
-        dispatch(stateGoCurrent({ privateId }));
-      })
-  );
-  //dispatch(actionCreators.login(email, password));
-  //return; // the login action should fetch the required data, so we're done here.
 }
 
 function loginSuccess(username, loginStatus, dispatch, getState) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -55,7 +55,7 @@ export function failedCloseNeed(event) {
         () =>
           // as the need and it's connections have been marked dirty
           // they will be reloaded on this action.
-          fetchDataForOwnedNeeds([needUri], () => undefined, dispatch)
+          fetchDataForOwnedNeeds([needUri], dispatch)
         //fetchAllAccessibleAndRelevantData([needUri])
       )
       .then(allThatData =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -51,12 +51,10 @@ export function failedCloseNeed(event) {
           )
         )
       )
-      .then(
-        () =>
-          // as the need and it's connections have been marked dirty
-          // they will be reloaded on this action.
-          fetchDataForOwnedNeeds([needUri], dispatch)
-        //fetchAllAccessibleAndRelevantData([needUri])
+      .then(() =>
+        // as the need and it's connections have been marked dirty
+        // they will be reloaded on this action.
+        fetchDataForOwnedNeeds([needUri], dispatch)
       )
       .then(allThatData =>
         dispatch({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -55,7 +55,7 @@ export function failedCloseNeed(event) {
         () =>
           // as the need and it's connections have been marked dirty
           // they will be reloaded on this action.
-          fetchDataForOwnedNeeds([needUri])
+          fetchDataForOwnedNeeds([needUri], () => undefined, dispatch)
         //fetchAllAccessibleAndRelevantData([needUri])
       )
       .then(allThatData =>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -17,13 +17,7 @@ import {
 
 export function fetchUnloadedNeeds() {
   return async dispatch => {
-    const curriedDispatch = payload => {
-      dispatch({
-        type: actionTypes.needs.fetchUnloadedNeeds,
-        payload: payload,
-      });
-    };
-    fetchUnloadedData(curriedDispatch, dispatch);
+    fetchUnloadedData(dispatch);
   };
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -23,7 +23,7 @@ export function fetchUnloadedNeeds() {
         payload: payload,
       });
     };
-    fetchUnloadedData(curriedDispatch);
+    fetchUnloadedData(curriedDispatch, dispatch);
   };
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -24,7 +24,7 @@ export function fetchUnloadedNeeds() {
 export function fetchSuggested(needUri) {
   return async dispatch => {
     fetchDataForNonOwnedNeedOnly(needUri).then(response => {
-      const suggestedPosts = response && response.get("theirNeeds");
+      const suggestedPosts = response && response.get("needs");
 
       if (suggestedPosts && suggestedPosts.size > 0) {
         const payload = Immutable.fromJS({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -86,8 +86,10 @@ function genLogoutConf() {
     getEmail() {
       if (this.isPrivateIdUser) {
         return "Anonymous";
-      } else {
+      } else if (this.email) {
         return ellipsizeString(this.email, this.maxEmailLength);
+      } else {
+        return "";
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -3,7 +3,6 @@
  */
 import angular from "angular";
 import { attach } from "../utils.js";
-import { ellipsizeString } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 
@@ -72,7 +71,6 @@ function genLogoutConf() {
 
       this.email = "";
       this.password = "";
-      this.maxEmailLength = 16;
 
       const logout = state => ({
         loggedIn: state.getIn(["account", "loggedIn"]),
@@ -86,11 +84,8 @@ function genLogoutConf() {
     getEmail() {
       if (this.isPrivateIdUser) {
         return "Anonymous";
-      } else if (this.email) {
-        return ellipsizeString(this.email, this.maxEmailLength);
-      } else {
-        return "";
       }
+      return this.email;
     }
   }
   Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
@@ -90,7 +90,9 @@ function genLoginConf() {
     }
 
     formKeyUp(event) {
-      this.view__clearLoginError();
+      if (this.loginError) {
+        this.view__clearLoginError();
+      }
       if (event.keyCode == 13) {
         this.account__login(
           {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -42,7 +42,9 @@ class SignupController {
   }
 
   formKeyup(event) {
-    this.view__clearRegisterError();
+    if (this.registerError) {
+      this.view__clearRegisterError();
+    }
     if (event.keyCode == 13 && this.$scope.registerForm.$valid) {
       if (this.isPrivateIdUser) {
         this.account__transfer({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
@@ -25,7 +25,7 @@ export default function(userData = initialState, action = {}) {
 
       return userData
         .set("loggedIn", true)
-        .set("username", username)
+        .set("email", username)
         .set("emailVerified", emailVerified)
         .set("acceptedTermsOfService", acceptedTermsOfService);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
@@ -24,6 +24,7 @@ export default function(userData = initialState, action = {}) {
       );
 
       return userData
+        .set("loggedIn", true)
         .set("username", username)
         .set("emailVerified", emailVerified)
         .set("acceptedTermsOfService", acceptedTermsOfService);
@@ -47,7 +48,7 @@ export default function(userData = initialState, action = {}) {
     case actionTypes.account.acceptTermsOfServiceFailed:
       return userData.set("acceptedTermsOfService", false);
 
-    case actionTypes.account.logout:
+    case actionTypes.account.reset:
       return initialState.set(
         "acceptedDisclaimer",
         userData.get("acceptedDisclaimer")

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
@@ -13,7 +13,6 @@ const initialState = Immutable.fromJS({
 
 export default function(userData = initialState, action = {}) {
   switch (action.type) {
-    case actionTypes.initialPageLoad:
     case actionTypes.account.login: {
       //because we get payload as immutablejs-map sometimes but not always
       const immutablePayload = Immutable.fromJS(action.payload);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -10,6 +10,8 @@ const initialState = Immutable.fromJS({
   waitingForAnswer: {},
   claimOnSuccess: {},
   refreshDataOnSuccess: {},
+  lostConnection: false,
+  reconnecting: false,
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
@@ -90,9 +92,7 @@ export function messagesReducer(messages = initialState, action = {}) {
     }
 
     case actionTypes.account.logoutFinished: {
-      return initialState
-        .set("lostConnection", false)
-        .set("reconnecting", false);
+      return initialState;
     }
 
     case actionTypes.reconnect.start:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -82,24 +82,12 @@ export function messagesReducer(messages = initialState, action = {}) {
         ? messages.set("lostConnection", false).set("reconnecting", false)
         : messages;
     }
+    case actionTypes.account.loginFinished: {
+      return messages.set("lostConnection", false).set("reconnecting", false);
+    }
 
-    case actionTypes.account.login: {
-      const loginFinished = getIn(action, ["payload", "loginFinished"]);
-      const httpSessionUpgraded =
-        !loginFinished && getIn(action, ["payload", "httpSessionUpgraded"]);
-      if (loginFinished) {
-        return messages.set("lostConnection", false).set("reconnecting", false);
-      } else if (httpSessionUpgraded) {
-        /*
-         * now that the session has been upgraded, we need to set the flag
-         * that triggers a websocket reset.
-         * This is part of the session-upgrade hack documented in:
-         * https://github.com/researchstudio-sat/webofneeds/issues/381#issuecomment-172569377
-         */
-        return messages.set("reconnecting", true);
-      } else {
-        return messages;
-      }
+    case actionTypes.upgradeHttpSession: {
+      return messages.set("reconnecting", true);
     }
 
     case actionTypes.account.logout: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -4,12 +4,7 @@
 
 import { actionTypes } from "../actions/actions.js";
 import Immutable from "immutable";
-import { getIn } from "../utils.js";
 
-/* TODO this fragment is part of an attempt to sketch a different
- * approach to asynchronity (Remove it or the thunk-based
- * solution afterwards)
- */
 const initialState = Immutable.fromJS({
   enqueued: {},
   waitingForAnswer: {},
@@ -90,29 +85,14 @@ export function messagesReducer(messages = initialState, action = {}) {
       return messages.set("reconnecting", true);
     }
 
-    case actionTypes.account.logout: {
-      const logoutFinished = getIn(action, ["payload", "logoutFinished"]);
-      const httpSessionDowngraded =
-        !logoutFinished && getIn(action, ["payload", "httpSessionDowngraded"]);
-      if (logoutFinished) {
-        return initialState
-          .set("lostConnection", false)
-          .set("reconnecting", false);
-      } else if (httpSessionDowngraded) {
-        /*
-         * now that the session has been downgraded, we need to set the flag
-         * that triggers a websocket reset.
-         * This is part of the session-upgrade hack documented in:
-         * https://github.com/researchstudio-sat/webofneeds/issues/381#issuecomment-172569377
-         */
-        return messages.set("reconnecting", true);
-      } else {
-        console.error(
-          "Got unexpected payload for `actionTypes.account.logout` ",
-          action
-        );
-        return messages;
-      }
+    case actionTypes.downgradeHttpSession: {
+      return messages.set("reconnecting", true);
+    }
+
+    case actionTypes.account.logoutFinished: {
+      return initialState
+        .set("lostConnection", false)
+        .set("reconnecting", false);
     }
 
     case actionTypes.reconnect.start:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -55,7 +55,7 @@ const initialState = Immutable.fromJS({});
 
 export default function(allNeedsInState = initialState, action = {}) {
   switch (action.type) {
-    case actionTypes.account.logout:
+    case actionTypes.account.reset:
     case actionTypes.needs.clean:
       return initialState;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -110,6 +110,47 @@ export default function(allNeedsInState = initialState, action = {}) {
       return addTheirNeedsInLoading(allNeedsInState, theirNeedUrisInLoading);
     }
 
+    case actionTypes.needs.fetchOwned: {
+      let ownedNeeds = action.payload.get("ownedNeeds");
+      ownedNeeds = ownedNeeds ? ownedNeeds : Immutable.Set();
+
+      return ownedNeeds.reduce(
+        (updatedState, ownedNeed) => addNeed(updatedState, ownedNeed, true),
+        allNeedsInState
+      );
+    }
+
+    case actionTypes.connections.fetchActiveUrisLoading: {
+      const needUriForConnections = action.payload.get("needUriForConnections");
+      const activeConnectionUrisLoading = action.payload.get(
+        "activeConnectionUrisLoading"
+      );
+
+      return addActiveConnectionsToNeedInLoading(
+        allNeedsInState,
+        needUriForConnections,
+        activeConnectionUrisLoading
+      );
+    }
+
+    case actionTypes.connections.fetchActive: {
+      return storeConnectionsData(
+        allNeedsInState,
+        action.payload.get("connections")
+      );
+    }
+
+    case actionTypes.needs.fetchTheirs:
+    case actionTypes.personas.fetchTheirs: {
+      let theirNeeds = action.payload.get("theirNeeds");
+      theirNeeds = theirNeeds ? theirNeeds : Immutable.Set();
+
+      return theirNeeds.reduce(
+        (updatedState, theirNeed) => addNeed(updatedState, theirNeed, false),
+        allNeedsInState
+      );
+    }
+
     case actionTypes.initialPageLoad:
     case actionTypes.needs.fetchUnloadedNeeds:
     case actionTypes.account.login: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -79,35 +79,35 @@ export default function(allNeedsInState = initialState, action = {}) {
       return stateWithSuggestedPosts;
     }
 
-    case actionTypes.needs.fetchOwnedActiveUris: {
+    case actionTypes.needs.storeOwnedActiveUris: {
       return addOwnActiveNeedsInLoading(
         allNeedsInState,
         action.payload.get("uris")
       );
     }
 
-    case actionTypes.needs.fetchOwnedInactiveUris: {
+    case actionTypes.needs.storeOwnedInactiveUris: {
       return addOwnInactiveNeedsToLoad(
         allNeedsInState,
         action.payload.get("uris")
       );
     }
 
-    case actionTypes.needs.fetchOwnedInactiveUrisLoading: {
+    case actionTypes.needs.storeOwnedInactiveUrisLoading: {
       return addOwnInactiveNeedsInLoading(
         allNeedsInState,
         action.payload.get("uris")
       );
     }
 
-    case actionTypes.needs.fetchTheirUrisLoading: {
+    case actionTypes.needs.storeTheirUrisLoading: {
       return addTheirNeedsInLoading(
         allNeedsInState,
         action.payload.get("uris")
       );
     }
 
-    case actionTypes.needs.fetchOwned: {
+    case actionTypes.needs.storeOwned: {
       let needs = action.payload.get("needs");
       needs = needs ? needs : Immutable.Set();
 
@@ -132,8 +132,8 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.needs.fetchTheirs:
-    case actionTypes.personas.fetchTheirs: {
+    case actionTypes.needs.storeTheirs:
+    case actionTypes.personas.storeTheirs: {
       let needs = action.payload.get("needs");
       needs = needs ? needs : Immutable.Set();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -80,56 +80,48 @@ export default function(allNeedsInState = initialState, action = {}) {
     }
 
     case actionTypes.needs.fetchOwnedActiveUris: {
-      const activeNeedUris = action.payload.get("activeNeedUris");
-
-      return addOwnActiveNeedsInLoading(allNeedsInState, activeNeedUris);
+      return addOwnActiveNeedsInLoading(
+        allNeedsInState,
+        action.payload.get("uris")
+      );
     }
 
     case actionTypes.needs.fetchOwnedInactiveUris: {
-      const inactiveNeedUris = action.payload.get("inactiveNeedUris");
-
-      return addOwnInactiveNeedsToLoad(allNeedsInState, inactiveNeedUris);
+      return addOwnInactiveNeedsToLoad(
+        allNeedsInState,
+        action.payload.get("uris")
+      );
     }
 
     case actionTypes.needs.fetchOwnedInactiveUrisLoading: {
-      const inactiveNeedUrisLoading = action.payload.get(
-        "inactiveNeedUrisLoading"
-      );
-
       return addOwnInactiveNeedsInLoading(
         allNeedsInState,
-        inactiveNeedUrisLoading
+        action.payload.get("uris")
       );
     }
 
     case actionTypes.needs.fetchTheirUrisLoading: {
-      const theirNeedUrisInLoading = action.payload.get(
-        "theirNeedUrisInLoading"
+      return addTheirNeedsInLoading(
+        allNeedsInState,
+        action.payload.get("uris")
       );
-
-      return addTheirNeedsInLoading(allNeedsInState, theirNeedUrisInLoading);
     }
 
     case actionTypes.needs.fetchOwned: {
-      let ownedNeeds = action.payload.get("ownedNeeds");
-      ownedNeeds = ownedNeeds ? ownedNeeds : Immutable.Set();
+      let needs = action.payload.get("needs");
+      needs = needs ? needs : Immutable.Set();
 
-      return ownedNeeds.reduce(
-        (updatedState, ownedNeed) => addNeed(updatedState, ownedNeed, true),
+      return needs.reduce(
+        (updatedState, need) => addNeed(updatedState, need, true),
         allNeedsInState
       );
     }
 
     case actionTypes.connections.fetchActiveUrisLoading: {
-      const needUriForConnections = action.payload.get("needUriForConnections");
-      const activeConnectionUrisLoading = action.payload.get(
-        "activeConnectionUrisLoading"
-      );
-
       return addActiveConnectionsToNeedInLoading(
         allNeedsInState,
-        needUriForConnections,
-        activeConnectionUrisLoading
+        action.payload.get("needUri"),
+        action.payload.get("connUris")
       );
     }
 
@@ -142,76 +134,12 @@ export default function(allNeedsInState = initialState, action = {}) {
 
     case actionTypes.needs.fetchTheirs:
     case actionTypes.personas.fetchTheirs: {
-      let theirNeeds = action.payload.get("theirNeeds");
-      theirNeeds = theirNeeds ? theirNeeds : Immutable.Set();
+      let needs = action.payload.get("needs");
+      needs = needs ? needs : Immutable.Set();
 
-      return theirNeeds.reduce(
-        (updatedState, theirNeed) => addNeed(updatedState, theirNeed, false),
+      return needs.reduce(
+        (updatedState, need) => addNeed(updatedState, need, false),
         allNeedsInState
-      );
-    }
-
-    case actionTypes.initialPageLoad:
-    case actionTypes.needs.fetchUnloadedNeeds:
-    case actionTypes.account.login: {
-      const activeNeedUris = action.payload.get("activeNeedUris");
-      const inactiveNeedUris = action.payload.get("inactiveNeedUris");
-      const inactiveNeedUrisLoading = action.payload.get(
-        "inactiveNeedUrisLoading"
-      );
-      const theirNeedUrisInLoading = action.payload.get(
-        "theirNeedUrisInLoading"
-      );
-
-      const needUriForConnections = action.payload.get("needUriForConnections");
-      const activeConnectionUrisLoading = action.payload.get(
-        "activeConnectionUrisLoading"
-      );
-
-      let ownedNeeds = action.payload.get("ownedNeeds");
-      ownedNeeds = ownedNeeds ? ownedNeeds : Immutable.Set();
-      let theirNeeds = action.payload.get("theirNeeds");
-      theirNeeds = theirNeeds ? theirNeeds : Immutable.Set();
-
-      const stateWithOwnInactiveNeedUrisToLoad = addOwnInactiveNeedsToLoad(
-        allNeedsInState,
-        inactiveNeedUris
-      );
-
-      const stateWithOwnInactiveNeedUrisInLoading = addOwnInactiveNeedsInLoading(
-        stateWithOwnInactiveNeedUrisToLoad,
-        inactiveNeedUrisLoading
-      );
-
-      const stateWithOwnedNeedUrisInLoading = addOwnActiveNeedsInLoading(
-        stateWithOwnInactiveNeedUrisInLoading,
-        activeNeedUris
-      );
-
-      const stateWithOwnedNeeds = ownedNeeds.reduce(
-        (updatedState, ownedNeed) => addNeed(updatedState, ownedNeed, true),
-        stateWithOwnedNeedUrisInLoading
-      );
-
-      const stateWithOwnedNeedsAndTheirNeedsInLoading = addTheirNeedsInLoading(
-        stateWithOwnedNeeds,
-        theirNeedUrisInLoading
-      );
-
-      const stateWithOwnAndTheirNeeds = theirNeeds.reduce(
-        (updatedState, theirNeed) => addNeed(updatedState, theirNeed, false),
-        stateWithOwnedNeedsAndTheirNeedsInLoading
-      );
-
-      const stateWithConnectionsToLoad = addActiveConnectionsToNeedInLoading(
-        stateWithOwnAndTheirNeeds,
-        needUriForConnections,
-        activeConnectionUrisLoading
-      );
-
-      return storeConnectionsData(
-        stateWithConnectionsToLoad,
-        action.payload.get("connections")
       );
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -117,7 +117,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.connections.fetchActiveUrisLoading: {
+    case actionTypes.connections.storeActiveUrisLoading: {
       return addActiveConnectionsToNeedInLoading(
         allNeedsInState,
         action.payload.get("needUri"),
@@ -125,7 +125,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.connections.fetchActive: {
+    case actionTypes.connections.storeActive: {
       return storeConnectionsData(
         allNeedsInState,
         action.payload.get("connections")

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -78,6 +78,38 @@ export default function(allNeedsInState = initialState, action = {}) {
 
       return stateWithSuggestedPosts;
     }
+
+    case actionTypes.needs.fetchOwnedActiveUris: {
+      const activeNeedUris = action.payload.get("activeNeedUris");
+
+      return addOwnActiveNeedsInLoading(allNeedsInState, activeNeedUris);
+    }
+
+    case actionTypes.needs.fetchOwnedInactiveUris: {
+      const inactiveNeedUris = action.payload.get("inactiveNeedUris");
+
+      return addOwnInactiveNeedsToLoad(allNeedsInState, inactiveNeedUris);
+    }
+
+    case actionTypes.needs.fetchOwnedInactiveUrisLoading: {
+      const inactiveNeedUrisLoading = action.payload.get(
+        "inactiveNeedUrisLoading"
+      );
+
+      return addOwnInactiveNeedsInLoading(
+        allNeedsInState,
+        inactiveNeedUrisLoading
+      );
+    }
+
+    case actionTypes.needs.fetchTheirUrisLoading: {
+      const theirNeedUrisInLoading = action.payload.get(
+        "theirNeedUrisInLoading"
+      );
+
+      return addTheirNeedsInLoading(allNeedsInState, theirNeedUrisInLoading);
+    }
+
     case actionTypes.initialPageLoad:
     case actionTypes.needs.fetchUnloadedNeeds:
     case actionTypes.account.login: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -61,15 +61,7 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.account.resendVerificationEmailFailed:
       return processState.set("processingResendVerificationEmail", false);
 
-    case actionTypes.account.login: {
-      if (getIn(action, ["payload", "loginFinished"])) {
-        return processState
-          .set("processingLogin", false)
-          .set("processingLoginForEmail", undefined);
-      }
-      return processState;
-    }
-
+    case actionTypes.account.loginFinished:
     case actionTypes.account.loginFailed:
       return processState
         .set("processingLogin", false)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -32,7 +32,7 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.account.logoutStarted:
       return processState.set("processingLogout", true);
 
-    case actionTypes.account.logout:
+    case actionTypes.account.logoutFinished:
       return processState.set("processingLogout", false);
 
     case actionTypes.account.loginStarted:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -102,8 +102,8 @@ export default reduceReducers(
        * that both are owned by the user, remain
        * in the state.
        */
-      case actionTypes.initialPageLoad:
       case actionTypes.account.login:
+      case actionTypes.initialLoadFinished:
       case actionTypes.messages.connectMessageSent:
       case actionTypes.messages.connectMessageReceived:
       case actionTypes.messages.hintMessageReceived:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -102,7 +102,7 @@ export default reduceReducers(
        * that both are owned by the user, remain
        * in the state.
        */
-      case actionTypes.account.login:
+      case actionTypes.account.loginFinished:
       case actionTypes.initialLoadFinished:
       case actionTypes.messages.connectMessageSent:
       case actionTypes.messages.connectMessageReceived:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/toast-reducer.js
@@ -14,7 +14,7 @@ export default function(allToasts = initialState, action = {}) {
       allToasts = pushNewToast(allToasts, "Info Toast", won.WON.infoToast);
       return allToasts;
 
-    case actionTypes.account.logout:
+    case actionTypes.account.reset:
       return initialState;
 
     case actionTypes.messages.connect.failure:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -22,7 +22,7 @@ export default function(viewState = initialState, action = {}) {
       return viewState.set("showMainMenu", true);
 
     case actionTypes.account.store:
-    case actionTypes.account.logout:
+    case actionTypes.account.reset:
     case actionTypes.view.hideMainMenu:
       return viewState.set("showMainMenu", false);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -21,7 +21,7 @@ export default function(viewState = initialState, action = {}) {
     case actionTypes.view.showMainMenu:
       return viewState.set("showMainMenu", true);
 
-    case actionTypes.account.login:
+    case actionTypes.account.store:
     case actionTypes.account.logout:
     case actionTypes.view.hideMainMenu:
       return viewState.set("showMainMenu", false);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -818,25 +818,6 @@ export function getParameters(url) {
   return params;
 }
 
-/**
- * Ellipsize a too long String
- * used in account-menu.js to ellipsize the email in the topnav
- * @param string
- * @param size
- * @returns {*}
- */
-export function ellipsizeString(string, size) {
-  if (string.length > size) {
-    return (
-      string.substring(0, 8) +
-      "…" +
-      string.substring(string.length - 5, string.length)
-    );
-  } else {
-    return string;
-  }
-}
-
 // from https://github.com/gagan-bansal/parse-svg/blob/master/index.js
 export function parseSVG(xmlString) {
   const div = document.createElementNS("http://www.w3.org/1999/xhtml", "div");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -521,7 +521,7 @@ export function fetchDataForNonOwnedNeedOnly(needUri) {
 export function fetchUnloadedData(dispatch) {
   return fetchOwnedInactiveNeedUris().then(needUris => {
     dispatch({
-      type: actionTypes.needs.fetchOwnedInactiveUrisLoading,
+      type: actionTypes.needs.storeOwnedInactiveUrisLoading,
       payload: wellFormedPayload({ uris: needUris }),
     });
     return fetchDataForOwnedNeeds(needUris, dispatch);
@@ -531,13 +531,13 @@ export function fetchUnloadedData(dispatch) {
 export function fetchOwnedData(email, dispatch) {
   return fetchOwnedInactiveNeedUris().then(inactiveNeedUris => {
     dispatch({
-      type: actionTypes.needs.fetchOwnedInactiveUris,
+      type: actionTypes.needs.storeOwnedInactiveUris,
       payload: wellFormedPayload({ uris: inactiveNeedUris }),
     });
 
     return fetchOwnedActiveNeedUris().then(needUris => {
       dispatch({
-        type: actionTypes.needs.fetchOwnedActiveUris,
+        type: actionTypes.needs.storeOwnedActiveUris,
         payload: wellFormedPayload({ uris: needUris }),
       });
 
@@ -690,7 +690,7 @@ export async function fetchDataForOwnedNeeds(ownedNeedUris, dispatch) {
 
   const theirNeedUris_ = Immutable.Set(theirNeedUris).toArray();
   dispatch({
-    type: actionTypes.needs.fetchTheirUrisLoading,
+    type: actionTypes.needs.storeTheirUrisLoading,
     payload: wellFormedPayload({ uris: theirNeedUris_ }),
   });
   const allTheirNeeds = await urisToLookupMap(theirNeedUris_, uri =>
@@ -746,7 +746,7 @@ function fetchOwnedNeedAndDispatch(needUri, dispatch) {
     .then(() => won.getNeed(needUri));
   needP.then(need =>
     dispatch({
-      type: actionTypes.needs.fetchOwned,
+      type: actionTypes.needs.storeOwned,
       payload: wellFormedPayload({ needs: { [needUri]: need } }),
     })
   );
@@ -771,7 +771,7 @@ function fetchTheirNeedAndDispatch(needUri, dispatch) {
       const personaUri = need["won:heldBy"]["@id"];
       won.getNeed(personaUri).then(personaNeed =>
         dispatch({
-          type: actionTypes.personas.fetchTheirs,
+          type: actionTypes.personas.storeTheirs,
           payload: wellFormedPayload({
             needs: { [personaUri]: personaNeed },
           }),
@@ -779,7 +779,7 @@ function fetchTheirNeedAndDispatch(needUri, dispatch) {
       );
     }
     dispatch({
-      type: actionTypes.needs.fetchTheirs,
+      type: actionTypes.needs.storeTheirs,
       payload: wellFormedPayload({ needs: { [needUri]: need } }),
     });
   });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -517,10 +517,6 @@ export async function buildCreateMessage(needData, wonNodeUri) {
   };
 }
 
-export function isSuccessMessage(event) {
-  return event.hasMessageType === won.WONMSG.successResponseCompacted;
-}
-
 export function fetchDataForNonOwnedNeedOnly(needUri) {
   return won
     .getNeed(needUri)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -728,7 +728,7 @@ async function fetchConnectionsOfNeedAndDispatch(needUri, dispatch) {
     connUri => !isConnUriClosed(connUri)
   );
   dispatch({
-    type: actionTypes.connections.fetchActiveUrisLoading,
+    type: actionTypes.connections.storeActiveUrisLoading,
     payload: wellFormedPayload({
       needUri: needUri,
       connUris: activeConnectionUris,
@@ -757,7 +757,7 @@ function fetchActiveConnectionAndDispatch(cnctUri, dispatch) {
   const cnctP = won.getNode(cnctUri);
   cnctP.then(connection =>
     dispatch({
-      type: actionTypes.connections.fetchActive,
+      type: actionTypes.connections.storeActive,
       payload: wellFormedPayload({ connections: { [cnctUri]: connection } }),
     })
   );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -704,7 +704,7 @@ export async function fetchDataForOwnedNeeds(ownedNeedUris, dispatch) {
   ]);
 
   return allDataRawPromise.then(
-    //TODO: ABCD DO STUFF HERE
+    //FIXME: NOT SURE IF THIS PROMISE IS ACTUALLY USING THE DATA STORED IN IT AT ALL
     ([ownedNeeds, connections, /* events, */ theirNeeds]) => {
       wellFormedPayload({
         ownedNeeds,


### PR DESCRIPTION
To make the reducer calls easier to read in the code and in the redux plugin, i refactored them to dispatch reducers named in a way that it is known what is actually stored in the state (instead of having multiple initialPageLoad or account.login dispatches)

This was not 100% necessary, but it makes the handling of reducers way easier and it gives us better insights in what is actually happening.

Due to this refactoring i found out that there is a big part of dead-code in the `load-action.js` as well as multiple duplicate reducer dispatches that could actually result in bugs that are hard to find.

I see this PR as preliminary work for our new privateId handling as well as for a completely different load approach in the future, we also have it easier now to extract view states from connections/needs/messages as we do not have to figure out a view state for the huge reducers actionTypes.account.login and actionTypes.initialPageLoad

Here is a log-snippet of the old redux dispatches:
![redux_reload_old](https://user-images.githubusercontent.com/8503486/49515842-55066500-f898-11e8-96e3-946201e3abf0.PNG)

Here is a log-snippet of the new redux dispatches:
![redux_reload_new](https://user-images.githubusercontent.com/8503486/49515862-60f22700-f898-11e8-871c-8dc5fadf4645.PNG)
