### PR TITLE
Feat classifieds usecases

### DIFF
--- a/webofneeds/won-docker/image/bigdata/RWStore.properties
+++ b/webofneeds/won-docker/image/bigdata/RWStore.properties
@@ -30,7 +30,7 @@ com.bigdata.journal.AbstractJournal.maximumExtent=209715200
 com.bigdata.rdf.sail.truthMaintenance=false
 com.bigdata.rdf.store.AbstractTripleStore.quads=true
 com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
-com.bigdata.rdf.store.AbstractTripleStore.textIndex=false
+com.bigdata.rdf.store.AbstractTripleStore.textIndex=true
 com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
 com.bigdata.rdf.store.AbstractTripleStore.geoSpatial=true
 

--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
@@ -149,6 +149,7 @@ public class SparqlMatcherActor extends UntypedActor {
             log.info(String.format("Caught exception when processing %s event %s. More info on loglevel 'debug'",
                     eventTypeForLogging, uriForLogging.orElse("[no uri available]")));
             log.debug("caught exception", e);
+            e.printStackTrace();
         }
     }
 

--- a/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
+++ b/webofneeds/won-matcher-sparql/src/main/java/won/matcher/sparql/actor/SparqlMatcherActor.java
@@ -149,7 +149,9 @@ public class SparqlMatcherActor extends UntypedActor {
             log.info(String.format("Caught exception when processing %s event %s. More info on loglevel 'debug'",
                     eventTypeForLogging, uriForLogging.orElse("[no uri available]")));
             log.debug("caught exception", e);
-            e.printStackTrace();
+            if(log.isDebugEnabled()){
+                e.printStackTrace();
+            }
         }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -349,6 +349,52 @@ export function tagOverlapScoreSubQuery({
 }
 
 /**
+ * Calculates the jaccard-index (i.e. normalized set-overlap) between own keywords
+ * and a potential match. Full overlap means 1, having none of the keywords means 0.
+ *
+ * @param {String} resultName a variable name that the score judges, e.g. `?need`
+ * @param {String} bindScoreAs the variable name for the score (use the same name for
+ *   sorting/aggregating in the parent query)
+ * @param {String} pathToText the predicates to be traversed to get to the text
+ *   in the RDF-graph.
+ * @param {*} prefixesInPath an object/map of prefix to full base-URL for all prefixes
+ *   used in the `pathToText`
+ * @param {String} keyword a keyword to intersect with potential matches' text
+ * @returns see `sparqlQuery`
+ */
+export function textSearchSubQuery({
+  resultName,
+  bindScoreAs,
+  pathToText,
+  prefixesInPath,
+  keyword,
+}) {
+  // TODO: rewrite this to fit text search instead of geo search
+  // see https://wiki.blazegraph.com/wiki/index.php/FullTextSearch
+  // TODO: what does the result mean?
+  if (!keyword || keyword.length <= 0) {
+    return undefined;
+  }
+
+  return sparqlQuery({
+    prefixes: {
+      ...prefixesInPath,
+      won: won.defaultContext["won"],
+      bds: "http://www.bigdata.com/rdf/search#",
+    },
+    variables: [resultName, bindScoreAs],
+    where: [
+      `${resultName} ${pathToText} ?lit`,
+      `SERVICE bds:search {
+              ?lit bds:search "${keyword}" .
+              ?lit bds:relevance ?score .
+            }`,
+      `BIND(?score as ${bindScoreAs})`,
+    ],
+  });
+}
+
+/**
  * Constructs a filter for which holds:
  *
  * `datetime - 12h <= matchedTime <= datetime + 12h`

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -369,9 +369,7 @@ export function textSearchSubQuery({
   prefixesInPath,
   keyword,
 }) {
-  // TODO: rewrite this to fit text search instead of geo search
   // see https://wiki.blazegraph.com/wiki/index.php/FullTextSearch
-  // TODO: what does the result mean?
   if (!keyword || keyword.length <= 0) {
     return undefined;
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/price.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/price.js
@@ -26,7 +26,11 @@ export const pricerange = {
   viewerComponent: "won-price-viewer",
   messageEnabled: true,
   parseToRDF: function({ value, identifier, contentUri }) {
-    if (!value || !(value.min || value.max) || !value.currency) {
+    if (
+      value === undefined ||
+      (value.min === undefined && value.max === undefined) ||
+      !value.currency
+    ) {
       return { "s:priceSpecification": undefined };
     }
     return {
@@ -70,7 +74,7 @@ export const pricerange = {
       "xsd:string"
     );
 
-    if (!minRent && !maxRent) {
+    if (minRent === undefined && maxRent === undefined) {
       return undefined;
     } else if (!currency) {
       return undefined;
@@ -90,6 +94,7 @@ export const pricerange = {
       const max = value.max;
 
       let amount;
+      // if min or max are 0, they equal to false -> fine here
       if (min && max) {
         amount = min + " - " + max;
       } else if (min) {
@@ -157,7 +162,12 @@ export const price = {
   ],
   messageEnabled: true,
   parseToRDF: function({ value, identifier, contentUri }) {
-    if (!value || value.amount === undefined || !value.currency) {
+    if (
+      !value ||
+      value.amount === undefined ||
+      value.amount < 0 ||
+      !value.currency
+    ) {
       return { "s:priceSpecification": undefined };
     }
 
@@ -193,7 +203,7 @@ export const price = {
       "xsd:string"
     );
 
-    if (!amount || !currency) {
+    if (amount === undefined || !currency) {
       return undefined;
     } else {
       return { amount: amount, currency: currency, unitCode: unitCode };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/price.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/price.js
@@ -44,7 +44,7 @@ export const pricerange = {
         ],
         "s:priceCurrency": value.currency,
         "s:unitCode": value.unitCode,
-        "s:description": "total rent per month in between min/max",
+        "s:description": "price in between min/max",
       },
     };
   },
@@ -157,7 +157,7 @@ export const price = {
   ],
   messageEnabled: true,
   parseToRDF: function({ value, identifier, contentUri }) {
-    if (!value || !value.amount || !value.currency) {
+    if (!value || value.amount === undefined || !value.currency) {
       return { "s:priceSpecification": undefined };
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -7,6 +7,7 @@ import { socialGroup } from "./usecases/social.js";
 import { professionalGroup } from "./usecases/professional/professional.js";
 import { mobilityGroup } from "./usecases/mobility.js";
 import { musicianGroup } from "./usecases/musician.js";
+import { classifiedsGroup } from "./usecases/classifieds.js";
 
 import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../app/won-utils.js";
 
@@ -72,6 +73,7 @@ export const useCaseGroups = {
   musician: musicianGroup,
   social: socialGroup,
   professional: professionalGroup,
+  classifieds: classifiedsGroup,
   other: {
     identifier: "othergroup",
     label: "Something Else",

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
@@ -4,8 +4,15 @@
 
 import { details, emptyDraft } from "../detail-definitions.js";
 import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
-//import won from "../../app/won-es6.js";
-//import { getIn, isValidDate } from "../../app/utils.js";
+import won from "../../app/won-es6.js";
+import { getIn, is } from "../../app/utils.js";
+import {
+  filterInVicinity,
+  textSearchSubQuery,
+  vicinityScoreSubQuery,
+  //concatenateFilters,
+  sparqlQuery,
+} from "../../app/sparql-builder-utils.js";
 
 const classifiedsUseCases = {
   goodsOffer: {
@@ -16,25 +23,139 @@ const classifiedsUseCases = {
     draft: {
       ...emptyDraft,
       content: {
-        title: "Offer Something",
+        title: "I'm offering something!",
         type: "s:Offer",
+      },
+      seeks: {
+        type: "s:Demand",
       },
     },
     details: {
       title: { ...details.title },
       description: { ...details.description },
-      fromDatetime: { ...details.fromDatetime },
-      throughDatetime: { ...details.throughDatetime },
+      price: { ...details.price, mandatory: true },
+      tags: { ...details.tags },
       location: { ...details.location },
-      price: { ...details.price },
       images: { ...details.images },
     },
+    // TODO: what should this match on?
     generateQuery: (draft, resultName) => {
-      if (draft && resultName) {
-        // do nothing
+      const location = getIn(draft, ["content", "location"]);
+
+      const filters = [
+        {
+          // to select seeks-branch
+          prefixes: {
+            won: won.defaultContext["won"],
+          },
+          operations: [
+            `${resultName} a won:Need.`,
+            `${resultName} won:seeks ?seeks.`,
+            location && "?seeks won:hasLocation/s:location ?location.",
+          ],
+        },
+
+        filterInVicinity("?location", location, /*radius=*/ 5),
+      ];
+
+      // exists only because of compile restrictions
+      if (draft && resultName && filters) {
+        // TODO: delete this
       }
     },
   },
