### PR TITLE
Feat improve queries

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateNeedFromJobAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateNeedFromJobAction.java
@@ -236,6 +236,7 @@ public class CreateNeedFromJobAction extends AbstractCreateNeedAction {
         }
 
         seeksPart.addProperty(RDF.type, SCHEMA.PERSON);
+        seeksPart.addProperty(WON.SEEKS, SCHEMA.JOBPOSTING);
 
         needModelWrapper.addFacet("#ChatFacet", WON.CHAT_FACET_STRING);
 

--- a/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
+++ b/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
@@ -232,9 +232,24 @@ public class SparqlQueryTest  {
         checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.hintForCounterpartQuery(op, resultName, scoreName,30));
     }
 
+    @Test
+    public void testSearchQuery() throws Exception {
+        String expectedQueryString = getResourceAsString("sparqlquerytest/searchstring-query/expected.rq");
+        Var resultName = Var.alloc("result");
+        Var scoreName = Var.alloc("score");
+        Op actualOp = SparqlMatcherUtils.createSearchQuery("The Query String", resultName, 3, false, false);
+        
+        Query expectedQuery = QueryFactory.create(expectedQueryString);
+        Op expectedOp = Algebra.compile(expectedQuery);
+        String actual = OpAsQuery.asQuery(actualOp).toString();
+        String expected = OpAsQuery.asQuery(expectedOp).toString();
+        Assert.assertEquals(expected, actual);
+    }
+    
     private void checkResult(String queryString, String expectedQueryString, Function<Op, Op> transform) {
         Query query = QueryFactory.create(queryString);
         Op queryOp = Algebra.compile(query);
+        
         
         Op actualOp = transform.apply(queryOp);
         Query expectedQuery = QueryFactory.create(expectedQueryString);

--- a/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
+++ b/webofneeds/won-matcher-sparql/src/test/java/won/matcher/sparql/SparqlQueryTest.java
@@ -93,7 +93,7 @@ public class SparqlQueryTest  {
         Query query = QueryFactory.create(queryString);
         Op queryOp = Algebra.compile(query);
         
-        Op transformed = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, Var.alloc("result"), Var.alloc("score"), 10);
+        Op transformed = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, Var.alloc("result"));
         
         
         System.out.println("query algebra: " + queryOp);
@@ -191,22 +191,22 @@ public class SparqlQueryTest  {
         Query query = QueryFactory.create(queryString);
         Op queryOp = Algebra.compile(query);
         
-        Op actualOp = SparqlMatcherUtils.noHintForCounterpartQuery(queryOp, resultName, scoreName, 30);
+        Op actualOp = SparqlMatcherUtils.noHintForCounterpartQuery(queryOp, resultName);
         Query expected = QueryFactory.create(queryStringNoHintForCounterpartExpected);
         Op expectedOp = Algebra.compile(expected);
         Assert.assertEquals(OpAsQuery.asQuery(expectedOp).toString(), OpAsQuery.asQuery(actualOp).toString());
         
-        actualOp = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, resultName, scoreName, 30);
+        actualOp = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, resultName);
         expected = QueryFactory.create(queryStringHintForCounterpartExpected);
         expectedOp = Algebra.compile(expected);
         Assert.assertEquals(OpAsQuery.asQuery(expectedOp).toString(), OpAsQuery.asQuery(actualOp).toString());
         
-        actualOp = SparqlMatcherUtils.noHintForCounterpartQuery(queryOp, resultName, scoreName, 30);
+        actualOp = SparqlMatcherUtils.noHintForCounterpartQuery(queryOp, resultName);
         expected = QueryFactory.create(queryStringNoHintForCounterpartExpected);
         expectedOp = Algebra.compile(expected);
         Assert.assertEquals(OpAsQuery.asQuery(expectedOp).toString(), OpAsQuery.asQuery(actualOp).toString());
         
-        actualOp = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, resultName, scoreName, 30);
+        actualOp = SparqlMatcherUtils.hintForCounterpartQuery(queryOp, resultName);
         expected = QueryFactory.create(queryStringHintForCounterpartExpected);
         expectedOp = Algebra.compile(expected);
         Assert.assertEquals(OpAsQuery.asQuery(expectedOp).toString(), OpAsQuery.asQuery(actualOp).toString());
