### PR TITLE
share icon in chatToGroup connection was not aligned in grid due to mismatch of name

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
@@ -13,7 +13,7 @@ won-group-post-messages {
   .gpm__header {
     display: grid;
     grid-template-columns: auto 1fr auto auto;
-    grid-template-areas: "header_back header_title header-share header_context";
+    grid-template-areas: "header_back header_title header_share header_context";
     grid-area: header;
     font-size: $normalFontSize;
     text-align: left;


### PR DESCRIPTION
how to test:

look at a suggested/connected groupchat you will see that the share icon is not at the same position as it is in a 1to1 chat