### PR TITLE
Only open one connection-need connection list

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -313,6 +313,12 @@ function genComponentConf() {
     }
 
     toggleDetails(ownedNeedUri) {
+      for (let key in this.open) {
+        if (key !== ownedNeedUri) {
+          this.open[key] = false;
+        }
+      }
+
       if (this.isOpen(ownedNeedUri)) {
         this.open[ownedNeedUri] = false;
         if (this.isOpenByConnection(ownedNeedUri)) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-selection-item.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-administration-selection-item.js
@@ -16,7 +16,6 @@ import "style/_group-administration-selection-item-line.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <!-- todo impl and include groupchat header -->
       <won-group-administration-header
         class="clickable"
         ng-click="self.setOpen()"


### PR DESCRIPTION
Collapse all other open connection-lists when opening a need-connection-list -> so that the view is not tooo cluttered....

However if another connection is currently open in the right side (is visible in the desktop view) the need-connection-list containing the open element will not be collapsed