### PR TITLE
Feat  verbose wonlogging

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -156,6 +156,8 @@ export function parseMessage(
     return Immutable.fromJS(parsedMessage);
   }
 }
+window.parseMessage4dbg = parseMessage;
+
 function hasContent(content) {
   for (let prop in content) {
     if (content[prop] !== undefined && content[prop] != null) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -914,14 +914,42 @@ won.wonMessageFromJsonLd = async function(wonMessageAsJsonLD) {
   const expandedJsonLd = await jsonld.promises.expand(wonMessageAsJsonLD);
   const wonMessage = new WonMessage(expandedJsonLd);
 
-  if (wonMessage.parseErrors && wonMessage.parseErrors.length > 0) {
-    console.warn("wonMessage ParseError: " + wonMessage.parseErrors);
-  }
-
   await wonMessage.frameInPromise();
   await wonMessage.generateContentGraphTrig();
   await wonMessage.generateCompactedFramedMessage();
   await wonMessage.generateContainedForwardedWonMessages();
+
+  if (wonMessage.hasParseErrors() && !wonMessage.isResponse()) {
+    console.warn(
+      "wonMessage<",
+      wonMessage.getMessageUri(),
+      "> msgType<",
+      wonMessage.getMessageType(),
+      "> ParseError: {" + wonMessage.parseErrors,
+      "} wonMessage: ",
+      wonMessage
+    );
+  }
+  if (wonMessage.hasContainedForwardedWonMessages()) {
+    console.debug(
+      "wonMessage<",
+      wonMessage.getMessageUri(),
+      "> msgType<",
+      wonMessage.getMessageType(),
+      "> contains forwardedMessages wonMessage: ",
+      wonMessage
+    );
+    wonMessage.getContainedForwardedWonMessages().map(forwardedWonMessage => {
+      console.debug(
+        "-- forwardedMessage<",
+        forwardedWonMessage.getMessageUri(),
+        "> msgType<",
+        forwardedWonMessage.getMessageType(),
+        ">, forwardedWonMessage: ",
+        forwardedWonMessage
+      );
+    });
+  }
 
   return wonMessage;
 };
@@ -1200,9 +1228,8 @@ WonMessage.prototype = {
 
       return Promise.resolve(this.containedForwardedWonMessages);
     } else if (forwardedMessageUris) {
-      console.warn(
-        "WonMessage contains more than one forwardedMessage on the same level: omitting forwardMessages, wonMessage:",
-        this
+      this.parseErrors.push(
+        "WonMessage contains more than one forwardedMessage on the same level: omitting forwardMessages"
       );
       return Promise.resolve(this.containedForwardedWonMessages);
     } else {
@@ -1451,6 +1478,9 @@ WonMessage.prototype = {
       this.containedForwardedWonMessages &&
       this.containedForwardedWonMessages.length > 0
     );
+  },
+  hasParseErrors: function() {
+    return this.parseErrors && this.parseErrors.length > 0;
   },
   getContainedForwardedWonMessages: function() {
     return this.containedForwardedWonMessages;


### PR DESCRIPTION
Adds reference to access parseMessage(wonMessage) method from the console

parseMessage4dbg -> 3 params, `parseMessage4dbg(wonMessageObject, boolAlreadyProcessed, boolForwardMessage)`
- the 2 bool parameters are more or less irrelevant, `boolAlreadyProcessed` sets the read flag to true by default `boolForwardMessage` returns a message that looks like a forwardedMessages (certain attributes are different but all in all it doesnt really matter to check parsing)