+  goodsDemand: {
+    identifier: "goodsDemand",
+    label: "Look for something",
+    icon: "#ico36_uc_plus",
+    draft: {
+      ...emptyDraft,
+      content: {
+        title: "I'm looking for something!",
+        type: "s:Demand",
+      },
+      seeks: {
+        type: "s:Offer",
+      },
+    },
+    details: {
+      location: { ...details.location }, // can this picker be displayed below other details?
+    },
+    seeksDetails: {
+      tags: {
+        ...details.tags,
+        label: "Keywords to search for",
+        mandatory: true,
+      },
+      priceRange: { ...details.pricerange },
+      description: { ...details.description },
+    },
+    generateQuery: (draft, resultName) => {
+      let subQueries = [];
+      // TODO: bindScoreAs should be unique, can't contain spaces -> filter tags and add to name
+      const tags = getIn(draft, ["seeks", "tags"]);
+      if (tags && is("Array", tags) && tags.length > 0) {
+        for (let tag of tags) {
+          let keywordTitleSQ = textSearchSubQuery({
+            resultName: resultName,
+            bindScoreAs: "?keywordsTitle_index",
+            pathToText: "dc:title",
+            prefixesInPath: {
+              dc: won.defaultContext["dc"],
+            },
+            keyword: tag,
+          });
+
+          subQueries.push(keywordTitleSQ);
+        }
+      }
+
+      const vicinityScoreSQ = vicinityScoreSubQuery({
+        resultName: resultName,
+        bindScoreAs: "?location_geoScore",
+        pathToGeoCoords: "s:location/s:geo",
+        prefixesInPath: {
+          s: won.defaultContext["s"],
+        },
+        geoCoordinates: getIn(draft, ["seeks", "location"]),
+      });
+
+      subQueries.push(vicinityScoreSQ);
+
+      subQueries = subQueries
+        .filter(sq => sq) // filters out "undefined" subqueries
+        .map(sq => ({
+          query: sq,
+          optional: true,
+        }));
+
+      const query = sparqlQuery({
+        prefixes: {
+          won: won.defaultContext["won"],
+          rdf: won.defaultContext["rdf"],
+          dc: won.defaultContext["dc"],
+          s: won.defaultContext["s"],
+        },
+        distinct: true,
+        variables: [resultName],
+        subQueries: subQueries,
+        where: [
+          `${resultName} rdf:type won:Need.`,
+          `${resultName} rdf:type s:Offer.`,
+
+          `BIND( ( 
+              COALESCE(?keywordsTitle_index, 0) +
+              COALESCE(?location_geoScore, 0) 
+            ) as ?aggregatedScore)`,
+        ],
+        orderBy: [{ order: "DESC", variable: "?aggregatedScore" }],
+      });
+
+      return query;
+    },
+  },
+  // TODO: go over details for fitting demand counterpart
+  // TODO: query
   servicesOffer: {
     identifier: "servicesOffer",
     label: "Offer a Service",
@@ -55,12 +176,13 @@ const classifiedsUseCases = {
       location: { ...details.location },
       price: { ...details.price },
     },
-    generateQuery: (draft, resultName) => {
-      if (draft && resultName) {
-        // do nothing
-      }
-    },
+    // generateQuery: (draft, resultName) => {
+    //   if (draft && resultName) {
+    //     // do nothing
+    //   }
+    // },
   },
