### PR TITLE
Fix #2603 duplicate price range detail

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -525,7 +525,7 @@ export function filterNumOfRoomsRange(rootSubject, min, max) {
   return wellFormedFilter({ operations, prefixes });
 }
 
-export function filterRentRange(rootSubject, min, max, currency) {
+export function filterPriceRange(rootSubject, min, max, currency) {
   const prefixes = {
     s: won.defaultContext["s"],
   };
@@ -554,9 +554,9 @@ export function filterRentRange(rootSubject, min, max, currency) {
 }
 
 /**
- * Uses a given rent to find needs that have a matching rentRange. Works like filterNumericProperty (see docs there).
+ * Uses a given rent to find needs that have a matching priceRange. Works like filterNumericProperty (see docs there).
  */
-export function filterRent(rootSubject, rent, currency, sparqlVarPrefix) {
+export function filterPrice(rootSubject, rent, currency, sparqlVarPrefix) {
   const prefixes = {
     s: won.defaultContext["s"],
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -8,7 +8,7 @@ import { getIn, is } from "../../app/utils.js";
 import {
   textSearchSubQuery,
   vicinityScoreSubQuery,
-  filterRentRange,
+  filterPriceRange,
   concatenateFilters,
   sparqlQuery,
 } from "../../app/sparql-builder-utils.js";
@@ -33,7 +33,7 @@ export const goodsServiceSearch = {
       label: "Keywords to search for",
       mandatory: true,
     },
-    rentRange: { ...details.pricerange },
+    priceRange: { ...details.pricerange },
     description: { ...details.description },
     location: { ...details.location },
   },
@@ -146,8 +146,7 @@ export const goodsServiceSearch = {
         ],
       },
       priceRange &&
-        // no idea why this method isn't called filterPriceRange
-        filterRentRange(
+        filterPriceRange(
           `${resultName}`,
           priceRange.min,
           priceRange.max,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -33,7 +33,7 @@ export const goodsServiceSearch = {
       label: "Keywords to search for",
       mandatory: true,
     },
-    priceRange: { ...details.pricerange },
+    rentRange: { ...details.pricerange },
     description: { ...details.description },
     location: { ...details.location },
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
@@ -13,7 +13,7 @@ import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-u
 import {
   filterInVicinity,
   filterNumericProperty,
-  filterRent,
+  filterPrice,
   concatenateFilters,
   sparqlQuery,
 } from "../../app/sparql-builder-utils.js";
@@ -83,7 +83,7 @@ export const rehearsalRoomOffer = {
           location && "?seeks won:hasLocation ?location.",
         ],
       },
-      rent && filterRent("?seeks", rent.amount, rent.currency, "rent"),
+      rent && filterPrice("?seeks", rent.amount, rent.currency, "rent"),
       floorSize &&
         filterNumericProperty("?seeks", floorSize, "s:floorSize", "size"),
       filterInVicinity("?location", location),

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
@@ -12,7 +12,7 @@ import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-u
 import {
   filterInVicinity,
   filterFloorSizeRange,
-  filterRentRange,
+  filterPriceRange,
   concatenateFilters,
   sparqlQuery,
 } from "../../app/sparql-builder-utils.js";
@@ -42,13 +42,13 @@ export const rehearsalRoomSearch = {
       ...realEstateFeaturesDetail,
       placeholder: "e.g. PA, Drumkit",
     },
-    rentRange: { ...perHourRentRangeDetail },
+    priceRange: { ...perHourRentRangeDetail },
     fromDatetime: { ...details.fromDatetime },
     throughDatetime: { ...details.throughDatetime },
   },
   generateQuery: (draft, resultName) => {
     const seeksBranch = draft && draft.seeks;
-    const rentRange = seeksBranch && seeksBranch.rentRange;
+    const rentRange = seeksBranch && seeksBranch.priceRange;
     const floorSizeRange = seeksBranch && seeksBranch.floorSizeRange;
     const location = seeksBranch && seeksBranch.location;
 
@@ -66,7 +66,7 @@ export const rehearsalRoomSearch = {
         ],
       },
       rentRange &&
-        filterRentRange(
+        filterPriceRange(
           `${resultName}`,
           rentRange.min,
           rentRange.max,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -13,7 +13,7 @@ import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-u
 import {
   filterInVicinity,
   filterNumericProperty,
-  filterRent,
+  filterPrice,
   concatenateFilters,
   sparqlQuery,
 } from "../../app/sparql-builder-utils.js";
@@ -79,7 +79,7 @@ export const rentRealEstateOffer = {
           location && "?seeks won:hasLocation ?location.",
         ],
       },
-      rent && filterRent("?seeks", rent.amount, rent.currency, "rent"),
+      rent && filterPrice("?seeks", rent.amount, rent.currency, "rent"),
       floorSize &&
         filterNumericProperty("?seeks", floorSize, "s:floorSize", "size"),
       numberOfRooms &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
@@ -14,7 +14,7 @@ import {
   filterInVicinity,
   filterFloorSizeRange,
   filterNumOfRoomsRange,
-  filterRentRange,
+  filterPriceRange,
   concatenateFilters,
   sparqlQuery,
 } from "../../app/sparql-builder-utils.js";
@@ -43,11 +43,11 @@ export const rentRealEstateSearch = {
     floorSizeRange: { ...realEstateFloorSizeRangeDetail },
     numberOfRoomsRange: { ...realEstateNumberOfRoomsRangeDetail },
     features: { ...realEstateFeaturesDetail },
-    rentRange: { ...realEstateRentRangeDetail },
+    priceRange: { ...realEstateRentRangeDetail },
   },
   generateQuery: (draft, resultName) => {
     const seeksBranch = draft && draft.seeks;
-    const rentRange = seeksBranch && seeksBranch.rentRange;
+    const rentRange = seeksBranch && seeksBranch.priceRange;
     const floorSizeRange = seeksBranch && seeksBranch.floorSizeRange;
     const numberOfRoomsRange = seeksBranch && seeksBranch.numberOfRoomsRange;
     const location = seeksBranch && seeksBranch.location;
@@ -64,7 +64,7 @@ export const rentRealEstateSearch = {
         ],
       },
       rentRange &&
-        filterRentRange(
+        filterPriceRange(
           `${resultName}`,
           rentRange.min,
           rentRange.max,


### PR DESCRIPTION
Fixes #2603 

Also refactors `rentRange` to `priceRange` because the chosen representation is not rent specific.