### PR TITLE
Fix  visitorload #2692

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -5,10 +5,7 @@
 import won from "../won-es6.js";
 import Immutable from "immutable";
 import { actionTypes, actionCreators } from "./actions.js";
-import {
-  fetchOwnedData,
-  loadNeedFromRouteParamIfExists,
-} from "../won-message-utils.js";
+import { fetchOwnedData } from "../won-message-utils.js";
 import {
   registerAccount,
   transferPrivateAccount,
@@ -114,7 +111,6 @@ export function accountLogin(credentials, redirectToFeed = false) {
       )
       .then(() => dispatch({ type: actionTypes.upgradeHttpSession }))
       .then(() => fetchOwnedData(dispatch))
-      .then(() => loadNeedFromRouteParamIfExists(dispatch, getState))
       .then(() => dispatch({ type: actionTypes.account.loginFinished }))
       .catch(error =>
         error.response.json().then(loginError => {
@@ -186,7 +182,6 @@ export function accountLogout() {
       .then(() => dispatch({ type: actionTypes.downgradeHttpSession }))
       .then(() => dispatch({ type: actionTypes.account.reset }))
       .then(() => won.clearStore())
-      .then(() => loadNeedFromRouteParamIfExists(dispatch, getState))
       .then(() => {
         _logoutInProcess = false;
       })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -9,10 +9,7 @@ import { checkAccessToCurrentRoute } from "../configRouting.js";
 
 import { checkLoginStatus } from "../won-utils.js";
 
-import {
-  fetchOwnedData,
-  loadNeedFromRouteParamIfExists,
-} from "../won-message-utils.js";
+import { fetchOwnedData } from "../won-message-utils.js";
 
 export const pageLoadAction = () => (dispatch, getState) => {
   checkLoginStatus()
@@ -27,7 +24,6 @@ export const pageLoadAction = () => (dispatch, getState) => {
       return loadingWhileSignedIn(dispatch);
     })
     .catch(() => handleNotLoggedIn()) //do not remove this line
-    .then(() => loadNeedFromRouteParamIfExists(dispatch, getState))
     .then(() => checkAccessToCurrentRoute(dispatch, getState))
     .then(() => dispatch({ type: actionTypes.initialLoadFinished }));
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -14,7 +14,7 @@ import * as viewSelectors from "../selectors/view-selectors.js";
 import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import * as needUtils from "../need-utils.js";
-import * as processUtils from "../../process-utils.js";
+import * as processUtils from "../process-utils.js";
 
 import "style/_post-header.scss";
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -7,11 +7,11 @@
 </header>
 <won-toasts></won-toasts>
 <won-slide-in ng-if="self.showSlideIns"></won-slide-in>
-<main class="postcontent" ng-class="{'postcontent--won-loading': self.postLoading, 'postcontent--won-failed': self.postFailedToLoad}">
+<main class="postcontent" ng-class="{'postcontent--won-loading': self.needLoading, 'postcontent--won-failed': self.needFailedToLoad}">
     <!-- Post info view when there's no connection-state/-type selected -->
-    <won-visitor-title-bar ng-if="!(self.postLoading || self.postFailedToLoad)" item="self.post"></won-visitor-title-bar>
-    <won-send-request ng-if="!(self.postLoading || self.postFailedToLoad) && self.post && !self.isOwnPost" class="won-send-request--noheader"></won-send-request>
-    <div class="pc__loading" ng-if="self.postLoading">
+    <won-visitor-title-bar ng-if="!(self.needLoading || self.needFailedToLoad)" item="self.need"></won-visitor-title-bar>
+    <won-send-request ng-if="!(self.needLoading || self.needFailedToLoad) && self.need && !self.isOwnedNeed" class="won-send-request--noheader"></won-send-request>
+    <div class="pc__loading" ng-if="self.needLoading">
         <svg class="pc__loading__spinner hspinner">
             <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
         </svg>
@@ -19,7 +19,7 @@
             Loading...
         </span>
     </div>
-    <div class="pc__failed" ng-if="self.postFailedToLoad">
+    <div class="pc__failed" ng-if="self.needFailedToLoad">
         <svg class="pc__failed__icon">
             <use xlink:href="#ico16_indicator_error" href="#ico16_indicator_error"></use>
         </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -3,19 +3,16 @@
  */
 import angular from "angular";
 import ngAnimate from "angular-animate";
-import { attach, getIn } from "../../utils.js";
+import { attach, getIn, get } from "../../utils.js";
 import won from "../../won-es6.js";
 import { actionCreators } from "../../actions/actions.js";
 import sendRequestModule from "../send-request.js";
 import visitorTitleBarModule from "../visitor-title-bar.js";
-import {
-  getPostUriFromRoute,
-  getViewNeedUriFromRoute,
-} from "../../selectors/general-selectors.js";
+import * as generalSelectors from "../../selectors/general-selectors.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
-
-import * as srefUtils from "../../sref-utils.js";
 import * as needUtils from "../../need-utils.js";
+import * as processUtils from "../../process-utils.js";
+import * as srefUtils from "../../sref-utils.js";
 
 import "style/_post-visitor.scss";
 import "style/_need-overlay.scss";
@@ -30,24 +27,26 @@ class Controller {
     Object.assign(this, srefUtils); // bind srefUtils to scope
 
     const selectFromState = state => {
-      const postUri = getPostUriFromRoute(state);
-      const viewNeedUri = getViewNeedUriFromRoute(state);
-      const post = state.getIn(["needs", postUri]);
+      const needUri = generalSelectors.getPostUriFromRoute(state);
+      const viewNeedUri = generalSelectors.getViewNeedUriFromRoute(state);
+      const need = getIn(state, ["needs", needUri]);
+
+      const process = get(state, "process");
 
       return {
-        postUri,
-        isOwnPost: needUtils.isOwned(post),
-        post,
+        needUri,
+        isOwnedNeed: needUtils.isOwned(need),
+        need,
         won: won.WON,
-        showModalDialog: getIn(state, ["view", "showModalDialog"]),
-        showNeedOverlay: !!viewNeedUri,
         showSlideIns:
           viewSelectors.hasSlideIns(state) && viewSelectors.showSlideIns(state),
+        showModalDialog: viewSelectors.showModalDialog(state),
+        showNeedOverlay: !!viewNeedUri,
         viewNeedUri,
-        postLoading:
-          !post || getIn(state, ["process", "needs", postUri, "loading"]),
-        postFailedToLoad:
-          post && getIn(state, ["process", "needs", postUri, "failedToLoad"]),
+        needLoading: !need || processUtils.isNeedLoading(process, needUri),
+        needToLoad: !need || processUtils.isNeedToLoad(process, needUri),
+        needFailedToLoad:
+          need && processUtils.hasNeedFailedToLoad(process, needUri),
       };
     };
 
@@ -57,9 +56,18 @@ class Controller {
     this.$scope.$on("$destroy", disconnect);
   }
 
+  ensureNeedIsLoaded() {
+    if (
+      this.needUri &&
+      (!this.need || (this.needToLoad && !this.needLoading))
+    ) {
+      this.needs__fetchUnloadedNeed(this.needUri);
+    }
+  }
+
   tryReload() {
-    if (this.postUri && this.postFailedToLoad) {
-      this.needs__fetchUnloadedNeed(this.postUri);
+    if (this.needUri && this.needFailedToLoad) {
+      this.needs__fetchUnloadedNeed(this.needUri);
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -3,7 +3,8 @@
  */
 import angular from "angular";
 import ngAnimate from "angular-animate";
-import { attach, getIn, get } from "../../utils.js";
+import { attach, getIn, get, delay } from "../../utils.js";
+import { connect2Redux } from "../../won-utils.js";
 import won from "../../won-es6.js";
 import { actionCreators } from "../../actions/actions.js";
 import sendRequestModule from "../send-request.js";
@@ -50,10 +51,13 @@ class Controller {
       };
     };
 
-    const disconnect = this.$ngRedux.connect(selectFromState, actionCreators)(
-      this
+    connect2Redux(selectFromState, actionCreators, [], this);
+
+    this.$scope.$watch(
+      () =>
+        this.needUri && (!this.need || (this.needToLoad && !this.needLoading)),
+      () => delay(0).then(() => this.ensureNeedIsLoaded())
     );
-    this.$scope.$on("$destroy", disconnect);
   }
 
   ensureNeedIsLoaded() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -14,6 +14,14 @@ export function showSlideIns(state) {
   return viewUtils.showSlideIns(get(state, "view"));
 }
 
+export function showModalDialog(state) {
+  return viewUtils.showModalDialog(get(state, "view"));
+}
+
+export function showRdf(state) {
+  return viewUtils.showRdf(get(state, "view"));
+}
+
 export function isAnonymousLinkSent(state) {
   return viewUtils.isAnonymousLinkSent(get(state, "view"));
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
@@ -17,6 +17,14 @@ export function showSlideIns(viewState) {
   return get(viewState, "showSlideIns");
 }
 
+export function showModalDialog(viewState) {
+  return get(viewState, "showModalDialog");
+}
+
+export function showRdf(viewState) {
+  return get(viewState, "showRdf");
+}
+
 export function isAnonymousLinkSent(viewState) {
   return getIn(viewState, ["anonymousSlideIn", "linkSent"]);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -4,7 +4,7 @@
 
 import won from "./won-es6.js";
 import Immutable from "immutable";
-import { checkHttpStatus, urisToLookupMap, is, getIn } from "./utils.js";
+import { checkHttpStatus, urisToLookupMap, is } from "./utils.js";
 
 import { ownerBaseUrl } from "config";
 import urljoin from "url-join";
@@ -12,7 +12,6 @@ import urljoin from "url-join";
 import { getRandomWonId, getAllDetails } from "./won-utils.js";
 import { isConnUriClosed } from "./won-localstorage.js";
 import { actionTypes } from "./actions/actions.js";
-import { getPostUriFromRoute } from "./selectors/general-selectors.js";
 
 /**
  * Checks if a wonMessage contains content/references that make it necessary for us to check which effects
@@ -673,23 +672,6 @@ export function fetchMessage(needUri, eventUri) {
   return fetch(url, httpOptions)
     .then(checkHttpStatus)
     .then(response => response.json());
-}
-
-export function loadNeedFromRouteParamIfExists(dispatch, getState) {
-  const postUri = getPostUriFromRoute(getState());
-
-  /*
-   if there is no postUri in the route we dont have to do anything
-
-   if the need is not in the state yet, we add it as a nonOwnedNeed
-   since we can be sure the need would be a non-owned need due to the fact that all Owned needs have been loaded before
-   already if the User is logged in
-   */
-  if (postUri && !getIn(getState(), ["needs", postUri])) {
-    return fetchDataForNonOwnedNeedOnly(postUri, dispatch);
-  } else {
-    return Promise.resolve();
-  }
 }
 
 export async function fetchDataForOwnedNeeds(ownedNeedUris, dispatch) {


### PR DESCRIPTION
Fixes #2692 

removed the check for visitorNeedUri fetching from account-actions.js and load-action.js in favor of fetching the need from within the visitor component (if it has not been loaded yet)

- that way we can react to needUri changes in the url and fetch the need if necessary without having to rely on a reload that would invoke the load-action or account-action promise chain