### PR TITLE
Return 404 errors on nonexistant connection instead of crashing

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/model/DataWithEtag.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/DataWithEtag.java
@@ -32,7 +32,7 @@ public class DataWithEtag<T>
 
 
   public static DataWithEtag dataNotFound(){
-    return new DataWithEtag(null, null, null, false, false);
+    return new DataWithEtag(null, null, null, true, false);
   }
 
   /**

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -414,6 +414,9 @@ public class LinkedDataServiceImpl implements LinkedDataService
       return DataWithEtag.dataNotChanged(data);
     }
     connection = data.getData();
+    if(connection == null) {
+      return DataWithEtag.dataNotFound();
+    }
     String newEtag = data.getEtag();
 
     // load the model from storage


### PR DESCRIPTION
Fixes #2590

This just uses the `notFound` flag in the dataset and does not check whether the connection was deleted or never existed in the first place. I'm not sure if we have that information but I would assume so.