### PR TITLE
Fix wrongstatus #2691

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
@@ -42,7 +42,12 @@ function genComponentConf() {
         };
       };
 
-      connect2Redux(selectFromState, actionCreators, ["self.postUri"], this);
+      connect2Redux(
+        selectFromState,
+        actionCreators,
+        ["self.postUri", "self.connectionUri"],
+        this
+      );
       classOnComponentRoot("won-is-loading", () => this.postLoading, this);
     }
   }
@@ -55,6 +60,7 @@ function genComponentConf() {
     bindToController: true, //scope-bindings -> ctrl
     scope: {
       postUri: "=",
+      connectionUri: "=",
     },
     template: template,
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -14,6 +14,7 @@ import { attach, delay, getIn, get } from "../utils.js";
 import * as needUtils from "../need-utils.js";
 import * as processUtils from "../process-utils.js";
 import * as connectionUtils from "../connection-utils.js";
+import * as messageUtils from "../message-utils.js";
 import {
   fetchAgreementProtocolUris,
   fetchPetriNetUris,
@@ -99,7 +100,8 @@ function genComponentConf() {
             <won-post-content-message
               class="won-cm--left"
               ng-if="self.showPostContentMessage"
-              post-uri="self.remoteNeedUri">
+              post-uri="self.remoteNeedUri"
+              connection-uri="self.connectionUri">
             </won-post-content-message>
             <div class="pm__content__loadspinner"
                 ng-if="self.isProcessingLoadingMessages || (self.showAgreementData && self.isProcessingLoadingAgreementData) || (self.showPetriNetData && self.isProcessingLoadingPetriNetData && !self.hasPetriNetData)">
@@ -277,7 +279,10 @@ function genComponentConf() {
         const chatMessages =
           connection &&
           connection.get("messages") &&
-          connection.get("messages").filter(msg => !msg.get("forwardMessage"));
+          connection
+            .get("messages")
+            .filter(msg => !msg.get("forwardMessage"))
+            .filter(msg => !messageUtils.isHintMessage(msg));
         const hasConnectionMessagesToLoad = hasMessagesToLoad(
           state,
           connectionUri
@@ -400,7 +405,7 @@ function genComponentConf() {
             !remoteNeed ||
             !ownedNeed ||
             processUtils.isNeedLoading(process, ownedNeed.get("uri")) ||
-            processUtils.isNeedLoading(process, remoteNeed.get("uri")) ||
+            processUtils.isNeedLoading(process, remoteNeedUri) ||
             processUtils.isConnectionLoading(process, connectionUri),
           showPostContentMessage:
             showChatData &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/message-utils.js
@@ -3,6 +3,7 @@
  */
 
 import won from "./won-es6.js";
+import { get } from "./utils.js";
 
 /**
  * Determines if a given message can be Proposed
@@ -279,6 +280,10 @@ export function isMessageClaim(msg) {
  */
 export function isMessageAgreement(msg) {
   return isMessageAccepted(msg) && !isMessageCancellationPending(msg);
+}
+
+export function isHintMessage(msg) {
+  return get(msg, "messageType") === won.WONMSG.hintMessage;
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-message.js
@@ -106,7 +106,9 @@ export function parseMessage(
       contentGraphTrigError: wonMessage.contentGraphTrigError,
       //Receive Status Flags
       unread:
-        !wonMessage.isFromOwner() && !isUriRead(wonMessage.getMessageUri()),
+        !wonMessage.isFromOwner() &&
+        !wonMessage.isHintMessage() &&
+        !isUriRead(wonMessage.getMessageUri()),
       //Send Status Flags
       isReceivedByOwn: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway
       isReceivedByRemote: alreadyProcessed || !wonMessage.isFromOwner(), //if the message is not from the owner we know it has been received anyway

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -47,7 +47,6 @@ won-connection-message {
   @include square-image($postIconSize, 0 0.5rem 0 0);
   display: grid;
   grid-template-areas: "icon content";
-  grid-template-columns: min-content minmax(min-content, max-content);
 
   won-square-image {
     grid-area: icon;
@@ -187,4 +186,12 @@ won-connection-message {
       }
     }
   }
+}
+
+won-post-content-message {
+  grid-template-columns: min-content 1fr;
+}
+
+won-connection-message {
+  grid-template-columns: min-content minmax(min-content, max-content);
 }


### PR DESCRIPTION
- Implements parsing any hintMessage as read (therefore no "unread" message will appear when they are fetched)
- Removes the hintMessages from being displayed as sep. messages in the chat-view (groupChat as well as 1to1 chat)
- Adds a new parameter to the post-content-message component (connectionUri) so we can figure out a way to display the (now) omitted hints and their respective rating in another way (in the future)


fixes #2691 
fixes #2359 
fixes #2600