### PR TITLE
Fixes #2645 (Race Condition in post-visitor-view)

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -66,7 +66,7 @@ function addNeedInLoading(needs, needUri, state, isOwned) {
 
 function addTheirNeedInLoading(needs, needUri) {
   const oldNeed = needs.get(needUri);
-  if (oldNeed && oldNeed.get("isOwned")) {
+  if (oldNeed) {
     return needs;
   } else {
     let need = Immutable.fromJS({
@@ -80,7 +80,7 @@ function addTheirNeedInLoading(needs, needUri) {
 
 export function addTheirNeedToLoad(needs, needUri) {
   const oldNeed = needs.get(needUri);
-  if (oldNeed && oldNeed.get("isOwned")) {
+  if (oldNeed) {
     return needs;
   } else {
     let need = Immutable.fromJS({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -506,14 +506,7 @@ export function addOriginatorNeedToLoad(
 
       if (originatorUri) {
         //Message is originally from another need, we might need to add the need as well
-        const needProcess = processState.getIn(["needs", originatorUri]);
-
-        if (
-          !needProcess &&
-          !needProcess.get("toLoad") &&
-          !needProcess.get("loading") &&
-          !needProcess.get("failedToLoad")
-        ) {
+        if (!processState.getIn(["needs", originatorUri])) {
           console.debug(
             "Originator Need is not in the state yet, we need to add it"
           );


### PR DESCRIPTION
Is supposed to fix "Race Condition" in the post-visitor-view

How To Reproduce:
- Create a GroupChat Need with a Persona
- Join the GroupChat with another need (which also holds the persona)
- Add x-other groupchat members (might not be necessary)

copy the shareLink and open it somewhere else -> see that it works now.

TL;DR:
The problem was that we flag certain needs as toLoad or InLoading -> depending on the current state of the webapp... we mark every holds needUri of a persona as well as every memberUri of a group Chat as "toLoad" in the process-state, as well as the need-state, the issue was that we did not check whether or not at least the need-stub is in the state already (and thus overwrote the already loaded need with a stub)

Additionally I changed a clause that did not make any sense at all