@@ -220,7 +220,7 @@ public class SparqlQueryTest  {
         String expectedQueryString = getResourceAsString("sparqlquerytest/no-hint-for-counterpart/expected.rq");
         Var resultName = Var.alloc("result");
         Var scoreName = Var.alloc("score");
-        checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.noHintForCounterpartQuery(op, resultName, scoreName,30));
+        checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.noHintForCounterpartQuery(op, resultName));
     }
     
     @Test
@@ -229,7 +229,16 @@ public class SparqlQueryTest  {
         String expectedQueryString = getResourceAsString("sparqlquerytest/hint-for-counterpart/expected.rq");
         Var resultName = Var.alloc("result");
         Var scoreName = Var.alloc("score");
-        checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.hintForCounterpartQuery(op, resultName, scoreName,30));
+        checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.hintForCounterpartQuery(op, resultName));
+    }
+    
+    @Test
+    public void testAddRequiredFlag_hintForCounterpart_complex1() throws Exception {
+        String queryString = getResourceAsString("sparqlquerytest/nhfc-complex-query1/input.rq");
+        String expectedQueryString = getResourceAsString("sparqlquerytest/nhfc-complex-query1/expected.rq");
+        Var resultName = Var.alloc("result");
+        Var scoreName = Var.alloc("score");
+        checkResult(queryString, expectedQueryString, op -> SparqlMatcherUtils.noHintForCounterpartQuery(op, resultName));
     }
 
     @Test
@@ -257,13 +266,13 @@ public class SparqlQueryTest  {
         String actual = OpAsQuery.asQuery(actualOp).toString();
         
         String expected = OpAsQuery.asQuery(expectedOp).toString();
-       /* System.out.println("expected:");
+        System.out.println("expected:");
         System.out.println(expectedOp);
         System.out.println(expected);
         System.out.println("actual:");
         System.out.println(actualOp);
         System.out.println(actual);
-        */
+        
         Assert.assertEquals(expected, actual);
     }
 }

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/hint-for-counterpart/expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/hint-for-counterpart/expected.rq
@@ -1,4 +1,4 @@
-SELECT DISTINCT  ?result ?score
+SELECT  ?result ?score
 WHERE
   { { BIND(( ( ( ( ( ( ( year(?created) - 1970 ) * 315360000 ) + ( month(?created) * 26280000 ) ) + ( day(?created) * 86400 ) ) + ( hours(?created) * 3600 ) ) + ( minutes(?created) * 60 ) ) + seconds(?created) ) AS ?score)
       ?result  a                     <http://purl.org/webofneeds/model#Need> ;
@@ -7,6 +7,4 @@ WHERE
     }
     FILTER NOT EXISTS { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart> }
   }
