### PR TITLE
Fix  #2761 and #2759

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -69,7 +69,7 @@ function genComponentConf() {
                   'won-cm__center--system': self.isFromSystem,
                   'won-cm__center--inject-into': self.isInjectIntoMessage
                 }"
-                in-view="$inview && self.markAsRead()">
+                in-view="self.isUnread && $inview && self.markAsRead()">
             <div class="won-cm__center__bubble"
                 ng-class="{
     			        'references' : 	self.hasReferences,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -3,6 +3,7 @@
  */
 
 import angular from "angular";
+import inviewModule from "angular-inview";
 import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
 import labelledHrModule from "./labelled-hr.js";
 import postContentGeneral from "./post-content-general.js";
@@ -23,6 +24,8 @@ import ngAnimate from "angular-animate";
 
 import "style/_post-content.scss";
 import "style/_rdflink.scss";
+
+const CONNECTION_READ_TIMEOUT = 1500;
 
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
@@ -89,11 +92,12 @@ function genComponentConf() {
               class="post-content__suggestions__suggestion"
               ng-repeat="conn in self.suggestionsArray"
               ng-if="self.hasSuggestions"
+              in-view="conn.get('unread') && $inview && self.markAsRead(conn)"
               ng-class="{'won-unread': conn.get('unread')}">
                 <div class="post-content__suggestions__suggestion__indicator"></div>
                 <won-post-header
                   class="clickable"
-                  ng-click="self.connections__markAsRead({connectionUri: conn.get('uri'), needUri: self.postUri}) && self.router__stateGoCurrent({viewConnUri: conn.get('uri'), viewNeedUri: undefined})"
+                  ng-click="self.viewSuggestion(conn)"
                   need-uri="::conn.get('remoteNeedUri')">
                 </won-post-header>
                 <div class="post-content__suggestions__suggestion__actions">
@@ -104,7 +108,7 @@ function genComponentConf() {
                     </div>
                     <div
                       class="post-content__suggestions__suggestion__actions__button red won-button--outlined thin"
-                      ng-click="self.closeConnection(conn.get('uri'))">
+                      ng-click="self.closeConnection(conn)">
                         Remove
                     </div>
                 </div>
@@ -237,8 +241,24 @@ function genComponentConf() {
       }
     }
 
-    closeConnection(connUri, rateBad = false) {
-      rateBad && this.connections__rate(connUri, won.WON.binaryRatingBad);
+    closeConnection(conn, rateBad = false) {
+      if (!conn) {
+        return;
+      }
+
+      const connUri = conn.get("uri");
+
+      if (rateBad) {
+        this.connections__rate(connUri, won.WON.binaryRatingBad);
+      }
+
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
       this.connections__close(connUri);
     }
 
@@ -250,6 +270,13 @@ function genComponentConf() {
       const connUri = get(conn, "uri");
       const remoteNeedUri = get(conn, "remoteNeedUri");
 
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
       if (this.isOwnedNeedWhatsX) {
         this.connections__close(connUri);
 
@@ -259,12 +286,7 @@ function genComponentConf() {
         //this.router__back();
       } else {
         this.connections__rate(connUri, won.WON.binaryRatingGood);
-        this.needs__connect(
-          this.post.get("uri"),
-          connUri,
-          remoteNeedUri,
-          message
-        );
+        this.needs__connect(this.postUri, connUri, remoteNeedUri, message);
       }
     }
 
@@ -274,6 +296,41 @@ function genComponentConf() {
 
     isSelectedTab(tabName) {
       return tabName === this.visibleTab;
+    }
+
+    markAsRead(conn) {
+      if (conn && conn.get("unread")) {
+        const payload = {
+          connectionUri: conn.get("uri"),
+          needUri: this.postUri,
+        };
+
+        const tmp_connections__markAsRead = this.connections__markAsRead;
+
+        setTimeout(function() {
+          tmp_connections__markAsRead(payload);
+        }, CONNECTION_READ_TIMEOUT);
+      }
+    }
+
+    viewSuggestion(conn) {
+      if (!conn) {
+        return;
+      }
+
+      const connUri = conn.get("uri");
+
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
+      self.router__stateGoCurrent({
+        viewConnUri: connUri,
+        viewNeedUri: undefined,
+      });
     }
 
     /**
@@ -313,5 +370,6 @@ export default angular
     postContentGeneral,
     postHeaderModule,
     trigModule,
+    inviewModule.name,
   ])
   .directive("wonPostContent", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -327,7 +327,7 @@ function genComponentConf() {
         });
       }
 
-      self.router__stateGoCurrent({
+      this.router__stateGoCurrent({
         viewConnUri: connUri,
         viewNeedUri: undefined,
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -46,7 +46,7 @@ function genComponentConf() {
             <div class="pm__header__back">
               <a class="pm__header__back__button clickable show-in-responsive"
                  ng-if="!self.showOverlayConnection"
-                 ng-click="self.router__back()"> <!-- TODO: Clicking on the back button in non-mobile view might lead to some confusing changes -->
+                 ng-click="self.router__back()">
                   <svg class="pm__header__back__button__icon">
                       <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                   </svg>
@@ -76,13 +76,14 @@ function genComponentConf() {
             <won-connection-context-dropdown show-petri-net-data-field="::self.showPetriNetDataField()" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
         </div>
         <div class="pm__header" ng-if="self.showAgreementData">
-            <a class="pm__header__back clickable"
-                ng-click="self.setShowAgreementData(false)">
-                <svg style="--local-primary:var(--won-primary-color);"
-                     class="pm__header__back__icon clickable">
-                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
-                </svg>
-            </a>
+            <div class="pm__header__back">
+              <a class="pm__header__back__button clickable"
+                  ng-click="self.setShowAgreementData(false)">
+                  <svg class="pm__header__back__button__icon clickable">
+                      <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
+                  </svg>
+              </a>
+            </div>
             <div class="pm__header__title clickable"
                 ng-click="self.setShowAgreementData(false)">
               Showing Agreement Data
@@ -90,13 +91,14 @@ function genComponentConf() {
             <won-connection-context-dropdown show-petri-net-data-field="::self.showPetriNetDataField()" show-agreement-data-field="::self.showAgreementDataField()"></won-connection-context-dropdown>
         </div>
         <div class="pm__header" ng-if="self.showPetriNetData">
-            <a class="pm__header__back clickable"
-                ng-click="self.setShowPetriNetData(false)">
-                <svg style="--local-primary:var(--won-primary-color);"
-                     class="pm__header__back__icon clickable">
-                    <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
-                </svg>
-            </a>
+            <div class="pm__header__back">
+              <a class="pm__header__back__button clickable"
+                  ng-click="self.setShowPetriNetData(false)">
+                  <svg class="pm__header__back__button__icon clickable">
+                      <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
+                  </svg>
+              </a>
+            </div>
             <div class="pm__header__title clickable"
                 ng-click="self.setShowAgreementData(false)">
               Showing PetriNet Data

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -4,6 +4,13 @@
 @import "animate";
 
 won-connection-message {
+  grid-template-columns: min-content minmax(min-content, max-content);
+  box-sizing: border-box;
+  padding: 0.5rem 0 0.5rem 0.5rem;
+  @include square-image($postIconSize, 0 0.5rem 0 0);
+  display: grid;
+  grid-template-areas: "icon content";
+
   &.won-is-multiSelect {
     padding-left: 3rem;
     cursor: pointer;
@@ -23,7 +30,8 @@ won-connection-message {
   }
 
   &.won-unread {
-    background-color: $won-unread;
+    border-left: 0.25rem solid $won-unread-attention;
+    padding-left: 0.25rem;
   }
 
   &.won-is-collapsed {
@@ -41,11 +49,6 @@ won-connection-message {
       margin: 0 0.5rem 0 0;
     }
   }
-
-  padding: 0.5rem 0;
-  @include square-image($postIconSize, 0 0.5rem 0 0);
-  display: grid;
-  grid-template-areas: "icon content";
 
   won-square-image {
     grid-area: icon;
@@ -179,8 +182,4 @@ won-connection-message {
       }
     }
   }
-}
-
-won-connection-message {
-  grid-template-columns: min-content minmax(min-content, max-content);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_group-post-messages.scss
@@ -61,7 +61,7 @@ won-group-post-messages {
 
   .gpm__content {
     grid-area: main;
-    padding: 0.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 0;
     background: white;
     border: $thinGrayBorder;
     overflow: auto;
@@ -69,9 +69,10 @@ won-group-post-messages {
 
     &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
     &__loadspinner {
-      width: 100%;
+      width: calc(100% - 0.5rem);
       height: 3rem;
       padding: 0.66em 2em;
+      margin-left: 0.5rem;
       text-align: center;
       box-sizing: border-box;
     }
@@ -82,6 +83,7 @@ won-group-post-messages {
       position: sticky;
       z-index: 10;
       margin-bottom: 0.5rem;
+      margin-left: 0.5rem;
 
       @include slideWithOpacityAnimationFixedHorizontal(
         0.5s,

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-message.scss
@@ -8,7 +8,7 @@ won-post-content-message {
     @include animateOpacityHeartBeat();
   }
 
-  padding: 0 0 0.5rem 0;
+  padding: 0 0 0.5rem 0.5rem;
   @include square-image($postIconSize, 0 0.5rem 0 0);
   display: grid;
   grid-template-areas: "content";

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-messages.scss
@@ -60,21 +60,14 @@ won-post-messages {
   }
 
   .pm__content {
+  }
+  .pm__content {
     grid-area: main;
-    padding: 0.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 0;
     background: white;
     border: $thinGrayBorder;
     overflow: auto;
     flex-grow: 1;
-
-    &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
-    &__loadspinner {
-      width: 100%;
-      height: 3rem;
-      padding: 0.66em 2em;
-      text-align: center;
-      box-sizing: border-box;
-    }
 
     &__unreadindicator {
       height: 3rem;
@@ -82,6 +75,7 @@ won-post-messages {
       position: sticky;
       z-index: 10;
       margin-bottom: 0.5rem;
+      margin-left: 0.5rem;
 
       @include slideWithOpacityAnimationFixedHorizontal(
         0.5s,
@@ -105,19 +99,12 @@ won-post-messages {
         white-space: nowrap;
       }
     }
-  }
-  .pm__content {
-    grid-area: main;
-    padding: 0.5rem;
-    background: white;
-    border: $thinGrayBorder;
-    overflow: auto;
-    flex-grow: 1;
     &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
     &__loadspinner {
-      width: 100%;
+      width: calc(100% - 0.5rem);
       height: 3rem;
       padding: 0.66em 2em;
+      margin-left: 0.5rem;
       text-align: center;
       box-sizing: border-box;
     }
@@ -127,12 +114,16 @@ won-post-messages {
     }
     &__petrinet__loadingtext,
     &__agreement__loadingtext {
+      padding-left: 0.5rem;
+      box-sizing: border-box;
       font-size: $smallFontSize;
       color: $won-subtitle-gray;
       text-align: center;
     }
     &__petrinet__emptytext,
     &__agreement__emptytext {
+      padding-left: 0.5rem;
+      box-sizing: border-box;
       text-align: center;
       font-size: $normalFontSize;
       color: $won-subtitle-gray;
@@ -158,15 +149,8 @@ won-post-messages {
       font-size: $normalFontSize;
       border-bottom: $thinGrayBorder;
       padding-bottom: 0.25rem;
+      padding-left: 0.5rem;
       margin-bottom: 0.25rem;
-    }
-    &__loadbutton, /* just so the button and spinner won't make the chatmessages "jump"*/
-    &__loadspinner {
-      width: 100%;
-      height: 3rem;
-      padding: 0.66em 2em;
-      text-align: center;
-      box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
Fixes #2761 -> quick-request/remove buttons in the suggestions list of a need, did not mark these connections as read and thus the propagation towards the need did not occur resulting in an always unread need even if nothing was visible unread -> this is fixed now

Fixes #2758 -> having to click every single suggestion to mark it as read was tedious -> this PR fixes this by marking all visible suggestions as read after a timeout (similar to unread connection messages)

Fixes styling issues with the petrinet and agreement-data header
Implements a nicer way to style unread messages (indicator is now the "same" styling as any other unread indicator (left border instead of background)