### PR TITLE
Feat  suggestedpost updates #2525

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -79,33 +79,51 @@ function genComponentConf() {
         const hasConnectionBetweenPosts =
           connectionsBetweenPosts && connectionsBetweenPosts.size > 0;
 
+        const isLoading = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "loading",
+        ]);
+        const toLoad = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "toLoad",
+        ]);
+        const failedToLoad = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "failedToLoad",
+        ]);
+
+        const fetchedSuggestion = !isLoading && !toLoad && !failedToLoad;
+
         return {
           suggestedPost,
           openedOwnPost,
           hasChatFacet: hasChatFacet(suggestedPost),
           hasGroupFacet: hasGroupFacet(suggestedPost),
           showConnectAction:
+            suggestedPost &&
+            fetchedSuggestion &&
             !hasGroupFacet(suggestedPost) &&
             hasChatFacet(suggestedPost) &&
             !hasConnectionBetweenPosts &&
-            suggestedPost &&
             !isOwned(suggestedPost) &&
-            self.openedOwnPost,
+            openedOwnPost,
           showJoinAction:
+            suggestedPost &&
+            fetchedSuggestion &&
             hasGroupFacet(suggestedPost) &&
             !hasChatFacet(suggestedPost) &&
             !hasConnectionBetweenPosts &&
-            suggestedPost &&
             !isOwned(suggestedPost) &&
-            self.openedOwnPost,
-          isLoading: state.getIn(["process", "needs", this.content, "loading"]),
-          toLoad: state.getIn(["process", "needs", this.content, "toLoad"]),
-          failedToLoad: state.getIn([
-            "process",
-            "needs",
-            this.content,
-            "failedToLoad",
-          ]),
+            openedOwnPost,
+          isLoading,
+          toLoad,
+          failedToLoad,
           multiSelectType: connection && connection.get("multiSelectType"),
           hasConnectionBetweenPosts,
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -43,6 +43,11 @@ function genComponentConf() {
               ng-click="self.connectWithPost()">
               Join
             </button>
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.hasConnectionBetweenPosts"
+              ng-click="self.router__stateGoCurrent({connectionUri: self.establishedConnectionUri})">
+              View Chat
+            </button>
             <div class="suggestpostv__content__post__info">
               {{ self.getInfoText() }}
             </div>
@@ -126,6 +131,9 @@ function genComponentConf() {
           failedToLoad,
           multiSelectType: connection && connection.get("multiSelectType"),
           hasConnectionBetweenPosts,
+          establishedConnectionUri:
+            hasConnectionBetweenPosts &&
+            get(connectionsBetweenPosts.first(), "uri"),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -2,7 +2,13 @@ import angular from "angular";
 import "ng-redux";
 import { actionCreators } from "../../../actions/actions.js";
 import postHeaderModule from "../../post-header.js";
-import { attach } from "../../../utils.js";
+import { attach, getIn, get } from "../../../utils.js";
+import {
+  isOwned,
+  isPersona,
+  hasChatFacet,
+  hasGroupFacet,
+} from "../../../need-utils.js";
 import { connect2Redux } from "../../../won-utils.js";
 import {
   getConnectionUriFromRoute,
@@ -21,29 +27,26 @@ function genComponentConf() {
           <span class="suggestpostv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
         </div>
         <div class="suggestpostv__content">
-          <div class="suggestpostv__content__post" ng-if="self.suggestedPost">
+          <div class="suggestpostv__content__post">
             <won-post-header
-               
-                need-uri="self.suggestedPost.get('uri')"
-                timestamp="self.suggestedPost.get('creationDate')"
-             
+                need-uri="self.content"
+                timestamp="self.suggestedPost && self.suggestedPost.get('creationDate')"
                 hide-image="::false">
             </won-post-header>
-          </div>
-          <div class="suggestpostv__content__notloaded" ng-if="!self.suggestedPost">
-              Suggestion not loaded yet. Click the Button below to retrieve the Suggested Post.
-          </div>
-          <button class="suggestpostv__content__action won-button--outlined thin red"
-              ng-if="!self.suggestedPost"
-              ng-click="self.loadPost()">
-              Load Post
-          </button>
-          <button class="suggestpostv__content__action won-button--outlined thin red"
-              ng-if="self.suggestedPost && !self.suggestedPost.get('isOwned') && self.openedOwnPost"
-              ng-disabled="self.hasConnectionBetweenPosts"
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.showConnectAction"
               ng-click="self.connectWithPost()">
-              {{ self.getConnectButtonLabel() }}
-          </button>
+              Connect
+            </button>
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.showJoinAction"
+              ng-click="self.connectWithPost()">
+              Join
+            </button>
+            <div class="suggestpostv__content__post__info">
+              {{ self.getInfoText() }}
+            </div>
+          </div>
         </div>
     `;
 
@@ -57,15 +60,15 @@ function genComponentConf() {
         const openedOwnPost =
           openedConnectionUri &&
           getOwnedNeedByConnectionUri(state, openedConnectionUri);
-        const connection =
-          openedOwnPost &&
-          openedOwnPost.getIn(["connections", openedConnectionUri]);
+        const connection = getIn(openedOwnPost, [
+          "connections",
+          openedConnectionUri,
+        ]);
 
-        const suggestedPost = state.getIn(["needs", this.content]);
-        const suggestedPostUri = suggestedPost && suggestedPost.get("uri");
+        const suggestedPost = getIn(state, ["needs", this.content]);
+        const suggestedPostUri = get(suggestedPost, "uri");
 
-        const connectionsOfOpenedOwnPost =
-          openedOwnPost && openedOwnPost.get("connections");
+        const connectionsOfOpenedOwnPost = get(openedOwnPost, "connections");
         const connectionsBetweenPosts =
           suggestedPostUri &&
           connectionsOfOpenedOwnPost &&
@@ -73,12 +76,38 @@ function genComponentConf() {
             conn => conn.get("remoteNeedUri") === suggestedPostUri
           );
 
+        const hasConnectionBetweenPosts =
+          connectionsBetweenPosts && connectionsBetweenPosts.size > 0;
+
         return {
           suggestedPost,
           openedOwnPost,
+          hasChatFacet: hasChatFacet(suggestedPost),
+          hasGroupFacet: hasGroupFacet(suggestedPost),
+          showConnectAction:
+            !hasGroupFacet(suggestedPost) &&
+            hasChatFacet(suggestedPost) &&
+            !hasConnectionBetweenPosts &&
+            suggestedPost &&
+            !isOwned(suggestedPost) &&
+            self.openedOwnPost,
+          showJoinAction:
+            hasGroupFacet(suggestedPost) &&
+            !hasChatFacet(suggestedPost) &&
+            !hasConnectionBetweenPosts &&
+            suggestedPost &&
+            !isOwned(suggestedPost) &&
+            self.openedOwnPost,
+          isLoading: state.getIn(["process", "needs", this.content, "loading"]),
+          toLoad: state.getIn(["process", "needs", this.content, "toLoad"]),
+          failedToLoad: state.getIn([
+            "process",
+            "needs",
+            this.content,
+            "failedToLoad",
+          ]),
           multiSelectType: connection && connection.get("multiSelectType"),
-          hasConnectionBetweenPosts:
-            connectionsBetweenPosts && connectionsBetweenPosts.size > 0,
+          hasConnectionBetweenPosts,
         };
       };
 
@@ -93,14 +122,33 @@ function genComponentConf() {
     getConnectButtonLabel() {
       return this.hasConnectionBetweenPosts
         ? "Already Connected With Post"
-        : "Connect with Post";
+        : "Request";
     }
 
-    loadPost() {
-      if (this.content) {
-        //this.content is the suggestedPostUri
-        this.needs__fetchUnloadedNeed(this.content);
+    getInfoText() {
+      if (this.isLoading) {
+        return "Loading Suggestion...";
+      } else if (this.toLoad) {
+        return "Suggestion marked toLoad";
+      } else if (this.failedToLoad) {
+        return "Failed to load Suggestion";
       }
+
+      if (isPersona(this.suggestedPost)) {
+        return isOwned(this.suggestedPost)
+          ? "This is one of your Personas"
+          : "This is someone elses Persona";
+      } else if (this.hasConnectionBetweenPosts) {
+        return "Already established a Connection with this Suggestion";
+      } else if (isOwned(this.suggestedPost)) {
+        return "This is one of your own Needs";
+      } else if (this.hasChatFacet && !this.hasGroupFacet) {
+        return "Click 'Request' to connect with this Need";
+      } else if (!this.hasChatFacet && this.hasGroupFacet) {
+        return "Click 'Join' to connect with this Group";
+      }
+
+      return "Click on the Icon to view Details";
     }
 
     connectWithPost() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -6,8 +6,26 @@ import won from "./won-es6.js";
 import { get, getIn } from "./utils.js";
 
 /**
+ * Determines if a given need is a Active
+ * @param need
+ * @returns {*|boolean}
+ */
+export function isActive(need) {
+  return get(need, "state") && get(need, "state") === won.WON.ActiveCompacted;
+}
+
+/**
+ * Determines if a given need is a Inactive
+ * @param need
+ * @returns {*|boolean}
+ */
+export function isInactive(need) {
+  return get(need, "state") && get(need, "state") === won.WON.InactiveCompacted;
+}
+
+/**
  * Determines if a given need is a WhatsAround-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isWhatsAroundNeed(need) {
@@ -19,7 +37,7 @@ export function isWhatsAroundNeed(need) {
 
 /**
  * Determines if a given need is a DirectResponse-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isDirectResponseNeed(need) {
@@ -53,7 +71,7 @@ export function hasGroupFacet(need) {
 
 /**
  * Determines if a given need is a Search-Need (see draft in create-search.js)
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isSearchNeed(need) {
@@ -62,7 +80,7 @@ export function isSearchNeed(need) {
 
 /**
  * Determines if a given need is a WhatsNew-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isWhatsNewNeed(need) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -14,6 +14,10 @@ export function isActive(need) {
   return get(need, "state") && get(need, "state") === won.WON.ActiveCompacted;
 }
 
+export function isOwned(need) {
+  return get(need, "isOwned");
+}
+
 /**
  * Determines if a given need is a Inactive
  * @param need

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -4,9 +4,8 @@
 
 import { createSelector } from "reselect";
 
-import won from "../won-es6.js";
 import { decodeUriComponentProperly, getIn } from "../utils.js";
-import { isPersona, isNeed } from "../need-utils.js";
+import { isPersona, isNeed, isActive, isInactive } from "../need-utils.js";
 import Color from "color";
 
 export const selectLastUpdateTime = state => state.get("lastUpdateTime");
@@ -33,29 +32,23 @@ export const getOwnedPosts = state =>
 
 export function getOwnedOpenPosts(state) {
   const allOwnedNeeds = getOwnedPosts(state);
-  return (
-    allOwnedNeeds &&
-    allOwnedNeeds.filter(post => post.get("state") === won.WON.ActiveCompacted)
-  );
+  return allOwnedNeeds && allOwnedNeeds.filter(post => isActive(post));
 }
 
 export function getOpenPosts(state) {
   const allPosts = getPosts(state);
-  return (
-    allPosts &&
-    allPosts.filter(post => post.get("state") === won.WON.ActiveCompacted)
-  );
+  return allPosts && allPosts.filter(post => isActive(post));
+}
+
+export function getActiveNeeds(state) {
+  const allNeeds = getNeeds(state);
+  return allNeeds && allNeeds.filter(need => isActive(need));
 }
 
 //TODO: METHOD NAME TO ACTUALLY REPRESENT WHAT THE SELECTOR DOES
 export function getOwnedClosedPosts(state) {
   const allOwnedNeeds = getOwnedPosts(state);
-  return (
-    allOwnedNeeds &&
-    allOwnedNeeds.filter(
-      post => post.get("state") === won.WON.InactiveCompacted
-    )
-  );
+  return allOwnedNeeds && allOwnedNeeds.filter(post => isInactive(post));
 }
 
 export function getOwnedNeedsInCreation(state) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
@@ -5,22 +5,37 @@ won-suggestpost-viewer {
   @include won-detail-viewer("suggestpostv");
 
   .suggestpostv__content {
-    display: grid;
-    grid-gap: 0.25rem;
-
-    &__post {
-      border: $thinGrayBorder;
+    & .suggestpostv__content__post {
       padding: 0.25rem;
+      border: $thinGrayBorder;
       background: white;
-    }
+      display: grid;
+      grid-row-gap: 0.5rem;
+      grid-template-areas:
+        "suggest_postheader suggest_action"
+        "suggest_info suggest_info";
+      grid-template-columns: 1fr min-content;
+      align-items: center;
 
-    &__notloaded {
-      font-size: $smallFontSize;
-    }
+      won-post-header {
+        grid-area: suggest_postheader;
+      }
 
-    &__action {
-      width: 100%;
-      font-size: $smallFontSize;
+      & .suggestpostv__content__post__action.won-button--outlined.red.thin {
+        grid-area: suggest_action;
+        font-size: $smallFontSize;
+        padding: 0.5rem;
+        height: 100%;
+        margin-left: 0.5rem;
+      }
+
+      & .suggestpostv__content__post__info {
+        grid-area: suggest_info;
+        color: $won-skeleton-color;
+        font-size: $smallFontSize;
+        border-top: $thinGrayBorder;
+        padding-top: 0.25rem;
+      }
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
@@ -68,4 +68,8 @@ won-suggestpost-picker {
       height: 0;
     }
   }
+
+  .suggestpostp__error {
+    font-size: $smallFontSize;
+  }
 }


### PR DESCRIPTION
- Fixes #2444 , Fixes #2443: you should be able to see a correct error message when trying to add a non need uri
- Fixes #2446: we only allow non-whatsx and active needs to be shared as suggestions, we even allow personas to be shared, since that could be beneficial (to view the needs of the persona for example)
- Fixes #2445 
- Fixes #2442: adds an info label to the suggested item
- Fixes #2449: label does not say connected anymore but informs the user that a connection has already been established (disregarding the state of the connection)