### PR TITLE
Feat fix bouncycastle docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,9 @@ webofneeds/won-docker/image/matcher-sparql/conf/
 webofneeds/won-docker/image/matcher-sparql/won-matcher-sparql.jar
 webofneeds/won-docker/image/owner/conf/
 webofneeds/won-docker/image/owner/owner.war
-webofneeds/won-docker/image/owner/tomcat-libs/
+webofneeds/won-docker/image/owner/required-libs/
 webofneeds/won-docker/image/wonnode/conf/
-webofneeds/won-docker/image/wonnode/tomcat-libs/
+webofneeds/won-docker/image/wonnode/required-libs/
 webofneeds/won-docker/image/wonnode/won.war
 webofneeds/won-utils/won-utils-import/sample_needs/
 

--- a/documentation/build-with-eclipse.md
+++ b/documentation/build-with-eclipse.md
@@ -115,6 +115,24 @@
 		*  edit `server.xml` 
 		*  find the xml element `<Host appBase="webapps" ...` and add the xml attribute `startStopThreads="2"` 
 8.  Follow instructions on https://github.com/researchstudio-sat/webofneeds/blob/5dc0db3747c201a87d94621453b8b898a34e7fc4/documentation/installation-cryptographic-keys-and-certificates.md and make sure that you have the `tcnative-1.dll` **in your tomcat's `bin/`-folder!**, and that you correctly point to it with the `-Djava.library.path` variable (Step 7). Otherwise you will get `InvalidKeystoreFormatException`s at server startup and an info message which says `The APR based Apache Tomcat Native library which allows optimal performance in production environments was not found on the java.library.path` => following path where to put the .dll 
-9.  Add the bouncy castle libraries `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar` your tomcat's `lib` folder. The two jars can be found in the `[your m2 repo]/org/bouncycastle` folder. Hint: Do **not** add the bouncycastle libraries to the "Installed JRE".
+9.  Install the bouncycaslte security provider: Locate the JRE you are using with eclipse (`Window -> Preferences -> Java -> Installed JREs`). 
+	* Navigate to the `[JRE]/lib/security` folder
+	* edit the file `java.security`
+	* find the `List of providers and their preference orders`, which looks like this:
+
+	```
+	security.provider.1=sun.security.provider.Sun
+	security.provider.2=sun.security.rsa.SunRsaSign
+	security.provider.3=sun.security.ec.SunEC
+	...
+	```
+
+	* add this line (replace `11` with the last number in the list plus one)
+	
+	```
+	security.provider.11=org.bouncycastle.jce.provider.BouncyCastleProvider
+	```
+
+	* copy `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar` from `[won-checkout-dir]/webofneeds/webofneeds/target/required-libs/` (which will be there after the first build) to the `[JRE]/lib/ext/` folder
 10.  Start server
 11.  Run the gulpfile outside eclipse: `npm run build` in `wepapp`, refresh the `won-owner-webapp` in eclipse (F5), click on the server –> "Publish"

--- a/documentation/installation-cryptographic-keys-and-certificates.md
+++ b/documentation/installation-cryptographic-keys-and-certificates.md
@@ -49,7 +49,27 @@
 
 10. Depending on your java-setup it might not be able to generate keys of a relevant length. In that case, you need to download and install the [Java Cryptography Extension](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html). There's a readme in the zip detailing its setup. At the time of this writing, this consists of copying the two jars into `$JAVA_HOME/(jre/)lib/security`. If you don't do this or the jars are in the wrong folder, you'll get an exception like `java.security.InvalidKeyException: Illegal key size` when trying to run the app.
 
-11. After building the project, copy the bouncycastle libraries (as of current state, `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar`) from the generated in your project `target/required-libs/` folder into the the tomcat's `lib/` (if you miss this step, you'll see BC exceptions when running the owner/node)
+11. Install the bouncycaslte security provider: Locate the JRE you are using with eclipse (`Window -> Preferences -> Java -> Installed JREs`). 
+	* Navigate to the `[JRE]/lib/security` folder
+	* edit the file `java.security`
+	* find the `List of providers and their preference orders`, which looks like this:
+
+	```
+	security.provider.1=sun.security.provider.Sun
+	security.provider.2=sun.security.rsa.SunRsaSign
+	security.provider.3=sun.security.ec.SunEC
+	...
+	```
+
+	* add this line (replace `11` with the last number in the list plus one)
+	
+	```
+	security.provider.11=org.bouncycastle.jce.provider.BouncyCastleProvider
+	```
+
+	* copy `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar` from `[won-checkout-dir]/webofneeds/webofneeds/target/required-libs/` (which will be there after the first build) to the `[JRE]/lib/ext/` folder 
+    
+    (if you miss this step, you'll see BC exceptions when running the owner/node)
 
 **NOTE:** During the steps layed out above, I've also updated to Tomcat 8 and I haven't verified that the app also runs on Tomcat 7.
 

--- a/documentation/installation-cryptographic-keys-and-certificates.md
+++ b/documentation/installation-cryptographic-keys-and-certificates.md
@@ -49,7 +49,7 @@
 
 10. Depending on your java-setup it might not be able to generate keys of a relevant length. In that case, you need to download and install the [Java Cryptography Extension](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html). There's a readme in the zip detailing its setup. At the time of this writing, this consists of copying the two jars into `$JAVA_HOME/(jre/)lib/security`. If you don't do this or the jars are in the wrong folder, you'll get an exception like `java.security.InvalidKeyException: Illegal key size` when trying to run the app.
 
-11. After building the project, copy the bouncycastle libraries (as of current state, `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar`) from the generated in your project `target/tomcat-libs/` folder into the the tomcat's `lib/` (if you miss this step, you'll see BC exceptions when running the owner/node)
+11. After building the project, copy the bouncycastle libraries (as of current state, `bcpkix-jdk15on-1.52.jar` and `bcprov-jdk15on-1.52.jar`) from the generated in your project `target/required-libs/` folder into the the tomcat's `lib/` (if you miss this step, you'll see BC exceptions when running the owner/node)
 
 **NOTE:** During the steps layed out above, I've also updated to Tomcat 8 and I haven't verified that the app also runs on Tomcat 7.
 