+  // TODO: servicesDemand: {},
 };
 
 export const classifiedsGroup = {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
@@ -53,7 +53,6 @@ const classifiedsUseCases = {
     draft: {
       ...emptyDraft,
       content: {
-        title: "I'm looking for something!",
         type: "s:Demand",
       },
       seeks: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
@@ -1,0 +1,71 @@
+/**
+ * Created by kweinberger on 06.12.2018.
+ */
+
+import { details, emptyDraft } from "../detail-definitions.js";
+import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
+//import won from "../../app/won-es6.js";
+//import { getIn, isValidDate } from "../../app/utils.js";
+
+const classifiedsUseCases = {
+  goodsOffer: {
+    identifier: "goodsOffer",
+    label: "Offer Something",
+    icon: "#ico36_uc_plus",
+    doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+    draft: {
+      ...emptyDraft,
+      content: {
+        title: "Offer Something",
+        type: "s:Offer",
+      },
+    },
+    details: {
+      title: { ...details.title },
+      description: { ...details.description },
+      fromDatetime: { ...details.fromDatetime },
+      throughDatetime: { ...details.throughDatetime },
+      location: { ...details.location },
+      price: { ...details.price },
+      images: { ...details.images },
+    },
+    generateQuery: (draft, resultName) => {
+      if (draft && resultName) {
+        // do nothing
+      }
+    },
+  },
+  servicesOffer: {
+    identifier: "servicesOffer",
+    label: "Offer a Service",
+    icon: "#ico36_uc_plus",
+    doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+    draft: {
+      ...emptyDraft,
+      content: {
+        title: "Offer a Service",
+        type: "s:Offer",
+      },
+    },
+    details: {
+      title: { ...details.title },
+      description: { ...details.description },
+      fromDatetime: { ...details.fromDatetime },
+      throughDatetime: { ...details.throughDatetime },
+      location: { ...details.location },
+      price: { ...details.price },
+    },
+    generateQuery: (draft, resultName) => {
+      if (draft && resultName) {
+        // do nothing
+      }
+    },
+  },
+};
+
+export const classifiedsGroup = {
+  identifier: "classifiedsgroup",
+  label: "Classified Ads",
+  icon: undefined,
+  useCases: { ...classifiedsUseCases },
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/classifieds.js
@@ -3,11 +3,10 @@
  */
 
 import { details, emptyDraft } from "../detail-definitions.js";
-import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
 import won from "../../app/won-es6.js";
 import { getIn, is } from "../../app/utils.js";
 import {
-  filterInVicinity,
+  // filterInVicinity,
   textSearchSubQuery,
   vicinityScoreSubQuery,
   filterRentRange,
@@ -16,16 +15,15 @@ import {
 } from "../../app/sparql-builder-utils.js";
 
 /*
-TODO: send hints to counterparts of searches
-TODO: queries for offers
+TODO: send hints to counterparts of searches (offers)
+TODO: create use case icons
 */
 
 const classifiedsUseCases = {
   goodsOffer: {
     identifier: "goodsOffer",
     label: "Offer Something",
-    icon: "#ico36_uc_plus",
-    doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+    icon: "#ico36_plus",
     draft: {
       ...emptyDraft,
       content: {
@@ -44,35 +42,14 @@ const classifiedsUseCases = {
       images: { ...details.images },
     },
     // TODO: what should this match on?
-    generateQuery: (draft, resultName) => {
-      const location = getIn(draft, ["content", "location"]);
-
-      const filters = [
-        {
-          // to select seeks-branch
-          prefixes: {
-            won: won.defaultContext["won"],
-          },
-          operations: [
-            `${resultName} a won:Need.`,
-            `${resultName} won:seeks ?seeks.`,
-            location && "?seeks won:hasLocation/s:location ?location.",
-          ],
-        },
-
-        filterInVicinity("?location", location, /*radius=*/ 5),
-      ];
-
-      // exists only because of compile restrictions
-      if (draft && resultName && filters) {
-        // TODO: delete this
-      }
-    },
+    // generateQuery: (draft, resultName) => {
+    //   // return query
+    // },
   },
   goodsDemand: {
     identifier: "goodsDemand",
     label: "Look for something",
-    icon: "#ico36_uc_plus",
+    icon: "#ico36_plus",
     draft: {
       ...emptyDraft,
       content: {
@@ -84,6 +61,7 @@ const classifiedsUseCases = {
       },
     },
     seeksDetails: {
+      title: { ...details.title },
       tags: {
         ...details.tags,
         label: "Keywords to search for",
@@ -235,27 +213,23 @@ const classifiedsUseCases = {
   servicesOffer: {
     identifier: "servicesOffer",
     label: "Offer a Service",
-    icon: "#ico36_uc_plus",
-    doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+    icon: "#ico36_plus",
     draft: {
       ...emptyDraft,
       content: {
-        title: "Offer a Service",
         type: "s:Offer",
       },
     },
     details: {
-      title: { ...details.title },
+      title: { ...details.title, mandatory: true },
       description: { ...details.description },
-      fromDatetime: { ...details.fromDatetime },
-      throughDatetime: { ...details.throughDatetime },
+      price: { ...details.price, mandatory: true },
+      tags: { ...details.tags },
       location: { ...details.location },
-      price: { ...details.price },
     },
+    // TODO: what should this match on?
     // generateQuery: (draft, resultName) => {
-    //   if (draft && resultName) {
-    //     // do nothing
-    //   }
+    //   // return query
     // },
   },
   // TODO: servicesDemand: {},


### PR DESCRIPTION
Adds usecases for "classified ads" that allow offering and searching for objects and services. The demand use case has a custom sparql query that matches to offers containing keywords, the offer use cases don't have custom queries yet. Matches should be symmetrical (i.e. hints sent to both needs), but currently aren't, only demands get hints.

This also changes a property in `webofneeds/won-docker/image/bigdata/RWStore.properties#33` that enables text indexing. As this is a potentially expensive operation, this may impact performance.

Closes #2512 