### PR TITLE
Feat  show details #2441

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -29,7 +29,7 @@ import { checkAccessToCurrentRoute } from "../configRouting.js";
 import { getIn } from "../utils.js";
 import { getOwnedConnectionUris } from "../selectors/connection-selectors.js";
 import { loadLatestMessagesOfConnection } from "./connections-actions.js";
-
+import { getPrivateIdFromRoute } from "../selectors/general-selectors.js";
 /**
  * Makes sure user is either logged in
  * or creates a private-ID account as fallback.
@@ -179,7 +179,7 @@ export function accountLogout() {
       })
       .then(() => {
         // for the case that we've been logged in to an anonymous account, we need to remove the privateId here.
-        if (getIn(state, ["router", "currentParams", "privateId"])) {
+        if (getPrivateIdFromRoute(state)) {
           return stateGoCurrent({ privateId: null })(dispatch, getState);
         }
       })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/cstm-router-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/cstm-router-actions.js
@@ -3,17 +3,15 @@
  */
 
 import Immutable from "immutable";
-
 import { getIn } from "../utils.js";
-
 import { actionCreators } from "./actions.js";
-
 import {
   defaultRoute,
   resetParams,
   resetParamsImm,
   addConstParams,
 } from "../configRouting.js";
+import { getCurrentParamsFromRoute } from "../selectors/general-selectors.js";
 
 /**
  * Action-Creator that goes back in the browser history
@@ -41,7 +39,7 @@ export function stateBack() {
  */
 export function stateGoAbs(state, queryParams) {
   return (dispatch, getState) => {
-    const currentParams = getIn(getState(), ["router", "currentParams"]);
+    const currentParams = getCurrentParamsFromRoute(getState());
     return dispatch(
       actionCreators.router__stateGo(
         state,
@@ -56,7 +54,7 @@ export function stateGoAbs(state, queryParams) {
  */
 export function stateGoResetParams(state) {
   return (dispatch, getState) => {
-    const currentParams = getIn(getState(), ["router", "currentParams"]);
+    const currentParams = getCurrentParamsFromRoute(getState());
     return dispatch(
       actionCreators.router__stateGo(
         state,
@@ -77,7 +75,7 @@ export function stateGoDefault() {
  */
 export function stateGoKeepParams(state, queryParamsList) {
   return (dispatch, getState) => {
-    const currentParams = getIn(getState(), ["router", "currentParams"]);
+    const currentParams = getCurrentParamsFromRoute(getState());
     const params = Immutable.Map(
       // [[k,v]] -> Map
       queryParamsList.map(
@@ -101,7 +99,7 @@ export function stateGoKeepParams(state, queryParamsList) {
 export function stateGoCurrent(queryParams) {
   return (dispatch, getState) => {
     const currentState = getIn(getState(), ["router", "currentState", "name"]);
-    const currentParams = getIn(getState(), ["router", "currentParams"]);
+    const currentParams = getCurrentParamsFromRoute(getState());
     return dispatch(
       actionCreators.router__stateGo(
         currentState,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -25,7 +25,7 @@ import "style/_connections-overview.scss";
 
 import {
   getRouterParams,
-  getGroupChatPostUriFromRoute,
+  getGroupPostAdminUriFromRoute,
   getOwnedNeedByConnectionUri,
   getOwnedNeedsInCreation,
   getConnectionUriFromRoute,
@@ -241,7 +241,7 @@ function genComponentConf() {
         const useCase = get(routerParams, "useCase");
         const useCaseGroup = get(routerParams, "useCaseGroup");
         const connUriInRoute = getConnectionUriFromRoute(state);
-        const groupPostAdminUriInRoute = getGroupChatPostUriFromRoute(state);
+        const groupPostAdminUriInRoute = getGroupPostAdminUriFromRoute(state);
         const needUriInRoute = getPostUriFromRoute(state);
         const needImpliedInRoute =
           (connUriInRoute &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.html
@@ -1,4 +1,7 @@
 <won-modal-dialog ng-if="self.showModalDialog"></won-modal-dialog>
+<div class="won-modal-needview" ng-if="self.showNeedOverlay">
+    <won-post-info include-header="true" need-uri="self.viewNeedUri"></won-post-info>
+</div>
 <header>
     <won-topnav></won-topnav>
 </header>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -24,6 +24,7 @@ import * as srefUtils from "../../sref-utils.js";
 
 import "style/_connections.scss";
 import "style/_responsiveness-utils.scss";
+import "style/_need-overlay.scss";
 
 const serviceDependencies = ["$element", "$ngRedux", "$scope", "$state"];
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -20,6 +20,7 @@ import {
   getViewNeedUriFromRoute,
   getUseCaseFromRoute,
   getUseCaseGroupFromRoute,
+  getGroupChatPostUriFromRoute,
 } from "../../selectors/general-selectors.js";
 import { isChatToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
@@ -43,11 +44,7 @@ class ConnectionsController {
       const selectedPost =
         selectedPostUri && getIn(state, ["needs", selectedPostUri]);
 
-      const showGroupPostAdministration = getIn(state, [
-        "router",
-        "currentParams",
-        "groupPostAdminUri",
-      ]);
+      const showGroupPostAdministration = getGroupChatPostUriFromRoute(state);
       const useCase = getUseCaseFromRoute(state);
       const useCaseGroup = getUseCaseGroupFromRoute(state);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -18,6 +18,8 @@ import {
   getConnectionUriFromRoute,
   getPostUriFromRoute,
   getViewNeedUriFromRoute,
+  getUseCaseFromRoute,
+  getUseCaseGroupFromRoute,
 } from "../../selectors/general-selectors.js";
 import { isChatToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
@@ -46,12 +48,8 @@ class ConnectionsController {
         "currentParams",
         "groupPostAdminUri",
       ]);
-      const useCase = getIn(state, ["router", "currentParams", "useCase"]);
-      const useCaseGroup = getIn(state, [
-        "router",
-        "currentParams",
-        "useCaseGroup",
-      ]);
+      const useCase = getUseCaseFromRoute(state);
+      const useCaseGroup = getUseCaseGroupFromRoute(state);
 
       const selectedConnectionUri = getConnectionUriFromRoute(state);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -20,7 +20,7 @@ import {
   getViewNeedUriFromRoute,
   getUseCaseFromRoute,
   getUseCaseGroupFromRoute,
-  getGroupChatPostUriFromRoute,
+  getGroupPostAdminUriFromRoute,
 } from "../../selectors/general-selectors.js";
 import { isChatToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
@@ -44,7 +44,7 @@ class ConnectionsController {
       const selectedPost =
         selectedPostUri && getIn(state, ["needs", selectedPostUri]);
 
-      const showGroupPostAdministration = getGroupChatPostUriFromRoute(state);
+      const showGroupPostAdministration = getGroupPostAdminUriFromRoute(state);
       const useCase = getUseCaseFromRoute(state);
       const useCaseGroup = getUseCaseGroupFromRoute(state);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections/connections.js
@@ -15,6 +15,9 @@ import { actionCreators } from "../../actions/actions.js";
 import {
   getOwnedNeedByConnectionUri,
   getOwnedNeeds,
+  getConnectionUriFromRoute,
+  getPostUriFromRoute,
+  getViewNeedUriFromRoute,
 } from "../../selectors/general-selectors.js";
 import { isChatToGroup } from "../../connection-utils.js";
 import * as srefUtils from "../../sref-utils.js";
@@ -32,9 +35,8 @@ class ConnectionsController {
     this.open = {};
 
     const selectFromState = state => {
-      const selectedPostUri = decodeURIComponent(
-        getIn(state, ["router", "currentParams", "postUri"])
-      );
+      const viewNeedUri = getViewNeedUriFromRoute(state);
+      const selectedPostUri = getPostUriFromRoute(state);
       const selectedPost =
         selectedPostUri && getIn(state, ["needs", selectedPostUri]);
 
@@ -50,9 +52,8 @@ class ConnectionsController {
         "useCaseGroup",
       ]);
 
-      const selectedConnectionUri = decodeURIComponent(
-        getIn(state, ["router", "currentParams", "connectionUri"])
-      );
+      const selectedConnectionUri = getConnectionUriFromRoute(state);
+
       const need =
         selectedConnectionUri &&
         getOwnedNeedByConnectionUri(state, selectedConnectionUri);
@@ -139,7 +140,8 @@ class ConnectionsController {
         showPostInfo:
           selectedPost && !useCaseGroup && !showGroupPostAdministration,
         showGroupPostAdministration: showGroupPostAdministration,
-
+        showNeedOverlay: !!viewNeedUri,
+        viewNeedUri,
         hideListSideInResponsive:
           !hasOwnedNeeds ||
           selectedConnection ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post-item.js
@@ -2,9 +2,13 @@ import angular from "angular";
 import ngAnimate from "angular-animate";
 import squareImageModule from "../components/square-image.js";
 import { actionCreators } from "../actions/actions.js";
-import { attach, getIn } from "../utils.js";
+import { attach } from "../utils.js";
 import { useCases } from "useCaseDefinitions";
 import { connect2Redux } from "../won-utils.js";
+import {
+  getUseCaseFromRoute,
+  getUseCaseGroupFromRoute,
+} from "../selectors/general-selectors.js";
 
 import "style/_create-post-item.scss";
 
@@ -98,17 +102,8 @@ function genComponentConf() {
       window.cpitem4dbg = this;
 
       const selectFromState = state => {
-        const useCaseGroup = getIn(state, [
-          "router",
-          "currentParams",
-          "useCaseGroup",
-        ]);
-
-        const useCaseString = getIn(state, [
-          "router",
-          "currentParams",
-          "useCase",
-        ]);
+        const useCaseGroup = getUseCaseGroupFromRoute(state);
+        const useCaseString = getUseCaseFromRoute(state);
 
         const listUseCases = this.getListUseCases();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -12,7 +12,10 @@ import publishButtonModule from "./publish-button.js";
 import { get, getIn, attach, delay } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
-import { selectIsConnected } from "../selectors/general-selectors.js";
+import {
+  selectIsConnected,
+  getUseCaseFromRoute,
+} from "../selectors/general-selectors.js";
 
 import { useCases } from "useCaseDefinitions";
 
@@ -122,11 +125,7 @@ function genComponentConf() {
       this.isNew = true;
 
       const selectFromState = state => {
-        const useCaseString = getIn(state, [
-          "router",
-          "currentParams",
-          "useCase",
-        ]);
+        const useCaseString = getUseCaseFromRoute(state);
 
         // needed to be able to reset matching context to default
         // TODO: is there an easier way to do this?

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -29,7 +29,10 @@ function genComponentConf() {
         <div class="suggestpostv__content">
           <div class="suggestpostv__content__post">
             <won-post-header
+                class="clickable"
                 need-uri="self.content"
+                ng-click="self.router__stateGoCurrent({viewNeedUri: self.content})"
+                ng-disabled="!self.fetchedSuggestion"
                 timestamp="self.suggestedPost && self.suggestedPost.get('creationDate')"
                 hide-image="::false">
             </won-post-header>
@@ -169,7 +172,7 @@ function genComponentConf() {
       } else if (isOwned(this.suggestedPost)) {
         return "This is one of your own Needs";
       } else if (this.hasChatFacet && !this.hasGroupFacet) {
-        return "Click 'Request' to connect with this Need";
+        return "Click 'Connect' to connect with this Need";
       } else if (!this.hasChatFacet && this.hasGroupFacet) {
         return "Click 'Join' to connect with this Group";
       }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -79,33 +79,51 @@ function genComponentConf() {
         const hasConnectionBetweenPosts =
           connectionsBetweenPosts && connectionsBetweenPosts.size > 0;
 
+        const isLoading = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "loading",
+        ]);
+        const toLoad = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "toLoad",
+        ]);
+        const failedToLoad = state.getIn([
+          "process",
+          "needs",
+          this.content,
+          "failedToLoad",
+        ]);
+
+        const fetchedSuggestion = !isLoading && !toLoad && !failedToLoad;
+
         return {
           suggestedPost,
           openedOwnPost,
           hasChatFacet: hasChatFacet(suggestedPost),
           hasGroupFacet: hasGroupFacet(suggestedPost),
           showConnectAction:
+            suggestedPost &&
+            fetchedSuggestion &&
             !hasGroupFacet(suggestedPost) &&
             hasChatFacet(suggestedPost) &&
             !hasConnectionBetweenPosts &&
-            suggestedPost &&
             !isOwned(suggestedPost) &&
-            self.openedOwnPost,
+            openedOwnPost,
           showJoinAction:
+            suggestedPost &&
+            fetchedSuggestion &&
             hasGroupFacet(suggestedPost) &&
             !hasChatFacet(suggestedPost) &&
             !hasConnectionBetweenPosts &&
-            suggestedPost &&
             !isOwned(suggestedPost) &&
-            self.openedOwnPost,
-          isLoading: state.getIn(["process", "needs", this.content, "loading"]),
-          toLoad: state.getIn(["process", "needs", this.content, "toLoad"]),
-          failedToLoad: state.getIn([
-            "process",
-            "needs",
-            this.content,
-            "failedToLoad",
-          ]),
+            openedOwnPost,
+          isLoading,
+          toLoad,
+          failedToLoad,
           multiSelectType: connection && connection.get("multiSelectType"),
           hasConnectionBetweenPosts,
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -43,6 +43,11 @@ function genComponentConf() {
               ng-click="self.connectWithPost()">
               Join
             </button>
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.hasConnectionBetweenPosts"
+              ng-click="self.router__stateGoCurrent({connectionUri: self.establishedConnectionUri})">
+              View Chat
+            </button>
             <div class="suggestpostv__content__post__info">
               {{ self.getInfoText() }}
             </div>
@@ -126,6 +131,9 @@ function genComponentConf() {
           failedToLoad,
           multiSelectType: connection && connection.get("multiSelectType"),
           hasConnectionBetweenPosts,
+          establishedConnectionUri:
+            hasConnectionBetweenPosts &&
+            get(connectionsBetweenPosts.first(), "uri"),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/suggestpost-viewer.js
@@ -2,7 +2,13 @@ import angular from "angular";
 import "ng-redux";
 import { actionCreators } from "../../../actions/actions.js";
 import postHeaderModule from "../../post-header.js";
-import { attach } from "../../../utils.js";
+import { attach, getIn, get } from "../../../utils.js";
+import {
+  isOwned,
+  isPersona,
+  hasChatFacet,
+  hasGroupFacet,
+} from "../../../need-utils.js";
 import { connect2Redux } from "../../../won-utils.js";
 import {
   getConnectionUriFromRoute,
@@ -21,29 +27,26 @@ function genComponentConf() {
           <span class="suggestpostv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
         </div>
         <div class="suggestpostv__content">
-          <div class="suggestpostv__content__post" ng-if="self.suggestedPost">
+          <div class="suggestpostv__content__post">
             <won-post-header
-               
-                need-uri="self.suggestedPost.get('uri')"
-                timestamp="self.suggestedPost.get('creationDate')"
-             
+                need-uri="self.content"
+                timestamp="self.suggestedPost && self.suggestedPost.get('creationDate')"
                 hide-image="::false">
             </won-post-header>
-          </div>
-          <div class="suggestpostv__content__notloaded" ng-if="!self.suggestedPost">
-              Suggestion not loaded yet. Click the Button below to retrieve the Suggested Post.
-          </div>
-          <button class="suggestpostv__content__action won-button--outlined thin red"
-              ng-if="!self.suggestedPost"
-              ng-click="self.loadPost()">
-              Load Post
-          </button>
-          <button class="suggestpostv__content__action won-button--outlined thin red"
-              ng-if="self.suggestedPost && !self.suggestedPost.get('isOwned') && self.openedOwnPost"
-              ng-disabled="self.hasConnectionBetweenPosts"
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.showConnectAction"
               ng-click="self.connectWithPost()">
-              {{ self.getConnectButtonLabel() }}
-          </button>
+              Connect
+            </button>
+            <button class="suggestpostv__content__post__action won-button--outlined thin red"
+              ng-if="self.showJoinAction"
+              ng-click="self.connectWithPost()">
+              Join
+            </button>
+            <div class="suggestpostv__content__post__info">
+              {{ self.getInfoText() }}
+            </div>
+          </div>
         </div>
     `;
 
@@ -57,15 +60,15 @@ function genComponentConf() {
         const openedOwnPost =
           openedConnectionUri &&
           getOwnedNeedByConnectionUri(state, openedConnectionUri);
-        const connection =
-          openedOwnPost &&
-          openedOwnPost.getIn(["connections", openedConnectionUri]);
+        const connection = getIn(openedOwnPost, [
+          "connections",
+          openedConnectionUri,
+        ]);
 
-        const suggestedPost = state.getIn(["needs", this.content]);
-        const suggestedPostUri = suggestedPost && suggestedPost.get("uri");
+        const suggestedPost = getIn(state, ["needs", this.content]);
+        const suggestedPostUri = get(suggestedPost, "uri");
 
-        const connectionsOfOpenedOwnPost =
-          openedOwnPost && openedOwnPost.get("connections");
+        const connectionsOfOpenedOwnPost = get(openedOwnPost, "connections");
         const connectionsBetweenPosts =
           suggestedPostUri &&
           connectionsOfOpenedOwnPost &&
@@ -73,12 +76,38 @@ function genComponentConf() {
             conn => conn.get("remoteNeedUri") === suggestedPostUri
           );
 
+        const hasConnectionBetweenPosts =
+          connectionsBetweenPosts && connectionsBetweenPosts.size > 0;
+
         return {
           suggestedPost,
           openedOwnPost,
+          hasChatFacet: hasChatFacet(suggestedPost),
+          hasGroupFacet: hasGroupFacet(suggestedPost),
+          showConnectAction:
+            !hasGroupFacet(suggestedPost) &&
+            hasChatFacet(suggestedPost) &&
+            !hasConnectionBetweenPosts &&
+            suggestedPost &&
+            !isOwned(suggestedPost) &&
+            self.openedOwnPost,
+          showJoinAction:
+            hasGroupFacet(suggestedPost) &&
+            !hasChatFacet(suggestedPost) &&
+            !hasConnectionBetweenPosts &&
+            suggestedPost &&
+            !isOwned(suggestedPost) &&
+            self.openedOwnPost,
+          isLoading: state.getIn(["process", "needs", this.content, "loading"]),
+          toLoad: state.getIn(["process", "needs", this.content, "toLoad"]),
+          failedToLoad: state.getIn([
+            "process",
+            "needs",
+            this.content,
+            "failedToLoad",
+          ]),
           multiSelectType: connection && connection.get("multiSelectType"),
-          hasConnectionBetweenPosts:
-            connectionsBetweenPosts && connectionsBetweenPosts.size > 0,
+          hasConnectionBetweenPosts,
         };
       };
 
@@ -93,14 +122,33 @@ function genComponentConf() {
     getConnectButtonLabel() {
       return this.hasConnectionBetweenPosts
         ? "Already Connected With Post"
-        : "Connect with Post";
+        : "Request";
     }
 
-    loadPost() {
-      if (this.content) {
-        //this.content is the suggestedPostUri
-        this.needs__fetchUnloadedNeed(this.content);
+    getInfoText() {
+      if (this.isLoading) {
+        return "Loading Suggestion...";
+      } else if (this.toLoad) {
+        return "Suggestion marked toLoad";
+      } else if (this.failedToLoad) {
+        return "Failed to load Suggestion";
       }
+
+      if (isPersona(this.suggestedPost)) {
+        return isOwned(this.suggestedPost)
+          ? "This is one of your Personas"
+          : "This is someone elses Persona";
+      } else if (this.hasConnectionBetweenPosts) {
+        return "Already established a Connection with this Suggestion";
+      } else if (isOwned(this.suggestedPost)) {
+        return "This is one of your own Needs";
+      } else if (this.hasChatFacet && !this.hasGroupFacet) {
+        return "Click 'Request' to connect with this Need";
+      } else if (!this.hasChatFacet && this.hasGroupFacet) {
+        return "Click 'Join' to connect with this Group";
+      }
+
+      return "Click on the Icon to view Details";
     }
 
     connectWithPost() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-selection-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-selection-item.js
@@ -6,7 +6,7 @@ import angular from "angular";
 import { attach } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { actionCreators } from "../actions/actions.js";
-import { getGroupChatPostUriFromRoute } from "../selectors/general-selectors.js";
+import { getGroupPostAdminUriFromRoute } from "../selectors/general-selectors.js";
 
 import groupAdministrationHeaderModule from "./group-administration-header.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -29,7 +29,7 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
 
       const selectFromState = state => {
-        const openGroupChatPostUri = getGroupChatPostUriFromRoute(state);
+        const openGroupChatPostUri = getGroupPostAdminUriFromRoute(state);
 
         return {
           openGroupChatPostUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
@@ -6,7 +6,7 @@ import labelledHrModule from "./labelled-hr.js";
 import { connect2Redux } from "../won-utils.js";
 import { attach, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
-import { getGroupChatPostUriFromRoute } from "../selectors/general-selectors.js";
+import { getGroupPostAdminUriFromRoute } from "../selectors/general-selectors.js";
 import { getGroupChatConnectionsByNeedUri } from "../selectors/connection-selectors.js";
 
 import "style/_group-administration.scss";
@@ -85,7 +85,7 @@ function genComponentConf() {
       this.won = won;
 
       const selectFromState = state => {
-        const groupPostAdminUri = getGroupChatPostUriFromRoute(state);
+        const groupPostAdminUri = getGroupPostAdminUriFromRoute(state);
         const groupChatPost = getIn(state, ["needs", groupPostAdminUri]);
         const groupChatConnections = getGroupChatConnectionsByNeedUri(
           state,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration.js
@@ -34,6 +34,8 @@ function genComponentConf() {
                 ng-if="self.hasGroupChatConnections"
                 ng-repeat="conn in self.groupChatConnectionsArray">
                 <won-post-header
+                  class="clickable"
+                  ng-click="self.router__stateGoCurrent({viewNeedUri: conn.get('remoteNeedUri')}"
                   need-uri="conn.get('remoteNeedUri')"
                   hide-image="::false">
                 </won-post-header>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -53,6 +53,8 @@ function genComponentConf() {
               class="post-content__members__member"
               ng-repeat="memberUri in self.groupMembersArray">
               <won-post-header
+                class="clickable"
+                ng-click="self.router__stateGoCurrent({viewNeedUri: memberUri})"
                 need-uri="memberUri"
                 hide-image="::false">
               </won-post-header>
@@ -66,6 +68,8 @@ function genComponentConf() {
               class="post-content__members__member"
               ng-repeat="heldPostUri in self.heldPostsArray">
               <won-post-header
+                class="clickable"
+                ng-click="self.router__stateGoCurrent({viewNeedUri: heldPostUri})"
                 need-uri="heldPostUri"
                 hide-image="::false">
               </won-post-header>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -130,7 +130,7 @@ function genComponentConf() {
     }
 
     goToPersona(personaUri) {
-      this.router__stateGoCurrent({ useCase: undefined, postUri: personaUri });
+      this.router__stateGoCurrent({ viewNeedUri: personaUri });
     }
 
     closePost() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -40,7 +40,7 @@ function genComponentConf() {
                 timestamp="self.createdTimestamp"
                 hide-image="::false">
             </won-post-header>
-            <won-post-context-dropdown></won-post-context-dropdown>
+            <won-post-context-dropdown need-uri="self.post.get('uri')"></won-post-context-dropdown>
         </div>
         <won-post-content post-uri="self.postUri"></won-post-content>
         <div class="post-info__footer" ng-if="!self.postLoading && !self.postFailedToLoad && self.showCreateWhatsAround()">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -20,10 +20,19 @@ function genComponentConf() {
   let template = `
         <div class="post-info__header" ng-if="self.includeHeader">
             <a class="post-info__header__back clickable"
-               ng-click="self.router__stateGoCurrent({postUri : null})">
+                ng-if="!self.showOverlayNeed"
+                ng-click="self.router__stateGoCurrent({postUri : null})">
                 <svg style="--local-primary:var(--won-primary-color);"
                      class="post-info__header__back__icon clickable">
                     <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
+                </svg>
+            </a>
+            <a class="post-info__header__back clickable"
+                ng-if="self.showOverlayNeed"
+                ng-click="self.router__back()">
+                <svg style="--local-primary:var(--won-primary-color);"
+                     class="post-info__header__back__icon clickable">
+                    <use xlink:href="#ico36_close" href="#ico36_close"></use>
                 </svg>
             </a>
             <won-post-header
@@ -54,7 +63,13 @@ function genComponentConf() {
       window.pi4dbg = this;
 
       const selectFromState = state => {
-        const postUri = getPostUriFromRoute(state);
+        /*
+          If the post-info component has a need-uri attribute we display this need-uri instead of the postUriFromTheRoute
+          This way we can include a overlay-close button instead of the current back-button handling
+        */
+        const postUri = this.needUri
+          ? this.needUri
+          : getPostUriFromRoute(state);
         const post = state.getIn(["needs", postUri]);
 
         return {
@@ -68,12 +83,13 @@ function genComponentConf() {
             post &&
             getIn(state, ["process", "needs", post.get("uri"), "failedToLoad"]),
           createdTimestamp: post && post.get("creationDate"),
+          showOverlayNeed: !!this.needUri,
         };
       };
       connect2Redux(
         selectFromState,
         actionCreators,
-        ["self.includeHeader"],
+        ["self.includeHeader", "self.needUri"],
         this
       );
 
@@ -100,6 +116,7 @@ function genComponentConf() {
     template: template,
     scope: {
       includeHeader: "=",
+      needUri: "=",
     },
   };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -1,4 +1,7 @@
 <won-modal-dialog ng-if="self.showModalDialog"></won-modal-dialog>
+<div class="won-modal-needview" ng-if="self.showNeedOverlay">
+    <won-post-info include-header="true" need-uri="self.viewNeedUri"></won-post-info>
+</div>
 <header>
     <won-topnav></won-topnav>
 </header>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -16,6 +16,7 @@ import {
 import * as srefUtils from "../../sref-utils.js";
 
 import "style/_post-visitor.scss";
+import "style/_need-overlay.scss";
 
 const serviceDependencies = ["$ngRedux", "$scope"];
 class Controller {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -8,7 +8,10 @@ import won from "../../won-es6.js";
 import { actionCreators } from "../../actions/actions.js";
 import sendRequestModule from "../send-request.js";
 import visitorTitleBarModule from "../visitor-title-bar.js";
-import { getPostUriFromRoute } from "../../selectors/general-selectors.js";
+import {
+  getPostUriFromRoute,
+  getViewNeedUriFromRoute,
+} from "../../selectors/general-selectors.js";
 
 import * as srefUtils from "../../sref-utils.js";
 
@@ -25,6 +28,7 @@ class Controller {
 
     const selectFromState = state => {
       const postUri = getPostUriFromRoute(state);
+      const viewNeedUri = getViewNeedUriFromRoute(state);
       const post = state.getIn(["needs", postUri]);
 
       const isOwnPost = post && post.get("isOwned");
@@ -35,6 +39,8 @@ class Controller {
         post,
         won: won.WON,
         showModalDialog: getIn(state, ["view", "showModalDialog"]),
+        showNeedOverlay: !!viewNeedUri,
+        viewNeedUri,
       };
     };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -9,6 +9,7 @@ import { attach, delay, getIn, toAbsoluteURL } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux, parseRestErrorMessage } from "../won-utils.js";
 import { ownerBaseUrl } from "config";
+import { getVerificationTokenFromRoute } from "../selectors/general-selectors.js";
 
 import * as srefUtils from "../sref-utils.js";
 
@@ -232,11 +233,7 @@ function genSlideInConf() {
       this.anonymousEmail = undefined;
 
       const selectFromState = state => {
-        const verificationToken = getIn(state, [
-          "router",
-          "currentParams",
-          "token",
-        ]);
+        const verificationToken = getVerificationTokenFromRoute(state);
 
         const privateId = getIn(state, ["account", "privateId"]);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.js
@@ -2,10 +2,11 @@ import angular from "angular";
 import ngAnimate from "angular-animate";
 import labelledHrModule from "./labelled-hr.js";
 import "ng-redux";
-import { attach, getIn } from "../utils.js";
+import { attach } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 import { useCaseGroups } from "useCaseDefinitions";
+import { getUseCaseGroupFromRoute } from "../selectors/general-selectors.js";
 
 import "style/_usecase-group.scss";
 
@@ -66,11 +67,7 @@ function genComponentConf() {
       this.useCaseGroups = useCaseGroups;
 
       const selectFromState = state => {
-        const selectedGroup = getIn(state, [
-          "router",
-          "currentParams",
-          "useCaseGroup",
-        ]);
+        const selectedGroup = getUseCaseGroupFromRoute(state);
         return {
           useCaseGroup: selectUseCaseGroupFrom(selectedGroup, useCaseGroups),
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -6,10 +6,13 @@ import ngAnimate from "angular-animate";
 import labelledHrModule from "./labelled-hr.js";
 
 import "ng-redux";
-import { attach, getIn } from "../utils.js";
+import { attach } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
-import { selectIsConnected } from "../selectors/general-selectors.js";
+import {
+  selectIsConnected,
+  getUseCaseGroupFromRoute,
+} from "../selectors/general-selectors.js";
 import { useCases, useCaseGroups } from "useCaseDefinitions";
 
 import "style/_usecase-picker.scss";
@@ -135,11 +138,7 @@ function genComponentConf() {
       this.searchResults = undefined;
 
       const selectFromState = state => {
-        const useCaseGroup = getIn(state, [
-          "router",
-          "currentParams",
-          "useCaseGroup",
-        ]);
+        const useCaseGroup = getUseCaseGroupFromRoute(state);
 
         return {
           useCaseGroup,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -28,7 +28,7 @@ function genComponentConf() {
                     </hgroup>
                 </div>
             </div>
-            <won-post-context-dropdown></won-post-context-dropdown>
+            <won-post-context-dropdown need-uri="self.post.get('uri')"></won-post-context-dropdown>
         </nav>
     `;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -5,7 +5,10 @@
 import Immutable from "immutable";
 import { actionCreators } from "./actions/actions.js";
 import { accountLogin } from "./actions/account-actions.js";
-import { getOwnedNeeds } from "./selectors/general-selectors.js";
+import {
+  getCurrentParamsFromRoute,
+  getOwnedNeeds,
+} from "./selectors/general-selectors.js";
 import { privateId2Credentials } from "./won-utils.js";
 
 import { getIn, firstToLowerCase, hyphen2Camel } from "./utils.js";
@@ -201,7 +204,7 @@ export function accessControl({
 export function checkAccessToCurrentRoute(dispatch, getState) {
   const appState = getState();
   let routingState = getIn(appState, ["router", "currentState"]);
-  let params = getIn(appState, ["router", "currentParams"]);
+  let params = getCurrentParamsFromRoute(appState);
   return accessControl({
     toState: routingState,
     fromState: routingState,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -21,6 +21,7 @@ import { getIn, firstToLowerCase, hyphen2Camel } from "./utils.js";
  */
 export const resetParams = Object.freeze({
   connectionUri: undefined,
+  viewNeedUri: undefined,
   postUri: undefined,
   useCase: undefined,
   useCaseGroup: undefined,
@@ -64,11 +65,11 @@ export const configRouting = [
       { path: "/settings", component: "settings" },
       {
         path:
-          "/connections?privateId?postUri?connectionUri?useCase?useCaseGroup?token?groupPostAdminUri",
+          "/connections?privateId?postUri?connectionUri?useCase?useCaseGroup?token?groupPostAdminUri?viewNeedUri",
         component: "connections",
         as: "connections",
       },
-      { path: "/post/?postUri", component: "post", as: "post" },
+      { path: "/post/?postUri?viewNeedUri", component: "post", as: "post" },
     ].forEach(({ path, component, as }) => {
       const cmlComponent = hyphen2Camel(component);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -6,8 +6,26 @@ import won from "./won-es6.js";
 import { get, getIn } from "./utils.js";
 
 /**
+ * Determines if a given need is a Active
+ * @param need
+ * @returns {*|boolean}
+ */
+export function isActive(need) {
+  return get(need, "state") && get(need, "state") === won.WON.ActiveCompacted;
+}
+
+/**
+ * Determines if a given need is a Inactive
+ * @param need
+ * @returns {*|boolean}
+ */
+export function isInactive(need) {
+  return get(need, "state") && get(need, "state") === won.WON.InactiveCompacted;
+}
+
+/**
  * Determines if a given need is a WhatsAround-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isWhatsAroundNeed(need) {
@@ -19,7 +37,7 @@ export function isWhatsAroundNeed(need) {
 
 /**
  * Determines if a given need is a DirectResponse-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isDirectResponseNeed(need) {
@@ -53,7 +71,7 @@ export function hasGroupFacet(need) {
 
 /**
  * Determines if a given need is a Search-Need (see draft in create-search.js)
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isSearchNeed(need) {
@@ -62,7 +80,7 @@ export function isSearchNeed(need) {
 
 /**
  * Determines if a given need is a WhatsNew-Need
- * @param msg
+ * @param need
  * @returns {*|boolean}
  */
 export function isWhatsNewNeed(need) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -14,6 +14,10 @@ export function isActive(need) {
   return get(need, "state") && get(need, "state") === won.WON.ActiveCompacted;
 }
 
+export function isOwned(need) {
+  return get(need, "isOwned");
+}
+
 /**
  * Determines if a given need is a Inactive
  * @param need

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -115,6 +115,13 @@ export const getPrivateIdFromRoute = createSelector(
   }
 );
 
+export const getVerificationTokenFromRoute = createSelector(
+  state => state,
+  state => {
+    return getIn(state, ["router", "currentParams", "token"]);
+  }
+);
+
 export const getConnectionUriFromRoute = createSelector(
   getRouterParams,
   routerParams => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -75,6 +75,13 @@ export function getOwnedNeedByConnectionUri(state, connectionUri) {
     .first();
 }
 
+export const getCurrentParamsFromRoute = createSelector(
+  state => state,
+  state => {
+    return getIn(state, ["router", "currentParams"]);
+  }
+);
+
 export const getViewNeedUriFromRoute = createSelector(
   state => state,
   state => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -138,7 +138,7 @@ export const getConnectionUriFromRoute = createSelector(
   }
 );
 
-export const getGroupChatPostUriFromRoute = createSelector(
+export const getGroupPostAdminUriFromRoute = createSelector(
   state => state,
   state => {
     const encodedPostUri = getIn(state, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -75,6 +75,38 @@ export function getOwnedNeedByConnectionUri(state, connectionUri) {
     .first();
 }
 
+export const getViewNeedUriFromRoute = createSelector(
+  state => state,
+  state => {
+    const encodedNeedUri = getIn(state, [
+      "router",
+      "currentParams",
+      "viewNeedUri",
+    ]);
+    return decodeUriComponentProperly(encodedNeedUri);
+  }
+);
+
+export const getUseCaseFromRoute = createSelector(
+  state => state,
+  state => {
+    const encodedNeedUri = getIn(state, ["router", "currentParams", "useCase"]);
+    return decodeUriComponentProperly(encodedNeedUri);
+  }
+);
+
+export const getUseCaseGroupFromRoute = createSelector(
+  state => state,
+  state => {
+    const encodedNeedUri = getIn(state, [
+      "router",
+      "currentParams",
+      "useCaseGroup",
+    ]);
+    return decodeUriComponentProperly(encodedNeedUri);
+  }
+);
+
 export const getConnectionUriFromRoute = createSelector(
   getRouterParams,
   routerParams => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -90,20 +90,21 @@ export const getViewNeedUriFromRoute = createSelector(
 export const getUseCaseFromRoute = createSelector(
   state => state,
   state => {
-    const encodedNeedUri = getIn(state, ["router", "currentParams", "useCase"]);
-    return decodeUriComponentProperly(encodedNeedUri);
+    return getIn(state, ["router", "currentParams", "useCase"]);
   }
 );
 
 export const getUseCaseGroupFromRoute = createSelector(
   state => state,
   state => {
-    const encodedNeedUri = getIn(state, [
-      "router",
-      "currentParams",
-      "useCaseGroup",
-    ]);
-    return decodeUriComponentProperly(encodedNeedUri);
+    return getIn(state, ["router", "currentParams", "useCaseGroup"]);
+  }
+);
+
+export const getPrivateIdFromRoute = createSelector(
+  state => state,
+  state => {
+    return getIn(state, ["router", "currentParams", "privateId"]);
   }
 );
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -4,9 +4,8 @@
 
 import { createSelector } from "reselect";
 
-import won from "../won-es6.js";
 import { decodeUriComponentProperly, getIn } from "../utils.js";
-import { isPersona, isNeed } from "../need-utils.js";
+import { isPersona, isNeed, isActive, isInactive } from "../need-utils.js";
 import Color from "color";
 
 export const selectLastUpdateTime = state => state.get("lastUpdateTime");
@@ -33,29 +32,23 @@ export const getOwnedPosts = state =>
 
 export function getOwnedOpenPosts(state) {
   const allOwnedNeeds = getOwnedPosts(state);
-  return (
-    allOwnedNeeds &&
-    allOwnedNeeds.filter(post => post.get("state") === won.WON.ActiveCompacted)
-  );
+  return allOwnedNeeds && allOwnedNeeds.filter(post => isActive(post));
 }
 
 export function getOpenPosts(state) {
   const allPosts = getPosts(state);
-  return (
-    allPosts &&
-    allPosts.filter(post => post.get("state") === won.WON.ActiveCompacted)
-  );
+  return allPosts && allPosts.filter(post => isActive(post));
+}
+
+export function getActiveNeeds(state) {
+  const allNeeds = getNeeds(state);
+  return allNeeds && allNeeds.filter(need => isActive(need));
 }
 
 //TODO: METHOD NAME TO ACTUALLY REPRESENT WHAT THE SELECTOR DOES
 export function getOwnedClosedPosts(state) {
   const allOwnedNeeds = getOwnedPosts(state);
-  return (
-    allOwnedNeeds &&
-    allOwnedNeeds.filter(
-      post => post.get("state") === won.WON.InactiveCompacted
-    )
-  );
+  return allOwnedNeeds && allOwnedNeeds.filter(post => isInactive(post));
 }
 
 export function getOwnedNeedsInCreation(state) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
@@ -1,25 +1,55 @@
 @import "won-config";
 @import "animate";
 
-.won-modal-needview {
-  @include appearAnimation(0.5s);
-  display: flex;
-  width: 100%;
-  height: 100%;
-  z-index: 10000;
+@media (max-width: $responsivenessBreakPoint) {
+  .won-modal-needview {
+    @include appearAnimation(0.5s);
+    display: flex;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
 
-  align-items: center;
-  justify-content: center;
-  align-content: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  background: rgba(0, 0, 0, 0.5);
+    align-items: center;
+    justify-content: center;
+    align-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.5);
 
-  won-post-info {
-    background: white;
-    display: grid;
-    grid-row-gap: 0.5rem;
-    padding: 0.5rem;
+    > won-post-info {
+      width: 100%;
+      height: 100%;
+      background: white;
+      display: grid;
+      grid-row-gap: 0.5rem;
+      padding: 0.5rem;
+    }
+  }
+}
+@media (min-width: $responsivenessBreakPoint) {
+  .won-modal-needview {
+    @include appearAnimation(0.5s);
+    display: flex;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
+
+    align-items: center;
+    justify-content: center;
+    align-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.5);
+
+    > won-post-info {
+      max-width: $maxContentWidth/2;
+      max-height: 75%;
+      background: white;
+      display: grid;
+      grid-row-gap: 0.5rem;
+      padding: 0.5rem;
+    }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
@@ -45,6 +45,7 @@
 
     > won-post-info {
       max-width: $maxContentWidth/2;
+      min-width: $maxContentWidth/2;
       max-height: 75%;
       background: white;
       display: grid;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
@@ -1,0 +1,25 @@
+@import "won-config";
+@import "animate";
+
+.won-modal-needview {
+  @include appearAnimation(0.5s);
+  display: flex;
+  width: 100%;
+  height: 100%;
+  z-index: 10000;
+
+  align-items: center;
+  justify-content: center;
+  align-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.5);
+
+  won-post-info {
+    background: white;
+    display: grid;
+    grid-row-gap: 0.5rem;
+    padding: 0.5rem;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpost-viewer.scss
@@ -5,22 +5,37 @@ won-suggestpost-viewer {
   @include won-detail-viewer("suggestpostv");
 
   .suggestpostv__content {
-    display: grid;
-    grid-gap: 0.25rem;
-
-    &__post {
-      border: $thinGrayBorder;
+    & .suggestpostv__content__post {
       padding: 0.25rem;
+      border: $thinGrayBorder;
       background: white;
-    }
+      display: grid;
+      grid-row-gap: 0.5rem;
+      grid-template-areas:
+        "suggest_postheader suggest_action"
+        "suggest_info suggest_info";
+      grid-template-columns: 1fr min-content;
+      align-items: center;
 
-    &__notloaded {
-      font-size: $smallFontSize;
-    }
+      won-post-header {
+        grid-area: suggest_postheader;
+      }
 
-    &__action {
-      width: 100%;
-      font-size: $smallFontSize;
+      & .suggestpostv__content__post__action.won-button--outlined.red.thin {
+        grid-area: suggest_action;
+        font-size: $smallFontSize;
+        padding: 0.5rem;
+        height: 100%;
+        margin-left: 0.5rem;
+      }
+
+      & .suggestpostv__content__post__info {
+        grid-area: suggest_info;
+        color: $won-skeleton-color;
+        font-size: $smallFontSize;
+        border-top: $thinGrayBorder;
+        padding-top: 0.25rem;
+      }
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_suggestpostpicker.scss
@@ -68,4 +68,8 @@ won-suggestpost-picker {
       height: 0;
     }
   }
+
+  .suggestpostp__error {
+    font-size: $smallFontSize;
+  }
 }


### PR DESCRIPTION
depends on #2640 

fixes #2441 

Clicking on:
- a suggested Need
- a responseTo Need (seen in the details view of directResponse needs)
- "show persona" seen in the context-dropdown of a post-info
- a held Need -> seen in the post-info of a persona
- a groupParticipant -> seen in the post-info of a groupFacet-need, as well as the group-administration

will result in an overlay displaying the need/persona information