### PR TITLE
Feat GroupChat

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -198,6 +198,8 @@ $ngRedux.getState();
        facets: Immutable.Map //all the facets that are present within the won:hasFacets predicate of a need
        state: "won:Active" | "won:Inactive", //state of the need
        types: Immutable.Set() // of need types e.g. won:Persona, won:Need, and any other types
+       groupMembers: Immutable.List() // needUris of participants of this needs (won:hasGroupMember) -> usually only set for groupChatNeeds
+       holds: Immutable.List() // needUris of the persona that holds these additional needs
        unread: true|false, //whether or not this need has new information that has not been read yet
        uri: string, //unique identifier of this need
        humanReadable: string, //a human Readable String that parses the content from is or seeks and searchString and makes a title out of it based on a certain logic

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -255,6 +255,13 @@ $ngRedux.getState();
            failedToLoad: true|false, //default is false, whether or not this connection was able to be loaded or not
            loadingMessages: true|false, //default is false, whether or not this connection is currently loading messages or processing agreements
            loading: true|false, //default is false, whether or not this connection is currently loading itself (similar to the loading in the need)
+           messages: {
+            [messageUri]: {
+                loading: true|false, //if the message is currently being loaded
+                failedToLoad: true|false, //if the message failed to load (fetch failed from the backend)
+                toLoad: true|false, //if the message is to be loaded (to figure out if a connection has messages that have not been loaded yet)
+            }
+           }
            petriNetData: {
                 loading: true|false, //default is false, whether or not the petriNetData has been loaded,
                 dirty: true|false //default is false, whether or not the currently stored petriNetData is (assumed to be) not correct anymore

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -324,8 +324,8 @@ export function reconnect() {
        */
       const connectionUris = getOwnedConnectionUris(state);
       await Promise.all(
-        connectionUris.map(async connectionUri => {
-          await loadLatestMessagesOfConnection({
+        connectionUris.map(connectionUri =>
+          loadLatestMessagesOfConnection({
             connectionUri,
             numberOfEvents: 10, //TODO magic number :|
             state,
@@ -335,8 +335,8 @@ export function reconnect() {
               success: actionTypes.reconnect.receivedConnectionData,
               failure: actionTypes.reconnect.connectionFailedToLoad,
             },
-          });
-        })
+          })
+        )
       );
     } catch (e) {
       if (e.message == "Unauthorized") {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -330,11 +330,6 @@ export function reconnect() {
             numberOfEvents: 10, //TODO magic number :|
             state,
             dispatch,
-            actionTypesToDispatch: {
-              start: actionTypes.reconnect.startingToLoadConnectionData,
-              success: actionTypes.reconnect.receivedConnectionData,
-              failure: actionTypes.reconnect.connectionFailedToLoad,
-            },
           })
         )
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -111,6 +111,7 @@ const actionHierarchy = {
     sendChatMessageFailed: INJ_DEFAULT,
     showLatestMessages: cnct.showLatestMessages,
     showMoreMessages: cnct.showMoreMessages,
+    fetchMessagesFailed: INJ_DEFAULT,
     markAsRead: INJ_DEFAULT,
     setLoadingAgreementData: INJ_DEFAULT,
     setLoadingPetriNetData: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -118,7 +118,6 @@ const actionHierarchy = {
     markAsRead: INJ_DEFAULT,
     setLoadingAgreementData: INJ_DEFAULT,
     setLoadingPetriNetData: INJ_DEFAULT,
-    setLoadingMessages: INJ_DEFAULT,
     showAgreementData: INJ_DEFAULT,
     showPetriNetData: INJ_DEFAULT,
     setMultiSelectType: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -48,7 +48,7 @@ import {
 import {
   needsConnect,
   fetchUnloadedNeeds,
-  fetchSuggested,
+  fetchUnloadedNeed,
   needsClose,
   needsDelete,
   needsOpen,
@@ -144,7 +144,7 @@ const actionHierarchy = {
     failed: INJ_DEFAULT,
     connect: needsConnect,
     fetchUnloadedNeeds: fetchUnloadedNeeds,
-    fetchSuggested: fetchSuggested,
+    fetchUnloadedNeed: fetchUnloadedNeed,
 
     storeOwnedInactiveUris: INJ_DEFAULT,
     storeOwnedInactiveUrisInLoading: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -111,7 +111,10 @@ const actionHierarchy = {
     sendChatMessageFailed: INJ_DEFAULT,
     showLatestMessages: cnct.showLatestMessages,
     showMoreMessages: cnct.showMoreMessages,
+    fetchMessagesStart: INJ_DEFAULT,
+    messageUrisInLoading: INJ_DEFAULT,
     fetchMessagesFailed: INJ_DEFAULT,
+    fetchMessagesSuccess: INJ_DEFAULT,
     markAsRead: INJ_DEFAULT,
     setLoadingAgreementData: INJ_DEFAULT,
     setLoadingPetriNetData: INJ_DEFAULT,
@@ -324,9 +327,6 @@ const actionHierarchy = {
   reconnect: {
     start: reconnect,
     success: INJ_DEFAULT,
-    startingToLoadConnectionData: INJ_DEFAULT,
-    receivedConnectionData: INJ_DEFAULT,
-    connectionFailedToLoad: INJ_DEFAULT,
   },
 
   view: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -589,7 +589,7 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
       .then(eventUris => {
         return urisToLookupSuccessAndFailedMap(
           eventUris,
-          eventUri => won.getWonMessage(eventUri, fetchParams),
+          eventUri => won.getWonMessage(eventUri, { requesterWebId: needUri }),
           []
         );
       })
@@ -668,7 +668,7 @@ export function loadLatestMessagesOfConnection({
     .then(eventUris => {
       return urisToLookupSuccessAndFailedMap(
         eventUris,
-        eventUri => won.getWonMessage(eventUri, fetchParams),
+        eventUri => won.getWonMessage(eventUri, { requesterWebId: needUri }),
         []
       );
     })
@@ -765,7 +765,7 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
       .then(eventUris => {
         return urisToLookupSuccessAndFailedMap(
           eventUris,
-          eventUri => won.getWonMessage(eventUri, fetchParams),
+          eventUri => won.getWonMessage(eventUri, { requesterWebId: needUri }),
           []
         );
       })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -576,15 +576,22 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
     return won
       .getConnectionWithEventUris(connectionUri, fetchParams)
       .then(connection => {
+        const messagesToFetch = limitNumberOfEventsToFetchInConnection(
+          state,
+          connection,
+          connectionUri,
+          numberOfEvents
+        );
+
         dispatch({
           type: actionTypes.connections.messageUrisInLoading,
           payload: Immutable.fromJS({
             connectionUri: connectionUri,
-            uris: connection.hasEvents,
+            uris: messagesToFetch,
           }),
         });
 
-        return connection.hasEvents;
+        return messagesToFetch;
       })
       .then(eventUris => {
         return urisToLookupSuccessAndFailedMap(
@@ -655,15 +662,22 @@ export function loadLatestMessagesOfConnection({
   return won
     .getConnectionWithEventUris(connectionUri_, fetchParams)
     .then(connection => {
+      const messagesToFetch = limitNumberOfEventsToFetchInConnection(
+        state,
+        connection,
+        connectionUri,
+        numberOfEvents
+      );
+
       dispatch({
         type: actionTypes.connections.messageUrisInLoading,
         payload: Immutable.fromJS({
           connectionUri: connectionUri_,
-          uris: connection.hasEvents,
+          uris: messagesToFetch,
         }),
       });
 
-      return connection.hasEvents;
+      return messagesToFetch;
     })
     .then(eventUris => {
       return urisToLookupSuccessAndFailedMap(
@@ -749,18 +763,24 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
     };
 
     won
-      .getEventUrisOfConnection(connectionUri, needUri)
       .getConnectionWithEventUris(connectionUri, fetchParams)
       .then(connection => {
+        const messagesToFetch = limitNumberOfEventsToFetchInConnection(
+          state,
+          connection,
+          connectionUri,
+          numberOfEvents
+        );
+
         dispatch({
           type: actionTypes.connections.messageUrisInLoading,
           payload: Immutable.fromJS({
             connectionUri: connectionUri,
-            uris: connection.hasEvents,
+            uris: messagesToFetch,
           }),
         });
 
-        return connection.hasEvents;
+        return messagesToFetch;
       })
       .then(eventUris => {
         return urisToLookupSuccessAndFailedMap(
@@ -800,4 +820,46 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
 function numOfEvts2pageSize(numberOfEvents) {
   // `*3*` to compensate for the *roughly* 2 additional success events per chat message
   return numberOfEvents * 3;
+}
+
+/**
+ * Helper Method to make sure we only load numberOfEvents messages into the store, seems that the cache is not doing what its supposed to do otherwise
+ * FIXME: remove this once the fetchpaging works again (or at all)
+ * @param state
+ * @param connection
+ * @param numberOfEvents
+ * @returns {Array}
+ */
+function limitNumberOfEventsToFetchInConnection(
+  state,
+  connection,
+  connectionUri,
+  numberOfEvents
+) {
+  const connectionImm = Immutable.fromJS(connection);
+  console.log(
+    "ConnectionFetch with numberOfEvents: ",
+    numberOfEvents,
+    " returned: ",
+    connectionImm.get("hasEvents") && connectionImm.get("hasEvents").size,
+    " events...",
+    connectionImm
+  );
+
+  const allMessagesToLoad = state
+    .getIn(["process", "connections", connectionUri, "messages"])
+    .filter(msg => msg.get("toLoad") && !msg.get("failedToLoad"));
+  let messagesToFetch = [];
+
+  connectionImm &&
+    connectionImm.get("hasEvents").map(eventUri => {
+      if (
+        allMessagesToLoad.has(eventUri) &&
+        messagesToFetch.length < numOfEvts2pageSize(numberOfEvents)
+      ) {
+        messagesToFetch.push(eventUri);
+      }
+    });
+
+  return messagesToFetch;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -837,14 +837,6 @@ function limitNumberOfEventsToFetchInConnection(
   numberOfEvents
 ) {
   const connectionImm = Immutable.fromJS(connection);
-  console.log(
-    "ConnectionFetch with numberOfEvents: ",
-    numberOfEvents,
-    " returned: ",
-    connectionImm.get("hasEvents") && connectionImm.get("hasEvents").size,
-    " events...",
-    connectionImm
-  );
 
   const allMessagesToLoad = state
     .getIn(["process", "connections", connectionUri, "messages"])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -853,8 +853,6 @@ export function processHintMessage(event) {
       );
     } else if (get(remoteNeed, "state") === won.WON.InactiveCompacted) {
       console.debug("ignoring hint for an inactive need:", remoteNeedUri);
-    } else if (get(remoteNeed, "isOwned")) {
-      console.debug("ignoring hint between owned needs:", remoteNeedUri);
     } else {
       won
         .invalidateCacheForNewConnection(ownedConnectionUri, ownedNeedUri)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -193,6 +193,7 @@ export function processOpenMessage(event) {
     } else {
       senderConnectionP = fetchActiveConnectionAndDispatch(
         senderConnectionUri,
+        senderNeedUri,
         dispatch
       ).then(() => true);
     }
@@ -210,6 +211,7 @@ export function processOpenMessage(event) {
     } else {
       receiverConnectionP = fetchActiveConnectionAndDispatch(
         receiverConnectionUri,
+        receiverNeedUri,
         dispatch
       ).then(() => true);
     }
@@ -552,6 +554,7 @@ export function processConnectMessage(event) {
     } else {
       senderCP = fetchActiveConnectionAndDispatch(
         senderConnectionUri,
+        senderNeedUri,
         dispatch
       ).then(() => true);
     }
@@ -573,6 +576,7 @@ export function processConnectMessage(event) {
     } else {
       receiverCP = fetchActiveConnectionAndDispatch(
         receiverConnectionUri,
+        receiverNeedUri,
         dispatch
       ).then(() => true);
     }
@@ -864,7 +868,11 @@ export function processHintMessage(event) {
           }
         })
         .then(() =>
-          fetchActiveConnectionAndDispatch(ownedConnectionUri, dispatch)
+          fetchActiveConnectionAndDispatch(
+            ownedConnectionUri,
+            ownedNeedUri,
+            dispatch
+          )
         );
     }
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -21,7 +21,7 @@ export function fetchUnloadedNeeds() {
   };
 }
 
-export function fetchSuggested(needUri) {
+export function fetchUnloadedNeed(needUri) {
   return async dispatch => {
     fetchDataForNonOwnedNeedOnly(needUri, dispatch);
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -10,7 +10,7 @@
 import angular from "angular";
 import "ng-redux";
 import ngAnimate from "angular-animate";
-import { dispatchEvent, attach, delay } from "../utils.js";
+import { dispatchEvent, attach, delay, get } from "../utils.js";
 import won from "../won-es6.js";
 import {
   getConnectionUriFromRoute,
@@ -31,7 +31,7 @@ import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
 import { actionCreators } from "../actions/actions.js";
 import labelledHrModule from "./labelled-hr.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
-import { isChatConnectionToGroup } from "../connection-utils.js";
+import { isChatToGroup } from "../connection-utils.js";
 import submitButtonModule from "./submit-button.js";
 
 import "style/_chattextfield.scss";
@@ -298,7 +298,11 @@ function genComponentConf() {
         const connection = post && post.getIn(["connections", connectionUri]);
         const connectionState = connection && connection.get("state");
 
-        const isGroupChatConnection = isChatConnectionToGroup(connection);
+        const isGroupChatConnection = isChatToGroup(
+          state.get("needs"),
+          get(post, "uri"),
+          connectionUri
+        );
 
         const messages = getMessagesByConnectionUri(state, connectionUri);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield-simple.js
@@ -31,6 +31,7 @@ import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
 import { actionCreators } from "../actions/actions.js";
 import labelledHrModule from "./labelled-hr.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
+import { isChatConnectionToGroup } from "../connection-utils.js";
 import submitButtonModule from "./submit-button.js";
 
 import "style/_chattextfield.scss";
@@ -44,30 +45,30 @@ function genComponentConf() {
           <div class="cts__details__grid"
               ng-if="!self.selectedDetail && !self.multiSelectType">
             <won-labelled-hr label="::'Actions'" class="cts__details__grid__hr"
-              ng-if="!self.multiSelectType && self.isConnected"></won-labelled-hr>
+              ng-if="!self.multiSelectType && self.isConnected && !self.isGroupChatConnection"></won-labelled-hr>
             <button
-                ng-if="!self.showAgreementData"
+                ng-if="!self.showAgreementData && !self.isGroupChatConnection"
                 class="cts__details__grid__action won-button--filled red"
                 ng-click="self.activateMultiSelect('proposes')"
                 ng-disabled="!self.hasProposableMessages">
                 Make Proposal
             </button>
             <button
-                ng-if="!self.showAgreementData"
+                ng-if="!self.showAgreementData && !self.isGroupChatConnection"
                 class="cts__details__grid__action won-button--filled red"
                 ng-click="self.activateMultiSelect('claims')"
                 ng-disabled="!self.hasClaimableMessages">
                 Make Claim
             </button>
             <button
-                ng-if="self.showAgreementData"
+                ng-if="self.showAgreementData && !self.isGroupChatConnection"
                 class="cts__details__grid__action won-button--filled red"
                 ng-click="self.activateMultiSelect('accepts')"
                 ng-disabled="!self.hasAcceptableMessages">
                 Accept Proposal(s)
             </button>
             <button
-                ng-if="self.showAgreementData"
+                ng-if="self.showAgreementData && !self.isGroupChatConnection"
                 class="cts__details__grid__action won-button--filled red"
                 ng-click="self.activateMultiSelect('rejects')"
                 ng-disabled="!self.hasRejectableMessages">
@@ -75,11 +76,13 @@ function genComponentConf() {
             </button>
             <button
                 class="cts__details__grid__action won-button--filled red"
+                ng-if="!self.isGroupChatConnection"
                 ng-click="self.activateMultiSelect('proposesToCancel')"
                 ng-disabled="!self.hasCancelableMessages">
                 Cancel Agreement(s)
             </button>
             <button class="cts__details__grid__action won-button--filled red"
+                ng-if="!self.isGroupChatConnection"
                 ng-click="self.activateMultiSelect('retracts')"
                 ng-disabled="!self.hasRetractableMessages">
                 Retract Message(s)
@@ -295,6 +298,8 @@ function genComponentConf() {
         const connection = post && post.getIn(["connections", connectionUri]);
         const connectionState = connection && connection.get("state");
 
+        const isGroupChatConnection = isChatConnectionToGroup(connection);
+
         const messages = getMessagesByConnectionUri(state, connectionUri);
 
         const selectedMessages =
@@ -339,6 +344,7 @@ function genComponentConf() {
           post,
           multiSelectType: connection && connection.get("multiSelectType"),
           showAgreementData: connection && connection.get("showAgreementData"),
+          isGroupChatConnection: isGroupChatConnection,
           isConnected: connectionState && connectionState === won.WON.Connected,
           selectedMessages: selectedMessages,
           hasClaimableMessages,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
@@ -6,13 +6,14 @@ import angular from "angular";
 import ngAnimate from "angular-animate";
 import { actionCreators } from "../actions/actions.js";
 import won from "../won-es6.js";
-import { attach, getIn, toAbsoluteURL } from "../utils.js";
+import { attach, get, getIn, toAbsoluteURL } from "../utils.js";
 import {
   getConnectionUriFromRoute,
   getOwnedNeedByConnectionUri,
 } from "../selectors/general-selectors.js";
 import { connect2Redux } from "../won-utils.js";
 import { ownerBaseUrl } from "config";
+import { isChatToGroup } from "../connection-utils.js";
 
 import "style/_context-dropdown.scss";
 
@@ -46,13 +47,13 @@ function genComponentConf() {
                         Show Details
                     </button>
                     <button
-                        ng-if="self.isConnected && !self.showAgreementData"
+                        ng-if="!self.isConnectionToGroup && self.isConnected && !self.showAgreementData"
                         class="won-button--outlined thin red"
                         ng-click="self.showAgreementDataField()">
                         Show Agreement Data
                     </button>
                     <button
-                        ng-if="self.isConnected && !self.showPetriNetData"
+                        ng-if="!self.isConnectionToGroup && self.isConnected && !self.showPetriNetData"
                         class="won-button--outlined thin red"
                         ng-click="self.showPetriNetDataField()">
                         Show PetriNet Data
@@ -98,6 +99,11 @@ function genComponentConf() {
           adminEmail: getIn(state, ["config", "theme", "adminEmail"]),
           remotePostUri,
           linkToPost,
+          isConnectionToGroup: isChatToGroup(
+            state.get("needs"),
+            get(post, "uri"),
+            connectionUri
+          ),
           showAgreementData: connection && connection.get("showAgreementData"),
           isConnected: connectionState === won.WON.Connected,
           isSentRequest: connectionState === won.WON.RequestSent,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -11,7 +11,7 @@ import { labels, relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { isDirectResponseNeed } from "../need-utils.js";
-import { isChatConnectionToGroup } from "../connection-utils.js";
+import { isChatToGroup } from "../connection-utils.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
 import {
   selectLastUpdateTime,
@@ -28,7 +28,7 @@ import "style/_connection-header.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <div class="ch__icon" ng-if="!self.connectionOrNeedsLoading && !self.isChatConnectionToGroup">
+      <div class="ch__icon" ng-if="!self.connectionOrNeedsLoading && !self.isConnectionToGroup">
           <won-square-image
             class="ch__icon__theirneed"
             src="self.remoteNeed.get('TODO')"
@@ -37,7 +37,7 @@ function genComponentConf() {
             ng-show="!self.hideImage">
           </won-square-image>
       </div>
-      <div class="ch__groupicons" ng-if="!self.connectionOrNeedsLoading && self.isChatConnectionToGroup">
+      <div class="ch__groupicons" ng-if="!self.connectionOrNeedsLoading && self.isConnectionToGroup">
           <!-- TODO: ADD REAL PARTICIPANTS OF THE GROUPCHAT -->
           <div class="ch__groupicons__icon one">
           </div>
@@ -157,7 +157,11 @@ function genComponentConf() {
           connection,
           ownedNeed,
           remoteNeed,
-          isChatConnectionToGroup: isChatConnectionToGroup(connection),
+          isConnectionToGroup: isChatToGroup(
+            state.get("needs"),
+            get(ownedNeed, "uri"),
+            this.connectionUri
+          ),
           isDirectResponseFromRemote: isDirectResponseNeed(remoteNeed),
           latestMessageHumanReadableString,
           latestMessageUnread,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -6,6 +6,7 @@ import angular from "angular";
 import won from "../won-es6.js";
 import "ng-redux";
 import squareImageModule from "./square-image.js";
+import groupImageModule from "./group-image.js";
 import { actionCreators } from "../actions/actions.js";
 import { labels, relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get } from "../utils.js";
@@ -37,20 +38,11 @@ function genComponentConf() {
             ng-show="!self.hideImage">
           </won-square-image>
       </div>
-      <div class="ch__groupicons" ng-if="!self.connectionOrNeedsLoading && self.isConnectionToGroup">
-          <!-- TODO: ADD REAL PARTICIPANTS OF THE GROUPCHAT -->
-          <div class="ch__groupicons__icon"
-              ng-repeat="groupMemberUri in self.groupMembersArray"
-              ng-if="self.groupMembersSize <= 4 || $index < 3"
-              class="ch__groupicons__icon">
-              <won-square-image
-                uri="groupMemberUri">
-              </won-square-image>
-          </div>
-          <div class="ch__groupicons__more" ng-if="self.groupMembersSize > 4">
-           +
-          </div>
-      </div>
+      <won-group-image
+        class="ch__groupicons"
+        ng-if="!self.connectionOrNeedsLoading && self.isConnectionToGroup"
+        connection-uri="self.connectionUri">
+      </won-group-image>
       <div class="ch__right" ng-if="!self.connectionOrNeedsLoading">
         <div class="ch__right__topline" ng-if="!self.remoteNeedFailedToLoad">
           <div class="ch__right__topline__title" ng-if="!self.isDirectResponseFromRemote && self.remoteNeed.get('humanReadable')" title="{{ self.remoteNeed.get('humanReadable') }}">
@@ -65,7 +57,7 @@ function genComponentConf() {
         </div>
         <div class="ch__right__subtitle" ng-if="!self.remoteNeedFailedToLoad">
           <span class="ch__right__subtitle__type">
-            <won-connection-state 
+            <won-connection-state
               connection-uri="self.connection.get('uri')">
             </won-connection-state>
             <span class="ch__right__subtitle__type__state" ng-if="!self.unreadMessageCount && !self.latestMessageHumanReadableString">
@@ -270,6 +262,7 @@ function genComponentConf() {
 export default angular
   .module("won.owner.components.connectionHeader", [
     squareImageModule,
+    groupImageModule,
     connectionStateModule,
   ])
   .directive("wonConnectionHeader", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -39,13 +39,15 @@ function genComponentConf() {
       </div>
       <div class="ch__groupicons" ng-if="!self.connectionOrNeedsLoading && self.isConnectionToGroup">
           <!-- TODO: ADD REAL PARTICIPANTS OF THE GROUPCHAT -->
-          <div class="ch__groupicons__icon one">
+          <div class="ch__groupicons__icon"
+              ng-repeat="groupMemberUri in self.groupMembersArray"
+              ng-if="self.groupMembersSize <= 4 || $index < 3"
+              class="ch__groupicons__icon">
+              <won-square-image
+                uri="groupMemberUri">
+              </won-square-image>
           </div>
-          <div class="ch__groupicons__icon two">
-          </div>
-          <div class="ch__groupicons__icon three">
-          </div>
-          <div class="ch__groupicons__more">
+          <div class="ch__groupicons__more" ng-if="self.groupMembersSize > 4">
            +
           </div>
       </div>
@@ -153,8 +155,12 @@ function genComponentConf() {
         const latestMessageUnread =
           latestMessage && latestMessage.get("unread");
 
+        const groupMembers = remoteNeed && remoteNeed.get("groupMembers");
+
         return {
           connection,
+          groupMembersArray: groupMembers && groupMembers.toArray(),
+          groupMembersSize: groupMembers ? groupMembers.size : 0,
           ownedNeed,
           remoteNeed,
           isConnectionToGroup: isChatToGroup(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.js
@@ -11,6 +11,7 @@ import { labels, relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { isDirectResponseNeed } from "../need-utils.js";
+import { isChatConnectionToGroup } from "../connection-utils.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
 import {
   selectLastUpdateTime,
@@ -27,7 +28,7 @@ import "style/_connection-header.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <div class="ch__icon" ng-if="!self.connectionOrNeedsLoading">
+      <div class="ch__icon" ng-if="!self.connectionOrNeedsLoading && !self.isChatConnectionToGroup">
           <won-square-image
             class="ch__icon__theirneed"
             src="self.remoteNeed.get('TODO')"
@@ -35,6 +36,18 @@ function genComponentConf() {
             uri="self.remoteNeed.get('uri')"
             ng-show="!self.hideImage">
           </won-square-image>
+      </div>
+      <div class="ch__groupicons" ng-if="!self.connectionOrNeedsLoading && self.isChatConnectionToGroup">
+          <!-- TODO: ADD REAL PARTICIPANTS OF THE GROUPCHAT -->
+          <div class="ch__groupicons__icon one">
+          </div>
+          <div class="ch__groupicons__icon two">
+          </div>
+          <div class="ch__groupicons__icon three">
+          </div>
+          <div class="ch__groupicons__more">
+           +
+          </div>
       </div>
       <div class="ch__right" ng-if="!self.connectionOrNeedsLoading">
         <div class="ch__right__topline" ng-if="!self.remoteNeedFailedToLoad">
@@ -144,6 +157,7 @@ function genComponentConf() {
           connection,
           ownedNeed,
           remoteNeed,
+          isChatConnectionToGroup: isChatConnectionToGroup(connection),
           isDirectResponseFromRemote: isDirectResponseNeed(remoteNeed),
           latestMessageHumanReadableString,
           latestMessageUnread,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-indicators.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-indicators.js
@@ -13,7 +13,10 @@ import { getChatConnectionsByNeedUri } from "../selectors/connection-selectors.j
 import { attach, sortByDate, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
-import { isChatConnection } from "../connection-utils.js";
+import {
+  isChatConnection,
+  isGroupChatConnection,
+} from "../connection-utils.js";
 
 import "style/_connection-indicators.scss";
 
@@ -120,7 +123,7 @@ function genComponentConf() {
 
             return (
               remoteNeedActiveOrLoading &&
-              isChatConnection(conn) &&
+              (isChatConnection(conn) || isGroupChatConnection(conn)) &&
               conn.get("state") === won.WON.Suggested
             );
           });
@@ -138,7 +141,7 @@ function genComponentConf() {
 
             return (
               remoteNeedActiveOrLoading &&
-              isChatConnection(conn) &&
+              (isChatConnection(conn) || isGroupChatConnection(conn)) &&
               conn.get("state") !== won.WON.Suggested &&
               conn.get("state") !== won.WON.Closed
             );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -35,7 +35,10 @@ import {
   getOwnedOpenPosts,
 } from "../selectors/general-selectors.js";
 import { getChatConnectionsToCrawl } from "../selectors/connection-selectors.js";
-import { isChatConnection } from "../connection-utils.js";
+import {
+  isChatConnection,
+  isGroupChatConnection,
+} from "../connection-utils.js";
 import { hasGroupFacet, hasChatFacet } from "../need-utils.js";
 
 const serviceDependencies = ["$ngRedux", "$scope"];
@@ -392,7 +395,8 @@ function genComponentConf() {
       return (
         need.get("state") === won.WON.ActiveCompacted &&
         need.get("connections").filter(conn => {
-          if (!isChatConnection(conn)) return false;
+          if (!isChatConnection(conn) && !isGroupChatConnection(conn))
+            return false;
           if (
             process &&
             process.getIn(["connections", conn.get("uri"), "loading"])
@@ -421,7 +425,8 @@ function genComponentConf() {
     getOpenChatConnectionsArraySorted(need, allNeeds, process) {
       return sortByDate(
         need.get("connections").filter(conn => {
-          if (!isChatConnection(conn)) return false;
+          if (!isChatConnection(conn) && !isGroupChatConnection(conn))
+            return false;
           if (
             process &&
             process.getIn(["connections", conn.get("uri"), "loading"])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -303,12 +303,6 @@ function genComponentConf() {
           const messageCount = messages ? messages.size : 0;
 
           if (messageCount == 0) {
-            console.debug(
-              "DISPATCH connections__showLatestMessages for connUri:",
-              conn.get("uri"),
-              " -> NO messages have already been loaded in the connection: ",
-              conn
-            );
             this.connections__showLatestMessages(conn.get("uri"), MESSAGECOUNT);
           } else {
             const receivedMessages = messages.filter(
@@ -318,12 +312,6 @@ function genComponentConf() {
               receivedMessages.filter(msg => !msg.get("unread")).size > 0;
 
             if (!receivedMessagesReadPresent) {
-              console.debug(
-                "DISPATCH connections__showMoreMessages for connUri:",
-                conn.get("uri"),
-                " -> ONLY unread messages are currently present:",
-                conn
-              );
               this.connections__showMoreMessages(conn.get("uri"), MESSAGECOUNT);
             }
           }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -339,6 +339,7 @@ function genComponentConf() {
             useCase: undefined,
             useCaseGroup: undefined,
             connectionUri: undefined,
+            groupPostAdminUri: undefined,
           });
         }
       } else {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
@@ -30,6 +30,7 @@
     <won-create-post ng-if="self.showCreatePost"></won-create-post>
     <won-create-search ng-if="self.showCreateSearch"></won-create-search>
     <won-post-messages ng-if="self.showPostMessages"></won-post-messages>
+    <won-group-post-messages ng-if="self.showGroupPostMessages"></won-group-post-messages>
     <won-group-administration ng-if="self.showGroupPostAdministration"></won-group-administration>
     <won-post-info include-header="true" ng-if="self.showPostInfo"></won-post-info>
 </main>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -16,7 +16,7 @@ import {
   getOwnedNeedByConnectionUri,
   getOwnedNeeds,
 } from "../../selectors/general-selectors.js";
-import { isChatConnectionToGroup } from "../../connection-utils.js";
+import { isChatToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
 
 import "style/_connections.scss";
@@ -60,7 +60,11 @@ class ConnectionsController {
         "connections",
         selectedConnectionUri,
       ]);
-      const isGroupChatConnection = isChatConnectionToGroup(selectedConnection);
+      const isSelectedConnectionGroupChat = isChatToGroup(
+        state.get("needs"),
+        get(need, "uri"),
+        selectedConnectionUri
+      );
 
       const selectedConnectionState = getIn(selectedConnection, ["state"]);
 
@@ -118,7 +122,7 @@ class ConnectionsController {
           !selectedPost &&
           !useCaseGroup &&
           !showGroupPostAdministration &&
-          !isGroupChatConnection &&
+          !isSelectedConnectionGroupChat &&
           (selectedConnectionState === won.WON.Connected ||
             selectedConnectionState === won.WON.RequestReceived ||
             selectedConnectionState === won.WON.RequestSent ||
@@ -127,7 +131,7 @@ class ConnectionsController {
           !selectedPost &&
           !useCaseGroup &&
           !showGroupPostAdministration &&
-          isGroupChatConnection &&
+          isSelectedConnectionGroupChat &&
           (selectedConnectionState === won.WON.Connected ||
             selectedConnectionState === won.WON.RequestReceived ||
             selectedConnectionState === won.WON.RequestSent ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -2,6 +2,7 @@ import angular from "angular";
 import won from "../../won-es6.js";
 import sendRequestModule from "../send-request.js";
 import postMessagesModule from "../post-messages.js";
+import groupPostMessagesModule from "../group-post-messages.js";
 import groupAdministrationModule from "../group-administration.js";
 import postInfoModule from "../post-info.js";
 import connectionsOverviewModule from "../connections-overview.js";
@@ -15,6 +16,7 @@ import {
   getOwnedNeedByConnectionUri,
   getOwnedNeeds,
 } from "../../selectors/general-selectors.js";
+import { isChatConnectionToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
 
 import "style/_connections.scss";
@@ -58,6 +60,8 @@ class ConnectionsController {
         "connections",
         selectedConnectionUri,
       ]);
+      const isGroupChatConnection = isChatConnectionToGroup(selectedConnection);
+
       const selectedConnectionState = getIn(selectedConnection, ["state"]);
 
       const ownedNeeds = getOwnedNeeds(state);
@@ -114,6 +118,16 @@ class ConnectionsController {
           !selectedPost &&
           !useCaseGroup &&
           !showGroupPostAdministration &&
+          !isGroupChatConnection &&
+          (selectedConnectionState === won.WON.Connected ||
+            selectedConnectionState === won.WON.RequestReceived ||
+            selectedConnectionState === won.WON.RequestSent ||
+            selectedConnectionState === won.WON.Suggested),
+        showGroupPostMessages:
+          !selectedPost &&
+          !useCaseGroup &&
+          !showGroupPostAdministration &&
+          isGroupChatConnection &&
           (selectedConnectionState === won.WON.Connected ||
             selectedConnectionState === won.WON.RequestReceived ||
             selectedConnectionState === won.WON.RequestSent ||
@@ -199,6 +213,7 @@ export default angular
   .module("won.owner.components.connections", [
     sendRequestModule,
     postMessagesModule,
+    groupPostMessagesModule,
     groupAdministrationModule,
     postInfoModule,
     usecasePickerModule,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -161,7 +161,7 @@ function genComponentConf() {
       uriToFetch = uriToFetch.trim();
 
       //TODO: ERROR HANDLING IF URL WAS NOT A FETCHABLE URL
-      this.needs__fetchSuggested(uriToFetch);
+      this.needs__fetchUnloadedNeed(uriToFetch);
       //this.update(uriToFetch);
       this.resetPostUriField();
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -99,7 +99,7 @@ function genComponentConf() {
     loadPost() {
       if (this.content) {
         //this.content is the suggestedPostUri
-        this.needs__fetchSuggested(this.content);
+        this.needs__fetchUnloadedNeed(this.content);
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/extended-connection-indicators.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/extended-connection-indicators.js
@@ -9,7 +9,10 @@ import { labels } from "../won-label-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { getPosts, getOwnedPosts } from "../selectors/general-selectors.js";
 import { getChatConnectionsByNeedUri } from "../selectors/connection-selectors.js";
-import { isChatConnection } from "../connection-utils.js";
+import {
+  isChatConnection,
+  isGroupChatConnection,
+} from "../connection-utils.js";
 import { attach, sortByDate, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 
@@ -152,7 +155,7 @@ function genComponentConf() {
             return (
               remoteNeedActive &&
               conn.get("state") === won.WON.Suggested &&
-              isChatConnection(conn)
+              (isChatConnection(conn) || isGroupChatConnection(conn))
             );
           });
         const connected =
@@ -171,7 +174,7 @@ function genComponentConf() {
               !!conn.get("state") &&
               conn.get("state") !== won.WON.Suggested &&
               conn.get("state") !== won.WON.Closed &&
-              isChatConnection(conn)
+              (isChatConnection(conn) || isGroupChatConnection(conn))
             );
           });
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
@@ -8,7 +8,7 @@ import { actionCreators } from "../actions/actions.js";
 import { attach, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { getGroupChatConnectionsByNeedUri } from "../selectors/connection-selectors.js";
-import { generateGroupChatParticipantsLabel } from "../connection-utils.js";
+import { generateGroupChatMembersLabel } from "../connection-utils.js";
 
 import "style/_group-administration-header.scss";
 
@@ -26,8 +26,8 @@ function genComponentConf() {
           </div>
         </div>
         <div class="ch__right__subtitle">
-          <span class="ch__right__subtitle__participants">
-            {{ self.participantsLabel }}
+          <span class="ch__right__subtitle__members">
+            {{ self.membersLabel }}
           </span>
         </div>
       </div>
@@ -46,9 +46,7 @@ function genComponentConf() {
 
         return {
           groupChatNeed,
-          participantsLabel: generateGroupChatParticipantsLabel(
-            groupChatConnections
-          ),
+          membersLabel: generateGroupChatMembersLabel(groupChatConnections),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
@@ -2,31 +2,21 @@
  * Created by quasarchimaere on 08.01.2019.
  */
 import angular from "angular";
-import won from "../won-es6.js";
 import "ng-redux";
-import squareImageModule from "./square-image.js";
+import groupImageModule from "./group-image.js";
 import { actionCreators } from "../actions/actions.js";
-import { labels, relativeTime } from "../won-label-utils.js";
 import { attach, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
-import { isDirectResponseNeed } from "../need-utils.js";
-import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
-import {
-  selectLastUpdateTime,
-  getNonOwnedNeeds,
-} from "../selectors/general-selectors.js";
-import { getUnreadMessagesByConnectionUri } from "../selectors/message-selectors.js";
-import { getMessagesByConnectionUri } from "../selectors/message-selectors.js";
-import connectionStateModule from "./connection-state.js";
-import { classOnComponentRoot } from "../cstm-ng-utils.js";
 
 import "style/_group-administration-header.scss";
 
-const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
   let template = `
-      <div class="ch__icon">
-      </div>
+      <won-group-image
+        class="ch__icon"
+        need-uri="self.needUri">
+      </won-group-image>
       <div class="ch__right">
         <div class="ch__right__topline">
           <div class="ch__right__topline__title">
@@ -35,184 +25,25 @@ function genComponentConf() {
         </div>
         <div class="ch__right__subtitle">
           <span class="ch__right__subtitle__type">
+            TODO: Add number of (current) participants
           </span>
         </div>
       </div>
-      <!--div class="ch__icon" ng-if="!self.connectionOrNeedsLoading">
-          <won-square-image
-            class="ch__icon__theirneed"
-            src="self.theirNeed.get('TODO')"
-            title="self.theirNeed.get('humanReadable')"
-            uri="self.theirNeed.get('uri')"
-            ng-show="!self.hideImage">
-          </won-square-image>
-      </div>
-      <div class="ch__right" ng-if="!self.connectionOrNeedsLoading">
-        <div class="ch__right__topline" ng-if="!self.theirNeedFailedToLoad">
-          <div class="ch__right__topline__title" ng-if="!self.isDirectResponseFromRemote && self.theirNeed.get('humanReadable')" title="{{ self.theirNeed.get('humanReadable') }}">
-            {{ self.theirNeed.get('humanReadable') }}
-          </div>
-          <div class="ch__right__topline__notitle" ng-if="!self.isDirectResponseFromRemote && !self.theirNeed.get('humanReadable')" title="no title">
-            no title
-          </div>
-          <div class="ch__right__topline__notitle" ng-if="self.isDirectResponseFromRemote" title="Direct Response">
-            Direct Response
-          </div>
-        </div>
-        <div class="ch__right__subtitle" ng-if="!self.theirNeedFailedToLoad">
-          <span class="ch__right__subtitle__type">
-            <won-connection-state 
-              connection-uri="self.connection.get('uri')">
-            </won-connection-state>
-            <span class="ch__right__subtitle__type__state" ng-if="!self.unreadMessageCount && !self.latestMessageHumanReadableString">
-              {{ self.connection && self.getTextForConnectionState(self.connection.get('state')) }}
-            </span>
-            <span class="ch__right__subtitle__type__unreadcount" ng-if="self.unreadMessageCount > 1">
-              {{ self.unreadMessageCount }} unread Messages
-            </span>
-            <span class="ch__right__subtitle__type__unreadcount" ng-if="self.unreadMessageCount == 1 && !self.latestMessageHumanReadableString">
-              {{ self.unreadMessageCount }} unread Message
-            </span>
-            <span class="ch__right__subtitle__type__message" ng-if="!(self.unreadMessageCount > 1) && self.latestMessageHumanReadableString"
-              ng-class="{'won-unread': self.latestMessageUnread}">
-              {{ self.latestMessageHumanReadableString }}
-            </span>
-          </span>
-          <div class="ch__right__subtitle__date">
-            {{ self.friendlyTimestamp }}
-          </div>
-        </div>
-        <div class="ch__right__topline" ng-if="self.theirNeedFailedToLoad">
-          <div class="ch__right__topline__notitle">
-            Remote Need Loading failed
-          </div>
-        </div>
-        <div class="ch__right__subtitle" ng-if="self.theirNeedFailedToLoad">
-          <span class="ch__right__subtitle__type">
-            <span class="ch__right__subtitle__type__state">
-              Need might have been deleted, you might want to close this connection.
-            </span>
-          </span>
-        </div>
-      </div>
-      <div class="ch__icon" ng-if="self.connectionOrNeedsLoading">
-          <div class="ch__icon__skeleton"></div>
-      </div>
-      <div class="ch__right" ng-if="self.connectionOrNeedsLoading">
-        <div class="ch__right__topline">
-          <div class="ch__right__topline__title"></div>
-          <div class="ch__right__topline__date"></div>
-        </div>
-        <div class="ch__right__subtitle">
-          <span class="ch__right__subtitle__type"></span>
-        </div>
-      </div-->
     `;
 
   class Controller {
     constructor() {
       attach(this, serviceDependencies, arguments);
-      this.labels = labels;
-      this.WON = won.WON;
+
       const selectFromState = state => {
         const groupChatNeed = getIn(state, ["needs", this.needUri]);
-        const ownedNeed = undefined;
-        const connection =
-          ownedNeed && ownedNeed.getIn(["connections", "FIXME: Remove"]);
-        const theirNeed =
-          connection &&
-          getNonOwnedNeeds(state).get(connection.get("remoteNeedUri"));
-        const allMessages = getMessagesByConnectionUri(state, "FIXME: Remove");
-        const unreadMessages = getUnreadMessagesByConnectionUri(
-          state,
-          "FIXME: Remove"
-        );
-
-        const sortedMessages = allMessages && allMessages.toArray();
-        if (sortedMessages) {
-          sortedMessages.sort(function(a, b) {
-            const aDate = a.get("date");
-            const bDate = b.get("date");
-
-            const aTime = aDate && aDate.getTime();
-            const bTime = bDate && bDate.getTime();
-
-            return bTime - aTime;
-          });
-        }
-
-        const latestMessage = sortedMessages && sortedMessages[0];
-        const latestMessageHumanReadableString =
-          latestMessage && getHumanReadableStringFromMessage(latestMessage);
-        const latestMessageUnread =
-          latestMessage && latestMessage.get("unread");
 
         return {
           groupChatNeed,
-          connection,
-          ownedNeed,
-          theirNeed,
-          isDirectResponseFromRemote: isDirectResponseNeed(theirNeed),
-          latestMessageHumanReadableString,
-          latestMessageUnread,
-          unreadMessageCount:
-            unreadMessages && unreadMessages.size > 0
-              ? unreadMessages.size
-              : undefined,
-          friendlyTimestamp:
-            theirNeed &&
-            relativeTime(
-              selectLastUpdateTime(state),
-              theirNeed.get("lastUpdateDate")
-            ),
-          theirNeedFailedToLoad:
-            theirNeed &&
-            getIn(state, [
-              "process",
-              "needs",
-              theirNeed.get("uri"),
-              "failedToLoad",
-            ]),
-          connectionOrNeedsLoading:
-            !connection ||
-            !theirNeed ||
-            !ownedNeed ||
-            getIn(state, [
-              "process",
-              "needs",
-              ownedNeed.get("uri"),
-              "loading",
-            ]) ||
-            getIn(state, [
-              "process",
-              "needs",
-              theirNeed.get("uri"),
-              "loading",
-            ]) ||
-            getIn(state, [
-              "process",
-              "connections",
-              connection.get("uri"),
-              "loading",
-            ]),
         };
       };
 
       connect2Redux(selectFromState, actionCreators, ["self.needUri"], this);
-
-      classOnComponentRoot(
-        "won-is-loading",
-        () => false && this.connectionOrNeedsLoading, //TODO: FIX THE LOADING BEHAVIOUR PROBABLY THERE IS NO LOADING BEHAVIOUR FOR THAT
-        this
-      );
-    }
-
-    getTextForConnectionState(state) {
-      let stateText = this.labels.connectionState[state];
-      if (!stateText) {
-        stateText = "unknown connection state";
-      }
-      return stateText;
     }
   }
   Controller.$inject = serviceDependencies;
@@ -223,19 +54,11 @@ function genComponentConf() {
     bindToController: true, //scope-bindings -> ctrl
     scope: {
       needUri: "=",
-
-      /**
-       * if set, the avatar will be hidden
-       */
-      hideImage: "=",
     },
     template: template,
   };
 }
 
 export default angular
-  .module("won.owner.components.groupAdministrationHeader", [
-    squareImageModule,
-    connectionStateModule,
-  ])
+  .module("won.owner.components.groupAdministrationHeader", [groupImageModule])
   .directive("wonGroupAdministrationHeader", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-header.js
@@ -7,6 +7,8 @@ import groupImageModule from "./group-image.js";
 import { actionCreators } from "../actions/actions.js";
 import { attach, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
+import { getGroupChatConnectionsByNeedUri } from "../selectors/connection-selectors.js";
+import { generateGroupChatParticipantsLabel } from "../connection-utils.js";
 
 import "style/_group-administration-header.scss";
 
@@ -24,8 +26,8 @@ function genComponentConf() {
           </div>
         </div>
         <div class="ch__right__subtitle">
-          <span class="ch__right__subtitle__type">
-            TODO: Add number of (current) participants
+          <span class="ch__right__subtitle__participants">
+            {{ self.participantsLabel }}
           </span>
         </div>
       </div>
@@ -37,9 +39,16 @@ function genComponentConf() {
 
       const selectFromState = state => {
         const groupChatNeed = getIn(state, ["needs", this.needUri]);
+        const groupChatConnections = getGroupChatConnectionsByNeedUri(
+          state,
+          this.needUri
+        );
 
         return {
           groupChatNeed,
+          participantsLabel: generateGroupChatParticipantsLabel(
+            groupChatConnections
+          ),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
@@ -1,7 +1,7 @@
 import won from "../won-es6.js";
 import angular from "angular";
 import groupAdministrationHeaderModule from "./group-administration-header.js";
-import connectionHeaderModule from "./connection-header.js";
+import postHeaderModule from "./post-header.js";
 import labelledHrModule from "./labelled-hr.js";
 import { connect2Redux } from "../won-utils.js";
 import { attach, getIn, delay } from "../utils.js";
@@ -30,40 +30,40 @@ function genComponentConf() {
             <!-- todo impl and include groupchat context-dropdown -->
         </div>
         <div class="ga__content">
-            <div class="ga__content__participant"
+            <div class="ga__content__member"
                 ng-if="self.hasGroupChatConnections"
                 ng-repeat="conn in self.groupChatConnectionsArray">
-                <won-connection-header
-                    connection-uri="conn.get('uri')"
-                    hide-image="::false">
-                </won-connection-header>
-                <div class="ga__content__participant__actions">
+                <won-post-header
+                  need-uri="conn.get('remoteNeedUri')"
+                  hide-image="::false">
+                </won-post-header>
+                <div class="ga__content__member__actions">
                     <div
-                      class="ga__content__participant__actions__button red won-button--outlined thin"
+                      class="ga__content__member__actions__button red won-button--outlined thin"
                       ng-click="self.openRequest(conn.get('uri'))"
                       ng-if="conn.get('state') === self.won.WON.RequestReceived">
                         Accept
                     </div>
                     <div
-                      class="ga__content__participant__actions__button red won-button--outlined thin"
+                      class="ga__content__member__actions__button red won-button--outlined thin"
                       ng-click="self.closeConnection(conn.get('uri'))"
                       ng-if="conn.get('state') === self.won.WON.RequestReceived">
                         Reject
                     </div>
                     <div
-                      class="ga__content__participant__actions__button red won-button--outlined thin"
+                      class="ga__content__member__actions__button red won-button--outlined thin"
                       ng-click="self.sendRequest(conn.get('uri'), conn.get('remoteNeedUri'))"
                       ng-if="conn.get('state') === self.won.WON.Suggested">
                         Request
                     </div>
                     <div
-                      class="ga__content__participant__actions__button red won-button--outlined thin"
+                      class="ga__content__member__actions__button red won-button--outlined thin"
                       ng-disabled="true"
                       ng-if="conn.get('state') === self.won.WON.RequestSent">
                         Waiting for Accept...
                     </div>
                     <div
-                      class="ga__content__participant__actions__button red won-button--outlined thin"
+                      class="ga__content__member__actions__button red won-button--outlined thin"
                       ng-click="self.closeConnection(conn.get('uri'))"
                       ng-if="conn.get('state') === self.won.WON.Suggested || conn.get('state') === self.won.WON.Connected">
                         Remove
@@ -194,7 +194,7 @@ function genComponentConf() {
 export default angular
   .module("won.owner.components.groupAdministration", [
     groupAdministrationHeaderModule,
-    connectionHeaderModule,
+    postHeaderModule,
     labelledHrModule,
   ])
   .directive("wonGroupAdministration", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
@@ -4,7 +4,7 @@ import groupAdministrationHeaderModule from "./group-administration-header.js";
 import postHeaderModule from "./post-header.js";
 import labelledHrModule from "./labelled-hr.js";
 import { connect2Redux } from "../won-utils.js";
-import { attach, getIn, delay } from "../utils.js";
+import { attach, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { getGroupChatPostUriFromRoute } from "../selectors/general-selectors.js";
 import { getGroupChatConnectionsByNeedUri } from "../selectors/connection-selectors.js";
@@ -84,8 +84,6 @@ function genComponentConf() {
       window.pgm4dbg = this;
       this.won = won;
 
-      this.scrollContainer().addEventListener("scroll", e => this.onScroll(e));
-
       const selectFromState = state => {
         const groupPostAdminUri = getGroupChatPostUriFromRoute(state);
         const groupChatPost = getIn(state, ["needs", groupPostAdminUri]);
@@ -102,67 +100,10 @@ function genComponentConf() {
             groupChatConnections && groupChatConnections.size > 0,
           groupChatConnectionsArray:
             groupChatConnections && groupChatConnections.toArray(),
-          /*isSentRequest:
-            connection && connection.get("state") === won.WON.RequestSent,
-          isReceivedRequest:
-            connection && connection.get("state") === won.WON.RequestReceived,
-          isConnected:
-            connection && connection.get("state") === won.WON.Connected,
-          isSuggested:
-            connection && connection.get("state") === won.WON.Suggested,*/
         };
       };
 
       connect2Redux(selectFromState, actionCreators, [], this);
-
-      this._snapBottom = true; //Don't snap to bottom immediately, because this scrolls the whole page... somehow?
-
-      this.$scope.$watch(
-        () => this.groupChatConnections && this.groupChatConnections.size, // trigger if there's messages added (or removed)
-        () =>
-          delay(0).then(() =>
-            // scroll to bottom directly after rendering, if snapped
-            this.updateScrollposition()
-          )
-      );
-    }
-
-    snapToBottom() {
-      this._snapBottom = true;
-      this.scrollToBottom();
-    }
-    unsnapFromBottom() {
-      this._snapBottom = false;
-    }
-    updateScrollposition() {
-      if (this._snapBottom) {
-        this.scrollToBottom();
-      }
-    }
-    scrollToBottom() {
-      this._programmaticallyScrolling = true;
-
-      this.scrollContainer().scrollTop = this.scrollContainer().scrollHeight;
-    }
-    onScroll() {
-      if (!this._programmaticallyScrolling) {
-        //only unsnap if the user scrolled themselves
-        this.unsnapFromBottom();
-      }
-
-      const sc = this.scrollContainer();
-      const isAtBottom = sc.scrollTop + sc.offsetHeight >= sc.scrollHeight;
-      if (isAtBottom) {
-        this.snapToBottom();
-      }
-
-      this._programmaticallyScrolling = false;
-    }
-    scrollContainer() {
-      if (!this._scrollContainer) {
-        this._scrollContainer = this.$element[0].querySelector(".ga__content");
-      }
-      return this._scrollContainer;
     }
 
     openRequest(connUri, message) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
@@ -71,6 +71,11 @@ function genComponentConf() {
                 </div>
             </div>
         </div>
+        <div class="ga__footer">
+            <button class="ga__footer__button won-button--filled red" ng-click="self.joinGroup()">
+                Join Group
+            </button>
+        </div>
     `;
 
   class Controller {
@@ -177,6 +182,19 @@ function genComponentConf() {
     closeConnection(connUri, rateBad = false) {
       rateBad && this.connections__rate(connUri, won.WON.binaryRatingBad);
       this.connections__close(connUri);
+    }
+
+    joinGroup(persona) {
+      //TODO: FIGURE OUT HOW TO USE won-submit-button instead so we can add a persona if need be
+      if (this.groupPostAdminUri) {
+        this.connections__connectAdHoc(
+          this.groupPostAdminUri,
+          "" /*message cant be undefined for whatever reason*/,
+          persona
+        );
+      }
+
+      //this.router__stateGoCurrent({connectionUri: null, sendAdHocRequest: null});
     }
   }
   Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
@@ -25,6 +25,7 @@ function genComponentConf() {
   let template = `
       <div class="gi__icons__icon"
         ng-repeat="groupMemberUri in self.groupMembersArray"
+        ng-class="{'gi__icons__icon--spanCol': self.groupMembersSize == 1}"
         ng-if="self.groupMembersSize <= 4 || $index < 3">
         <won-square-image
           uri="groupMemberUri">
@@ -32,6 +33,15 @@ function genComponentConf() {
       </div>
       <div class="gi__icons__more" ng-if="self.groupMembersSize > 4">
          +
+      </div>
+      <div
+        class="gi__icons__more"
+        ng-if="self.groupMembersSize <= 3"
+        ng-class="{
+          'gi__icons__more--spanCol': self.groupMembersSize == 2,
+          'gi__icons__more--spanRow': self.groupMembersSize == 0
+        }">
+        {{ self.groupMembersSize }}
       </div>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
@@ -1,0 +1,89 @@
+/**
+ * Component for rendering the icon of a groupChat (renders participants icons)
+ * Created by quasarchimaere on 15.01.2019.
+ */
+import angular from "angular";
+import won from "../won-es6.js";
+import "ng-redux";
+import squareImageModule from "./square-image.js";
+import { actionCreators } from "../actions/actions.js";
+import { labels } from "../won-label-utils.js";
+import { attach, get } from "../utils.js";
+import { connect2Redux } from "../won-utils.js";
+import { isChatToGroup } from "../connection-utils.js";
+import {
+  getOwnedNeedByConnectionUri,
+  getNeeds,
+} from "../selectors/general-selectors.js";
+
+import "style/_group-image.scss";
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <div class="gi__icons__icon"
+        ng-repeat="groupMemberUri in self.groupMembersArray"
+        ng-if="self.groupMembersSize <= 4 || $index < 3">
+        <won-square-image
+          uri="groupMemberUri">
+        </won-square-image>
+      </div>
+      <div class="gi__icons__more" ng-if="self.groupMembersSize > 4">
+         +
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.labels = labels;
+      this.WON = won.WON;
+      const selectFromState = state => {
+        const ownedNeed = getOwnedNeedByConnectionUri(
+          state,
+          this.connectionUri
+        );
+        const connection =
+          ownedNeed && ownedNeed.getIn(["connections", this.connectionUri]);
+        const remoteNeed =
+          connection && get(getNeeds(state), connection.get("remoteNeedUri"));
+        const groupMembers = remoteNeed && remoteNeed.get("groupMembers");
+
+        return {
+          connection,
+          groupMembersArray: groupMembers && groupMembers.toArray(),
+          groupMembersSize: groupMembers ? groupMembers.size : 0,
+          ownedNeed,
+          remoteNeed,
+          isConnectionToGroup: isChatToGroup(
+            state.get("needs"),
+            get(ownedNeed, "uri"),
+            this.connectionUri
+          ),
+        };
+      };
+
+      connect2Redux(
+        selectFromState,
+        actionCreators,
+        ["self.connectionUri"],
+        this
+      );
+    }
+  }
+  Controller.$inject = serviceDependencies;
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      connectionUri: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.groupImage", [squareImageModule])
+  .directive("wonGroupImage", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-image.js
@@ -38,7 +38,7 @@ function genComponentConf() {
         class="gi__icons__more"
         ng-if="self.groupMembersSize <= 3"
         ng-class="{
-          'gi__icons__more--spanCol': self.groupMembersSize == 2,
+          'gi__icons__more--spanCol': self.groupMembersSize == 2 || self.groupMembersSize == 0,
           'gi__icons__more--spanRow': self.groupMembersSize == 0
         }">
         {{ self.groupMembersSize }}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -1,0 +1,814 @@
+import won from "../won-es6.js";
+import Immutable from "immutable";
+import angular from "angular";
+import chatTextFieldSimpleModule from "./chat-textfield-simple.js";
+import connectionMessageModule from "./messages/connection-message.js";
+import postContentMessageModule from "./messages/post-content-message.js";
+import petrinetStateModule from "./petrinet-state.js";
+import connectionHeaderModule from "./connection-header.js";
+import labelledHrModule from "./labelled-hr.js";
+import connectionContextDropdownModule from "./connection-context-dropdown.js";
+import { connect2Redux } from "../won-utils.js";
+import { attach, delay, getIn } from "../utils.js";
+import { isWhatsAroundNeed, isWhatsNewNeed } from "../need-utils.js";
+import {
+  fetchAgreementProtocolUris,
+  fetchPetriNetUris,
+  fetchMessage,
+} from "../won-message-utils.js";
+import { actionCreators } from "../actions/actions.js";
+import {
+  getConnectionUriFromRoute,
+  getOwnedNeedByConnectionUri,
+} from "../selectors/general-selectors.js";
+import {
+  getAgreementMessagesByConnectionUri,
+  getCancellationPendingMessagesByConnectionUri,
+  getProposalMessagesByConnectionUri,
+  getUnreadMessagesByConnectionUri,
+} from "../selectors/message-selectors.js";
+import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
+import { classOnComponentRoot } from "../cstm-ng-utils.js";
+
+import "style/_group-post-messages.scss";
+import "style/_rdflink.scss";
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+
+function genComponentConf() {
+  let template = `
+        <div class="gpm__header" ng-if="self.showChatData">
+            <a class="gpm__header__back clickable"
+               ng-click="self.router__stateGoCurrent({connectionUri : undefined})">
+                <svg style="--local-primary:var(--won-primary-color);"
+                     class="gpm__header__back__icon clickable">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
+                </svg>
+            </a>
+            <won-connection-header
+                connection-uri="self.connectionUri"
+                timestamp="self.lastUpdateTimestamp"
+                hide-image="::false">
+            </won-connection-header>
+            <won-connection-context-dropdown show-petri-net-data-field="::self.showPetriNetDataField()" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
+        </div>
+        <div
+          class="gpm__content">
+            <div class="gpm__content__unreadindicator"
+              ng-if="self.unreadMessageCount && (!self._snapBottom || !self.showChatView)">
+              <div class="gpm__content__unreadindicator__content won-button--filled red"
+                ng-click="self.goToUnreadMessages()">
+                {{self.unreadMessageCount}} unread Messages
+              </div>
+            </div>
+            <won-post-content-message
+              class="won-cm--left"
+              ng-if="self.showChatData && !self.multiSelectType && self.nonOwnedNeedUri"
+              post-uri="self.nonOwnedNeedUri">
+            </won-post-content-message>
+            <div class="gpm__content__loadspinner"
+                ng-if="self.isProcessingLoadingMessages || (self.showAgreementData && self.isProcessingLoadingAgreementData) || (self.showPetriNetData && self.isProcessingLoadingPetriNetData && !self.hasPetriNetData)">
+                <svg class="hspinner">
+                  <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
+                </svg>
+            </div>
+            <button class="gpm__content__loadbutton won-button--outlined thin red"
+                ng-if="!self.isSuggested && self.showChatData && !self.isProcessingLoadingMessages && !self.allMessagesLoaded"
+                ng-click="self.loadPreviousMessages()">
+                Load previous messages
+            </button>
+
+            <!-- CHATVIEW SPECIFIC CONTENT START-->
+            <won-connection-message
+                ng-if="self.showChatData"
+                ng-click="self.multiSelectType && self.selectMessage(msg)"
+                ng-repeat="msg in self.sortedMessages"
+                connection-uri="self.connectionUri"
+                message-uri="msg.get('uri')">
+            </won-connection-message>
+            <!-- CHATVIEW SPECIFIC CONTENT END-->
+
+            <a class="rdflink clickable"
+               ng-if="self.shouldShowRdf"
+               target="_blank"
+               href="{{ self.connectionUri }}">
+                    <svg class="rdflink__small">
+                        <use xlink:href="#rdf_logo_1" href="#rdf_logo_1"></use>
+                    </svg>
+                    <span class="rdflink__label">Connection</span>
+            </a>
+        </div>
+        <div class="gpm__footer" ng-if="!self.showPetriNetData && self.isConnected">
+            <chat-textfield-simple
+                class="gpm__footer__chattexfield"
+                placeholder="self.shouldShowRdf? 'Enter TTL...' : 'Your message...'"
+                submit-button-label="self.shouldShowRdf? 'Send&#160;RDF' : 'Send'"
+                on-submit="self.send(value, additionalContent, referencedContent, self.shouldShowRdf)"
+                help-text="self.shouldShowRdf? self.rdfTextfieldHelpText : ''"
+                allow-empty-submit="::false"
+                allow-details="!self.shouldShowRdf"
+                is-code="self.shouldShowRdf? 'true' : ''"
+            >
+            </chat-textfield-simple>
+        </div>
+        <div class="gpm__footer" ng-if="!self.showPetriNetData && !self.multiSelectType && self.isSentRequest">
+            Waiting for the Group Administrator to accept your request.
+        </div>
+
+        <div class="gpm__footer" ng-if="!self.showPetriNetData && !self.multiSelectType && self.isReceivedRequest">
+            <chat-textfield-simple
+                class="gpm__footer__chattexfield"
+                placeholder="::'Message (optional)'"
+                on-submit="::self.openRequest(value)"
+                allow-details="::false"
+                allow-empty-submit="::true"
+                submit-button-label="::'Accept&#160;Invite'"
+            >
+            </chat-textfield-simple>
+            <won-labelled-hr label="::'Or'" class="gpm__footer__labelledhr"></won-labelled-hr>
+            <button class="gpm__footer__button won-button--filled black" ng-click="self.closeConnection()">
+                Decline
+            </button>
+        </div>
+        <div class="gpm__footer" ng-if="!self.showPetriNetData && !self.multiSelectType && self.isSuggested">
+            <chat-textfield-simple
+                placeholder="::'Message (optional)'"
+                on-submit="::self.sendRequest(value, selectedPersona)"
+                allow-details="::false"
+                allow-empty-submit="::true"
+                show-personas="self.isOwnedNeedWhatsX"
+                submit-button-label="::'Ask&#160;to&#160;Join'"
+            >
+            </chat-textfield-simple>
+            <won-labelled-hr label="::'Or'" class="gpm__footer__labelledhr"></won-labelled-hr>
+            <button class="gpm__footer__button won-button--filled black" ng-click="self.closeConnection(true)">
+                Bad match - remove!
+            </button>
+        </div>
+    `;
+
+  class Controller {
+    constructor(/* arguments = dependency injections */) {
+      attach(this, serviceDependencies, arguments);
+      window.pm4dbg = this;
+
+      this.rdfTextfieldHelpText =
+        "Expects valid turtle. " +
+        `<${won.WONMSG.uriPlaceholder.event}> will ` +
+        "be replaced by the uri generated for this message. " +
+        "Use it, so your TTL can be found when parsing the messages. " +
+        "See `won.defaultTurtlePrefixes` " +
+        "for prefixes that will be added automatically. E.g." +
+        `\`<${
+          won.WONMSG.uriPlaceholder.event
+        }> won:hasTextMessage "hello world!". \``;
+
+      this.scrollContainer().addEventListener("scroll", e => this.onScroll(e));
+
+      const selectFromState = state => {
+        const connectionUri = getConnectionUriFromRoute(state);
+        const ownedNeed = getOwnedNeedByConnectionUri(state, connectionUri);
+        const connection =
+          ownedNeed && ownedNeed.getIn(["connections", connectionUri]);
+        const isOwnedNeedWhatsX =
+          this.ownedNeed &&
+          (isWhatsAroundNeed(this.ownedNeed) || isWhatsNewNeed(this.ownedNeed));
+        const nonOwnedNeedUri = connection && connection.get("remoteNeedUri");
+        const nonOwnedNeed =
+          nonOwnedNeedUri && state.getIn(["needs", nonOwnedNeedUri]);
+        const chatMessages =
+          connection &&
+          connection.get("messages") &&
+          connection.get("messages").filter(msg => !msg.get("forwardMessage"));
+        const allMessagesLoaded =
+          chatMessages &&
+          chatMessages.filter(
+            msg => msg.get("messageType") === won.WONMSG.connectMessage
+          ).size > 0;
+
+        const agreementData = connection && connection.get("agreementData");
+        const petriNetData = connection && connection.get("petriNetData");
+
+        const agreementMessages = getAgreementMessagesByConnectionUri(
+          state,
+          connectionUri
+        );
+        const cancellationPendingMessages = getCancellationPendingMessagesByConnectionUri(
+          state,
+          connectionUri
+        );
+        const proposalMessages = getProposalMessagesByConnectionUri(
+          state,
+          connectionUri
+        );
+
+        let sortedMessages = chatMessages && chatMessages.toArray();
+        sortedMessages &&
+          sortedMessages.sort(function(a, b) {
+            const aDate = a.get("date");
+            const bDate = b.get("date");
+
+            const aTime = aDate && aDate.getTime();
+            const bTime = bDate && bDate.getTime();
+
+            return aTime - bTime;
+          });
+
+        const unreadMessages = getUnreadMessagesByConnectionUri(
+          state,
+          connectionUri
+        );
+
+        const chatMessagesWithUnknownState =
+          chatMessages &&
+          chatMessages.filter(msg => !msg.get("isMessageStatusUpToDate"));
+
+        return {
+          ownedNeed,
+          nonOwnedNeed,
+          nonOwnedNeedUri,
+          connectionUri,
+          connection,
+          isOwnedNeedWhatsX,
+
+          sortedMessages: sortedMessages,
+          chatMessages,
+          chatMessagesWithUnknownState,
+          unreadMessageCount: unreadMessages && unreadMessages.size,
+          isProcessingLoadingMessages:
+            connection &&
+            getIn(state, [
+              "process",
+              "connections",
+              connectionUri,
+              "loadingMessages",
+            ]),
+          isProcessingLoadingAgreementData:
+            connection &&
+            getIn(state, [
+              "process",
+              "connections",
+              connectionUri,
+              "agreementData",
+              "loading",
+            ]),
+          isProcessingLoadingPetriNetData:
+            connection &&
+            getIn(state, [
+              "process",
+              "connections",
+              connectionUri,
+              "petriNetData",
+              "loading",
+            ]),
+          showAgreementData: connection && connection.get("showAgreementData"),
+          showPetriNetData: connection && connection.get("showPetriNetData"),
+          showChatData:
+            connection &&
+            !(
+              connection.get("showAgreementData") ||
+              connection.get("showPetriNetData")
+            ),
+          agreementData,
+          petriNetData,
+          petriNetDataArray: petriNetData && petriNetData.toArray(),
+          agreementDataLoaded:
+            agreementData &&
+            getIn(state, [
+              "process",
+              "connections",
+              connectionUri,
+              "agreementData",
+              "loaded",
+            ]),
+          petriNetDataLoaded:
+            petriNetData &&
+            getIn(state, [
+              "process",
+              "connections",
+              connectionUri,
+              "petriNetData",
+              "loaded",
+            ]),
+          multiSelectType: connection && connection.get("multiSelectType"),
+          lastUpdateTimestamp: connection && connection.get("lastUpdateDate"),
+          isSentRequest:
+            connection && connection.get("state") === won.WON.RequestSent,
+          isReceivedRequest:
+            connection && connection.get("state") === won.WON.RequestReceived,
+          isConnected:
+            connection && connection.get("state") === won.WON.Connected,
+          isSuggested:
+            connection && connection.get("state") === won.WON.Suggested,
+          debugmode: won.debugmode,
+          shouldShowRdf: state.getIn(["view", "showRdf"]),
+          // if the connect-message is here, everything else should be as well
+          allMessagesLoaded,
+          hasAgreementMessages: agreementMessages && agreementMessages.size > 0,
+          hasPetriNetData: petriNetData && petriNetData.size > 0,
+          agreementMessagesArray:
+            agreementMessages && agreementMessages.toArray(),
+          hasProposalMessages: proposalMessages && proposalMessages.size > 0,
+          proposalMessagesArray: proposalMessages && proposalMessages.toArray(),
+          hasCancellationPendingMessages:
+            cancellationPendingMessages && cancellationPendingMessages.size > 0,
+          cancellationPendingMessagesArray:
+            cancellationPendingMessages &&
+            cancellationPendingMessages.toArray(),
+          connectionOrNeedsLoading:
+            !connection ||
+            !nonOwnedNeed ||
+            !ownedNeed ||
+            getIn(state, [
+              "process",
+              "needs",
+              ownedNeed.get("uri"),
+              "loading",
+            ]) ||
+            getIn(state, [
+              "process",
+              "needs",
+              nonOwnedNeed.get("uri"),
+              "loading",
+            ]) ||
+            getIn(state, ["process", "connections", connectionUri, "loading"]),
+        };
+      };
+
+      connect2Redux(selectFromState, actionCreators, [], this);
+
+      this._snapBottom = true; //Don't snap to bottom immediately, because this scrolls the whole page... somehow?
+
+      this.$scope.$watchGroup(["self.connection"], () => {
+        this.ensureMessagesAreLoaded();
+        this.ensureAgreementDataIsLoaded();
+        this.ensurePetriNetDataIsLoaded();
+        this.ensureMessageStateIsUpToDate();
+      });
+
+      this.$scope.$watch(
+        () => this.sortedMessages && this.sortedMessages.length, // trigger if there's messages added (or removed)
+        () =>
+          delay(0).then(() =>
+            // scroll to bottom directly after rendering, if snapped
+            this.updateScrollposition()
+          )
+      );
+
+      classOnComponentRoot(
+        "won-is-loading",
+        () => this.connectionOrNeedsLoading,
+        this
+      );
+    }
+
+    ensureMessagesAreLoaded() {
+      delay(0).then(() => {
+        // make sure latest messages are loaded
+        const INITIAL_MESSAGECOUNT = 15;
+        if (
+          this.connection &&
+          !this.isProcessingLoadingMessages &&
+          !(this.allMessagesLoaded || this.connection.get("messages").size > 0)
+        ) {
+          this.connections__showLatestMessages(
+            this.connection.get("uri"),
+            INITIAL_MESSAGECOUNT
+          );
+        }
+      });
+    }
+
+    ensurePetriNetDataIsLoaded(forceFetch = false) {
+      delay(0).then(() => {
+        if (
+          forceFetch ||
+          (this.isConnected &&
+            !this.isProcessingLoadingPetriNetData &&
+            !this.petriNetDataLoaded)
+        ) {
+          const connectionUri = this.connection && this.connection.get("uri");
+
+          this.connections__setLoadingPetriNetData({
+            connectionUri: connectionUri,
+            loadingPetriNetData: true,
+          });
+
+          fetchPetriNetUris(connectionUri)
+            .then(response => {
+              const petriNetData = {};
+
+              response.forEach(entry => {
+                if (entry.processURI) {
+                  petriNetData[entry.processURI] = entry;
+                }
+              });
+
+              const petriNetDataImm = Immutable.fromJS(petriNetData);
+
+              this.connections__updatePetriNetData({
+                connectionUri: connectionUri,
+                petriNetData: petriNetDataImm,
+              });
+            })
+            .catch(error => {
+              console.error("Error:", error);
+              this.connections__setLoadingPetriNetData({
+                connectionUri: connectionUri,
+                loadingPetriNetData: false,
+              });
+            });
+        }
+      });
+    }
+
+    ensureAgreementDataIsLoaded(forceFetch = false) {
+      delay(0).then(() => {
+        if (
+          forceFetch ||
+          (this.isConnected &&
+            !this.isProcessingLoadingAgreementData &&
+            !this.agreementDataLoaded)
+        ) {
+          this.connections__setLoadingAgreementData({
+            connectionUri: this.connectionUri,
+            loadingAgreementData: true,
+          });
+          fetchAgreementProtocolUris(this.connection.get("uri"))
+            .then(response => {
+              let proposedMessageUris = [];
+              const pendingProposals = response.pendingProposals;
+
+              if (pendingProposals) {
+                pendingProposals.forEach(prop => {
+                  if (prop.proposes) {
+                    proposedMessageUris = proposedMessageUris.concat(
+                      prop.proposes
+                    );
+                  }
+                });
+              }
+
+              const agreementData = Immutable.fromJS({
+                agreementUris: Immutable.Set(response.agreementUris),
+                pendingProposalUris: Immutable.Set(
+                  response.pendingProposalUris
+                ),
+                acceptedCancellationProposalUris: Immutable.Set(
+                  response.acceptedCancellationProposalUris
+                ),
+                cancellationPendingAgreementUris: Immutable.Set(
+                  response.cancellationPendingAgreementUris
+                ),
+                pendingCancellationProposalUris: Immutable.Set(
+                  response.pendingCancellationProposalUris
+                ),
+                cancelledAgreementUris: Immutable.Set(
+                  response.cancelledAgreementUris
+                ),
+                rejectedMessageUris: Immutable.Set(
+                  response.rejectedMessageUris
+                ),
+                retractedMessageUris: Immutable.Set(
+                  response.retractedMessageUris
+                ),
+                proposedMessageUris: Immutable.Set(proposedMessageUris),
+                claimedMessageUris: Immutable.Set(response.claimedMessageUris),
+              });
+
+              this.connections__updateAgreementData({
+                connectionUri: this.connectionUri,
+                agreementData: agreementData,
+              });
+
+              //Retrieve all the relevant messages
+              agreementData.map((uriList, key) =>
+                uriList.map(uri => this.addMessageToState(uri, key))
+              );
+            })
+            .catch(error => {
+              console.error("Error:", error);
+              this.connections__setLoadingAgreementData({
+                connectionUri: this.connectionUri,
+                loadingAgreementData: false,
+              });
+            });
+        }
+      });
+    }
+
+    ensureMessageStateIsUpToDate() {
+      delay(0).then(() => {
+        if (
+          this.isConnected &&
+          !this.isProcessingLoadingAgreementData &&
+          !this.isProcessingLoadingMessages &&
+          this.agreementDataLoaded &&
+          this.chatMessagesWithUnknownState &&
+          this.chatMessagesWithUnknownState.size > 0
+        ) {
+          console.debug(
+            "Ensure Message Status is up-to-date for: ",
+            this.chatMessagesWithUnknownState.size,
+            " Messages"
+          );
+          this.chatMessagesWithUnknownState.forEach(msg => {
+            let messageStatus = msg && msg.get("messageStatus");
+            const msgUri = msg.get("uri");
+            const remoteMsgUri = msg.get("remoteUri");
+
+            const acceptedUris =
+              this.agreementData && this.agreementData.get("agreementUris");
+            const rejectedUris =
+              this.agreementData &&
+              this.agreementData.get("rejectedMessageUris");
+            const retractedUris =
+              this.agreementData &&
+              this.agreementData.get("retractedMessageUris");
+            const cancelledUris =
+              this.agreementData &&
+              this.agreementData.get("cancelledAgreementUris");
+            const cancellationPendingUris =
+              this.agreementData &&
+              this.agreementData.get("cancellationPendingAgreementUris");
+            const claimedUris =
+              this.agreementData &&
+              this.agreementData.get("claimedMessageUris"); //TODO not sure if this is correct
+            const proposedUris =
+              this.agreementData &&
+              this.agreementData.get("proposedMessageUris"); //TODO not sure if this is correct
+
+            const isProposed = messageStatus && messageStatus.get("isProposed");
+            const isClaimed = messageStatus && messageStatus.get("isClaimed");
+            const isAccepted = messageStatus && messageStatus.get("isAccepted");
+            const isRejected = messageStatus && messageStatus.get("isRejected");
+            const isRetracted =
+              messageStatus && messageStatus.get("isRetracted");
+            const isCancelled =
+              messageStatus && messageStatus.get("isCancelled");
+            const isCancellationPending =
+              messageStatus && messageStatus.get("isCancellationPending");
+
+            const isOldProposed =
+              proposedUris &&
+              !!(proposedUris.get(msgUri) || proposedUris.get(remoteMsgUri));
+            const isOldClaimed =
+              claimedUris &&
+              !!(claimedUris.get(msgUri) || claimedUris.get(remoteMsgUri));
+            const isOldAccepted =
+              acceptedUris &&
+              !!(acceptedUris.get(msgUri) || acceptedUris.get(remoteMsgUri));
+            const isOldRejected =
+              rejectedUris &&
+              !!(rejectedUris.get(msgUri) || rejectedUris.get(remoteMsgUri));
+            const isOldRetracted =
+              retractedUris &&
+              !!(retractedUris.get(msgUri) || retractedUris.get(remoteMsgUri));
+            const isOldCancelled =
+              cancelledUris &&
+              !!(cancelledUris.get(msgUri) || cancelledUris.get(remoteMsgUri));
+            const isOldCancellationPending =
+              cancellationPendingUris &&
+              !!(
+                cancellationPendingUris.get(msgUri) ||
+                cancellationPendingUris.get(remoteMsgUri)
+              );
+
+            messageStatus = messageStatus
+              .set("isProposed", isProposed || isOldProposed)
+              .set("isClaimed", isClaimed || isOldClaimed)
+              .set("isAccepted", isAccepted || isOldAccepted)
+              .set("isRejected", isRejected || isOldRejected)
+              .set("isRetracted", isRetracted || isOldRetracted)
+              .set("isCancelled", isCancelled || isOldCancelled)
+              .set(
+                "isCancellationPending",
+                isCancellationPending || isOldCancellationPending
+              );
+
+            this.messages__updateMessageStatus({
+              messageUri: msgUri,
+              connectionUri: this.connectionUri,
+              needUri: this.ownedNeed.get("uri"),
+              messageStatus: messageStatus,
+            });
+          });
+        }
+      });
+    }
+
+    loadPreviousMessages() {
+      delay(0).then(() => {
+        const MORE_MESSAGECOUNT = 5;
+        if (this.connection && !this.isProcessingLoadingMessages) {
+          this.connections__showMoreMessages(
+            this.connection.get("uri"),
+            MORE_MESSAGECOUNT
+          );
+        }
+      });
+    }
+
+    goToUnreadMessages() {
+      if (this.showAgreementData) {
+        this.setShowAgreementData(false);
+      }
+      if (this.showPetriNetData) {
+        this.setShowPetriNetData(false);
+      }
+      this.snapToBottom();
+    }
+
+    snapToBottom() {
+      this._snapBottom = true;
+      this.scrollToBottom();
+    }
+    unsnapFromBottom() {
+      this._snapBottom = false;
+    }
+    updateScrollposition() {
+      if (this._snapBottom) {
+        this.scrollToBottom();
+      }
+    }
+    scrollToBottom() {
+      this._programmaticallyScrolling = true;
+
+      this.scrollContainer().scrollTop = this.scrollContainer().scrollHeight;
+    }
+    onScroll() {
+      if (!this._programmaticallyScrolling) {
+        //only unsnap if the user scrolled themselves
+        this.unsnapFromBottom();
+      }
+
+      const sc = this.scrollContainer();
+      const isAtBottom = sc.scrollTop + sc.offsetHeight >= sc.scrollHeight;
+      if (isAtBottom) {
+        this.snapToBottom();
+      }
+
+      this._programmaticallyScrolling = false;
+    }
+    scrollContainer() {
+      if (!this._scrollContainer) {
+        this._scrollContainer = this.$element[0].querySelector(".gpm__content");
+      }
+      return this._scrollContainer;
+    }
+
+    send(chatMessage, additionalContent, referencedContent, isTTL = false) {
+      this.setShowAgreementData(false);
+      this.view__hideAddMessageContent();
+
+      const trimmedMsg = chatMessage.trim();
+      if (trimmedMsg || additionalContent || referencedContent) {
+        this.connections__sendChatMessage(
+          trimmedMsg,
+          additionalContent,
+          referencedContent,
+          this.connection.get("uri"),
+          isTTL
+        );
+      }
+    }
+
+    showAgreementDataField() {
+      this.setShowPetriNetData(false);
+      this.setShowAgreementData(true);
+    }
+
+    showPetriNetDataField() {
+      this.setShowAgreementData(false);
+      this.setShowPetriNetData(true);
+    }
+
+    setShowAgreementData(value) {
+      this.connections__showAgreementData({
+        connectionUri: this.connectionUri,
+        showAgreementData: value,
+      });
+    }
+
+    setShowPetriNetData(value) {
+      this.connections__showPetriNetData({
+        connectionUri: this.connectionUri,
+        showPetriNetData: value,
+      });
+    }
+
+    addMessageToState(eventUri, key) {
+      const ownedNeedUri = this.ownedNeed.get("uri");
+      return fetchMessage(ownedNeedUri, eventUri).then(response => {
+        won.wonMessageFromJsonLd(response).then(msg => {
+          if (msg.isFromOwner() && msg.getReceiverNeed() === ownedNeedUri) {
+            /*if we find out that the receiverneed of the crawled event is actually our
+              need we will call the method again but this time with the correct eventUri
+            */
+            this.addMessageToState(msg.getRemoteMessageUri(), key);
+          } else {
+            //If message isnt in the state we add it
+            if (!this.chatMessages.get(eventUri)) {
+              this.messages__processAgreementMessage(msg);
+            }
+          }
+        });
+      });
+    }
+
+    openRequest(message) {
+      this.connections__open(this.connectionUri, message);
+    }
+
+    sendRequest(message, persona) {
+      if (!this.connection || this.isOwnedNeedWhatsX) {
+        this.router__stateGoResetParams("connections");
+
+        if (this.isOwnedNeedWhatsX) {
+          //Close the connection if there was a present connection for a whatsaround need
+          this.connections__close(this.connectionUri);
+        }
+
+        if (this.nonOwnedNeedUri) {
+          this.connections__connectAdHoc(
+            this.nonOwnedNeedUri,
+            message,
+            persona
+          );
+        }
+
+        //this.router__stateGoCurrent({connectionUri: null, sendAdHocRequest: null});
+      } else {
+        this.connections__rate(this.connectionUri, won.WON.binaryRatingGood);
+        this.needs__connect(
+          this.ownedNeed.get("uri"),
+          this.connectionUri,
+          this.nonOwnedNeedUri,
+          message
+        );
+        this.router__stateGoCurrent({ connectionUri: this.connectionUri });
+      }
+    }
+
+    closeConnection(rateBad = false) {
+      rateBad &&
+        this.connections__rate(
+          this.connection.get("uri"),
+          won.WON.binaryRatingBad
+        );
+      this.connections__close(this.connection.get("uri"));
+      this.router__stateGoCurrent({ connectionUri: null });
+    }
+
+    rateMatch(rating) {
+      if (!this.isConnected) {
+        return;
+      }
+      switch (rating) {
+        case won.WON.binaryRatingGood:
+          this.connections__rate(this.connectionUri, won.WON.binaryRatingGood);
+          break;
+
+        case won.WON.binaryRatingBad:
+          this.connections__close(this.connectionUri);
+          this.connections__rate(this.connectionUri, won.WON.binaryRatingBad);
+          this.router__stateGoCurrent({ connectionUri: null });
+          break;
+      }
+    }
+
+    selectMessage(msg) {
+      const selected = msg.getIn(["viewState", "isSelected"]);
+
+      this.messages__viewState__markAsSelected({
+        messageUri: msg.get("uri"),
+        connectionUri: this.connection.get("uri"),
+        needUri: this.ownedNeed.get("uri"),
+        isSelected: !selected,
+      });
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {},
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.groupPostMessages", [
+    autoresizingTextareaModule,
+    chatTextFieldSimpleModule,
+    connectionMessageModule,
+    connectionHeaderModule,
+    labelledHrModule,
+    connectionContextDropdownModule,
+    postContentMessageModule,
+    petrinetStateModule,
+  ])
+  .directive("wonGroupPostMessages", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -7,7 +7,7 @@ import connectionHeaderModule from "./connection-header.js";
 import labelledHrModule from "./labelled-hr.js";
 import connectionContextDropdownModule from "./connection-context-dropdown.js";
 import { connect2Redux } from "../won-utils.js";
-import { attach, delay, getIn } from "../utils.js";
+import { attach, delay, getIn, get } from "../utils.js";
 import { isWhatsAroundNeed, isWhatsNewNeed } from "../need-utils.js";
 import { fetchMessage } from "../won-message-utils.js";
 import { actionCreators } from "../actions/actions.js";
@@ -44,7 +44,7 @@ function genComponentConf() {
         <div
           class="gpm__content">
             <div class="gpm__content__unreadindicator"
-              ng-if="self.unreadMessageCount && (!self._snapBottom || !self.showChatView)">
+              ng-if="self.unreadMessageCount && !self._snapBottom">
               <div class="gpm__content__unreadindicator__content won-button--filled red"
                 ng-click="self.goToUnreadMessages()">
                 {{self.unreadMessageCount}} unread Messages
@@ -156,18 +156,12 @@ function genComponentConf() {
       const selectFromState = state => {
         const connectionUri = getConnectionUriFromRoute(state);
         const ownedNeed = getOwnedNeedByConnectionUri(state, connectionUri);
-        const connection =
-          ownedNeed && ownedNeed.getIn(["connections", connectionUri]);
+        const connection = getIn(ownedNeed, ["connections", connectionUri]);
         const isOwnedNeedWhatsX =
-          this.ownedNeed &&
-          (isWhatsAroundNeed(this.ownedNeed) || isWhatsNewNeed(this.ownedNeed));
-        const nonOwnedNeedUri = connection && connection.get("remoteNeedUri");
-        const nonOwnedNeed =
-          nonOwnedNeedUri && state.getIn(["needs", nonOwnedNeedUri]);
-        const chatMessages =
-          connection &&
-          connection.get("messages") &&
-          connection.get("messages").filter(msg => !msg.get("forwardMessage"));
+          isWhatsAroundNeed(this.ownedNeed) || isWhatsNewNeed(this.ownedNeed);
+        const nonOwnedNeedUri = get(connection, "remoteNeedUri");
+        const nonOwnedNeed = getIn(state, ["needs", nonOwnedNeedUri]);
+        const chatMessages = get(connection, "messages");
         const allMessagesLoaded =
           chatMessages &&
           chatMessages.filter(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -268,6 +268,7 @@ function genComponentConf() {
         if (
           this.connection &&
           !this.isProcessingLoadingMessages &&
+          this.connection.get("messages").size < INITIAL_MESSAGECOUNT &&
           this.hasConnectionMessagesToLoad
         ) {
           this.connections__showLatestMessages(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -70,7 +70,6 @@ function genComponentConf() {
 
             <!-- CHATVIEW SPECIFIC CONTENT START-->
             <won-connection-message
-                ng-click="self.selectMessage(msg)"
                 ng-repeat="msg in self.sortedMessages"
                 connection-uri="self.connectionUri"
                 message-uri="msg.get('uri')"
@@ -426,17 +425,6 @@ function genComponentConf() {
           this.router__stateGoCurrent({ connectionUri: null });
           break;
       }
-    }
-
-    selectMessage(msg) {
-      const selected = msg.getIn(["viewState", "isSelected"]);
-
-      this.messages__viewState__markAsSelected({
-        messageUri: msg.get("uri"),
-        connectionUri: this.connection.get("uri"),
-        needUri: this.ownedNeed.get("uri"),
-        isSelected: !selected,
-      });
     }
   }
   Controller.$inject = serviceDependencies;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -15,6 +15,7 @@ import {
   getConnectionUriFromRoute,
   getOwnedNeedByConnectionUri,
 } from "../selectors/general-selectors.js";
+import { hasMessagesToLoad } from "../selectors/connection-selectors.js";
 import { getUnreadMessagesByConnectionUri } from "../selectors/message-selectors.js";
 import autoresizingTextareaModule from "../directives/textarea-autogrow.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -62,7 +63,7 @@ function genComponentConf() {
                 </svg>
             </div>
             <button class="gpm__content__loadbutton won-button--outlined thin red"
-                ng-if="!self.isSuggested && !self.isProcessingLoadingMessages && !self.allMessagesLoaded"
+                ng-if="!self.isSuggested && !self.isProcessingLoadingMessages && self.hasConnectionMessagesToLoad"
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
@@ -163,11 +164,10 @@ function genComponentConf() {
         const nonOwnedNeedUri = get(connection, "remoteNeedUri");
         const nonOwnedNeed = getIn(state, ["needs", nonOwnedNeedUri]);
         const chatMessages = get(connection, "messages");
-        const allMessagesLoaded =
-          chatMessages &&
-          chatMessages.filter(
-            msg => msg.get("messageType") === won.WONMSG.connectMessage
-          ).size > 0;
+        const hasConnectionMessagesToLoad = hasMessagesToLoad(
+          state,
+          connectionUri
+        );
 
         let sortedMessages = chatMessages && chatMessages.toArray();
         sortedMessages &&
@@ -216,7 +216,7 @@ function genComponentConf() {
           debugmode: won.debugmode,
           shouldShowRdf: state.getIn(["view", "showRdf"]),
           // if the connect-message is here, everything else should be as well
-          allMessagesLoaded,
+          hasConnectionMessagesToLoad,
           connectionOrNeedsLoading:
             !connection ||
             !nonOwnedNeed ||
@@ -268,7 +268,7 @@ function genComponentConf() {
         if (
           this.connection &&
           !this.isProcessingLoadingMessages &&
-          !(this.allMessagesLoaded || this.connection.get("messages").size > 0)
+          this.hasConnectionMessagesToLoad
         ) {
           this.connections__showLatestMessages(
             this.connection.get("uri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -72,7 +72,8 @@ function genComponentConf() {
                 ng-click="self.selectMessage(msg)"
                 ng-repeat="msg in self.sortedMessages"
                 connection-uri="self.connectionUri"
-                message-uri="msg.get('uri')">
+                message-uri="msg.get('uri')"
+                group-chat-message="::true">
             </won-connection-message>
             <!-- CHATVIEW SPECIFIC CONTENT END-->
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -26,14 +26,14 @@ function genComponentConf() {
       <div class="msg__header msg__header--agreement" ng-if="self.isConnectionMessage && (self.hasClaims || self.hasProposes) && !self.hasNotBeenLoaded">
           <div class="msg__header__type">{{ self.getAgreementHeaderLabel() }}</div>
       </div>
-      <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded">
+      <div class="msg__header msg__header--forwarded-from" ng-if="self.isConnectionMessage && self.originatorUri && !self.hasNotBeenLoaded && !self.isGroupChatMessage">
           <div class="msg__header__type">Forwarded from:</div>
           <won-square-image
             class="msg__header__originator"
             uri="self.originatorUri">
           </won-square-image>
       </div>
-      <div class="msg__header msg__header--inject-into" ng-if="self.isConnectionMessage && self.isInjectIntoMessage && !self.hasNotBeenLoaded">
+      <div class="msg__header msg__header--inject-into" ng-if="self.isConnectionMessage && self.isInjectIntoMessage && !self.hasNotBeenLoaded && !self.isGroupChatMessage">
           <div class="msg__header__type">Forward to:</div>
           <won-square-image
             class="msg__header__inject"
@@ -99,6 +99,7 @@ function genComponentConf() {
           hasClaims: referencesClaims && referencesClaims.size > 0,
           hasProposes: referencesProposes && referencesProposes.size > 0,
           messageStatus: message && message.get("messageStatus"),
+          isGroupChatMessage: this.groupChatMessage,
           isInjectIntoMessage: injectInto && injectInto.size > 0, //contains the remoteConnectionUris
           originatorUri: message && message.get("originatorUri"),
           injectIntoArray: injectInto && Array.from(injectInto.toSet()),
@@ -110,7 +111,7 @@ function genComponentConf() {
       connect2Redux(
         selectFromState,
         actionCreators,
-        ["self.connectionUri", "self.messageUri"],
+        ["self.connectionUri", "self.messageUri", "self.groupChatMessage"],
         this
       );
 
@@ -241,6 +242,7 @@ function genComponentConf() {
     scope: {
       messageUri: "=",
       connectionUri: "=",
+      groupChatMessage: "=",
     },
     template: template,
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -95,7 +95,7 @@ function genComponentConf() {
                   {{ self.generateCollapsedLabel() }}
     			      </div>
                 <div class="won-cm__center__bubble__carret clickable"
-                    ng-if="!self.isCollapsed && (self.isProposable || self.isClaimable) && !self.multiSelectType"
+                    ng-if="!self.isGroupChatMessage && !self.isCollapsed && (self.isProposable || self.isClaimable) && !self.multiSelectType"
                     ng-click="self.toggleActions()">
                     <svg ng-show="!self.showActions">
                         <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -6,8 +6,9 @@ import angular from "angular";
 import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
 import labelledHrModule from "./labelled-hr.js";
 import postContentGeneral from "./post-content-general.js";
+import postHeaderModule from "./post-header.js";
 import trigModule from "./trig.js";
-import { attach, getIn } from "../utils.js";
+import { attach, getIn, get } from "../utils.js";
 import won from "../won-es6.js";
 import { labels } from "../won-label-utils.js";
 import { connect2Redux } from "../won-utils.js";
@@ -44,7 +45,21 @@ function genComponentConf() {
           <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.hasContent && self.hasSeeksBranch"></won-labelled-hr>
           <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.hasSeeksBranch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
 
+          <!-- PARTICIPANT INFORMATION -->
+          <won-labelled-hr label="::'Group Members'" class="cp__labelledhr" ng-if="self.hasGroupMembers"></won-labelled-hr>
+          <div class="post-content__members" ng-if="self.hasGroupMembers">
+            <div
+              class="post-content__members__member"
+              ng-repeat="memberUri in self.groupMembersArray">
+              <won-post-header
+                need-uri="memberUri"
+                hide-image="::false">
+              </won-post-header>
+            </div>
+          </div>
+
           <!-- GENERAL INFORMATION -->
+          <won-labelled-hr label="::'General Information'" class="cp__labelledhr" ng-if="self.hasGroupMembers"></won-labelled-hr>
           <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
           <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
             <h2 class="post-info__heading">
@@ -84,20 +99,24 @@ function genComponentConf() {
 
       const selectFromState = state => {
         const openConnectionUri = getConnectionUriFromRoute(state);
-        const post = state.getIn(["needs", this.postUri]);
+        const post = getIn(state, ["needs", this.postUri]);
         const content = post ? post.get("content") : undefined;
 
         //TODO it will be possible to have more than one seeks
-        const seeks = post && post.get("seeks");
+        const seeks = get(post, "seeks");
 
         const hasContent = content && content.size > 0;
         const hasSeeksBranch = seeks && seeks.size > 0;
+
+        const groupMembers = get(post, "groupMembers");
 
         return {
           WON: won.WON,
           hasContent,
           hasSeeksBranch,
           post,
+          hasGroupMembers: groupMembers && groupMembers.size > 0,
+          groupMembersArray: groupMembers && groupMembers.toArray(),
           postLoading:
             !post ||
             getIn(state, ["process", "needs", post.get("uri"), "loading"]),
@@ -131,6 +150,7 @@ export default angular
     postIsOrSeeksInfoModule,
     labelledHrModule,
     postContentGeneral,
+    postHeaderModule,
     trigModule,
   ])
   .directive("wonPostContent", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -36,8 +36,6 @@ function genComponentConf() {
             <div class="post-skeleton__details"></div>
         </div>
         <div class="post-content" ng-if="!self.postLoading">
-          <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
-
           <won-gallery ng-if="self.post.get('hasImages')">
           </won-gallery>
 
@@ -45,6 +43,9 @@ function genComponentConf() {
           <won-post-is-or-seeks-info branch="::'content'" ng-if="self.hasContent" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
           <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.hasContent && self.hasSeeksBranch"></won-labelled-hr>
           <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.hasSeeksBranch" post-uri="self.post.get('uri')"></won-post-is-or-seeks-info>
+
+          <!-- GENERAL INFORMATION -->
+          <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
           <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
             <h2 class="post-info__heading">
                 RDF

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -12,6 +12,7 @@ import { attach, getIn, get } from "../utils.js";
 import won from "../won-es6.js";
 import { labels } from "../won-label-utils.js";
 import { connect2Redux } from "../won-utils.js";
+import { isPersona } from "../need-utils.js";
 import { getConnectionUriFromRoute } from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -58,8 +59,21 @@ function genComponentConf() {
             </div>
           </div>
 
+          <!-- OTHER NEEDS -->
+          <won-labelled-hr label="::'Posts of this Persona'" class="cp__labelledhr" ng-if="self.isPersona && self.hasHeldPosts"></won-labelled-hr>
+          <div class="post-content__members" ng-if="self.isPersona && self.hasHeldPosts">
+            <div
+              class="post-content__members__member"
+              ng-repeat="heldPostUri in self.heldPostsArray">
+              <won-post-header
+                need-uri="heldPostUri"
+                hide-image="::false">
+              </won-post-header>
+            </div>
+          </div>
+
           <!-- GENERAL INFORMATION -->
-          <won-labelled-hr label="::'General Information'" class="cp__labelledhr" ng-if="self.hasGroupMembers"></won-labelled-hr>
+          <won-labelled-hr label="::'General Information'" class="cp__labelledhr"></won-labelled-hr>
           <won-post-content-general post-uri="self.post.get('uri')"></won-post-content-general>
           <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
             <h2 class="post-info__heading">
@@ -110,11 +124,16 @@ function genComponentConf() {
 
         const groupMembers = get(post, "groupMembers");
 
+        const heldPosts = get(post, "holds");
+
         return {
           WON: won.WON,
           hasContent,
           hasSeeksBranch,
           post,
+          isPersona: isPersona(post),
+          hasHeldPosts: isPersona && heldPosts && heldPosts.size > 0,
+          heldPostsArray: isPersona && heldPosts && heldPosts.toArray(),
           hasGroupMembers: groupMembers && groupMembers.size > 0,
           groupMembersArray: groupMembers && groupMembers.toArray(),
           postLoading:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -6,7 +6,7 @@ import angular from "angular";
 import ngAnimate from "angular-animate";
 import { actionCreators } from "../actions/actions.js";
 import won from "../won-es6.js";
-import { attach, toAbsoluteURL, getIn } from "../utils.js";
+import { attach, toAbsoluteURL, getIn, get } from "../utils.js";
 import {
   connect2Redux,
   createDocumentDefinitionFromPost,
@@ -42,6 +42,12 @@ function genComponentConf() {
                         </svg>
                     </div>
                     <!-- Buttons for post -->
+                    <button
+                        class="won-button--outlined thin red"
+                        ng-if="self.personaUri"
+                        ng-click="self.goToPersona(self.personaUri)">
+                        View Persona
+                    </button>
                     <button class="won-button--outlined thin red"
                         ng-click="self.exportPdf()">
                         Export as PDF
@@ -86,8 +92,11 @@ function genComponentConf() {
           linkToPost = toAbsoluteURL(ownerBaseUrl).toString() + path;
         }
 
+        const personaUri = get(post, "heldBy");
+
         return {
           adminEmail: getIn(state, ["config", "theme", "adminEmail"]),
+          personaUri,
           isOwnPost: post && post.get("isOwned"),
           isActive: postState === won.WON.ActiveCompacted,
           isInactive: postState === won.WON.InactiveCompacted,
@@ -118,6 +127,10 @@ function genComponentConf() {
       });
 
       window.document.addEventListener("click", callback);
+    }
+
+    goToPersona(personaUri) {
+      this.router__stateGoCurrent({ useCase: undefined, postUri: personaUri });
     }
 
     closePost() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -157,7 +157,10 @@ function genComponentConf() {
     }
 
     ensureNeedIsLoaded() {
-      if (this.postToLoad && !this.postLoading) {
+      if (
+        this.needUri &&
+        (!this.need || (this.postToLoad && !this.postLoading))
+      ) {
         this.needs__fetchUnloadedNeed(this.needUri);
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -12,7 +12,12 @@ import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
 import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
-import { generateNeedTypesLabel, isDirectResponseNeed } from "../need-utils.js";
+import {
+  generateNeedTypesLabel,
+  isDirectResponseNeed,
+  hasGroupFacet,
+  hasChatFacet,
+} from "../need-utils.js";
 
 import "style/_post-header.scss";
 
@@ -29,7 +34,7 @@ function genComponentConf() {
     <div class="ph__right" ng-if="!self.need.get('isBeingCreated') && !self.postLoading">
       <div class="ph__right__topline" ng-if="!self.postFailedToLoad">
         <div class="ph__right__topline__title" ng-if="self.hasTitle()">
-         {{ self.generateTitle() }}
+          {{ self.generateTitle() }}
         </div>
         <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && self.isDirectResponse">
           RE: no title
@@ -40,6 +45,14 @@ function genComponentConf() {
       </div>
       <div class="ph__right__subtitle" ng-if="!self.postFailedToLoad">
         <span class="ph__right__subtitle__type">
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && !self.isChatEnabled">
+            Group Chat
+          </span>
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && self.isChatEnabled">
+            Group Chat enabled
+          </span>
           {{ self.generateNeedTypesLabel(self.need) }}
         </span>
         <div class="ph__right__subtitle__date">
@@ -66,7 +79,14 @@ function genComponentConf() {
       </div>
       <div class="ph__right__subtitle">
         <span class="ph__right__subtitle__type">
-          <!-- TODO: We Do not store a single type anymore but a list of types... adapt accordingly -->
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && !self.isChatEnabled">
+            Group Chat
+          </span>
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && self.isChatEnabled">
+            Group Chat enabled
+          </span>
           {{ self.generateNeedTypesLabel(self.need) }}
         </span>
       </div>
@@ -109,6 +129,8 @@ function genComponentConf() {
             need &&
             getIn(state, ["process", "needs", need.get("uri"), "failedToLoad"]),
           isDirectResponse: isDirectResponse,
+          isGroupChatEnabled: hasGroupFacet(need),
+          isChatEnabled: hasChatFacet(need),
           friendlyTimestamp:
             need &&
             relativeTime(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -7,7 +7,7 @@ import "ng-redux";
 import squareImageModule from "./square-image.js";
 import { actionCreators } from "../actions/actions.js";
 import { relativeTime } from "../won-label-utils.js";
-import { attach, getIn } from "../utils.js";
+import { attach, getIn, delay } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
 import won from "../won-es6.js";
@@ -149,6 +149,17 @@ function genComponentConf() {
 
       classOnComponentRoot("won-is-loading", () => this.postLoading, this);
       classOnComponentRoot("won-is-toload", () => this.postToLoad, this);
+
+      this.$scope.$watch(
+        () => this.needUri,
+        () => delay(0).then(() => this.ensureNeedIsLoaded())
+      );
+    }
+
+    ensureNeedIsLoaded() {
+      if (this.postToLoad && !this.postLoading) {
+        this.needs__fetchUnloadedNeed(this.needUri);
+      }
     }
 
     hasTitle() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -34,7 +34,7 @@ function genComponentConf() {
             <won-post-context-dropdown></won-post-context-dropdown>
         </div>
         <won-post-content post-uri="self.postUri"></won-post-content>
-        <div class="post-info__footer" ng-if="!self.postLoading && !self.postFailedToLoad">
+        <div class="post-info__footer" ng-if="!self.postLoading && !self.postFailedToLoad && self.showCreateWhatsAround()">
             <button class="won-button--filled red post-info__footer__button"
                 ng-if="self.showCreateWhatsAround()"
                 ng-click="self.createWhatsAround()"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -460,6 +460,7 @@ function genComponentConf() {
         if (
           this.connection &&
           !this.isProcessingLoadingMessages &&
+          this.connection.get("messages").size < INITIAL_MESSAGECOUNT &&
           this.hasConnectionMessagesToLoad
         ) {
           this.connections__showLatestMessages(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -21,6 +21,7 @@ import {
   getConnectionUriFromRoute,
   getOwnedNeedByConnectionUri,
 } from "../selectors/general-selectors.js";
+import { hasMessagesToLoad } from "../selectors/connection-selectors.js";
 import {
   getAgreementMessagesByConnectionUri,
   getCancellationPendingMessagesByConnectionUri,
@@ -111,7 +112,7 @@ function genComponentConf() {
               Calculating PetriNet Status
             </div>
             <button class="pm__content__loadbutton won-button--outlined thin red"
-                ng-if="!self.isSuggested && self.showChatData && !self.isProcessingLoadingMessages && !self.allMessagesLoaded"
+                ng-if="!self.isSuggested && self.showChatData && !self.isProcessingLoadingMessages && self.hasConnectionMessagesToLoad"
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
@@ -271,11 +272,10 @@ function genComponentConf() {
           connection &&
           connection.get("messages") &&
           connection.get("messages").filter(msg => !msg.get("forwardMessage"));
-        const allMessagesLoaded =
-          chatMessages &&
-          chatMessages.filter(
-            msg => msg.get("messageType") === won.WONMSG.connectMessage
-          ).size > 0;
+        const hasConnectionMessagesToLoad = hasMessagesToLoad(
+          state,
+          connectionUri
+        );
 
         const agreementData = connection && connection.get("agreementData");
         const petriNetData = connection && connection.get("petriNetData");
@@ -394,7 +394,7 @@ function genComponentConf() {
           debugmode: won.debugmode,
           shouldShowRdf: state.getIn(["view", "showRdf"]),
           // if the connect-message is here, everything else should be as well
-          allMessagesLoaded,
+          hasConnectionMessagesToLoad,
           hasAgreementMessages: agreementMessages && agreementMessages.size > 0,
           hasPetriNetData: petriNetData && petriNetData.size > 0,
           agreementMessagesArray:
@@ -460,7 +460,7 @@ function genComponentConf() {
         if (
           this.connection &&
           !this.isProcessingLoadingMessages &&
-          !(this.allMessagesLoaded || this.connection.get("messages").size > 0)
+          this.hasConnectionMessagesToLoad
         ) {
           this.connections__showLatestMessages(
             this.connection.get("uri"),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
@@ -26,6 +26,13 @@ function genComponentConf($ngRedux) {
         $ngRedux.dispatch(actionCreators.personas__create(persona));
       });
 
+      elmApp.ports.updatePersonas.subscribe(() => {
+        const personas = getOwnedPersonas($ngRedux.getState());
+        if (personas) {
+          elmApp.ports.personaIn.send(personas.toJS());
+        }
+      });
+
       const personas = getOwnedPersonas($ngRedux.getState());
       if (personas) {
         elmApp.ports.personaIn.send(personas.toJS());

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/square-image.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/square-image.js
@@ -2,6 +2,7 @@ import angular from "angular";
 
 import won from "../won-es6.js";
 import { attach, generateRgbColorArray, get, getIn } from "../utils.js";
+import { isPersona } from "../need-utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -40,6 +41,7 @@ function genComponentConf() {
         const personaIdenticonSvg = this.parseIdenticon(personaUri);
 
         return {
+          isPersona: isPersona(need),
           needInactive:
             need && get(need, "state") === won.WON.InactiveCompacted,
           needFailedToLoad:
@@ -64,6 +66,8 @@ function genComponentConf() {
         () => this.needFailedToLoad,
         this
       );
+
+      classOnComponentRoot("won-is-persona", () => this.isPersona, this);
     }
 
     parseIdenticon(input) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -206,7 +206,7 @@ function genComponentConf() {
     // TODO: group search results by use case groups - only showing groups with results
     updateSearch() {
       const query = this.textfield().value;
-      let results = [];
+      let results = new Map();
 
       if (query && query.trim().length > 1) {
         this.isSearching = true;
@@ -216,7 +216,7 @@ function genComponentConf() {
 
           for (const useCase of group) {
             if (this.searchFunction(useCase, query)) {
-              results.push(useCase);
+              results.set(useCase.identifier, useCase);
             }
           }
         }
@@ -226,7 +226,7 @@ function genComponentConf() {
           this.isSearching = false;
         }
 
-        this.searchResults = results;
+        this.searchResults = Array.from(results.values());
       } else {
         this.searchResults = undefined;
         this.isSearching = false;
@@ -238,7 +238,6 @@ function genComponentConf() {
       if (!this.displayableUseCase(useCase)) {
         return false;
       }
-
       // check for searchString in use case label and draft
       const useCaseLabel = JSON.stringify(useCase.label).toLowerCase();
       const useCaseDraft = JSON.stringify(useCase.draft).toLowerCase();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -105,3 +105,70 @@ export function isChatToGroup(needs, needUri, connUri) {
     }
   }
 }
+
+/**
+ * Creates a label of the participants and suggestions/requests/invites of a given set of groupChatConnections
+ * @param groupChatConnections
+ */
+export function generateGroupChatParticipantsLabel(groupChatConnections) {
+  const participantsSize = groupChatConnections.filter(
+    conn => conn.get("state") === won.WON.Connected
+  ).size;
+  const suggestedSize = groupChatConnections.filter(
+    conn => conn.get("state") === won.WON.Suggested
+  ).size;
+  const invitedSize = groupChatConnections.filter(
+    conn => conn.get("state") === won.WON.RequestSent
+  ).size;
+  const requestedSize = groupChatConnections.filter(
+    conn => conn.get("state") === won.WON.RequestReceived
+  ).size;
+
+  const createPartOfLabel = (size, entitySingular, entityPlural) => {
+    if (size == 0) {
+      return "No " + entityPlural + " yet";
+    }
+    if (size == 1) {
+      return size + " " + entitySingular;
+    } else if (size > 1) {
+      return size + " " + entityPlural;
+    }
+  };
+
+  let participantsLabel = createPartOfLabel(
+    participantsSize,
+    "Participant",
+    "Participants"
+  );
+
+  if (invitedSize > 0) {
+    if (participantsLabel.length > 0) {
+      participantsLabel += ", ";
+    }
+    participantsLabel += createPartOfLabel(invitedSize, "Invited", "Invited");
+  }
+
+  if (requestedSize > 0) {
+    if (participantsLabel.length > 0) {
+      participantsLabel += ", ";
+    }
+    participantsLabel += createPartOfLabel(
+      requestedSize,
+      "Request",
+      "Requests"
+    );
+  }
+
+  if (suggestedSize > 0) {
+    if (participantsLabel.length > 0) {
+      participantsLabel += ", ";
+    }
+    participantsLabel += createPartOfLabel(
+      suggestedSize,
+      "Suggested",
+      "Suggested"
+    );
+  }
+
+  return participantsLabel;
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -110,8 +110,8 @@ export function isChatToGroup(needs, needUri, connUri) {
  * Creates a label of the participants and suggestions/requests/invites of a given set of groupChatConnections
  * @param groupChatConnections
  */
-export function generateGroupChatParticipantsLabel(groupChatConnections) {
-  const participantsSize = groupChatConnections.filter(
+export function generateGroupChatMembersLabel(groupChatConnections) {
+  const groupMembersSize = groupChatConnections.filter(
     conn => conn.get("state") === won.WON.Connected
   ).size;
   const suggestedSize = groupChatConnections.filter(
@@ -135,24 +135,24 @@ export function generateGroupChatParticipantsLabel(groupChatConnections) {
     }
   };
 
-  let participantsLabel = createPartOfLabel(
-    participantsSize,
-    "Participant",
-    "Participants"
+  let groupMembersLabel = createPartOfLabel(
+    groupMembersSize,
+    "Group Member",
+    "Group Members"
   );
 
   if (invitedSize > 0) {
-    if (participantsLabel.length > 0) {
-      participantsLabel += ", ";
+    if (groupMembersLabel.length > 0) {
+      groupMembersLabel += ", ";
     }
-    participantsLabel += createPartOfLabel(invitedSize, "Invited", "Invited");
+    groupMembersLabel += createPartOfLabel(invitedSize, "Invited", "Invited");
   }
 
   if (requestedSize > 0) {
-    if (participantsLabel.length > 0) {
-      participantsLabel += ", ";
+    if (groupMembersLabel.length > 0) {
+      groupMembersLabel += ", ";
     }
-    participantsLabel += createPartOfLabel(
+    groupMembersLabel += createPartOfLabel(
       requestedSize,
       "Request",
       "Requests"
@@ -160,15 +160,15 @@ export function generateGroupChatParticipantsLabel(groupChatConnections) {
   }
 
   if (suggestedSize > 0) {
-    if (participantsLabel.length > 0) {
-      participantsLabel += ", ";
+    if (groupMembersLabel.length > 0) {
+      groupMembersLabel += ", ";
     }
-    participantsLabel += createPartOfLabel(
+    groupMembersLabel += createPartOfLabel(
       suggestedSize,
       "Suggested",
       "Suggested"
     );
   }
 
-  return participantsLabel;
+  return groupMembersLabel;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -3,10 +3,11 @@
  */
 
 import won from "./won-es6.js";
-
+import { hasGroupFacet, hasChatFacet } from "./need-utils.js";
+import { get, getIn } from "./utils.js";
 /**
  * Determines if a given connection is a chatConnection
- * @param msg
+ * @param conn
  * @returns {*|boolean}
  */
 export function isChatConnection(conn) {
@@ -19,7 +20,7 @@ export function isChatConnection(conn) {
 
 /**
  * Determines if a given connection is a groupChatConnection
- * @param msg
+ * @param conn
  * @returns {*|boolean}
  */
 export function isGroupChatConnection(conn) {
@@ -32,7 +33,7 @@ export function isGroupChatConnection(conn) {
 
 /**
  * Determines if a given connection is a chatConnection on the remoteSide
- * @param msg
+ * @param conn
  * @returns {*|boolean}
  */
 export function isRemoteChatConnection(conn) {
@@ -45,7 +46,7 @@ export function isRemoteChatConnection(conn) {
 
 /**
  * Determines if a given connection is a groupChatConnection on the remoteSide
- * @param msg
+ * @param conn
  * @returns {*|boolean}
  */
 export function isRemoteGroupChatConnection(conn) {
@@ -58,9 +59,65 @@ export function isRemoteGroupChatConnection(conn) {
 
 /**
  * Determines if a given connection is a chatConnection connected to a groupFacet on the remoteSide
- * @param msg
+ * @param conn
  * @returns {*|boolean}
  */
-export function isChatConnectionToGroup(conn) {
+function isChatConnectionToGroup(conn) {
   return isChatConnection(conn) && isRemoteGroupChatConnection(conn);
+}
+
+/**
+ * Determines if the connection is between a single need and a groupChat
+ * This method is only necessary because certain connections (e.g. suggested connections), do not have a remoteConnection
+ * and therefore we can't distinguish between chatToGroup and chatToChat connections without looking into the remoteNeed
+ * in addition to the connection itself -> should be resolved once the hints store the remoteFacet in addition to the facet
+ * FIXME: Current workaround for suggestedConnections that do not contains a remoteFacet
+ * FIXME: once both remote and own facet are present in the connection we should be able to use the isChatConnectionToGroup function without any workaround
+ * @param needs reduxState needs
+ * @param connUri to check
+ * @param needUri to check
+ * @returns {boolean}
+ */
+export function isChatToGroup(needs, needUri, connUri) {
+  const need = get(needs, needUri);
+  const conn = getIn(need, ["connections", connUri]);
+
+  if (isChatConnectionToGroup(conn)) {
+    return true;
+  } else {
+    const remoteNeedUri = get(conn, "remoteNeedUri");
+    const remoteNeed = get(needs, remoteNeedUri);
+
+    if (hasGroupFacet(remoteNeed)) {
+      if (hasChatFacet(remoteNeed)) {
+        console.warn(
+          "The remoteNeed contains the chatFacet as well as the groupFacet, we do not know if this connection is connecting with the groupFacet or with the chatFacet just yet: remoteNeed:",
+          remoteNeed,
+          ", need:",
+          need,
+          " conn:",
+          conn
+        );
+      }
+      console.log(
+        "needUri",
+        needUri,
+        "connUri:",
+        connUri,
+        "isChatToGroup?",
+        true
+      );
+      return true;
+    } else {
+      console.log(
+        "needUri",
+        needUri,
+        "connUri:",
+        connUri,
+        "isChatToGroup?",
+        false
+      );
+      return false;
+    }
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -99,24 +99,8 @@ export function isChatToGroup(needs, needUri, connUri) {
           conn
         );
       }
-      console.log(
-        "needUri",
-        needUri,
-        "connUri:",
-        connUri,
-        "isChatToGroup?",
-        true
-      );
       return true;
     } else {
-      console.log(
-        "needUri",
-        needUri,
-        "connUri:",
-        connUri,
-        "isChatToGroup?",
-        false
-      );
       return false;
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -56,6 +56,11 @@ export function isRemoteGroupChatConnection(conn) {
   );
 }
 
+/**
+ * Determines if a given connection is a chatConnection connected to a groupFacet on the remoteSide
+ * @param msg
+ * @returns {*|boolean}
+ */
 export function isChatConnectionToGroup(conn) {
   return isChatConnection(conn) && isRemoteGroupChatConnection(conn);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/connection-utils.js
@@ -5,7 +5,7 @@
 import won from "./won-es6.js";
 
 /**
- * Determines if a given connection is a chatConnection or a groupChatConnection
+ * Determines if a given connection is a chatConnection
  * @param msg
  * @returns {*|boolean}
  */
@@ -13,8 +13,7 @@ export function isChatConnection(conn) {
   return (
     conn &&
     conn.get("facet") &&
-    (conn.get("facet") === won.WON.ChatFacetCompacted ||
-      isGroupChatConnection(conn))
+    conn.get("facet") === won.WON.ChatFacetCompacted
   );
 }
 
@@ -29,4 +28,34 @@ export function isGroupChatConnection(conn) {
     conn.get("facet") &&
     conn.get("facet") === won.WON.GroupFacetCompacted
   );
+}
+
+/**
+ * Determines if a given connection is a chatConnection on the remoteSide
+ * @param msg
+ * @returns {*|boolean}
+ */
+export function isRemoteChatConnection(conn) {
+  return (
+    conn &&
+    conn.get("facet") &&
+    conn.get("facet") === won.WON.ChatFacetCompacted
+  );
+}
+
+/**
+ * Determines if a given connection is a groupChatConnection on the remoteSide
+ * @param msg
+ * @returns {*|boolean}
+ */
+export function isRemoteGroupChatConnection(conn) {
+  return (
+    conn &&
+    conn.get("remoteFacet") &&
+    conn.get("remoteFacet") === won.WON.GroupFacetCompacted
+  );
+}
+
+export function isChatConnectionToGroup(conn) {
+  return isChatConnection(conn) && isRemoteGroupChatConnection(conn);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -29,6 +29,14 @@ export function isDirectResponseNeed(need) {
   );
 }
 
+export function isPersona(need) {
+  return get(need, "types") && get(need, "types").has("won:Persona");
+}
+
+export function isNeed(need) {
+  return get(need, "types") && get(need, "types").has("won:Need");
+}
+
 export function hasChatFacet(need) {
   return (
     get(need, "facets") &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -1,8 +1,9 @@
-import won from "./won-es6.js";
-
 /**
  * Created by fsuda on 08.11.2018.
  */
+
+import won from "./won-es6.js";
+import { get, getIn } from "./utils.js";
 
 /**
  * Determines if a given need is a WhatsAround-Need
@@ -11,9 +12,8 @@ import won from "./won-es6.js";
  */
 export function isWhatsAroundNeed(need) {
   return (
-    need &&
-    need.getIn(["content", "flags"]) &&
-    need.getIn(["content", "flags"]).contains("won:WhatsAround")
+    getIn(need, ["content", "flags"]) &&
+    getIn(need, ["content", "flags"]).contains("won:WhatsAround")
   );
 }
 
@@ -24,25 +24,22 @@ export function isWhatsAroundNeed(need) {
  */
 export function isDirectResponseNeed(need) {
   return (
-    need &&
-    need.getIn(["content", "flags"]) &&
-    need.getIn(["content", "flags"]).contains("won:DirectResponse")
+    getIn(need, ["content", "flags"]) &&
+    getIn(need, ["content", "flags"]).contains("won:DirectResponse")
   );
 }
 
 export function hasChatFacet(need) {
   return (
-    need &&
-    need.get("facets") &&
-    need.get("facets").contains(won.WON.ChatFacetCompacted)
+    get(need, "facets") &&
+    get(need, "facets").contains(won.WON.ChatFacetCompacted)
   );
 }
 
 export function hasGroupFacet(need) {
   return (
-    need &&
-    need.get("facets") &&
-    need.get("facets").contains(won.WON.GroupFacetCompacted)
+    get(need, "facets") &&
+    get(need, "facets").contains(won.WON.GroupFacetCompacted)
   );
 }
 
@@ -52,7 +49,7 @@ export function hasGroupFacet(need) {
  * @returns {*|boolean}
  */
 export function isSearchNeed(need) {
-  return need && need.get("types") && need.get("types").has("won:PureSearch");
+  return get(need, "types") && get(need, "types").has("won:PureSearch");
 }
 
 /**
@@ -62,9 +59,8 @@ export function isSearchNeed(need) {
  */
 export function isWhatsNewNeed(need) {
   return (
-    need &&
-    need.getIn(["content", "flags"]) &&
-    need.getIn(["content", "flags"]).contains("won:WhatsNew")
+    getIn(need, ["content", "flags"]) &&
+    getIn(need, ["content", "flags"]).contains("won:WhatsNew")
   );
 }
 
@@ -72,8 +68,8 @@ export function isWhatsNewNeed(need) {
  * Generates a string that can be used as a Types Label for any given need, includes the matchingContexts
  */
 export function generateNeedTypesLabel(needImm) {
-  const matchingContexts = needImm && needImm.get("matchingContexts");
-  const types = needImm && needImm.get("types");
+  const matchingContexts = get(needImm, "matchingContexts");
+  const types = get(needImm, "types");
 
   //TODO: GENERATE CORRECT LABEL
   //self.labels.type[self.need.get('type')]

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -770,10 +770,9 @@ export default function(allNeedsInState = initialState, action = {}) {
         eventUri,
       ];
       if (allNeedsInState.getIn(path)) {
-        allNeedsInState = allNeedsInState.setIn(
-          [...path, "isReceivedByRemote"],
-          true
-        );
+        allNeedsInState = allNeedsInState
+          .setIn([...path, "isReceivedByRemote"], true)
+          .setIn([...path, "isReceivedByOwn"], true);
       } else {
         console.error(
           "chatMessage.successRemote for message that was not sent(or was not loaded in the state yet, wonMessage: ",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -61,20 +61,6 @@ export default function(allNeedsInState = initialState, action = {}) {
         need.set("isOwned", false).set("connections", Immutable.Map())
       );
 
-    case actionTypes.needs.fetchSuggested: {
-      const suggestedPosts = action.payload.get("suggestedPosts");
-
-      if (!suggestedPosts) {
-        return allNeedsInState;
-      }
-
-      return suggestedPosts.reduce(
-        (updatedState, suggestedPost) =>
-          addNeed(updatedState, suggestedPost, false),
-        allNeedsInState
-      );
-    }
-
     case actionTypes.needs.storeOwnedActiveUris: {
       return addOwnActiveNeedsInLoading(
         allNeedsInState,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -784,11 +784,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       return allNeedsInState;
     }
 
-    case actionTypes.reconnect.startingToLoadConnectionData:
-    case actionTypes.reconnect.receivedConnectionData:
-    case actionTypes.reconnect.connectionFailedToLoad:
-    case actionTypes.connections.showLatestMessages:
-    case actionTypes.connections.showMoreMessages: {
+    case actionTypes.connections.fetchMessagesSuccess: {
       const loadedMessages = action.payload.get("events");
       if (loadedMessages) {
         allNeedsInState = addExistingMessages(allNeedsInState, loadedMessages);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-connection.js
@@ -9,6 +9,7 @@ export function parseConnection(jsonldConnection) {
   let parsedConnection = {
     belongsToUri: undefined,
     facetUri: jsonldConnectionImm.get("hasFacet"),
+    remoteFacetUri: jsonldConnectionImm.get("hasRemoteFacet"),
     data: {
       uri: undefined,
       state: undefined,
@@ -29,6 +30,7 @@ export function parseConnection(jsonldConnection) {
       petriNetData: Immutable.Map(),
       remoteNeedUri: undefined,
       remoteConnectionUri: undefined,
+      remoteFacet: undefined, //will be determined by the reduce-connections
       creationDate: undefined,
       lastUpdateDate: undefined,
       unread: undefined,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -24,6 +24,9 @@ export function parseNeed(jsonldNeed, isOwned) {
       holds:
         won.parseListFrom(jsonldNeedImm, ["won:holds"], "xsd:ID") ||
         Immutable.List(),
+      groupMembers:
+        won.parseListFrom(jsonldNeedImm, ["won:hasGroupMember"], "xsd:ID") ||
+        Immutable.List(),
       content: generateContent(jsonldNeedImm, detailsToParse),
       seeks: generateContent(jsonldNeedImm.get("won:seeks"), detailsToParse),
       creationDate: extractCreationDate(jsonldNeedImm),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -352,10 +352,6 @@ export function setMultiSelectType(
 }
 
 export function addActiveConnectionsToNeedInLoading(state, needUri, connUris) {
-  needUri &&
-    connUris &&
-    connUris.size > 0 &&
-    console.debug("addActiveConnectionsToNeedInLoading: ", connUris);
   let newState = state;
   needUri &&
     connUris &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -30,6 +30,7 @@ function addConnectionFull(state, connection) {
     const need = state.get(needUri);
 
     if (need) {
+      const remoteNeedUri = parsedConnection.getIn(["data", "remoteNeedUri"]);
       const connectionUri = parsedConnection.getIn(["data", "uri"]);
 
       const facetUri = parsedConnection.get("facetUri");
@@ -38,7 +39,7 @@ function addConnectionFull(state, connection) {
       parsedConnection = parsedConnection.setIn(["data", "facet"], realFacet);
 
       if (realFacet === won.WON.HolderFacetCompacted) {
-        const holdsUri = parsedConnection.getIn(["data", "remoteNeedUri"]);
+        const holdsUri = remoteNeedUri;
         console.debug(
           "Handling a holderFacet-connection within need: ",
           needUri,
@@ -56,7 +57,7 @@ function addConnectionFull(state, connection) {
         }
       } else if (realFacet === won.WON.HoldableFacetCompacted) {
         //holdableFacet Connection from need to persona -> need to add heldBy remoteNeedUri to the need
-        const heldByUri = parsedConnection.getIn(["data", "remoteNeedUri"]);
+        const heldByUri = remoteNeedUri;
         console.debug(
           "Handling a holdableFacet-connection within need: ",
           needUri,
@@ -66,6 +67,20 @@ function addConnectionFull(state, connection) {
 
         if (heldByUri) {
           state = state.setIn([needUri, "heldBy"], heldByUri);
+        }
+      }
+
+      const remoteNeed = state.get(remoteNeedUri);
+
+      if (remoteNeed) {
+        const remoteFacetUri = parsedConnection.get("remoteFacetUri");
+        const realRemoteFacet = remoteNeed.getIn(["facets", remoteFacetUri]);
+
+        if (realRemoteFacet) {
+          parsedConnection = parsedConnection.setIn(
+            ["data", "remoteFacet"],
+            realRemoteFacet
+          );
         }
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -66,12 +66,9 @@ export function addMessage(
       }
 
       if (needUri) {
-        console.debug(
-          "Adding Message to connection with connUri: ",
-          connectionUri,
-          " isGroupChat: ",
-          isChatToGroup(state, needUri, connectionUri)
-        );
+        if (isChatToGroup(state, needUri, connectionUri)) {
+          console.log("Adding message to a chatToGroup Connection");
+        }
 
         if (wonMessage.hasContainedForwardedWonMessages()) {
           const containedForwardedWonMessages = wonMessage.getContainedForwardedWonMessages();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -1,6 +1,7 @@
 import { parseMessage } from "./parse-message.js";
 import { markUriAsRead } from "../../won-localstorage.js";
 import { markConnectionAsRead } from "./reduce-connections.js";
+import { addTheirNeedToLoad } from "./reduce-needs.js";
 import { getOwnMessageUri } from "../../message-utils.js";
 import { isChatToGroup } from "../../connection-utils.js";
 
@@ -62,6 +63,18 @@ export function addMessage(
             [needUri, "connections", connectionUri, "unread"],
             true
           );
+        }
+      }
+
+      const originatorUri = parsedMessage.getIn(["data", "originatorUri"]);
+
+      if (originatorUri) {
+        //Message is originally from another need, we might need to add the need as well
+        if (!state.has(originatorUri)) {
+          console.debug(
+            "Originator Need is not in the state yet, we need to add it"
+          );
+          state = addTheirNeedToLoad(state, originatorUri);
         }
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -2,6 +2,8 @@ import { parseMessage } from "./parse-message.js";
 import { markUriAsRead } from "../../won-localstorage.js";
 import { markConnectionAsRead } from "./reduce-connections.js";
 import { getOwnMessageUri } from "../../message-utils.js";
+import { isChatConnectionToGroup } from "../../connection-utils.js";
+import { getIn } from "../../utils.js";
 
 /*
  "alreadyProcessed" flag, which indicates that we do not care about the
@@ -65,6 +67,14 @@ export function addMessage(
       }
 
       if (needUri) {
+        const conn = getIn(state, [needUri, "connections", connectionUri]);
+        console.debug(
+          "Adding Message to connection with connUri: ",
+          connectionUri,
+          " chatToGroupConnection: ",
+          isChatConnectionToGroup(conn)
+        );
+
         if (wonMessage.hasContainedForwardedWonMessages()) {
           const containedForwardedWonMessages = wonMessage.getContainedForwardedWonMessages();
           containedForwardedWonMessages.map(forwardedWonMessage => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -66,11 +66,9 @@ export function addMessage(
       }
 
       if (needUri) {
-        if (isChatToGroup(state, needUri, connectionUri)) {
-          console.log("Adding message to a chatToGroup Connection");
-        }
+        const hasContainedForwardedWonMessages = wonMessage.hasContainedForwardedWonMessages();
 
-        if (wonMessage.hasContainedForwardedWonMessages()) {
+        if (hasContainedForwardedWonMessages) {
           const containedForwardedWonMessages = wonMessage.getContainedForwardedWonMessages();
           containedForwardedWonMessages.map(forwardedWonMessage => {
             state = addMessage(
@@ -94,10 +92,24 @@ export function addMessage(
           //ignore messages for nonexistant connections
           return state;
         }
-        messages = messages.set(
-          parsedMessage.getIn(["data", "uri"]),
-          parsedMessage.get("data")
-        );
+
+        /*
+        Group Chat messages that are received are in the form of injected/referenced messages
+        But we do not want to display these messages in that manner, therefore we simply ignore
+        the encapsulating message and not store it within our state.
+        */
+        if (
+          !(
+            hasContainedForwardedWonMessages &&
+            isChatToGroup(state, needUri, connectionUri)
+          )
+        ) {
+          messages = messages.set(
+            parsedMessage.getIn(["data", "uri"]),
+            parsedMessage.get("data")
+          );
+        }
+
         return state.setIn(
           [needUri, "connections", connectionUri, "messages"],
           messages

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -2,8 +2,7 @@ import { parseMessage } from "./parse-message.js";
 import { markUriAsRead } from "../../won-localstorage.js";
 import { markConnectionAsRead } from "./reduce-connections.js";
 import { getOwnMessageUri } from "../../message-utils.js";
-import { isChatConnectionToGroup } from "../../connection-utils.js";
-import { getIn } from "../../utils.js";
+import { isChatToGroup } from "../../connection-utils.js";
 
 /*
  "alreadyProcessed" flag, which indicates that we do not care about the
@@ -67,12 +66,11 @@ export function addMessage(
       }
 
       if (needUri) {
-        const conn = getIn(state, [needUri, "connections", connectionUri]);
         console.debug(
           "Adding Message to connection with connUri: ",
           connectionUri,
-          " chatToGroupConnection: ",
-          isChatConnectionToGroup(conn)
+          " isGroupChat: ",
+          isChatToGroup(state, needUri, connectionUri)
         );
 
         if (wonMessage.hasContainedForwardedWonMessages()) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -20,6 +20,24 @@ export function addNeed(needs, jsonldNeed, isOwned) {
           .set("connections", existingNeed.get("connections"))
           .set("isOwned", false);
       }
+
+      const heldNeedUris = parsedNeed.get("holds");
+      if (heldNeedUris.size > 0) {
+        heldNeedUris.map(needUri => {
+          if (!needs.get(needUri) || !needs.getIn([needUri, "isOwned"])) {
+            needs = addTheirNeedToLoad(needs, needUri);
+          }
+        });
+      }
+
+      const groupMemberUris = parsedNeed.get("groupMembers");
+      if (groupMemberUris.size > 0) {
+        groupMemberUris.map(needUri => {
+          if (!needs.get(needUri) || !needs.getIn([needUri, "isOwned"])) {
+            needs = addTheirNeedToLoad(needs, needUri);
+          }
+        });
+      }
     }
 
     return needs.set(parsedNeed.get("uri"), parsedNeed);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -60,6 +60,20 @@ function addTheirNeedInLoading(needs, needUri) {
   }
 }
 
+export function addTheirNeedToLoad(needs, needUri) {
+  const oldNeed = needs.get(needUri);
+  if (oldNeed && oldNeed.get("isOwned")) {
+    return needs;
+  } else {
+    let need = Immutable.fromJS({
+      uri: needUri,
+      isOwned: false,
+      connections: Immutable.Map(),
+    });
+    return needs.setIn([needUri], need);
+  }
+}
+
 export function addOwnActiveNeedsInLoading(needs, needUris) {
   let newState = needs;
   needUris &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -188,6 +188,20 @@ export default function(processState = initialState, action = {}) {
       });
     }
 
+    case actionTypes.connections.fetchMessagesFailed: {
+      const connUri = action.payload.get("connectionUri");
+      const error = action.payload.get("error");
+
+      if (error) {
+        processState = updateConnectionProcess(processState, connUri, {
+          loadingMessages: false,
+          failedToLoad: true,
+        });
+      }
+
+      return processState;
+    }
+
     case actionTypes.reconnect.startingToLoadConnectionData:
     case actionTypes.reconnect.receivedConnectionData:
     case actionTypes.reconnect.connectionFailedToLoad:
@@ -199,6 +213,7 @@ export default function(processState = initialState, action = {}) {
       if (loadingMessages) {
         processState = updateConnectionProcess(processState, connUri, {
           loadingMessages: true,
+          failedToLoad: false,
         });
       }
 
@@ -206,6 +221,7 @@ export default function(processState = initialState, action = {}) {
       if (loadedMessages) {
         processState = updateConnectionProcess(processState, connUri, {
           loadingMessages: false,
+          failedToLoad: false,
         });
       }
       const error = action.payload.get("error");
@@ -213,6 +229,7 @@ export default function(processState = initialState, action = {}) {
       if (error) {
         processState = updateConnectionProcess(processState, connUri, {
           loadingMessages: false,
+          failedToLoad: true,
         });
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -208,15 +208,6 @@ export default function(processState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.connections.setLoadingMessages: {
-      const loadingMessages = action.payload.loadingMessages;
-      const connUri = action.payload.connectionUri;
-
-      return updateConnectionProcess(processState, connUri, {
-        loadingMessages: loadingMessages,
-      });
-    }
-
     case actionTypes.connections.fetchMessagesStart: {
       const connUri = action.payload.get("connectionUri");
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -126,46 +126,6 @@ export default function(processState = initialState, action = {}) {
       return processState.set("processingPublish", false);
     }
 
-    case actionTypes.needs.fetchSuggested: {
-      const suggestedPosts = action.payload.get("suggestedPosts");
-
-      if (!suggestedPosts) {
-        return processState;
-      }
-      return suggestedPosts.reduce((updatedState, suggestedPost) => {
-        const parsedNeed = suggestedPost && parseNeed(suggestedPost);
-        const needUri = get(parsedNeed, "uri");
-
-        const heldNeedUris = parsedNeed.get("holds");
-        if (heldNeedUris.size > 0) {
-          heldNeedUris.map(heldNeedUri => {
-            if (!processState.getIn(["needs", heldNeedUri])) {
-              processState = updateNeedProcess(processState, heldNeedUri, {
-                toLoad: true,
-              });
-            }
-          });
-        }
-
-        const groupMemberUris = parsedNeed.get("groupMembers");
-        if (groupMemberUris.size > 0) {
-          groupMemberUris.map(groupMemberUri => {
-            if (!processState.getIn(["needs", groupMemberUri])) {
-              processState = updateNeedProcess(processState, groupMemberUri, {
-                toLoad: true,
-              });
-            }
-          });
-        }
-
-        return updateNeedProcess(processState, needUri, {
-          toLoad: false,
-          failedToLoad: false,
-          loading: false,
-        });
-      }, processState);
-    }
-
     case actionTypes.account.logoutStarted:
       return processState.set("processingLogout", true);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -241,7 +241,6 @@ export default function(processState = initialState, action = {}) {
 
       const loadedMessages = action.payload.get("events");
       if (loadedMessages) {
-        console.log("fetchMessagesSuccess: loadedMessages: ", loadedMessages);
         processState = updateConnectionProcess(processState, connUri, {
           loadingMessages: false,
           failedToLoad: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -2,6 +2,7 @@
  * Created by fsuda on 05.11.2018.
  */
 
+import Immutable from "immutable";
 import {
   getOwnedNeedByConnectionUri,
   getOwnedNeeds,
@@ -56,7 +57,9 @@ export function getGroupChatConnectionsByNeedUri(state, needUri) {
   const need = needs && needs.get(needUri);
   const connections = need && need.get("connections");
 
-  return connections && connections.filter(conn => isGroupChatConnection(conn));
+  return connections
+    ? connections.filter(conn => isGroupChatConnection(conn))
+    : Immutable.Map();
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -103,3 +103,19 @@ export function getChatConnectionsToCrawl(state) {
     );
   return connectionsWithoutConnectMessage;
 }
+
+export function hasMessagesToLoad(state, connUri) {
+  const messageProcess = getIn(state, [
+    "process",
+    "connections",
+    connUri,
+    "messages",
+  ]);
+
+  return (
+    messageProcess &&
+    messageProcess.filter(msg => {
+      msg.get("toLoad");
+    }).size > 0
+  );
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -70,7 +70,7 @@ export function getChatConnectionsToCrawl(state) {
   const chatConnections =
     allConnections &&
     allConnections
-      .filter(conn => isChatConnection(conn))
+      .filter(conn => isChatConnection(conn) || isGroupChatConnection(conn))
       .filter(
         conn =>
           !getIn(state, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -73,6 +73,7 @@ export function getChatConnectionsToCrawl(state) {
       .filter(conn => isChatConnection(conn) || isGroupChatConnection(conn))
       .filter(
         conn =>
+          false &&
           !getIn(state, [
             "process",
             "connections",
@@ -113,9 +114,6 @@ export function hasMessagesToLoad(state, connUri) {
   ]);
 
   return (
-    messageProcess &&
-    messageProcess.filter(msg => {
-      msg.get("toLoad");
-    }).size > 0
+    messageProcess && messageProcess.filter(msg => msg.get("toLoad")).size > 0
   );
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -78,6 +78,12 @@ export function getChatConnectionsToCrawl(state) {
             "connections",
             conn.get("uri"),
             "loadingMessages",
+          ]) &&
+          !getIn(state, [
+            "process",
+            "connections",
+            conn.get("uri"),
+            "failedToLoad",
           ])
       );
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -73,7 +73,6 @@ export function getChatConnectionsToCrawl(state) {
       .filter(conn => isChatConnection(conn) || isGroupChatConnection(conn))
       .filter(
         conn =>
-          false &&
           !getIn(state, [
             "process",
             "connections",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -6,6 +6,7 @@ import { createSelector } from "reselect";
 
 import won from "../won-es6.js";
 import { decodeUriComponentProperly, getIn } from "../utils.js";
+import { isPersona, isNeed } from "../need-utils.js";
 import Color from "color";
 
 export const selectLastUpdateTime = state => state.get("lastUpdateTime");
@@ -23,9 +24,7 @@ export function getPosts(state) {
   return needs.filter(need => {
     if (!need.get("types")) return true;
 
-    return (
-      need.get("types").has("won:Need") && !need.get("types").has("won:Persona")
-    );
+    return isNeed(need) && !isPersona(need);
   });
 }
 
@@ -128,9 +127,7 @@ export const getAboutSectionFromRoute = createSelector(
 
 export function getOwnedPersonas(state) {
   const needs = getOwnedNeeds(state);
-  const personas = needs
-    .toList()
-    .filter(need => need.get("types") && need.get("types").has("won:Persona"));
+  const personas = needs.toList().filter(need => isPersona(need));
   return personas.map(persona => {
     const graph = persona.get("jsonld");
     return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1385,7 +1385,7 @@ import won from "./won.js";
       .catch(error => {
         console.error(
           'Error in won.getWonMessage("' + eventUri + '",',
-          fetchParams,
+          JSON.stringify(fetchParams),
           ") promiseChain",
           error
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1385,15 +1385,6 @@ import won from "./won.js";
     return won
       .getRawEvent(eventUri, fetchParams)
       .then(rawEvent => won.wonMessageFromJsonLd(rawEvent));
-    /*.catch(error => {
-        console.error(
-          'Error in won.getWonMessage("' + eventUri + '",',
-          JSON.stringify(fetchParams),
-          ") promiseChain",
-          error
-        );
-        throw new Error(error);
-      })*/
   };
 
   window.getWonMessage4dbg = won.getWonMessage;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1381,43 +1381,6 @@ import won from "./won.js";
     );
   };
 
-  /**
-   * @param connectionUri
-   * @param fetchParams See `ensureLoaded`.
-   * @return {*} the connections predicates along with the uris of associated events
-   */
-  won.getEventUrisOfConnection = function(connectionUri, needUri) {
-    if (!is("String", connectionUri)) {
-      throw new Error(
-        "Tried to request connection infos for sthg that isn't an uri: " +
-          connectionUri
-      );
-    }
-    return (
-      won
-        .getNode(connectionUri, {
-          requesterWebId: needUri,
-        })
-        //add the eventUris
-        .then(connection =>
-          won.getNode(connection.hasEventContainer, {
-            requesterWebId: needUri,
-          })
-        )
-        .then(
-          eventContainer =>
-            /*
-           * if there's only a single rdfs:member in the event
-           * container, getNode will not return an array, so we
-           * need to make sure it's one from here on out.
-           */
-            is("Array", eventContainer.member)
-              ? eventContainer.member
-              : [eventContainer.member]
-        )
-    );
-  };
-
   won.getWonMessage = (eventUri, fetchParams) => {
     return won
       .getRawEvent(eventUri, fetchParams)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -956,35 +956,45 @@ import won from "./won.js";
    * with a request for the connection-container
    * to get the connection-uris. Thus it's faster.
    */
-  won.getNeed = async function(needUri) {
-    await won.ensureLoaded(needUri);
-    const needGraph = await new Promise(resolve =>
-      privateData.store.graph(needUri, (a, b) => resolve(b))
-    );
+  won.getNeed = needUri =>
+    won
+      .ensureLoaded(needUri)
+      .then(
+        () =>
+          new Promise(resolve =>
+            privateData.store.graph(needUri, (a, b) => resolve(b))
+          )
+      )
+      .then(needGraph =>
+        triples2framedJson(needUri, needGraph.triples, {
+          /* frame */
+          "@id": needUri, // start the framing from this uri. Otherwise will generate all possible nesting-variants.
+          "@context": won.defaultContext,
+        })
+      )
+      .then(needJsonLd => {
+        // usually the need-data will be in a single object in the '@graph' array.
+        // We can flatten this and still have valid json-ld
+        const flattenedNeedJsonLd = getIn(needJsonLd, ["@graph", 0])
+          ? getIn(needJsonLd, ["@graph", 0])
+          : needJsonLd;
+        flattenedNeedJsonLd["@context"] = needJsonLd["@context"]; // keep context
 
-    const needJsonLd = await triples2framedJson(needUri, needGraph.triples, {
-      /* frame */
-      "@id": needUri, // start the framing from this uri. Otherwise will generate all possible nesting-variants.
-      "@context": won.defaultContext,
-    });
+        if (
+          !flattenedNeedJsonLd ||
+          getIn(flattenedNeedJsonLd, ["@graph", "length"]) === 0
+        ) {
+          console.error(
+            "Received empty graph ",
+            needJsonLd,
+            " for need ",
+            needUri
+          );
+          return { "@context": flattenedNeedJsonLd["@context"] };
+        }
 
-    // usually the need-data will be in a single object in the '@graph' array.
-    // We can flatten this and still have valid json-ld
-    const flattenedNeedJsonLd = getIn(needJsonLd, ["@graph", 0])
-      ? getIn(needJsonLd, ["@graph", 0])
-      : needJsonLd;
-    flattenedNeedJsonLd["@context"] = needJsonLd["@context"]; // keep context
-
-    if (
-      !flattenedNeedJsonLd ||
-      getIn(flattenedNeedJsonLd, ["@graph", "length"]) === 0
-    ) {
-      console.error("Received empty graph ", needJsonLd, " for need ", needUri);
-      return { "@context": flattenedNeedJsonLd["@context"] };
-    }
-
-    return flattenedNeedJsonLd;
-  };
+        return flattenedNeedJsonLd;
+      });
 
   //taken from https://www.w3.org/TR/rdf-interfaces/#triple-filters
   won.tripleFilters = {
@@ -1313,26 +1323,23 @@ import won from "./won.js";
    * @param connectionUri
    * @param fetchParams See `ensureLoaded`.
    */
-  won.getWonMessagesOfConnection = async function(connectionUri, fetchParams) {
-    const eventUris = await won.getEventUrisOfConnection(
-      connectionUri,
-      fetchParams
-    );
-    return urisToLookupMap(eventUris, eventUri =>
-      won.getWonMessage(eventUri, fetchParams)
-    );
-  };
-
-  /**
-   * Returns the uris of all events associated with a given connection
-   * @param connectionUri
-   * @param fetchParams See `ensureLoaded`.
-   * @returns promise for an array strings (the uris)
-   */
-  won.getEventUrisOfConnection = function(connectionUri, fetchParams) {
+  won.getWonMessagesOfConnection = (connectionUri, fetchParams) => {
     return won
       .getConnectionWithEventUris(connectionUri, fetchParams)
-      .then(connection => connection.hasEvents);
+      .then(connection => connection.hasEvents)
+      .then(eventUris => {
+        console.debug(
+          "Trying to get the messages of the connection[",
+          connectionUri,
+          "] messages[",
+          eventUris,
+          "]"
+        );
+
+        return urisToLookupMap(eventUris, eventUri =>
+          won.getWonMessage(eventUri, fetchParams)
+        );
+      });
   };
 
   /**
@@ -1371,53 +1378,73 @@ import won from "./won.js";
     );
   };
 
-  won.getWonMessage = async (eventUri, fetchParams) => {
-    const rawEvent = await won.getRawEvent(eventUri, fetchParams);
-    const wonMessage = await won.wonMessageFromJsonLd(rawEvent);
-    return wonMessage;
+  won.getWonMessage = (eventUri, fetchParams) => {
+    return won
+      .getRawEvent(eventUri, fetchParams)
+      .then(rawEvent => won.wonMessageFromJsonLd(rawEvent))
+      .catch(error => {
+        console.error(
+          'Error in won.getWonMessage("' + eventUri + '",',
+          fetchParams,
+          ") promiseChain",
+          error
+        );
+        return undefined;
+      });
   };
 
-  won.getRawEvent = async (eventUri, fetchParams) => {
-    await won.ensureLoaded(eventUri, fetchParams);
-    const eventGraphs = await Promise.all(
-      Array.from(privateData.documentToGraph[eventUri]).map(async graphUri => {
-        const graphTriples = await won.getCachedGraphTriples(graphUri);
-        const quadString = rdfstoreTriplesToString(graphTriples, graphUri);
-        //graphQuads = graphQuads.map(q => ({ subject: q.subject.nominalValue,  predicate: q.predicate.nominalValue,  object: q.object.nominalValue,  graph: q.graph.nominalValue}))
-        //graphQuads = graphQuads.map(q => toQuadToken(q.subject) + " " + toQuadToken(q.predicate) + " " + toQuadToken(q.object) + " " + toQuadToken(q.graph) + " .").join("\n")
+  window.getWonMessage4dbg = won.getWonMessage;
 
-        let parsedJsonLd = await jsonld.promises.fromRDF(quadString, {
-          format: "application/nquads",
-        });
-        if (parsedJsonLd.length !== 1) {
-          throw new Error(
-            "Got more or less than the expected one graph " +
-              JSON.stringify(parsedJsonLd)
-          );
-        } else {
-          parsedJsonLd = parsedJsonLd[0];
-        }
-        let jsonLdString = JSON.stringify(parsedJsonLd)
-          .replace(NEWLINE_REPLACEMENT_PATTERN, "\\n")
-          .replace(DOUBLEQUOTE_REPLACEMENT_PATTERN, '\\"');
+  won.getRawEvent = (eventUri, fetchParams) => {
+    return won
+      .ensureLoaded(eventUri, fetchParams)
+      .then(() => {
+        return Promise.all(
+          Array.from(privateData.documentToGraph[eventUri]).map(graphUri => {
+            return won
+              .getCachedGraphTriples(graphUri)
+              .then(graphTriples =>
+                jsonld.promises.fromRDF(
+                  rdfstoreTriplesToString(graphTriples, graphUri),
+                  {
+                    format: "application/nquads",
+                  }
+                )
+              )
+              .then(parsedJsonLd => {
+                if (parsedJsonLd.length !== 1) {
+                  throw new Error(
+                    "Got more or less than the expected one graph " +
+                      JSON.stringify(parsedJsonLd)
+                  );
+                } else {
+                  parsedJsonLd = parsedJsonLd[0];
+                }
+                let jsonLdString = JSON.stringify(parsedJsonLd)
+                  .replace(NEWLINE_REPLACEMENT_PATTERN, "\\n")
+                  .replace(DOUBLEQUOTE_REPLACEMENT_PATTERN, '\\"');
 
-        return JSON.parse(jsonLdString); //TODO: REMOVE FUGLY FIX AND JUST RETURN parsedJsonLd ONCE n3.js is not having issues with newlines anymore
+                return JSON.parse(jsonLdString); //TODO: REMOVE FUGLY FIX AND JUST RETURN parsedJsonLd ONCE n3.js is not having issues with newlines anymore
+              });
+          })
+        );
       })
-    );
+      .then(eventGraphs => {
+        if (!is("Array", eventGraphs)) {
+          throw new Error(
+            "event graphs weren't an array. something didn't go as expected: " +
+              JSON.stringify(eventGraphs)
+          );
+        }
 
-    if (!is("Array", eventGraphs)) {
-      throw new Error(
-        "event graphs weren't an array. something " +
-          "didn't go as expected: " +
-          JSON.stringify(eventGraphs)
-      );
-    }
-
-    return {
-      "@graph": eventGraphs,
-      "@context": clone(won.defaultContext),
-    };
+        return {
+          "@graph": eventGraphs,
+          "@context": clone(won.defaultContext),
+        };
+      });
   };
+
+  window.getRawEvent4dbg = won.getRawEvent;
 
   /**
    * Fetches the triples where URI is subject and add objects of those triples to the
@@ -1631,25 +1658,21 @@ import won from "./won.js";
     });
   };
 
-  won.getCachedGraphTriples = async function(
-    graphUri,
-    removeAtGraphTriples = true
-  ) {
-    const graph = await rdfStoreGetGraph(privateData.store, graphUri);
-
-    if (removeAtGraphTriples) {
-      return (
-        graph.triples
-          // `store.graph` in `rdfStoreGetGraph` returns some
-          // triples with `@graph` as predicate and a string
-          // as value, which isn't proper json-ld, so we filter
-          // them out here.
-          .filter(t => getIn(t, ["predicate", "nominalValue"]) !== "@graph")
-      );
-    } else {
-      return graph.triples;
-    }
-  };
+  won.getCachedGraphTriples = (graphUri, removeAtGraphTriples = true) =>
+    rdfStoreGetGraph(privateData.store, graphUri).then(graph => {
+      if (removeAtGraphTriples) {
+        return (
+          graph.triples
+            // `store.graph` in `rdfStoreGetGraph` returns some
+            // triples with `@graph` as predicate and a string
+            // as value, which isn't proper json-ld, so we filter
+            // them out here.
+            .filter(t => getIn(t, ["predicate", "nominalValue"]) !== "@graph")
+        );
+      } else {
+        return graph.triples;
+      }
+    });
 
   /**
    * Thin wrapper around `store.graph` that returns a promise.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1336,8 +1336,11 @@ import won from "./won.js";
           "]"
         );
 
-        return urisToLookupMap(eventUris, eventUri =>
-          won.getWonMessage(eventUri, fetchParams)
+        return urisToLookupMap(
+          eventUris,
+          eventUri => won.getWonMessage(eventUri, fetchParams),
+          [],
+          true
         );
       });
   };
@@ -1381,16 +1384,16 @@ import won from "./won.js";
   won.getWonMessage = (eventUri, fetchParams) => {
     return won
       .getRawEvent(eventUri, fetchParams)
-      .then(rawEvent => won.wonMessageFromJsonLd(rawEvent))
-      .catch(error => {
+      .then(rawEvent => won.wonMessageFromJsonLd(rawEvent));
+    /*.catch(error => {
         console.error(
           'Error in won.getWonMessage("' + eventUri + '",',
           JSON.stringify(fetchParams),
           ") promiseChain",
           error
         );
-        return undefined;
-      });
+        throw new Error(error);
+      })*/
   };
 
   window.getWonMessage4dbg = won.getWonMessage;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1381,6 +1381,43 @@ import won from "./won.js";
     );
   };
 
+  /**
+   * @param connectionUri
+   * @param fetchParams See `ensureLoaded`.
+   * @return {*} the connections predicates along with the uris of associated events
+   */
+  won.getEventUrisOfConnection = function(connectionUri, needUri) {
+    if (!is("String", connectionUri)) {
+      throw new Error(
+        "Tried to request connection infos for sthg that isn't an uri: " +
+          connectionUri
+      );
+    }
+    return (
+      won
+        .getNode(connectionUri, {
+          requesterWebId: needUri,
+        })
+        //add the eventUris
+        .then(connection =>
+          won.getNode(connection.hasEventContainer, {
+            requesterWebId: needUri,
+          })
+        )
+        .then(
+          eventContainer =>
+            /*
+           * if there's only a single rdfs:member in the event
+           * container, getNode will not return an array, so we
+           * need to make sure it's one from here on out.
+           */
+            is("Array", eventContainer.member)
+              ? eventContainer.member
+              : [eventContainer.member]
+        )
+    );
+  };
+
   won.getWonMessage = (eventUri, fetchParams) => {
     return won
       .getRawEvent(eventUri, fetchParams)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -913,6 +913,11 @@ won.DomainObjectFactory.prototype = {
 won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD) {
   const expandedJsonLd = await jsonld.promises.expand(wonMessageAsJsonLD);
   const wonMessage = new WonMessage(expandedJsonLd);
+
+  if (wonMessage.parseErrors && wonMessage.parseErrors.length > 0) {
+    console.warn("wonMessage ParseError: " + wonMessage.parseErrors);
+  }
+
   await wonMessage.frameInPromise();
   await wonMessage.generateContentGraphTrig();
   await wonMessage.generateCompactedFramedMessage();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -415,6 +415,56 @@ export function urisToLookupMap(
 }
 
 /**
+ * Takes a single uri or an array of uris, performs the lookup function on each
+ * of them seperately, collects the results and builds an map/object
+ * with the uris as keys and the results as values.
+ * If any call to the asyncLookupFunction fails, the corresponding
+ * key-value-pair will not be contained in the success-result but rather in the failed-results.
+ * @param uris
+ * @param asyncLookupFunction
+ * @param excludeUris uris to exclude from lookup
+ * @return {*}
+ */
+export function urisToLookupSuccessAndFailedMap(
+  uris,
+  asyncLookupFunction,
+  excludeUris = []
+) {
+  //make sure we have an array and not a single uri.
+  const urisAsArray = is("Array", uris) ? uris : [uris];
+  const excludeUrisAsArray = is("Array", excludeUris)
+    ? excludeUris
+    : [excludeUris];
+
+  const urisAsArrayWithoutExcludes = urisAsArray.filter(uri => {
+    const exclude = excludeUrisAsArray.indexOf(uri) < 0;
+    if (exclude) {
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  const asyncLookups = urisAsArrayWithoutExcludes.map(uri =>
+    asyncLookupFunction(uri).catch(error => {
+      return error;
+    })
+  );
+  return Promise.all(asyncLookups).then(dataObjects => {
+    const lookupMap = { success: {}, failed: {} };
+    //make sure there's the same
+    uris.forEach((uri, i) => {
+      if (dataObjects[i] instanceof Error) {
+        lookupMap["failed"][uri] = dataObjects[i];
+      } else if (dataObjects[i]) {
+        lookupMap["success"][uri] = dataObjects[i];
+      }
+    });
+    return lookupMap;
+  });
+}
+
+/**
  * Maps an asynchronous function over the values of an object or
  * the elements of an array. It returns a promise with the result,
  * when all applications of the asyncFunction have finished.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -743,8 +743,8 @@ function fetchConnectionsOfNeedAndDispatch(needUri, dispatch) {
         }),
       });
 
-      return urisToLookupMap(activeConnectionUris, uri =>
-        fetchActiveConnectionAndDispatch(uri, dispatch)
+      return urisToLookupMap(activeConnectionUris, connUri =>
+        fetchActiveConnectionAndDispatch(connUri, needUri, dispatch)
       );
     });
 }
@@ -768,20 +768,25 @@ function fetchOwnedNeedAndDispatch(needUri, dispatch) {
     });
 }
 
-export function fetchActiveConnectionAndDispatch(cnctUri, dispatch) {
+export function fetchActiveConnectionAndDispatch(connUri, needUri, dispatch) {
   return won
-    .getNode(cnctUri)
+    .getConnectionWithEventUris(connUri, { requesterWebId: needUri })
     .then(connection => {
+      console.log(
+        "fetchActiveConnectionAndDispatch with eventUris: ",
+        connection.hasEvents
+      );
+
       dispatch({
         type: actionTypes.connections.storeActive,
-        payload: Immutable.fromJS({ connections: { [cnctUri]: connection } }),
+        payload: Immutable.fromJS({ connections: { [connUri]: connection } }),
       });
       return connection;
     })
     .catch(() => {
       dispatch({
         type: actionTypes.connections.storeUriFailed,
-        payload: Immutable.fromJS({ uri: cnctUri }),
+        payload: Immutable.fromJS({ uri: connUri }),
       });
       return;
     });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -772,11 +772,6 @@ export function fetchActiveConnectionAndDispatch(connUri, needUri, dispatch) {
   return won
     .getConnectionWithEventUris(connUri, { requesterWebId: needUri })
     .then(connection => {
-      console.log(
-        "fetchActiveConnectionAndDispatch with eventUris: ",
-        connection.hasEvents
-      );
-
       dispatch({
         type: actionTypes.connections.storeActive,
         payload: Immutable.fromJS({ connections: { [connUri]: connection } }),

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Persona.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Persona.elm
@@ -3,6 +3,7 @@ port module Persona exposing
     , PersonaData
     , SaveState(..)
     , data
+    , getNewPersonas
     , savePersona
     , saved
     , subscription
@@ -75,10 +76,18 @@ savePersona data_ =
     personaOut <| encodeData data_
 
 
+getNewPersonas : Cmd msg
+getNewPersonas =
+    updatePersonas ()
+
+
 port personaIn : (Value -> msg) -> Sub msg
 
 
 port personaOut : Value -> Cmd msg
+
+
+port updatePersonas : () -> Cmd msg
 
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
@@ -106,7 +106,7 @@ init () =
     ( { viewState = Inactive
       , personas = Dict.empty
       }
-    , Cmd.none
+    , Persona.getNewPersonas
     )
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -53,8 +53,8 @@ won-connection-header {
     grid-template-rows: 1fr 1fr;
     align-content: center;
 
-    &__more,
-    &__icon {
+    & .ch__groupicons__icon,
+    & .ch__groupicons__more {
       @include square-image($postIconSize/2);
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -45,40 +45,6 @@ won-connection-header {
     @include square-image($postIconSize);
   }
 
-  .ch__groupicons {
-    grid-area: icon;
-    width: $postIconSize;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr 1fr;
-    align-content: center;
-
-    & .ch__groupicons__icon,
-    & .ch__groupicons__more {
-      @include square-image($postIconSize/2);
-    }
-
-    &__more {
-      font-size: $smallFontSize;
-      text-align: center;
-      line-height: $postIconSize/2;
-      background: $won-line-gray;
-      color: white;
-    }
-
-    &__icon {
-      &.one {
-        background: #fab;
-      }
-      &.two {
-        background: #baf;
-      }
-      &.three {
-        background: #ffc;
-      }
-    }
-  }
-
   .ch__right {
     grid-area: main;
     display: grid;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -35,12 +35,50 @@ won-connection-header {
   grid-column-gap: 0.5rem;
   min-width: 0;
 
+  .ch__groupicons,
   .ch__icon {
     grid-area: icon;
     width: $postIconSize;
+  }
 
+  .ch__icon {
     @include square-image($postIconSize);
   }
+
+  .ch__groupicons {
+    grid-area: icon;
+    width: $postIconSize;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    align-content: center;
+
+    &__more,
+    &__icon {
+      @include square-image($postIconSize/2);
+    }
+
+    &__more {
+      font-size: $smallFontSize;
+      text-align: center;
+      line-height: $postIconSize/2;
+      background: $won-line-gray;
+      color: white;
+    }
+
+    &__icon {
+      &.one {
+        background: #fab;
+      }
+      &.two {
+        background: #baf;
+      }
+      &.three {
+        background: #ffc;
+      }
+    }
+  }
+
   .ch__right {
     grid-area: main;
     display: grid;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
@@ -4,30 +4,7 @@
 @import "animate";
 
 won-group-administration-header {
-  &.won-is-loading {
-    @include animateOpacityHeartBeat();
-    pointer-events: none;
-
-    .ch__icon__skeleton {
-      @include fixed-square($postIconSize);
-      background-color: $won-skeleton-color;
-    }
-
-    .ch__right__subtitle__type {
-      height: $smallFontSize;
-      width: 5rem;
-      background-color: $won-skeleton-color;
-    }
-
-    .ch__right__topline__title {
-      height: $normalFontSize;
-      width: 7rem;
-      background-color: $won-skeleton-color;
-    }
-  }
-
   color: black;
-  //padding: 0.5rem;
 
   display: grid;
   grid-template-areas: "icon main";
@@ -35,11 +12,9 @@ won-group-administration-header {
   grid-column-gap: 0.5rem;
   min-width: 0;
 
-  .ch__icon {
+  & won-group-image.ch__icon {
     grid-area: icon;
     width: $postIconSize;
-
-    @include square-image($postIconSize);
   }
   .ch__right {
     grid-area: main;
@@ -50,16 +25,12 @@ won-group-administration-header {
       grid-area: topline;
       min-width: 0;
 
-      &__notitle,
       &__title {
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
         font-weight: 400;
         min-width: 0;
-      }
-      &__notitle {
-        color: $won-subtitle-gray;
       }
     }
     &__subtitle {
@@ -77,15 +48,6 @@ won-group-administration-header {
         overflow: hidden;
         white-space: nowrap;
 
-        won-connection-state {
-          display: inline-block;
-          padding-right: 0.25rem;
-
-          svg {
-            @include fixed-square($smallFontSize);
-          }
-        }
-
         &__message.won-unread,
         &__unreadcount {
           color: $won-primary-color;
@@ -94,14 +56,6 @@ won-group-administration-header {
         &__message {
           font-style: italic;
         }
-      }
-
-      &__date {
-        font-size: $smallFontSize;
-        color: $won-subtitle-gray;
-        white-space: nowrap;
-        padding-left: 0.5rem;
-        min-width: 0;
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
@@ -39,7 +39,7 @@ won-group-administration-header {
       font-size: $smallFontSize;
       min-width: 0;
 
-      &__participants {
+      &__members {
         display: flex;
         align-items: center;
         text-overflow: ellipsis;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration-header.scss
@@ -35,27 +35,16 @@ won-group-administration-header {
     }
     &__subtitle {
       grid-area: subtitle;
-      display: grid;
-      grid-template-columns: 1fr min-content;
       color: $won-subtitle-gray;
       font-size: $smallFontSize;
       min-width: 0;
 
-      &__type {
+      &__participants {
         display: flex;
         align-items: center;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
-
-        &__message.won-unread,
-        &__unreadcount {
-          color: $won-primary-color;
-        }
-
-        &__message {
-          font-style: italic;
-        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
@@ -45,26 +45,26 @@ won-group-administration {
     overflow: auto;
     flex-grow: 1;
 
-    .ga__content__participant {
+    .ga__content__member {
       padding: 0.5rem;
       border: $thinGrayBorder;
       background: white;
       display: grid;
-      grid-template-areas: "participant_info participant_actions";
+      grid-template-areas: "member_info member_actions";
       grid-template-columns: 1fr min-content;
       grid-gap: 0.25rem;
       align-items: center;
       margin-bottom: 0.5rem;
 
-      won-connection-header {
-        grid-area: participant_info;
+      won-post-header {
+        grid-area: member_info;
       }
 
       &__actions {
         display: grid;
         grid-auto-flow: column;
         grid-gap: 0.25rem;
-        grid-area: participant_actions;
+        grid-area: member_actions;
 
         &__button.won-button--outlined.red.thin {
           font-size: $smallFontSize;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
@@ -4,8 +4,8 @@
 
 won-group-administration {
   display: grid;
-  grid-template-areas: "header" "main";
-  grid-template-rows: min-content minmax($minimalGridRows, 1fr);
+  grid-template-areas: "header" "main" "footer";
+  grid-template-rows: min-content minmax($minimalGridRows, 1fr) min-content;
   grid-row-gap: $gridRowGap;
   box-sizing: border-box;
   padding: $gridRowGap;
@@ -71,6 +71,14 @@ won-group-administration {
           padding: 0.5rem;
         }
       }
+    }
+  }
+
+  .ga__footer {
+    grid-area: footer;
+
+    &__button {
+      width: 100%;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-administration.scss
@@ -4,8 +4,8 @@
 
 won-group-administration {
   display: grid;
-  grid-template-areas: "header" "main" "footer";
-  grid-template-rows: min-content minmax($minimalGridRows, 1fr) min-content;
+  grid-template-areas: "header" "main";
+  grid-template-rows: min-content minmax($minimalGridRows, 1fr);
   grid-row-gap: $gridRowGap;
   box-sizing: border-box;
   padding: $gridRowGap;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
@@ -13,6 +13,13 @@ won-group-image {
   & .gi__icons__icon,
   & .gi__icons__more {
     @include square-image($postIconSize/2);
+
+    &--spanRow {
+      grid-row: auto / span 2;
+    }
+    &--spanCol {
+      grid-column: auto / span 2;
+    }
   }
 
   & .gi__icons__more {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
@@ -23,6 +23,10 @@ won-group-image {
   }
 
   & .gi__icons__more {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     font-size: $smallFontSize;
     text-align: center;
     line-height: $postIconSize/2;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-image.scss
@@ -1,0 +1,25 @@
+@import "won-config";
+@import "sizing-utils";
+@import "square-image";
+@import "animate";
+
+won-group-image {
+  width: $postIconSize;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  align-content: center;
+
+  & .gi__icons__icon,
+  & .gi__icons__more {
+    @include square-image($postIconSize/2);
+  }
+
+  & .gi__icons__more {
+    font-size: $smallFontSize;
+    text-align: center;
+    line-height: $postIconSize/2;
+    background: $won-line-gray;
+    color: white;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
@@ -1,0 +1,99 @@
+@import "sizing-utils";
+@import "won-config";
+@import "animate";
+
+won-group-post-messages {
+  display: grid;
+  grid-template-areas: "header" "main" "footer";
+  grid-template-rows: min-content minmax($minimalGridRows, 1fr) min-content;
+  grid-row-gap: $gridRowGap;
+  box-sizing: border-box;
+  padding: $gridRowGap;
+
+  .gpm__header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: "header_back header_title header_context";
+    grid-area: header;
+    font-size: $normalFontSize;
+    text-align: left;
+    min-width: 0;
+    align-items: center;
+
+    &__back {
+      grid-area: header_back;
+      &__icon {
+        @include fixed-square($backIconSize);
+      }
+    }
+
+    &__title,
+    won-connection-header {
+      grid-area: header_title;
+    }
+
+    won-connection-context-dropdown {
+      grid-area: header_context;
+    }
+  }
+
+  .gpm__footer {
+    grid-area: footer;
+
+    &__chattextfield {
+      padding: 0.5rem 0;
+    }
+
+    &__button {
+      width: 100%;
+    }
+  }
+
+  .gpm__content {
+    grid-area: main;
+    padding: 0.5rem;
+    background: white;
+    border: $thinGrayBorder;
+    overflow: auto;
+    flex-grow: 1;
+
+    &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
+    &__loadspinner {
+      width: 100%;
+      height: 3rem;
+      padding: 0.66em 2em;
+      text-align: center;
+      box-sizing: border-box;
+    }
+
+    &__unreadindicator {
+      height: 3rem;
+      top: 0;
+      position: sticky;
+      z-index: 10;
+      margin-bottom: 0.5rem;
+
+      @include slideWithOpacityAnimationFixedHorizontal(
+        0.5s,
+        linear,
+        3rem,
+        0,
+        0,
+        0,
+        0.5rem
+      );
+
+      &__content {
+        height: 3rem;
+        padding: 0.66em;
+        margin-bottom: 0.5rem;
+        box-sizing: border-box;
+        font-size: $normalFontSize;
+        line-height: $normalFontSize;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -21,6 +21,24 @@ won-post-content {
       border: $thinGrayBorder;
       padding: 0.5rem;
     }
+
+    .post-content__members {
+      & .post-content__members__member {
+        padding: 0.5rem;
+        border: $thinGrayBorder;
+        background: white;
+        display: grid;
+        grid-template-areas: "member_info member_actions";
+        grid-template-columns: 1fr min-content;
+        grid-gap: 0.25rem;
+        align-items: center;
+        margin-bottom: 0.5rem;
+
+        won-post-header {
+          grid-area: member_info;
+        }
+      }
+    }
   }
 
   &.won-is-loading {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -39,6 +39,24 @@ won-post-content {
         }
       }
     }
+
+    .post-content__otherneeds {
+      & .post-content__otherneeds__otherneed {
+        padding: 0.5rem;
+        border: $thinGrayBorder;
+        background: white;
+        display: grid;
+        grid-template-areas: "member_info member_actions";
+        grid-template-columns: 1fr min-content;
+        grid-gap: 0.25rem;
+        align-items: center;
+        margin-bottom: 0.5rem;
+
+        won-post-header {
+          grid-area: member_info;
+        }
+      }
+    }
   }
 
   &.won-is-loading {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
@@ -87,6 +87,7 @@ won-post-header {
           background: $won-line-gray;
           margin: 0.1rem;
           padding: 0 0.25rem;
+          display: inline-block;
         }
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-header.scss
@@ -81,6 +81,13 @@ won-post-header {
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
+
+        &__groupchat {
+          border-radius: 0.19rem;
+          background: $won-line-gray;
+          margin: 0.1rem;
+          padding: 0 0.25rem;
+        }
       }
 
       &__date {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
@@ -30,6 +30,7 @@
       @include fixed-square($size/2);
       right: $size/7 * -1;
       bottom: $size/7 * -1;
+      z-index: 2;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_square-image.scss
@@ -8,6 +8,10 @@
     position: relative;
     height: $size;
 
+    &.won-is-persona .image {
+      border-radius: 100%;
+    }
+
     &.inactive {
       -webkit-filter: grayscale(100%);
       filter: grayscale(100%);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -77,6 +77,7 @@ body {
       }
 
       > won-group-administration,
+      > won-group-post-messages,
       > won-post-messages {
         height: calc(100vh - var(--headerHeight));
       }


### PR DESCRIPTION
fixes #2626

This PR implements a first version of the GroupChat functionality.
What has been done:
- Ability to Create A GroupChat need within UseCase selection: more... -> New GroupChat Post)
- Administrative View of a GroupChat as an item similar to the connection of an ownedPost, in this view requests can be accepted, denied, or revoked
- GroupChat messages will ignore the forwardMessage wrapper and display the message itself
- Post-Info of a groupChat need shows all currently existing groupmembers (everything that was in derivedData)
- Post loading was "slightly" refactored
- Message fetching of a connection now looks at all the eventUris that are still to be loaded (-> not  relying on the connectMessage any longer)

What is not in the Scope of this PR:
- Updating the participants upon receiving messages (reload necessary for others to see new groupMembers)
- latest MessageFetch on login/reload does not display the latest messages anymore but a set of X that are still to be loaded -> due to caching issues
- Notifications for owner of groupChatNeed are not presented within the notification indicators yet
- function isChatToGroup needs to be refactored -> see comment in `connection-utils.js` for details
- Join Group for the groupChatOwner does not automatically accept the request created by the adhoc need
- Join Group for the groupChatOwner should allow joining with a persona