@@ -62,7 +62,7 @@ Deploy sripts for building and running web of needs as docker containsers (see `
 **NOTE:** Inspecting keystores using `keytool`:
 owner/node keystores are saved in bouncycastle's UBER format. Therefore, the bouncycastle libraries need to be present in the `<YOUR_JRE_DIR>/lib/ext` folder. Follow these steps:
 
-1. build the project. the bouncycastle libs are copied to `webofneeds/webofneeds/target/tomcat-libs/`
+1. build the project. the bouncycastle libs are copied to `webofneeds/webofneeds/target/required-libs/`
 2. copy the bouncycastle libs to your JRE's `bin/ext` folder
 3. use keytool to inspect the keystore, naming the `providerclass` as shown below :
 

--- a/webofneeds/won-cryptography/pom.xml
+++ b/webofneeds/won-cryptography/pom.xml
@@ -103,7 +103,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.parent.basedir}/target/tomcat-libs</outputDirectory>
+                            <outputDirectory>${project.parent.basedir}/target/required-libs</outputDirectory>
                             <includeGroupIds>org.bouncycastle</includeGroupIds>
                         </configuration>
                     </execution>

--- a/webofneeds/won-docker/image/owner/Dockerfile
+++ b/webofneeds/won-docker/image/owner/Dockerfile
@@ -35,7 +35,7 @@ RUN unzip /usr/local/tomcat/webapps/owner.war -d /usr/local/tomcat/webapps/owner
 RUN rm /usr/local/tomcat/webapps/owner.war
 
 # add the bouncy castle libraries to the jre as well as to the java.security config (we need them in the jre, only tomcat lib folder doesn't work)
-ADD ./tomcat-libs/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/
+ADD ./required-libs/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/
 ADD ./jce/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/
 
 # add the webofneeds configuration files for the application

--- a/webofneeds/won-docker/image/wonnode/Dockerfile
+++ b/webofneeds/won-docker/image/wonnode/Dockerfile
@@ -34,7 +34,7 @@ RUN unzip /usr/local/tomcat/webapps/won.war -d /usr/local/tomcat/webapps/won
 RUN rm /usr/local/tomcat/webapps/won.war
 
 # add the bouncy castle libraries to the jre as well as to the java.security config (we need them in the jre, only tomcat lib folder doesn't work)
-ADD ./tomcat-libs/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/
+ADD ./required-libs/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/
 ADD ./jce/* /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/
 
 # add the webofneeds configuration files for the application

--- a/webofneeds/won-docker/pom.xml
+++ b/webofneeds/won-docker/pom.xml
@@ -94,10 +94,10 @@
                         </goals>
                         <configuration>
                             <overwrite>true</overwrite>
-                            <outputDirectory>${project.basedir}/image/wonnode/tomcat-libs</outputDirectory>
+                            <outputDirectory>${project.basedir}/image/wonnode/required-libs</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.parent.basedir}/target/tomcat-libs</directory>
+                                    <directory>${project.parent.basedir}/target/required-libs</directory>
                                 </resource>
                             </resources>
                         </configuration>
@@ -147,10 +147,10 @@
                         </goals>
                         <configuration>
                             <overwrite>true</overwrite>
-                            <outputDirectory>${project.basedir}/image/owner/tomcat-libs</outputDirectory>
+                            <outputDirectory>${project.basedir}/image/owner/required-libs</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.parent.basedir}/target/tomcat-libs</directory>
+                                    <directory>${project.parent.basedir}/target/required-libs</directory>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
Improved bouncycastle install documentation, limiting it to modifying the local java installation (instead of fiddling with the IDE and Tomcat)

Changed the name of the folder into which the maven build copies the bouncycastle libs from `tomcat-libs` to `required-libs`.