### PR TITLE
Fixes post-visitor view and viewNeedUri-modalbox view for deletedNeeds

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-selection-item.js
@@ -22,6 +22,7 @@ function genComponentConf() {
       <won-connection-header
         connection-uri="self.connectionUri"
         timestamp="self.lastUpdateTimestamp"
+        ng-disabled="self.remoteNeedFailedToLoad"
         ng-click="self.setOpen()"
         class="clickable">
       </won-connection-header>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -37,7 +37,15 @@ function genComponentConf() {
             <h2 class="post-skeleton__heading"></h2>
             <div class="post-skeleton__details"></div>
         </div>
-        <div class="post-content" ng-if="!self.postLoading">
+        <div class="post-failedtoload" ng-if="self.postFailedToLoad">
+          <svg class="post-failedtoload__icon">
+              <use xlink:href="#ico16_indicator_error" href="#ico16_indicator_error"></use>
+          </svg>
+          <span class="post-failedtoload__label">
+              Failed To Load - Need might have been deleted
+          </span>
+        </div>
+        <div class="post-content" ng-if="!self.postLoading && !self.postFailedToLoad">
           <won-gallery ng-if="self.post.get('hasImages')">
           </won-gallery>
 
@@ -143,6 +151,9 @@ function genComponentConf() {
           postLoading:
             !post ||
             getIn(state, ["process", "needs", post.get("uri"), "loading"]),
+          postFailedToLoad:
+            post &&
+            getIn(state, ["process", "needs", post.get("uri"), "failedToLoad"]),
           createdTimestamp: post && post.get("creationDate"),
           shouldShowRdf: state.getIn(["view", "showRdf"]),
           fromConnection: !!openConnectionUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -22,12 +22,12 @@ const serviceDependencies = ["$scope", "$ngRedux", "$element"];
 function genComponentConf() {
   let template = `
             <svg class="cdd__icon__small"
-                ng-if="self.postLoading"
+                ng-if="self.postLoading || self.postFailedToLoad"
                 style="--local-primary:var(--won-skeleton-color);">
                     <use xlink:href="#ico16_contextmenu" href="#ico16_contextmenu"></use>
             </svg>
             <svg class="cdd__icon__small clickable"
-                ng-if="!self.postLoading"
+                ng-if="!self.postLoading && !self.postFailedToLoad"
                 style="--local-primary:var(--won-secondary-color);"
                 ng-click="self.contextMenuOpen = true">
                     <use xlink:href="#ico16_contextmenu" href="#ico16_contextmenu"></use>
@@ -101,6 +101,9 @@ function genComponentConf() {
           postLoading:
             !post ||
             getIn(state, ["process", "needs", post.get("uri"), "loading"]),
+          postFailedToLoad:
+            post &&
+            getIn(state, ["process", "needs", post.get("uri"), "failedToLoad"]),
           linkToPost,
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -7,9 +7,25 @@
 </header>
 <won-toasts></won-toasts>
 <won-slide-in></won-slide-in>
-<main class="postcontent">
+<main class="postcontent" ng-class="{'postcontent--won-loading': self.postLoading, 'postcontent--won-failed': self.postFailedToLoad}">
     <!-- Post info view when there's no connection-state/-type selected -->
-    <won-visitor-title-bar item="self.post"></won-visitor-title-bar>
-    <won-send-request ng-if="self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
+    <won-visitor-title-bar ng-if="!(self.postLoading || self.postFailedToLoad)" item="self.post"></won-visitor-title-bar>
+    <won-send-request ng-if="!(self.postLoading || self.postFailedToLoad) && self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
+    <div class="pc__loading" ng-if="self.postLoading">
+        <svg class="pc__loading__spinner hspinner">
+            <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
+        </svg>
+        <span class="pc__loading__label">
+            Loading...
+        </span>
+    </div>
+    <div class="pc__failed" ng-if="self.postFailedToLoad">
+        <svg class="pc__failed__icon">
+            <use xlink:href="#ico16_indicator_error" href="#ico16_indicator_error"></use>
+        </svg>
+        <span class="pc__failed__label">
+            Failed To Load - Need might have been deleted
+        </span>
+    </div>
 </main>
 <won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -42,6 +42,10 @@ class Controller {
         showModalDialog: getIn(state, ["view", "showModalDialog"]),
         showNeedOverlay: !!viewNeedUri,
         viewNeedUri,
+        postLoading:
+          !post || getIn(state, ["process", "needs", postUri, "loading"]),
+        postFailedToLoad:
+          post && getIn(state, ["process", "needs", postUri, "failedToLoad"]),
       };
     };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
@@ -33,7 +33,7 @@
     display: flex;
     width: 100%;
     height: 100%;
-    z-index: 10000;
+    z-index: 9900;
 
     align-items: center;
     justify-content: center;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -59,6 +59,25 @@ won-post-content {
     }
   }
 
+  .post-failedtoload {
+    display: grid;
+    grid-template-areas: "failed_icon failed_label";
+    align-items: center;
+    justify-content: center;
+    padding: 5rem 0;
+    grid-gap: 0.5rem;
+
+    > .post-failedtoload__icon {
+      grid-area: failed_icon;
+      @include fixed-square(5rem);
+      --local-primary: #{$won-primary-color};
+    }
+    > .post-failedtoload__label {
+      grid-area: failed_label;
+      text-align: center;
+    }
+  }
+
   &.won-is-loading {
     @include animateOpacityHeartBeat();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-visitor.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-visitor.scss
@@ -9,15 +9,53 @@ main.postcontent {
   box-sizing: border-box;
   align-items: stretch;
   max-width: $maxContentWidth;
-  border-left: $thinGrayBorder;
-  border-right: $thinGrayBorder;
-  border-bottom: $thinGrayBorder;
-  background: white;
+
+  &:not(.postcontent--won-failed):not(.postcontent--won-loading) {
+    border-left: $thinGrayBorder;
+    border-right: $thinGrayBorder;
+    border-bottom: $thinGrayBorder;
+    background: white;
+  }
   width: 100%;
   margin: 0 auto;
 
   @media (max-width: $responsivenessBreakPoint) {
     border-left: none;
     border-right: none;
+  }
+
+  & > .pc__loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 5rem 0;
+
+    > .pc__loading__spinner.hspinner {
+      @include fixed-square(5rem);
+    }
+    > .pc__loading__label {
+      color: $won-line-gray;
+      text-align: center;
+    }
+  }
+
+  & > .pc__failed {
+    display: grid;
+    grid-template-areas: "failed_icon failed_label";
+    align-items: center;
+    justify-content: center;
+    padding: 5rem 0;
+    grid-gap: 0.5rem;
+
+    > .pc__failed__icon {
+      grid-area: failed_icon;
+      @include fixed-square(5rem);
+      --local-primary: #{$won-primary-color};
+    }
+    > .pc__failed__label {
+      grid-area: failed_label;
+      text-align: center;
+    }
   }
 }


### PR DESCRIPTION
Show loading indicator while loading, and failedToLoad info if the post was not able to be fetched

fixes #2630 

How to Test:
- open a visitorlink of a deletedNeed -> you should see that the need has been deleted
- open a visitorlink of a need that takes long to load (e.g. a need with images) -> you should see a loading indicator until the need has been loaded
- open a deleted post by adding &viewNeedUri=[deletedNeedUri] into the connections url -> this way you will mock clicking on a suggestedPost and see that the need has been deleted in the overlay
- look at a hint of a deletedNeed (e.g. if a whatsNew match could not be loaded) -> see that the click interaction to open the right side (view connection) was removed -> fixes #2631