-ORDER BY DESC(?score)
-OFFSET  0
-LIMIT   30
+

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/nhfc-complex-query1/expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/nhfc-complex-query1/expected.rq
@@ -1,0 +1,43 @@
+SELECT DISTINCT  ?result ?score
+WHERE
+  { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart>
+    { { { OPTIONAL
+            { { SELECT DISTINCT  ?result ?industry_jaccardIndex
+                WHERE
+                  { { { SELECT  ?result (SUM(?var0) AS ?targetOverlap) (COUNT(?result) AS ?targetTotal)
+                        WHERE
+                          { ?result  <http://schema.org/industry>  ?tag
+                            BIND(if(( str(?tag) = "KarosseriebauerIn" ), 1, 0) AS ?var0)
+                          }
+                        GROUP BY ?result
+                      }
+                      BIND(( ?targetOverlap / ( ( ?targetTotal + 1 ) - ?targetOverlap ) ) AS ?industry_jaccardIndex)
+                    }
+                    FILTER ( ?industry_jaccardIndex > 0 )
+                  }
+              }
+            }
+          OPTIONAL
+            { { SELECT  ?result (if(( ?geoScoreRaw > 0 ), ?geoScoreRaw, 0) AS ?jobLocation_geoScore)
+                WHERE
+                  { ?result <http://schema.org/jobLocation>/<http://schema.org/geo> ?geo
+                    { SERVICE <http://www.bigdata.com/rdf/geospatial#search>
+                        { ?geo  <http://www.bigdata.com/rdf/geospatial#search>  "inCircle" ;
+                                <http://www.bigdata.com/rdf/geospatial#searchDatatype>  <http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon> ;
+                                <http://www.bigdata.com/rdf/geospatial#predicate>  <http://purl.org/webofneeds/model#geoSpatial> ;
+                                <http://www.bigdata.com/rdf/geospatial#spatialCircleCenter>  "48.22350935259615#16.38684868812561" ;
+                                <http://www.bigdata.com/rdf/geospatial#spatialCircleRadius>  "10" ;
+                                <http://www.bigdata.com/rdf/geospatial#distanceValue>  ?geoDistance}
+                      BIND(( ( 10 - ?geoDistance ) / 10 ) AS ?geoScoreRaw)
+                    }
+                  }
+              }
+            }
+        }
+        ?result  a                     <http://purl.org/webofneeds/model#Need> ;
+                 a                     <http://schema.org/JobPosting>
+      }
+      BIND(( ( ( ( ( coalesce(?industry_jaccardIndex, 0) + coalesce(?skills_jaccardIndex, 0) ) + coalesce(?organizationName_jaccardIndex, 0) ) + coalesce(?employmentTypes_jaccardIndex, 0) ) + coalesce(?jobLocation_geoScore, 0) ) / 5 ) AS ?score)
+    }
+  }
+ORDER BY DESC(?score)

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/nhfc-complex-query1/input.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/nhfc-complex-query1/input.rq
@@ -1,0 +1,40 @@
+PREFIX won: <http://purl.org/webofneeds/model#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX s: <http://schema.org/>
+PREFIX geo: <http://www.bigdata.com/rdf/geospatial#>
+PREFIX geoliteral: <http://www.bigdata.com/rdf/geospatial/literals/v1#>
+SELECT DISTINCT ?result ?score WHERE {
+  OPTIONAL {
+    SELECT DISTINCT ?result ?industry_jaccardIndex WHERE {
+      {
+        SELECT ?result (SUM(?var0) AS ?targetOverlap) (COUNT(?result) AS ?targetTotal) WHERE {
+          ?result s:industry ?tag.
+          BIND(IF((STR(?tag)) = "KarosseriebauerIn", 1 , 0 ) AS ?var0)
+        }
+        GROUP BY ?result
+      }
+      BIND(?targetOverlap / ((?targetTotal + 1 ) - ?targetOverlap) AS ?industry_jaccardIndex)
+      FILTER(?industry_jaccardIndex > 0 )
+    }
+  }
+  OPTIONAL {
+    SELECT ?result ?jobLocation_geoScore WHERE {
+      ?result (s:jobLocation/s:geo) ?geo.
+      {
+      SERVICE geo:search {
+        ?geo geo:search "inCircle";
+          geo:searchDatatype geoliteral:lat-lon;
+          geo:predicate won:geoSpatial;
+          geo:spatialCircleCenter "48.22350935259615#16.38684868812561";
+          geo:spatialCircleRadius "10";
+          geo:distanceValue ?geoDistance.
+      }
+      BIND((10  - ?geoDistance) / 10  AS ?geoScoreRaw)
+      }
+      BIND(IF(?geoScoreRaw > 0 , ?geoScoreRaw, 0 ) AS ?jobLocation_geoScore)
+    }
+  }
+  ?result rdf:type won:Need, s:JobPosting.
+  BIND((((((COALESCE(?industry_jaccardIndex, 0 )) + (COALESCE(?skills_jaccardIndex, 0 ))) + (COALESCE(?organizationName_jaccardIndex, 0 ))) + (COALESCE(?employmentTypes_jaccardIndex, 0 ))) + (COALESCE(?jobLocation_geoScore, 0 ))) / 5  AS ?score)
+}
+ORDER BY DESC (?score)

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/no-hint-for-counterpart/expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/no-hint-for-counterpart/expected.rq
@@ -1,13 +1,9 @@
-SELECT DISTINCT  ?result ?score
+SELECT  ?result ?score
 WHERE
   { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart>
-    { { BIND(( ( ( ( ( ( ( year(?created) - 1970 ) * 315360000 ) + ( month(?created) * 26280000 ) ) + ( day(?created) * 86400 ) ) + ( hours(?created) * 3600 ) ) + ( minutes(?created) * 60 ) ) + seconds(?created) ) AS ?score)
-        ?result  a                     <http://purl.org/webofneeds/model#Need> ;
-                 <http://purl.org/webofneeds/model#isInState>  <http://purl.org/webofneeds/model#Active> ;
-                 <http://purl.org/dc/terms/created>  ?created
-      }
+    { BIND(( ( ( ( ( ( ( year(?created) - 1970 ) * 315360000 ) + ( month(?created) * 26280000 ) ) + ( day(?created) * 86400 ) ) + ( hours(?created) * 3600 ) ) + ( minutes(?created) * 60 ) ) + seconds(?created) ) AS ?score)
+      ?result  a                     <http://purl.org/webofneeds/model#Need> ;
+               <http://purl.org/webofneeds/model#isInState>  <http://purl.org/webofneeds/model#Active> ;
+               <http://purl.org/dc/terms/created>  ?created
     }
   }
-ORDER BY DESC(?score)
-OFFSET  0
-LIMIT   30

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/query-searchstring-hintForCounterpart-expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/query-searchstring-hintForCounterpart-expected.rq
@@ -1,12 +1,10 @@
-SELECT DISTINCT  *
+SELECT  ?result ?score
 WHERE
-  { SELECT  ?result
-    WHERE
-      { ?result  a                     <http://purl.org/webofneeds/model#Need> ;
-                 ?prop                 ?textSearchTarget
-        FILTER contains(lcase(?textSearchTarget), "wtf")
-        FILTER NOT EXISTS { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart> }
-      }
-    OFFSET  0
-    LIMIT   30
+  { { BIND(( ( ( ( ( ( ( year(?created) - 1970 ) * 315360000 ) + ( month(?created) * 26280000 ) ) + ( day(?created) * 86400 ) ) + ( hours(?created) * 3600 ) ) + ( minutes(?created) * 60 ) ) + seconds(?created) ) AS ?score)
+      ?result  a                     <http://purl.org/webofneeds/model#Need> ;
+               <http://purl.org/webofneeds/model#isInState>  <http://purl.org/webofneeds/model#Active> ;
+               <http://purl.org/dc/terms/created>  ?created
+    }
+    FILTER NOT EXISTS { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart> }
   }
+

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/query-searchstring-noHintForCounterpart-expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/query-searchstring-noHintForCounterpart-expected.rq
@@ -1,13 +1,9 @@
-SELECT DISTINCT  *
+SELECT  ?result ?score
 WHERE
-  { SELECT  ?result
-    WHERE
-      { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart>
-        { ?result  a                     <http://purl.org/webofneeds/model#Need> ;
-                   ?prop                 ?textSearchTarget
-          FILTER contains(lcase(?textSearchTarget), "wtf")
-        }
-      }
-    OFFSET  0
-    LIMIT   30
+  { ?result  <http://purl.org/webofneeds/model#hasFlag>  <http://purl.org/webofneeds/model#NoHintForCounterpart>
+    { BIND(( ( ( ( ( ( ( year(?created) - 1970 ) * 315360000 ) + ( month(?created) * 26280000 ) ) + ( day(?created) * 86400 ) ) + ( hours(?created) * 3600 ) ) + ( minutes(?created) * 60 ) ) + seconds(?created) ) AS ?score)
+      ?result  a                     <http://purl.org/webofneeds/model#Need> ;
+               <http://purl.org/webofneeds/model#isInState>  <http://purl.org/webofneeds/model#Active> ;
+               <http://purl.org/dc/terms/created>  ?created
+    }
   }

--- a/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/searchstring-query/expected.rq
+++ b/webofneeds/won-matcher-sparql/src/test/resources/sparqlquerytest/searchstring-query/expected.rq
@@ -1,0 +1,19 @@
+SELECT  *
+WHERE
+  { ?result  a                     <http://purl.org/webofneeds/model#Need>
+      {   { ?result  ?tmpProp_0  ?textSearchTarget
+            FILTER contains(lcase(?textSearchTarget), "the query string")
+          }
+        UNION
+          { ?result   ?tmpProp_0  ?tmpObj_0 .
+            ?tmpObj_0  ?tmpProp_1  ?textSearchTarget
+            FILTER contains(lcase(?textSearchTarget), "the query string")
+          }
+      }
+    UNION
+      { ?result   ?tmpProp_0  ?tmpObj_0 .
+        ?tmpObj_0  ?tmpProp_1  ?tmpObj_1 .
+        ?tmpObj_1  ?tmpProp_2  ?textSearchTarget
+        FILTER contains(lcase(?textSearchTarget), "the query string")
+      }
+  }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -306,7 +306,7 @@ public class NeedInformationServiceImpl implements NeedInformationService
             Integer version = Integer.valueOf(etag);
             need = needRepository.findOneByNeedURIAndVersionNot(needURI, version);
         }
-        boolean isDeleted = !!(need.getState() == NeedState.DELETED);
+        boolean isDeleted = need != null && (need.getState() == NeedState.DELETED);
         
         return new DataWithEtag<>(need, need == null ? etag : Integer.toString(need.getVersion()), etag, isDeleted);
     }
@@ -316,7 +316,7 @@ public class NeedInformationServiceImpl implements NeedInformationService
   {
     if (needURI == null) throw new IllegalArgumentException("needURI is not set");
     Need need = DataAccessUtils.loadNeed(needRepository, needURI);
-    return need.getState() == NeedState.DELETED? ModelFactory.createDefaultModel() : need.getDatatsetHolder().getDataset().getDefaultModel();
+    return (need == null || need.getState() == NeedState.DELETED) ? ModelFactory.createDefaultModel() : need.getDatatsetHolder().getDataset().getDefaultModel();
   }
 
   @Override

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -189,7 +189,7 @@ import { Generator } from "sparqljs";
       const queryMask = {
         type: "query",
         queryType: "SELECT",
-        variables: ["?result"],
+        variables: ["?result", "?score"],
       };
 
       let useCaseQuery = {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -256,6 +256,7 @@ export function vicinityScoreSubQuery({
     variables: [resultName, bindScoreAs],
     where: [
       `${resultName} ${pathToGeoCoords} ?geo`,
+      `{`,
       `SERVICE geo:search {
             ?geo geo:search "inCircle" .
             ?geo geo:searchDatatype geoliteral:lat-lon .
@@ -265,6 +266,7 @@ export function vicinityScoreSubQuery({
             ?geo geo:distanceValue ?geoDistance .
           }`,
       `BIND((${radius} - ?geoDistance) / ${radius} as ?geoScoreRaw)`, // 100 is the spatialCircleRadius / maxDistance in km
+      `}`, //we have to separate the two BIND operators to circumvent a jena Op->Sparql bug 
       `BIND(IF(?geoScoreRaw > 0, ?geoScoreRaw , 0 ) as ${bindScoreAs})`,
     ],
   });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -602,6 +602,8 @@ export function generateWhatsAroundQuery(latitude, longitude) {
                       ?location_geo geo:distanceValue ?location_geoDistance.
                   }
                   FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
+                  FILTER NOT EXISTS { ?result won:hasFlag won:WhatsNew }
+                  FILTER NOT EXISTS { ?result won:hasFlag won:WhatsAround }
               }
             }
           UNION {
@@ -624,6 +626,8 @@ export function generateWhatsAroundQuery(latitude, longitude) {
                       ?location_geo geo:distanceValue ?location_geoDistance.
                   }
                   FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
+                  FILTER NOT EXISTS { ?result won:hasFlag won:WhatsNew }
+                  FILTER NOT EXISTS { ?result won:hasFlag won:WhatsAround }
               }
             }
           }
