### PR TITLE
Refac  post content general

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -155,8 +155,6 @@ const actionHierarchy = {
     storeTheirs: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
-
-    toggleGeneralInfo: INJ_DEFAULT,
     selectTab: INJ_DEFAULT,
   },
   personas: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -23,7 +23,6 @@ import {
   getOwnedNeedByConnectionUri,
 } from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
-import ratingView from "./rating-view.js";
 
 import "style/_post-content-general.scss";
 import { getOwnedConnectionByUri } from "../selectors/connection-selectors.js";
@@ -34,17 +33,6 @@ function genComponentConf() {
       <div class="pcg__columns">
       <!-- LEFT COLUMN -->
         <div class="pcg__columns__left">
-          <!-- PERSONA -->
-          <div class="pcg__columns__left__item" ng-if="self.persona">
-            <div class="pcg__columns__left__item__label">
-              Persona
-            </div>
-            <div class="pcg__columns__left__item__value">
-              {{ self.persona.get('humanReadable') }}
-              <won-rating-view rating="self.rating()" rating-connection-uri="self.ratingConnectionUri"></won-rating-view>
-            </div>
-          </div>
-          <!-- RATING -->
           <div class="pcg__columns__left__item" ng-if="self.friendlyTimestamp">
             <div class="pcg__columns__left__item__label">
               Created
@@ -135,15 +123,10 @@ function genComponentConf() {
             : null;
 
         const post = this.postUri && getIn(state, ["needs", this.postUri]);
-        const persona = post && getIn(state, ["needs", get(post, "heldBy")]);
-        const personaHolds = get(persona, "holds");
-        const personaRating = get(persona, "rating");
-
         const viewState = get(state, "view");
 
         return {
           WON: won.WON,
-          post,
           fullTypesLabel: post && generateFullNeedTypesLabel(post),
           shortTypesLabel: post && generateShortNeedTypesLabel(post),
           matchingContext: post && generateNeedMatchingContext(post),
@@ -151,11 +134,6 @@ function genComponentConf() {
           shortFlags: post && generateShortNeedFlags(post),
           fullFacets: post && generateFullNeedFacets(post),
           shortFacets: post && generateShortNeedFacets(post),
-          persona:
-            personaHolds && personaHolds.includes(post.get("uri"))
-              ? persona
-              : undefined,
-          personaRating: personaRating,
           friendlyTimestamp:
             post &&
             relativeTime(
@@ -167,22 +145,6 @@ function genComponentConf() {
         };
       };
       connect2Redux(selectFromState, actionCreators, ["self.postUri"], this);
-    }
-
-    rating() {
-      // Return actuall rating!
-      /*
-      let sum = 0;
-      for (const char of this.persona.get("uri")) {
-        sum += char.charCodeAt(0);
-      }
-      return (sum % 5) + 1;
-      */
-      const rating = this.personaRating
-        ? this.personaRating.get("aggregateRating")
-        : 0;
-
-      return Math.round(rating);
     }
   }
 
@@ -200,5 +162,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.postContentGeneral", [ratingView])
+  .module("won.owner.components.postContentGeneral", [])
   .directive("wonPostContentGeneral", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -60,14 +60,14 @@ function genComponentConf() {
         </div>
         </div>
         <div class="post-content" ng-if="!self.postLoading && !self.postFailedToLoad">
+          <!-- GENERAL INFORMATION -->
+          <won-post-content-general ng-if="self.isSelectedTab('DETAIL')" post-uri="self.postUri"></won-post-content-general>
           <!-- DETAIL INFORMATION -->
           <won-post-is-or-seeks-info branch="::'content'" ng-if="self.isSelectedTab('DETAIL') && self.hasContent" post-uri="self.postUri"></won-post-is-or-seeks-info>
           <won-labelled-hr label="::'Search'" class="cp__labelledhr" ng-show="self.isSelectedTab('DETAIL') && self.hasContent && self.hasSeeksBranch"></won-labelled-hr>
           <won-post-is-or-seeks-info branch="::'seeks'" ng-if="self.isSelectedTab('DETAIL') && self.hasSeeksBranch" post-uri="self.postUri"></won-post-is-or-seeks-info>
 
-          <!-- GENERAL INFORMATION -->
-          <won-labelled-hr ng-if="self.isSelectedTab('DETAIL')" ng-click="self.toggleShowGeneral()" arrow="self.showGeneral ? 'up' : 'down'" label="::'General Information'" class="cp__labelledhr"></won-labelled-hr>
-          <won-post-content-general class="post-collapsible-general" ng-if="self.isSelectedTab('DETAIL') && self.showGeneral" post-uri="self.postUri"></won-post-content-general>
+
 
           <!-- PERSONA INFORMATION -->
           <won-post-content-persona ng-if="self.isSelectedTab('HELDBY')" holds-uri="self.postUri"></won-post-content-persona>
@@ -234,10 +234,6 @@ function genComponentConf() {
           shouldShowRdf: viewUtils.showRdf(viewState),
           fromConnection: !!openConnectionUri,
           openConnectionUri,
-          showGeneral: viewUtils.isShowingGeneralInfoByNeedUri(
-            viewState,
-            this.postUri
-          ),
           visibleTab: viewUtils.getVisibleTabByNeedUri(viewState, this.postUri),
         };
       };
@@ -299,10 +295,6 @@ function genComponentConf() {
         this.connections__rate(connUri, won.WON.binaryRatingGood);
         this.needs__connect(this.postUri, connUri, remoteNeedUri, message);
       }
-    }
-
-    toggleShowGeneral() {
-      this.needs__toggleGeneralInfo(this.postUri);
     }
 
     isSelectedTab(tabName) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -140,13 +140,6 @@ export default function(viewState = initialState, action = {}) {
         .setIn(["anonymousSlideIn", "linkCopied"], true)
         .setIn(["anonymousSlideIn", "linkSent"], false);
 
-    case actionTypes.needs.toggleGeneralInfo:
-      return viewState.updateIn(
-        ["needs", action.payload],
-        initialNeedState,
-        needState => needState.update("showGeneralInfo", show => !show)
-      );
-
     case actionTypes.needs.selectTab: {
       const needUri = action.payload.get("needUri");
       const selectTab = action.payload.get("selectTab");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
@@ -57,7 +57,3 @@ export function getVisibleTabByNeedUri(
   const tab = getIn(viewState, ["needs", needUri, "visibleTab"]);
   return tab || notFoundTab;
 }
-
-export function isShowingGeneralInfoByNeedUri(viewState, needUri) {
-  return getIn(viewState, ["needs", needUri, "showGeneralInfo"]);
-}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-general.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-general.scss
@@ -6,8 +6,8 @@ won-post-content-general {
   display: grid;
   grid-auto-flow: row;
   font-size: $smallFontSize;
-  margin: 0.25rem 0 0 0;
   background: var(--won-lighter-gray);
+  border: $thinGrayBorder;
   padding: 0.5rem;
   grid-gap: 0.25rem;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -188,13 +188,4 @@ won-post-content {
       font-weight: 700;
     }
   }
-
-  .post-collapsible-general {
-    @include slideWithOpacityAnimationFixedHorizontal(
-      0.25s,
-      linear,
-      10rem,
-      0.5rem
-    );
-  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -42,6 +42,10 @@ won-post-content {
         align-items: center;
         margin-top: 0.5rem;
 
+        &:first-of-type {
+          margin-top: 0;
+        }
+
         &:hover {
           background: white;
         }
@@ -78,6 +82,10 @@ won-post-content {
         align-items: center;
         margin-top: 0.5rem;
 
+        &:first-of-type {
+          margin-top: 0;
+        }
+
         &:hover {
           background: white;
         }
@@ -104,6 +112,10 @@ won-post-content {
         grid-template-columns: min-content 1fr min-content;
         align-items: center;
         margin-top: 0.5rem;
+
+        &:first-of-type {
+          margin-top: 0;
+        }
 
         & > .post-content__suggestions__suggestion__indicator {
           grid-area: member_indicator;


### PR DESCRIPTION
- Removes Persona & Rating from post-content-general -> is in Persona tab now
- Adds Border to post-content-general to be more suitable for our default style
- Removes the ability to collapse the general-info (since not alot of info is going to clutter the interface anymore anyway)
- Moves the post-content-general to the top of the post-content again