### PR TITLE
Refactor access within component to use extracted Content instead of jsonld parsing

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.js
@@ -105,7 +105,7 @@ function genComponentConf() {
           relevantNeedUri && getIn(allNeeds, [relevantNeedUri, "heldBy"]);
         const personaName =
           relevantPersonaUri &&
-          getIn(allNeeds, [relevantPersonaUri, "jsonld", "s:name"]);
+          getIn(allNeeds, [relevantPersonaUri, "content", "personaName"]);
 
         return {
           allNeeds,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -30,7 +30,7 @@ function genComponentConf() {
               Author
             </div>
             <div class="pcg__columns__left__item__value">
-              {{ self.persona.getIn(['jsonld', 's:name']) }}
+              {{ self.persona.get('humanReadable') }}
               <won-rating-view rating="self.rating()" rating-connection-uri="self.ratingConnectionUri"></won-rating-view>
             </div>
           </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -5,7 +5,9 @@ import {
   isWhatsNewNeed,
   isWhatsAroundNeed,
   isSearchNeed,
+  isPersona,
 } from "../../need-utils.js";
+import { getIn } from "../../utils.js";
 
 export function parseNeed(jsonldNeed, isOwned) {
   const jsonldNeedImm = Immutable.fromJS(jsonldNeed);
@@ -168,7 +170,9 @@ function getHumanReadableStringFromNeed(need, detailsToParse) {
 
     const immNeed = Immutable.fromJS(need);
 
-    if (isWhatsNewNeed(immNeed)) {
+    if (isPersona(need)) {
+      return getIn(need, ["content", "personaName"]);
+    } else if (isWhatsNewNeed(immNeed)) {
       return "What's New";
     } else if (isWhatsAroundNeed(immNeed)) {
       let location =

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -4,7 +4,7 @@
 
 import { createSelector } from "reselect";
 
-import { decodeUriComponentProperly, getIn } from "../utils.js";
+import { decodeUriComponentProperly, getIn, get } from "../utils.js";
 import { isPersona, isNeed, isActive, isInactive } from "../need-utils.js";
 import Color from "color";
 
@@ -169,14 +169,13 @@ export function getOwnedPersonas(state) {
   const needs = getOwnedNeeds(state);
   const personas = needs.toList().filter(need => isPersona(need));
   return personas.map(persona => {
-    const graph = persona.get("jsonld");
     return {
-      displayName: graph.get("s:name"),
-      website: graph.get("s:url"),
-      aboutMe: graph.get("s:description"),
-      url: persona.get("uri"),
-      saved: !persona.get("isBeingCreated"),
-      timestamp: persona.get("creationDate").toISOString(),
+      displayName: getIn(persona, ["content", "personaName"]),
+      website: getIn(persona, ["content", "website"]),
+      aboutMe: getIn(persona, ["content", "description"]),
+      url: get(persona, "uri"),
+      saved: !get(persona, "isBeingCreated"),
+      timestamp: get(persona, "creationDate").toISOString(),
     };
   });
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -18,6 +18,7 @@ export const emptyDraft = {
 
 export const details = {
   title: basicDetails.title,
+  personaName: basicDetails.personaName,
   description: basicDetails.description,
   tags: basicDetails.tags,
   searchString: basicDetails.searchString,
@@ -38,6 +39,7 @@ export const details = {
   price: priceDetails.price,
   review: reviewDetails.review,
   responseToUri: basicDetails.responseToUri,
+  website: basicDetails.website,
   flags: basicDetails.flags,
 };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -29,6 +29,55 @@ export const title = {
   },
 };
 
+export const personaName = {
+  identifier: "personaName",
+  label: "Name",
+  icon: "#ico36_detail_title",
+  placeholder: "Your Name",
+  component: "won-title-picker",
+  viewerComponent: "won-title-viewer",
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+    return {
+      "s:name": val,
+    };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseFrom(jsonLDImm, ["s:name"], "xsd:string");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};
+
+export const website = {
+  //FIXME: Implement URL Picker once the persona-creator also generates url type urls, instead of strings
+  identifier: "website",
+  label: "Website",
+  icon: "#ico36_detail_title",
+  placeholder: "Website",
+  component: "won-title-picker",
+  viewerComponent: "won-title-viewer",
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+    return {
+      "s:url": val,
+    };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseFrom(jsonLDImm, ["s:url"], "xsd:string");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};
+
 export const searchString = {
   identifier: "searchString",
   label: "Searching for",


### PR DESCRIPTION
Fixes #2465

Generates HumanReadable for Persona using the personaName instead of looking into the jsonld like a fool

Adds website and personaName details so we do not have to parse any special things for viewing a persona or displaying a "author" any longer


This also enables us to show ALL the data stored within a Persona-Need (when viewing a persona)