@@ -635,18 +639,20 @@ export function generateWhatsNewQuery() {
   return `PREFIX won: <http://purl.org/webofneeds/model#>
         PREFIX s: <http://schema.org/>
         PREFIX dct: <http://purl.org/dc/terms/>
-        SELECT DISTINCT ?result ?score WHERE {
-          BIND ((YEAR(?created) - 1970) * 315360000
+        SELECT DISTINCT ?result ((YEAR(?created) - 1970) * 315360000
                + MONTH(?created) * 26280000
                + DAY(?created) * 86400
                + HOURS(?created) * 3600
                + MINUTES(?created) * 60
                + SECONDS(?created)
                 as ?score)
+                WHERE {
           ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.
-          ?result won:isInState  won:Active .
+          ?result won:isInState won:Active .
           ?result dct:created ?created.
           FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
+          FILTER NOT EXISTS { ?result won:hasFlag won:WhatsNew }
+          FILTER NOT EXISTS { ?result won:hasFlag won:WhatsAround }
         }
-        ORDER BY DESC(?score)`;
+        ORDER BY DESC(?created)`;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -266,7 +266,7 @@ export function vicinityScoreSubQuery({
             ?geo geo:distanceValue ?geoDistance .
           }`,
       `BIND((${radius} - ?geoDistance) / ${radius} as ?geoScoreRaw)`, // 100 is the spatialCircleRadius / maxDistance in km
-      `}`, //we have to separate the two BIND operators to circumvent a jena Op->Sparql bug 
+      `}`, //we have to separate the two BIND operators to circumvent a jena Op->Sparql bug
       `BIND(IF(?geoScoreRaw > 0, ?geoScoreRaw , 0 ) as ${bindScoreAs})`,
     ],
   });

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/complain.js
@@ -22,7 +22,9 @@ export const complainGroup = {
           title: "WTF?",
           tags: ["wtf"],
         },
