### PR TITLE
Removed fibers from dependencies

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -3102,12 +3102,6 @@
         "repeating": "^2.0.0"
       }
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
-    },
     "dfa": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.1.0.tgz",
@@ -3952,15 +3946,6 @@
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
         "websocket-driver": ">=0.5.1"
-      }
-    },
-    "fibers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.1.1.tgz",
-      "integrity": "sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3"
       }
     },
     "figgy-pudding": {

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -71,7 +71,6 @@
     "eslint-loader": "^2.1.1",
     "eslint-plugin-prettier": "^2.7.0",
     "exports-loader": "^0.7.0",
-    "fibers": "^3.1.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.3.0",
     "mini-css-extract-plugin": "^0.4.5",

--- a/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
+++ b/webofneeds/won-owner-webapp/src/main/webapp/webpack.config.ts
@@ -8,7 +8,6 @@ import * as CopyWebpackPlugin from "copy-webpack-plugin";
 import * as WatchTimePlugin from "webpack-watch-time-plugin";
 import * as UnusedWebpackPlugin from "unused-webpack-plugin";
 import * as DartSass from "dart-sass";
-import * as Fiber from "fibers";
 
 export default config;
 
@@ -98,7 +97,6 @@ function config(env, argv): Configuration {
               options: {
                 sourceMap: mode == "development",
                 implementation: DartSass,
-                fiber: Fiber,
               },
             },
           ],


### PR DESCRIPTION

Fibers speeds up our sass builds, but needs a native build, which causes problems with our windows machines.