### PR TITLE
Refac  overlaystyle

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.js
@@ -162,7 +162,7 @@ function genComponentConf() {
     }
 
     goToPost(postUri) {
-      this.router__stateGoCurrent({ useCase: undefined, postUri: postUri });
+      this.router__stateGoCurrent({ useCase: undefined, viewNeedUri: postUri });
     }
 
     generateCloseConnectionLabel() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -50,13 +50,13 @@ function genComponentConf() {
         <won-square-image
             class="clickable"
             uri="::self.theirNeed.get('uri')"
-            ng-click="!self.multiSelectType && self.router__stateGoCurrent({postUri: self.theirNeed.get('uri')})"
+            ng-click="!self.multiSelectType && self.router__stateGoCurrent({viewNeedUri: self.theirNeed.get('uri')})"
             ng-if="!self.isSent && !(self.isGroupChatMessage && self.originatorUri)">
         </won-square-image>
         <won-square-image
             class="clickable"
             uri="::self.originatorUri"
-            ng-click="!self.multiSelectType && self.router__stateGoCurrent({postUri: self.originatorUri})"
+            ng-click="!self.multiSelectType && self.router__stateGoCurrent({viewNeedUri: self.originatorUri})"
             ng-if="self.isReceived && self.isGroupChatMessage && self.originatorUri">
         </won-square-image>
         <won-square-image

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/post-content-message.js
@@ -17,7 +17,7 @@ function genComponentConf() {
             class="clickable"
             uri="::self.postUri"
             ng-if="!self.postLoading"
-            ng-click="self.router__stateGoCurrent({postUri: self.postUri})">
+            ng-click="self.router__stateGoCurrent({viewNeedUri: self.postUri})">
         </won-square-image>
         <div class="won-cm__center">
             <div class="won-cm__center__bubble">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -88,12 +88,6 @@ function genComponentConf() {
           <!-- GENERAL INFORMATION -->
           <won-labelled-hr ng-click="self.toggleShowGeneral()" arrow="self.showGeneral ? 'up' : 'down'" label="::'General Information'" class="cp__labelledhr"></won-labelled-hr>
           <won-post-content-general class="post-collapsible-general" ng-if="self.showGeneral" post-uri="self.post.get('uri')"></won-post-content-general>
-          <button
-              class="won-button--outlined thin red post-content__button__template"
-              ng-if="self.isUsableAsTemplate"
-              ng-click="self.router__stateGoAbs('connections', {fromNeedUri: self.postUri, mode: 'DUPLICATE'})">
-              Post this too!
-          </button>
           <!-- RDF REPRESENTATION -->
           <div class="post-info__content__rdf" ng-if="self.shouldShowRdf">
             <h2 class="post-info__heading">
@@ -146,14 +140,11 @@ function genComponentConf() {
 
         const heldPosts = get(post, "holds");
 
-        const isUsableAsTemplate = needUtils.isUsableAsTemplate(post);
-
         return {
           WON: won.WON,
           hasContent,
           hasSeeksBranch,
           post,
-          isUsableAsTemplate,
           isPersona: needUtils.isPersona(post),
           hasHeldPosts: needUtils.isPersona && heldPosts && heldPosts.size > 0,
           heldPostsArray:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -10,7 +10,8 @@ import {
   connect2Redux,
   createDocumentDefinitionFromPost,
 } from "../won-utils.js";
-import { isActive, isInactive, isOwned } from "../need-utils.js";
+import * as needUtils from "../need-utils.js";
+import * as processUtils from "../process-utils.js";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
 
@@ -51,6 +52,12 @@ function genComponentConf() {
                         ng-click="self.exportPdf()">
                         Export as PDF
                     </button>
+                    <button
+                        class="won-button--outlined thin red"
+                        ng-if="self.isUsableAsTemplate"
+                        ng-click="self.router__stateGoAbs('connections', {fromNeedUri: self.needUri, mode: 'DUPLICATE'})">
+                        Post this too!
+                    </button>
                     <a class="won-button--outlined thin red"
                         ng-if="self.adminEmail"
                         href="mailto:{{ self.adminEmail }}?{{ self.generateReportPostMailParams()}}">
@@ -90,20 +97,20 @@ function genComponentConf() {
         }
 
         const personaUri = get(post, "heldBy");
+        const process = get(state, "process");
 
         return {
           adminEmail: getIn(state, ["config", "theme", "adminEmail"]),
           personaUri,
-          isOwnPost: isOwned(post),
-          isActive: isActive(post),
-          isInactive: isInactive(post),
+          isOwnPost: needUtils.isOwned(post),
+          isActive: needUtils.isActive(post),
+          isInactive: needUtils.isInactive(post),
+          isUsableAsTemplate: needUtils.isUsableAsTemplate(post),
           post,
           postLoading:
-            !post ||
-            getIn(state, ["process", "needs", post.get("uri"), "loading"]),
+            !post || processUtils.isNeedLoading(process, post.get("uri")),
           postFailedToLoad:
-            post &&
-            getIn(state, ["process", "needs", post.get("uri"), "failedToLoad"]),
+            post && processUtils.hasNeedFailedToLoad(process, post.get("uri")),
           linkToPost,
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -32,8 +32,12 @@ function genComponentConf() {
                 ng-if="self.showOverlayNeed"
                 ng-click="self.router__back()">
                 <svg style="--local-primary:var(--won-primary-color);"
-                     class="post-info__header__back__icon clickable">
+                     class="post-info__header__back__icon clickable hide-in-responsive">
                     <use xlink:href="#ico36_close" href="#ico36_close"></use>
+                </svg>
+                <svg style="--local-primary:var(--won-primary-color);"
+                     class="post-info__header__back__icon clickable show-in-responsive">
+                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
             </a>
             <won-post-header

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.html
@@ -10,7 +10,7 @@
 <main class="postcontent" ng-class="{'postcontent--won-loading': self.needLoading, 'postcontent--won-failed': self.needFailedToLoad}">
     <!-- Post info view when there's no connection-state/-type selected -->
     <won-visitor-title-bar ng-if="!(self.needLoading || self.needFailedToLoad)" item="self.need"></won-visitor-title-bar>
-    <won-send-request ng-if="!(self.needLoading || self.needFailedToLoad) && self.need && !self.isOwnedNeed" class="won-send-request--noheader"></won-send-request>
+    <won-send-request ng-if="!(self.needLoading || self.needFailedToLoad) && self.need" class="won-send-request--noheader"></won-send-request>
     <div class="pc__loading" ng-if="self.needLoading">
         <svg class="pc__loading__spinner hspinner">
             <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-overlay.scss
@@ -46,11 +46,12 @@
     > won-post-info {
       max-width: $maxContentWidth/2;
       min-width: $maxContentWidth/2;
-      max-height: 75%;
       background: white;
       display: grid;
       grid-row-gap: 0.5rem;
       padding: 0.5rem;
+      min-height: 75vh;
+      max-height: 75vh;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -24,11 +24,6 @@ won-post-content {
       padding: 0.5rem;
     }
 
-    .post-content__button__template.won-button--outlined.thin.red {
-      font-size: $smallFontSize;
-      margin-top: 0.5rem;
-    }
-
     .post-content__members {
       & .post-content__members__member {
         padding: 0.5rem;


### PR DESCRIPTION
Changes the Overlay "back"-button icon from the close image to the back image in mobile -> this prevents confusion as the close did not actually close the overlay (if you went from one overlay to the another for example)

Changes the min and max height of the overlay in desktop view, so that the close button seems to close the "top"-element and show the element underneath (aka the previous element), due to the fixed height we somewhat indicate that the previous view was still underneath the current overlay and thus the interface seems less jumpy and confusing


requires #2746  (due to included changes)

Changes the link for the following clickable Elements:
- Clicking on the NeedIcon within a chat (the one next to the chat-message) opens the need detail view as an overlay (instead of showing it within the rightside of the connections view)
- Same goes for "Show Details"-Button in the connection-context-dropdown
- Same goes for the Need-Icon next to the post-content-message (aka the need description message within a chat)
... this should reduce unclear interface routechanges