-        seeks: {},
+        seeks: {
+          type: "won:HandleComplaint",
+        },
       },
       details: {
         title: { ...details.title },
@@ -43,6 +45,7 @@ export const complainGroup = {
         content: {
           type: "won:HandleComplaint",
           title: "I'll discuss complaints",
+          searchString: "wtf",
         },
         seeks: {
           type: "won:Complaint",

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/complain.js
@@ -18,9 +18,9 @@ export const complainGroup = {
       draft: {
         ...emptyDraft,
         content: {
+          type: "won:Complaint",
           title: "WTF?",
           tags: ["wtf"],
-          searchString: "wtf",
         },
         seeks: {},
       },
@@ -41,10 +41,12 @@ export const complainGroup = {
       draft: {
         ...emptyDraft,
         content: {
+          type: "won:HandleComplaint",
           title: "I'll discuss complaints",
-          searchString: "wtf",
         },
-        seeks: {},
+        seeks: {
+          type: "won:Complaint",
+        },
       },
       details: {
         title: { ...details.title },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-offer.js
@@ -148,7 +148,7 @@ export const jobOffer = {
         s: won.defaultContext["s"],
       },
       distinct: true,
-      variables: [resultName],
+      variables: [resultName, "?score"],
       subQueries: subQueries,
       where: [
         `${resultName} rdf:type won:Need.`,
@@ -161,10 +161,10 @@ export const jobOffer = {
           COALESCE(?organizationName_jaccardIndex, 0) + 
           COALESCE(?employmentTypes_jaccardIndex, 0) + 
           COALESCE(?jobLocation_geoScore, 0) 
-        ) / 5  as ?aggregatedScore)`,
-        // `FILTER(?aggregatedScore > 0)`, // not necessary atm to filter; there are parts of job-postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
+        ) / 5  as ?score)`,
+        // `FILTER(?score > 0)`, // not necessary atm to filter; there are parts of job-postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
       ],
-      orderBy: [{ order: "DESC", variable: "?aggregatedScore" }],
+      orderBy: [{ order: "DESC", variable: "?score" }],
     });
 
     return query;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/professional/job-search.js
@@ -156,7 +156,7 @@ export const jobSearch = {
         s: won.defaultContext["s"],
       },
       distinct: true,
-      variables: [resultName],
+      variables: [resultName, "?score"],
       subQueries: subQueries,
       where: [
         `${resultName} rdf:type won:Need.`,
@@ -169,10 +169,10 @@ export const jobSearch = {
           COALESCE(?organizationName_jaccardIndex, 0) + 
           COALESCE(?employmentTypes_jaccardIndex, 0) + 
           COALESCE(?jobLocation_geoScore, 0) 
-        ) / 5  as ?aggregatedScore)`,
-        // `FILTER(?aggregatedScore > 0)`, // not necessary atm to filter; there are parts of job-postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
+        ) / 5  as ?score)`,
+        // `FILTER(?score > 0)`, // not necessary atm to filter; there are parts of job-postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
       ],
-      orderBy: [{ order: "DESC", variable: "?aggregatedScore" }],
+      orderBy: [{ order: "DESC", variable: "?score" }],
     });
 
     return query;


### PR DESCRIPTION
Improvements to embedded queries for whatsX and jobs
whatsX:

* filter out more results earlier
* jobs:
    * project the aggregated score so the matcher can sort properly
    * adapted vicinity subquery: two consecutive BIND operators trigger a jena bug in op-> query  
* SparqlMatcherActor & Utils: fix op/query manipulation
* need-builder: always project '?score'
