### PR TITLE
Changed db lock strategy to avoid debugBot deadlock

### DIFF
--- a/webofneeds/conf/node.properties
+++ b/webofneeds/conf/node.properties
@@ -79,7 +79,7 @@ rdf.file.path=
 
 #hsql db configuration
 db.sql.jdbcDriverClass=org.hsqldb.jdbcDriver
-db.sql.jdbcUrl=jdbc:hsqldb:mem:testdb
+db.sql.jdbcUrl=jdbc:hsqldb:mem:testdb;hsqldb.tx=mvcc
 db.sql.user=sa
 db.sql.password=
 db.ddl.strategy=create

--- a/webofneeds/conf/owner.properties
+++ b/webofneeds/conf/owner.properties
@@ -53,7 +53,7 @@ uri.need.protocol.endpoint.default=${uri.prefix.node.default}/protocol/owner
 
 # DB - Alternative: local hsql
 db.sql.jdbcDriverClass=org.hsqldb.jdbcDriver
-db.sql.jdbcUrl=jdbc:hsqldb:mem:testdb2
+db.sql.jdbcUrl=jdbc:hsqldb:mem:testdb2;hsqldb.tx=mvcc
 db.sql.user=sa
 db.sql.password=
 db.ddl.strategy=create


### PR DESCRIPTION
**Config file change** - this needs updating of your local configurations

This change prevents a deadlock that may occur when running a debugbot locally with an hqsl db (as according to the default configuration). The deadlock prevents `CONNECT` from being executed successfully as the bot's write-lock prevents the bot to read to check access rights. 

As this happens only with hsql's default transaction model and not e.g. with postgresql's default of MVCC, this PR changes the hsql config to use MVCC. (see [this thread on Stack Overflow](https://stackoverflow.com/questions/16108643/unit-tests-of-hibernate-based-code-on-top-of-hsqldb-1-8-1-3-no-longer-work-on-hs))

fixes #2598 ( i just assume that this issue is going to be fixed since the problem seems to/could be the same)
