### PR TITLE
Allow attaching and detaching of personas

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -91,6 +91,7 @@ import {
   createPersona,
   reviewPersona,
   connectPersona,
+  disconnectPersona,
 } from "./persona-actions.js";
 
 // </action-creators>
@@ -167,6 +168,7 @@ const actionHierarchy = {
     create: createPersona,
     review: reviewPersona,
     connect: connectPersona,
+    disconnect: disconnectPersona,
 
     storeTheirs: INJ_DEFAULT,
     storeTheirUrisInLoading: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -87,7 +87,11 @@ import * as configActions from "./config-actions.js";
 
 import { pageLoadAction } from "./load-action.js";
 import { stateGo, stateReload } from "redux-ui-router";
-import { createPersona, reviewPersona } from "./persona-actions.js";
+import {
+  createPersona,
+  reviewPersona,
+  connectPersona,
+} from "./persona-actions.js";
 
 // </action-creators>
 
@@ -162,6 +166,7 @@ const actionHierarchy = {
   personas: {
     create: createPersona,
     review: reviewPersona,
+    connect: connectPersona,
 
     storeTheirs: INJ_DEFAULT,
     storeTheirUrisInLoading: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -108,6 +108,39 @@ async function connectReview(
   });
 }
 
+export function connectPersona(needUri, personaUri) {
+  return async dispatch => {
+    const response = await fetch("rest/action/connect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        {
+          pending: false,
+          facet: `${personaUri}#holderFacet`,
+        },
+        {
+          pending: false,
+          facet: `${needUri}#holdableFacet`,
+        },
+      ]),
+      credentials: "include",
+    });
+    if (!response.ok) {
+      const errorMsg = await response.text();
+      throw new Error(`Could not connect identity: ${errorMsg}`);
+    }
+    dispatch({
+      type: actionTypes.personas.connect,
+      payload: {
+        needUri: needUri,
+        personaUri: personaUri,
+      },
+    });
+  };
+}
+
 export function reviewPersona(reviewableConnectionUri, review) {
   return (dispatch, getState) => {
     const state = getState();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/elm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/elm.js
@@ -2,6 +2,8 @@ import angular from "angular";
 import { currentSkin } from "../selectors/general-selectors";
 import { actionCreators } from "../actions/actions";
 
+import "../../style/_elm-ui-shim.scss";
+
 function genComponentConf($ngRedux) {
   return {
     restrict: "E",
@@ -18,7 +20,7 @@ function genComponentConf($ngRedux) {
         flags: {
           state: $ngRedux.getState().toJS(),
           attributes: scope.attributes,
-          skin: currentSkin(),
+          style: currentSkin(),
         },
       });
 
@@ -27,7 +29,7 @@ function genComponentConf($ngRedux) {
           window.requestAnimationFrame(() => {
             elmApp.ports.inPort.send({
               newState: state.toJS(),
-              newSkin: currentSkin(),
+              newStyle: currentSkin(),
             });
           })
       );
@@ -41,7 +43,7 @@ function genComponentConf($ngRedux) {
       if (elmApp.ports.outPort) {
         elmApp.ports.outPort.subscribe(({ action, payload }) => {
           if (actionCreators[action]) {
-            $ngRedux.dispatch(actionCreators[action](payload));
+            $ngRedux.dispatch(actionCreators[action](...payload));
           } else {
             scope.onAction({ action, payload });
           }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/elm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/elm.js
@@ -1,0 +1,70 @@
+import angular from "angular";
+import { currentSkin } from "../selectors/general-selectors";
+import { actionCreators } from "../actions/actions";
+
+function genComponentConf($ngRedux) {
+  return {
+    restrict: "E",
+    scope: {
+      module: "<",
+      attributes: "<",
+      onAction: "&",
+    },
+    link: (scope, element) => {
+      const childElement = document.createElement("div");
+      element[0].appendChild(childElement);
+      const elmApp = scope.module.init({
+        node: childElement,
+        flags: {
+          state: $ngRedux.getState().toJS(),
+          attributes: scope.attributes,
+          skin: currentSkin(),
+        },
+      });
+
+      const disconnectState = $ngRedux.connect(state => ({ state: state }))(
+        ({ state }) =>
+          window.requestAnimationFrame(() => {
+            elmApp.ports.inPort.send({
+              newState: state.toJS(),
+              newSkin: currentSkin(),
+            });
+          })
+      );
+
+      scope.$watch("attributes", attributes => {
+        elmApp.ports.inPort.send({
+          newAttributes: attributes,
+        });
+      });
+
+      if (elmApp.ports.outPort) {
+        elmApp.ports.outPort.subscribe(({ action, payload }) => {
+          if (actionCreators[action]) {
+            $ngRedux.dispatch(actionCreators[action](payload));
+          } else {
+            scope.onAction({ action, payload });
+          }
+        });
+      }
+
+      elmApp.ports.errorPort.subscribe(error => {
+        console.error(error);
+      });
+
+      scope.$on("destroy", () => {
+        disconnectState();
+        if (elmApp.ports.outPort) {
+          elmApp.ports.outPort.unsubscribe();
+        }
+        elmApp.ports.errorPort.unsubscribe();
+      });
+    },
+  };
+}
+
+genComponentConf.$inject = ["$ngRedux"];
+
+export default angular
+  .module("won.owner.components.elm", [])
+  .directive("wonElm", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -22,9 +22,11 @@ import { getConnectionUriFromRoute } from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import ngAnimate from "angular-animate";
+import { Elm } from "../../elm/EditNeed.elm";
 
 import "style/_post-content.scss";
 import "style/_rdflink.scss";
+import elmModule from "./elm.js";
 
 const CONNECTION_READ_TIMEOUT = 1500;
 
@@ -147,7 +149,7 @@ function genComponentConf() {
                 This Persona does not have any Needs.
             </div>
           </div>
-
+          <won-elm module="self.editNeedModule" attributes="self.post.get('uri')"></won-elm>
           <!-- RDF REPRESENTATION -->
           <div class="post-info__content__rdf" ng-if="self.isSelectedTab('RDF')">
             <a class="rdflink clickable"
@@ -181,6 +183,8 @@ function genComponentConf() {
       this.labels = labels;
 
       window.postcontent4dbg = this;
+
+      this.editNeedModule = Elm.EditNeed;
 
       const selectFromState = state => {
         const openConnectionUri = getConnectionUriFromRoute(state);
@@ -301,6 +305,14 @@ function genComponentConf() {
       }
     }
 
+    addPersona(persona) {
+      this.personas__connect(this.postUri, persona);
+    }
+
+    canAttachPersona() {
+      return this.post.get("isOwned") && !this.post.get("heldBy");
+    }
+
     toggleShowGeneral() {
       this.needs__toggleGeneralInfo(this.postUri);
     }
@@ -383,5 +395,6 @@ export default angular
     postHeaderModule,
     trigModule,
     inviewModule.name,
+    elmModule,
   ])
   .directive("wonPostContent", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm.json
@@ -4,7 +4,6 @@
   "elm-version": "0.19.0",
   "dependencies": {
     "direct": {
-      "Gizra/elm-all-set": "1.0.1",
       "NoRedInk/elm-json-decode-pipeline": "1.0.0",
       "avh4/elm-color": "1.0.0",
       "elm/browser": "1.0.1",
@@ -15,12 +14,12 @@
       "elm/regex": "1.0.0",
       "elm/time": "1.0.0",
       "elm/url": "1.0.0",
+      "elm-community/dict-extra": "2.4.0",
       "elm-community/json-extra": "4.0.0",
       "elm-community/result-extra": "2.2.1",
       "elm-community/string-extra": "3.0.0",
       "mdgriffith/elm-ui": "1.1.0",
       "noahzgordon/elm-color-extra": "1.0.1",
-      "pzp1997/assoc-list": "1.0.0",
       "rtfeldman/elm-validate": "4.0.1"
     },
     "indirect": {

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "direct": {
       "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+      "avh4/elm-color": "1.0.0",
       "elm/browser": "1.0.1",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",
@@ -18,8 +19,7 @@
       "elm-community/string-extra": "3.0.0",
       "mdgriffith/elm-ui": "1.1.0",
       "pzp1997/assoc-list": "1.0.0",
-      "rtfeldman/elm-validate": "4.0.1",
-      "tesk9/palette": "1.3.0"
+      "rtfeldman/elm-validate": "4.0.1"
     },
     "indirect": {
       "elm/bytes": "1.0.7",

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm.json
@@ -4,6 +4,7 @@
   "elm-version": "0.19.0",
   "dependencies": {
     "direct": {
+      "Gizra/elm-all-set": "1.0.1",
       "NoRedInk/elm-json-decode-pipeline": "1.0.0",
       "avh4/elm-color": "1.0.0",
       "elm/browser": "1.0.1",
@@ -18,6 +19,7 @@
       "elm-community/result-extra": "2.2.1",
       "elm-community/string-extra": "3.0.0",
       "mdgriffith/elm-ui": "1.1.0",
+      "noahzgordon/elm-color-extra": "1.0.1",
       "pzp1997/assoc-list": "1.0.0",
       "rtfeldman/elm-validate": "4.0.1"
     },
@@ -25,7 +27,10 @@
       "elm/bytes": "1.0.7",
       "elm/file": "1.0.1",
       "elm/parser": "1.1.0",
+      "elm/random": "1.0.0",
       "elm/virtual-dom": "1.0.2",
+      "elm-explorations/test": "1.2.1",
+      "fredcy/elm-parseint": "2.0.1",
       "rtfeldman/elm-iso8601-date-strings": "1.1.2"
     }
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm.json
@@ -4,6 +4,7 @@
   "elm-version": "0.19.0",
   "dependencies": {
     "direct": {
+      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
       "elm/browser": "1.0.1",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",
@@ -13,9 +14,12 @@
       "elm/time": "1.0.0",
       "elm/url": "1.0.0",
       "elm-community/json-extra": "4.0.0",
+      "elm-community/result-extra": "2.2.1",
       "elm-community/string-extra": "3.0.0",
       "mdgriffith/elm-ui": "1.1.0",
-      "rtfeldman/elm-validate": "4.0.1"
+      "pzp1997/assoc-list": "1.0.0",
+      "rtfeldman/elm-validate": "4.0.1",
+      "tesk9/palette": "1.3.0"
     },
     "indirect": {
       "elm/bytes": "1.0.7",

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
@@ -1,0 +1,23 @@
+port module Actions exposing (connectPersona)
+
+import Json.Encode as Encode exposing (Value)
+import Url exposing (Url)
+
+
+port outPort : { action : String, payload : Value } -> Cmd msg
+
+
+connectPersona :
+    { personaUrl : Url
+    , needUrl : Url
+    }
+    -> Cmd msg
+connectPersona { personaUrl, needUrl } =
+    outPort
+        { action = "personas__connect"
+        , payload =
+            Encode.list Encode.string
+                [ Url.toString needUrl
+                , Url.toString personaUrl
+                ]
+        }

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
@@ -1,15 +1,15 @@
 port module Actions exposing (connectPersona)
 
+import Application exposing (Id)
 import Json.Encode as Encode exposing (Value)
-import Url exposing (Url)
 
 
 port outPort : { action : String, payload : Value } -> Cmd msg
 
 
 connectPersona :
-    { personaUrl : Url
-    , needUrl : Url
+    { personaUrl : Id
+    , needUrl : Id
     }
     -> Cmd msg
 connectPersona { personaUrl, needUrl } =
@@ -17,7 +17,7 @@ connectPersona { personaUrl, needUrl } =
         { action = "personas__connect"
         , payload =
             Encode.list Encode.string
-                [ Url.toString needUrl
-                , Url.toString personaUrl
+                [ needUrl
+                , personaUrl
                 ]
         }

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Actions.elm
@@ -1,4 +1,7 @@
-port module Actions exposing (connectPersona)
+port module Actions exposing
+    ( connectPersona
+    , disconnectPersona
+    )
 
 import Application exposing (Id)
 import Json.Encode as Encode exposing (Value)
@@ -15,6 +18,22 @@ connectPersona :
 connectPersona { personaUrl, needUrl } =
     outPort
         { action = "personas__connect"
+        , payload =
+            Encode.list Encode.string
+                [ needUrl
+                , personaUrl
+                ]
+        }
+
+
+disconnectPersona :
+    { personaUrl : Id
+    , needUrl : Id
+    }
+    -> Cmd msg
+disconnectPersona { personaUrl, needUrl } =
+    outPort
+        { action = "personas__disconnect"
         , payload =
             Encode.list Encode.string
                 [ needUrl

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Application.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Application.elm
@@ -248,8 +248,17 @@ ownedDecoder =
                 |> Decode.fromResult
 
         decodeIsOwned =
-            Decode.maybe <|
-                Decode.field "isOwned" (Decode.succeed ())
+            Decode.field "isOwned" Decode.bool
+                |> Decode.maybe
+                |> Decode.map
+                    (\isOwned ->
+                        case isOwned of
+                            Just True ->
+                                Just ()
+
+                            _ ->
+                                Nothing
+                    )
 
         convertToUrls ( url, isOwned ) =
             case isOwned of

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/AssocList/Extra.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/AssocList/Extra.elm
@@ -1,0 +1,18 @@
+module AssocList.Extra exposing (filterMap)
+
+import AssocList exposing (Dict)
+
+
+filterMap : (key -> value1 -> Maybe value2) -> Dict key value1 -> Dict key value2
+filterMap filter dict =
+    AssocList.foldl
+        (\key value state ->
+            case filter key value of
+                Just newValue ->
+                    AssocList.insert key newValue state
+
+                Nothing ->
+                    state
+        )
+        AssocList.empty
+        dict

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
@@ -1,0 +1,60 @@
+module EditNeed exposing (main)
+
+import Application exposing (State)
+import Browser
+import Element.Styled as Element exposing (Element, none)
+import Json.Decode as JD exposing (Value)
+import Palette exposing (..)
+
+
+type alias Attributes =
+    String
+
+
+type alias Model =
+    {}
+
+
+type Msg
+    = Msg
+
+
+init : Attributes -> State -> ( Model, Cmd Msg )
+init attrs state =
+    let
+        log =
+            Debug.log "state" state
+    in
+    ( {}, Cmd.none )
+
+
+update : Attributes -> State -> Msg -> Model -> ( Model, Cmd Msg )
+update attrs state msg model =
+    ( model, Cmd.none )
+
+
+view : Attributes -> State -> Model -> Element Msg
+view _ _ _ =
+    dropdownButton
+        { direction = DropDown
+        , label = "Add Persona"
+        , menu = none
+        , open = False
+        , toggleMsg = Msg
+        , onPress = Nothing
+        }
+
+
+attributeParser : JD.Decoder Attributes
+attributeParser =
+    JD.string
+
+
+main =
+    Application.element
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = \_ _ _ -> Sub.none
+        , attributeParser = attributeParser
+        }

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
@@ -3,16 +3,17 @@ module EditNeed exposing (main)
 import Actions
 import Application
     exposing
-        ( Need(..)
+        ( Id
+        , Need(..)
         , NeedData
         , NeedStorage(..)
         , Persona
         , State
         , ownedNeeds
         )
-import AssocList as Dict exposing (Dict)
-import AssocList.Extra as Dict
 import Browser
+import Dict exposing (Dict)
+import Dict.Extra as Dict
 import Element.Input.Styled as Input
 import Element.Styled as Element exposing (Element, fill, none)
 import Json.Decode as JD exposing (Value)
@@ -22,7 +23,7 @@ import Url exposing (Url)
 
 
 type alias ActiveUrl =
-    Url
+    Id
 
 
 type alias Model =
@@ -32,11 +33,11 @@ type alias Model =
 
 type Msg
     = ToggleDropdown
-    | SelectPersona Url
+    | SelectPersona Id
     | RemovePersona
 
 
-getNeed : State -> Url -> Maybe Need
+getNeed : State -> Id -> Maybe Need
 getNeed state url =
     case Dict.get url state.needs of
         Just (Loaded needData) ->
@@ -66,7 +67,7 @@ hasPersona state activeNeed =
         |> Maybe.withDefault False
 
 
-getOwnedPersonas : State -> Dict Url Persona
+getOwnedPersonas : State -> Dict Id Persona
 getOwnedPersonas state =
     let
         filter url needStorage =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
@@ -168,7 +168,11 @@ view activeUrl state model =
                                     (\url persona ->
                                         Input.button [ Element.width fill ]
                                             { onPress = Just (SelectPersona url)
-                                            , label = Element.text <| NonEmpty.get persona.name
+                                            , label =
+                                                Element.row [ Element.spacing 3 ]
+                                                    [ identicon 3 url
+                                                    , Element.text <| NonEmpty.get persona.name
+                                                    ]
                                             }
                                     )
                                 |> Dict.values

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/EditNeed.elm
@@ -1,53 +1,172 @@
 module EditNeed exposing (main)
 
-import Application exposing (State)
+import Actions
+import Application
+    exposing
+        ( Need(..)
+        , NeedData
+        , NeedStorage(..)
+        , Persona
+        , State
+        , ownedNeeds
+        )
+import AssocList as Dict exposing (Dict)
+import AssocList.Extra as Dict
 import Browser
-import Element.Styled as Element exposing (Element, none)
+import Element.Input.Styled as Input
+import Element.Styled as Element exposing (Element, fill, none)
 import Json.Decode as JD exposing (Value)
+import NonEmpty
 import Palette exposing (..)
+import Url exposing (Url)
 
 
-type alias Attributes =
-    String
+type alias ActiveUrl =
+    Url
 
 
 type alias Model =
-    {}
+    { dropdownOpen : Bool
+    }
 
 
 type Msg
-    = Msg
+    = ToggleDropdown
+    | SelectPersona Url
+    | RemovePersona
 
 
-init : Attributes -> State -> ( Model, Cmd Msg )
-init attrs state =
+getNeed : State -> Url -> Maybe Need
+getNeed state url =
+    case Dict.get url state.needs of
+        Just (Loaded needData) ->
+            Just needData.need
+
+        _ ->
+            Nothing
+
+
+hasPersona : State -> ActiveUrl -> Bool
+hasPersona state activeNeed =
+    getNeed state activeNeed
+        |> Maybe.map
+            (\need ->
+                case Debug.log "need" need of
+                    Other { holder } ->
+                        case holder of
+                            Just _ ->
+                                True
+
+                            Nothing ->
+                                False
+
+                    _ ->
+                        False
+            )
+        |> Maybe.withDefault False
+
+
+getOwnedPersonas : State -> Dict Url Persona
+getOwnedPersonas state =
     let
-        log =
+        filter url needStorage =
+            case needStorage of
+                Loaded { need } ->
+                    case need of
+                        PersonaNeed persona ->
+                            Just persona
+
+                        _ ->
+                            Nothing
+
+                _ ->
+                    Nothing
+    in
+    ownedNeeds state
+        |> Dict.filterMap filter
+
+
+init : ActiveUrl -> State -> ( Model, Cmd Msg )
+init attrs state =
+    ( { dropdownOpen = False
+      }
+    , Cmd.none
+    )
+
+
+update : ActiveUrl -> State -> Msg -> Model -> ( Model, Cmd Msg )
+update activeUrl state msg model =
+    let
+        dbg =
             Debug.log "state" state
     in
-    ( {}, Cmd.none )
+    case msg of
+        ToggleDropdown ->
+            ( { model
+                | dropdownOpen = not model.dropdownOpen
+              }
+            , Cmd.none
+            )
+
+        SelectPersona personaUrl ->
+            ( { model
+                | dropdownOpen = False
+              }
+            , Actions.connectPersona
+                { personaUrl = personaUrl
+                , needUrl = activeUrl
+                }
+            )
+
+        RemovePersona ->
+            ( model, Cmd.none )
 
 
-update : Attributes -> State -> Msg -> Model -> ( Model, Cmd Msg )
-update attrs state msg model =
-    ( model, Cmd.none )
+view : ActiveUrl -> State -> Model -> Element Msg
+view activeUrl state model =
+    let
+        dbg =
+            Debug.log "viewstate" state
+    in
+    if hasPersona state activeUrl then
+        button
+            { label = "Remove Persona"
+            , onPress = Just RemovePersona
+            }
+
+    else
+        dropdown
+            { direction = DropUp
+            , label = "Add Persona"
+            , menu =
+                if model.dropdownOpen then
+                    Just <|
+                        Element.column [ Element.width fill ]
+                            (getOwnedPersonas state
+                                |> Dict.map
+                                    (\url persona ->
+                                        Input.button [ Element.width fill ]
+                                            { onPress = Just (SelectPersona url)
+                                            , label = Element.text <| NonEmpty.get persona.name
+                                            }
+                                    )
+                                |> Dict.values
+                            )
+
+                else
+                    Nothing
+            , onToggle =
+                if Dict.isEmpty (getOwnedPersonas state) then
+                    Nothing
+
+                else
+                    Just ToggleDropdown
+            }
 
 
-view : Attributes -> State -> Model -> Element Msg
-view _ _ _ =
-    dropdownButton
-        { direction = DropDown
-        , label = "Add Persona"
-        , menu = none
-        , open = False
-        , toggleMsg = Msg
-        , onPress = Nothing
-        }
-
-
-attributeParser : JD.Decoder Attributes
+attributeParser : JD.Decoder ActiveUrl
 attributeParser =
-    JD.string
+    Application.urlDecoder
 
 
 main =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Background/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Background/Styled.elm
@@ -1,9 +1,15 @@
 module Element.Background.Styled exposing (color)
 
+import Color exposing (Color)
+import Element
 import Element.Background as Background
 import Element.Styled as Element exposing (..)
 
 
 color : Color -> Attr decorative msg
 color col =
-    pureAttr <| Background.color col
+    let
+        elmUiColor =
+            Color.toRgba col |> Element.fromRgb
+    in
+    pureAttr <| Background.color elmUiColor

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Background/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Background/Styled.elm
@@ -1,0 +1,9 @@
+module Element.Background.Styled exposing (color)
+
+import Element.Background as Background
+import Element.Styled as Element exposing (..)
+
+
+color : Color -> Attr decorative msg
+color col =
+    pureAttr <| Background.color col

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Border/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Border/Styled.elm
@@ -1,10 +1,15 @@
 module Element.Border.Styled exposing
-    ( roundEach
+    ( color
+    , roundEach
     , rounded
+    , shadow
+    , width
     )
 
+import Color exposing (Color)
+import Element
 import Element.Border as Border
-import Element.Styled as Element exposing (Attribute, pureAttr)
+import Element.Styled as Element exposing (Attr, Attribute, pureAttr)
 
 
 roundEach :
@@ -21,3 +26,38 @@ roundEach corners =
 rounded : Int -> Attribute msg
 rounded radius =
     pureAttr <| Border.rounded radius
+
+
+color : Color -> Attribute msg
+color col =
+    let
+        elmUiColor =
+            Color.toRgba col |> Element.fromRgb
+    in
+    pureAttr <| Border.color elmUiColor
+
+
+width : Int -> Attribute msg
+width w =
+    pureAttr <| Border.width w
+
+
+shadow :
+    { offset : ( Float, Float )
+    , size : Float
+    , blur : Float
+    , color : Color
+    }
+    -> Attr decorative msg
+shadow opts =
+    let
+        elmUiColor =
+            Color.toRgba opts.color |> Element.fromRgb
+    in
+    pureAttr <|
+        Border.shadow
+            { offset = opts.offset
+            , size = opts.size
+            , blur = opts.blur
+            , color = elmUiColor
+            }

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Border/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Border/Styled.elm
@@ -1,0 +1,23 @@
+module Element.Border.Styled exposing
+    ( roundEach
+    , rounded
+    )
+
+import Element.Border as Border
+import Element.Styled as Element exposing (Attribute, pureAttr)
+
+
+roundEach :
+    { topLeft : Int
+    , topRight : Int
+    , bottomLeft : Int
+    , bottomRight : Int
+    }
+    -> Attribute msg
+roundEach corners =
+    pureAttr <| Border.roundEach corners
+
+
+rounded : Int -> Attribute msg
+rounded radius =
+    pureAttr <| Border.rounded radius

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Font/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Font/Styled.elm
@@ -4,6 +4,8 @@ module Element.Font.Styled exposing
     , size
     )
 
+import Color exposing (Color)
+import Element
 import Element.Font as Font
 import Element.Styled exposing (..)
 
@@ -15,7 +17,11 @@ size len =
 
 color : Color -> Attr decorative msg
 color col =
-    pureAttr <| Font.color col
+    let
+        elmUiColors =
+            Color.toRgba col |> Element.fromRgb
+    in
+    pureAttr <| Font.color elmUiColors
 
 
 center : Attribute msg

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Font/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Font/Styled.elm
@@ -1,0 +1,23 @@
+module Element.Font.Styled exposing
+    ( center
+    , color
+    , size
+    )
+
+import Element.Font as Font
+import Element.Styled exposing (..)
+
+
+size : Int -> Attr decorative msg
+size len =
+    pureAttr <| Font.size len
+
+
+color : Color -> Attr decorative msg
+color col =
+    pureAttr <| Font.color col
+
+
+center : Attribute msg
+center =
+    pureAttr Font.center

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Input/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Input/Styled.elm
@@ -1,0 +1,23 @@
+module Element.Input.Styled exposing (button)
+
+import Element.Input as Input
+import Element.Styled as Element exposing (..)
+
+
+button :
+    List (Attribute msg)
+    ->
+        { onPress : Maybe msg
+        , label : Element msg
+        }
+    -> Element msg
+button attrs opts =
+    (\_ label a ->
+        Input.button a
+            { label = label
+            , onPress = opts.onPress
+            }
+    )
+        |> getElement opts.label
+        |> getAttrList attrs
+        |> element

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Styled.elm
@@ -2,23 +2,34 @@ module Element.Styled exposing
     ( Attr
     , Attribute
     , Element
+    , Length
     , Style
     , above
+    , alignRight
     , below
+    , centerX
     , column
     , el
     , element
     , fill
+    , focused
     , getAttrList
     , getElement
     , height
+    , html
     , layout
+    , layoutWith
     , modular
+    , mouseOver
+    , moveDown
+    , moveUp
+    , noStaticStyleSheet
     , none
     , padding
     , pureAttr
     , px
     , row
+    , shrink
     , spacing
     , styleDecoder
     , text
@@ -34,8 +45,11 @@ import Json.Decode as Decode exposing (Decoder)
 
 type alias Style =
     { primary : Color
-    , secondary : Color
     }
+
+
+type alias Option =
+    Element.Option
 
 
 colorDecoder : Decoder Color
@@ -48,9 +62,8 @@ colorDecoder =
 
 styleDecoder : Decoder Style
 styleDecoder =
-    Decode.map2 Style
+    Decode.map Style
         (Decode.field "primaryColor" colorDecoder)
-        (Decode.field "secondaryColor" colorDecoder)
 
 
 type Element msg
@@ -65,6 +78,16 @@ type Attr decorative msg
     = Attr (Style -> Element.Attr decorative msg)
 
 
+centerX : Attribute msg
+centerX =
+    pureAttr Element.centerX
+
+
+alignRight : Attribute msg
+alignRight =
+    pureAttr Element.alignRight
+
+
 type alias Length =
     Element.Length
 
@@ -72,6 +95,11 @@ type alias Length =
 fill : Length
 fill =
     Element.fill
+
+
+shrink : Length
+shrink =
+    Element.shrink
 
 
 px : Int -> Length
@@ -128,6 +156,27 @@ layout style attrs elem =
         (applyEl style elem)
 
 
+layoutWith :
+    { options : List Option }
+    -> Style
+    -> List (Attribute msg)
+    -> Element msg
+    -> Html msg
+layoutWith opts style attrs elem =
+    Element.layoutWith
+        opts
+        (List.map
+            (applyAttr style)
+            attrs
+        )
+        (applyEl style elem)
+
+
+noStaticStyleSheet : Option
+noStaticStyleSheet =
+    Element.noStaticStyleSheet
+
+
 withStyle : (Style -> Element msg) -> Element msg
 withStyle elemFn =
     Element <|
@@ -137,6 +186,26 @@ withStyle elemFn =
                     elemFn style
             in
             fn style
+
+
+type alias Decoration =
+    Attr Never Never
+
+
+focused : List Decoration -> Attribute msg
+focused attrs =
+    Attr <|
+        \style ->
+            Element.focused
+                (List.map (applyAttr style) attrs)
+
+
+mouseOver : List Decoration -> Attribute msg
+mouseOver attrs =
+    Attr <|
+        \style ->
+            Element.mouseOver
+                (List.map (applyAttr style) attrs)
 
 
 row : List (Attribute msg) -> List (Element msg) -> Element msg
@@ -215,3 +284,18 @@ getAttrList attrs fn style =
 none : Element msg
 none =
     Element (\_ -> Element.none)
+
+
+html : Html msg -> Element msg
+html elem =
+    Element <| \_ -> Element.html elem
+
+
+moveDown : Float -> Attribute msg
+moveDown len =
+    pureAttr <| Element.moveDown len
+
+
+moveUp : Float -> Attribute msg
+moveUp len =
+    pureAttr <| Element.moveUp len

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Styled.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Element/Styled.elm
@@ -1,0 +1,198 @@
+module Element.Styled exposing
+    ( Attr
+    , Attribute
+    , Color
+    , Element
+    , above
+    , below
+    , column
+    , el
+    , element
+    , fill
+    , getAttrList
+    , getElement
+    , height
+    , layout
+    , modular
+    , none
+    , padding
+    , pureAttr
+    , px
+    , row
+    , spacing
+    , text
+    , width
+    , withSkin
+    )
+
+import Element
+import Html exposing (Html)
+import Skin exposing (Skin)
+
+
+type Element msg
+    = Element (Skin -> Element.Element msg)
+
+
+type alias Attribute msg =
+    Attr () msg
+
+
+type Attr decorative msg
+    = Attr (Skin -> Element.Attr decorative msg)
+
+
+type alias Color =
+    Element.Color
+
+
+type alias Length =
+    Element.Length
+
+
+fill : Length
+fill =
+    Element.fill
+
+
+px : Int -> Length
+px len =
+    Element.px len
+
+
+width : Length -> Attribute msg
+width len =
+    pureAttr <| Element.width len
+
+
+height : Length -> Attribute msg
+height len =
+    pureAttr <| Element.height len
+
+
+padding : Int -> Attribute msg
+padding len =
+    pureAttr <| Element.padding len
+
+
+spacing : Int -> Attribute msg
+spacing len =
+    pureAttr <| Element.spacing len
+
+
+text : String -> Element msg
+text str =
+    Element <|
+        \_ -> Element.text str
+
+
+applyAttr skin (Attr fn) =
+    fn skin
+
+
+applyEl skin (Element fn) =
+    fn skin
+
+
+modular : Float -> Float -> Int -> Float
+modular =
+    Element.modular
+
+
+layout : Skin -> List (Attribute msg) -> Element msg -> Html msg
+layout skin attrs elem =
+    Element.layout
+        (List.map
+            (applyAttr skin)
+            attrs
+        )
+        (applyEl skin elem)
+
+
+withSkin : (Skin -> Element msg) -> Element msg
+withSkin elemFn =
+    Element <|
+        \skin ->
+            let
+                (Element fn) =
+                    elemFn skin
+            in
+            fn skin
+
+
+row : List (Attribute msg) -> List (Element msg) -> Element msg
+row attrs elements =
+    Element <|
+        \skin ->
+            Element.row
+                (List.map (applyAttr skin) attrs)
+                (List.map (applyEl skin) elements)
+
+
+column : List (Attribute msg) -> List (Element msg) -> Element msg
+column attrs elements =
+    Element <|
+        \skin ->
+            Element.column
+                (List.map (applyAttr skin) attrs)
+                (List.map (applyEl skin) elements)
+
+
+above : Element msg -> Attribute msg
+above elem =
+    Attr
+        (\skin ->
+            Element.above <|
+                applyEl skin elem
+        )
+
+
+below : Element msg -> Attribute msg
+below elem =
+    Attr
+        (\skin ->
+            Element.below <|
+                applyEl skin elem
+        )
+
+
+el : List (Attribute msg) -> Element msg -> Element msg
+el attrs elem =
+    Element <|
+        \skin ->
+            Element.el
+                (List.map (applyAttr skin) attrs)
+                (applyEl skin elem)
+
+
+pureAttr : Element.Attr decorative msg -> Attr decorative msg
+pureAttr attr =
+    Attr (\_ -> attr)
+
+
+element : (Skin -> Element.Element msg) -> Element msg
+element fn =
+    Element fn
+
+
+getElement :
+    Element msg
+    -> (Skin -> Element.Element msg -> b)
+    -> Skin
+    -> b
+getElement elem fn skin =
+    fn skin (applyEl skin elem)
+
+
+getAttrList :
+    List (Attr decorative msg)
+    -> (Skin -> List (Element.Attr decorative msg) -> b)
+    -> Skin
+    -> b
+getAttrList attrs fn skin =
+    fn skin (List.map (applyAttr skin) attrs)
+
+
+none : Element msg
+none =
+    Element (\_ -> Element.none)

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Elements.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Elements.elm
@@ -14,7 +14,7 @@ import Element.Font as Font
 import Element.Input as Input
 import Html exposing (node)
 import Html.Attributes as HA
-import Skin exposing (Skin)
+import Old.Skin as Skin exposing (Skin)
 
 
 type alias Button msg =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Icons.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Icons.elm
@@ -1,0 +1,54 @@
+module Icons exposing
+    ( arrowDown
+    , arrowUp
+    )
+
+import Color exposing (Color)
+import Element.Styled as Element exposing (..)
+import Html
+import Html.Attributes as HA
+
+
+arrowDown =
+    svgIcon "ico16_arrow_down"
+
+
+arrowUp =
+    svgIcon "ico16_arrow_up"
+
+
+svgIcon : String -> Color -> Element msg
+svgIcon name color =
+    el
+        [ width fill
+        , height fill
+        ]
+    <|
+        html <|
+            Html.node "won-svg-icon"
+                [ HA.attribute "icon" name
+                , HA.attribute "color" (Color.toCssString color)
+                , HA.style "width" "100%"
+                , HA.style "height" "100%"
+                ]
+                []
+
+
+
+-- svgIcon :
+--     List (Attribute msg)
+--     ->
+--         { color : Color
+--         , name : String
+--         }
+--     -> Element msg
+-- svgIcon attributes { color, name } =
+--     el attributes <|
+--         html <|
+--             Html.node "won-svg-icon"
+--                 [ HA.attribute "icon" name
+--                 , HA.attribute "color" (Skin.cssColor color)
+--                 , HA.style "width" "100%"
+--                 , HA.style "height" "100%"
+--                 ]
+--                 []

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Old/Persona.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Old/Persona.elm
@@ -1,4 +1,4 @@
-port module Persona exposing
+port module Old.Persona exposing
     ( Persona
     , PersonaData
     , SaveState(..)

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Old/Skin.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Old/Skin.elm
@@ -1,4 +1,4 @@
-port module Skin exposing
+port module Old.Skin exposing
     ( Skin
     , SkinFlags
     , black

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
@@ -1,0 +1,148 @@
+module Palette exposing
+    ( DropdownDirection(..)
+    , dropdownButton
+    )
+
+import Element.Background.Styled as Background
+import Element.Border.Styled as Border
+import Element.Font.Styled as Font
+import Element.Input.Styled as Input
+import Element.Styled exposing (..)
+import Skin
+
+
+type DropdownDirection
+    = DropDown
+    | DropUp
+
+
+scaled =
+    modular 16 1.25
+
+
+buttonRadius =
+    3
+
+
+type ButtonRole
+    = Primary
+    | Secondary
+
+
+type alias Button msg =
+    { role : ButtonRole
+    , enabled : Bool
+    , onPress : msg
+    , label : Element msg
+    }
+
+
+rawButton :
+    { left : Bool
+    , right : Bool
+    }
+    -> Button msg
+    -> Element msg
+rawButton { left, right } { role, enabled, onPress, label } =
+    let
+        enabledRadius hasRadius =
+            if hasRadius then
+                buttonRadius
+
+            else
+                0
+
+        radius =
+            { topLeft = enabledRadius left
+            , bottomLeft = enabledRadius left
+            , topRight = enabledRadius right
+            , bottomRight = enabledRadius right
+            }
+
+        col color =
+            if enabled then
+                color
+
+            else
+                color
+    in
+    withSkin <|
+        \skin ->
+            Debug.todo ""
+
+
+dropdownButton :
+    { direction : DropdownDirection
+    , menu : Element msg
+    , label : String
+    , open : Bool
+    , onPress : Maybe msg
+    , toggleMsg : msg
+    }
+    -> Element msg
+dropdownButton { direction, menu, label, open, toggleMsg, onPress } =
+    let
+        dropattr =
+            case direction of
+                DropDown ->
+                    below
+
+                DropUp ->
+                    above
+
+        defaultAttrs =
+            [ width fill
+            , spacing 3
+            ]
+
+        attrs =
+            defaultAttrs
+                ++ (if open then
+                        [ dropattr menu ]
+
+                    else
+                        []
+                   )
+    in
+    withSkin
+        (\skin ->
+            row
+                attrs
+                [ Input.button
+                    [ Background.color skin.primaryColor
+                    , Border.roundEach
+                        { topLeft = 5
+                        , bottomLeft = 5
+                        , topRight = 0
+                        , bottomRight = 0
+                        }
+                    , width fill
+                    ]
+                    { label =
+                        el
+                            [ padding <| round <| scaled 1 / 2
+                            , width fill
+                            , Font.size <|
+                                round <|
+                                    scaled 1
+                            , Font.color Skin.white
+                            , Font.center
+                            ]
+                        <|
+                            text label
+                    , onPress = onPress
+                    }
+                , Input.button
+                    [ Background.color skin.primaryColor
+                    , Border.roundEach
+                        { topLeft = 0
+                        , bottomLeft = 0
+                        , topRight = 5
+                        , bottomRight = 5
+                        }
+                    ]
+                    { label = none
+                    , onPress = Just toggleMsg
+                    }
+                ]
+        )

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
@@ -2,6 +2,7 @@ module Palette exposing
     ( DropdownDirection(..)
     , button
     , dropdown
+    , identicon
     )
 
 import Color
@@ -11,6 +12,8 @@ import Element.Border.Styled as Border
 import Element.Font.Styled as Font
 import Element.Input.Styled as Input
 import Element.Styled as Element exposing (..)
+import Html
+import Html.Attributes as HA
 import Icons
 
 
@@ -189,3 +192,19 @@ dropdown { direction, menu, label, onToggle } =
                             ]
                     , onPress = onToggle
                     }
+
+
+identicon : Int -> String -> Element msg
+identicon size string =
+    el
+        [ width <| px <| round <| scaled size
+        , height <| px <| round <| scaled size
+        ]
+    <|
+        html <|
+            Html.node "won-identicon"
+                [ HA.attribute "data" string
+                , HA.style "width" "100%"
+                , HA.style "height" "100%"
+                ]
+                []

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Palette.elm
@@ -3,12 +3,12 @@ module Palette exposing
     , dropdownButton
     )
 
+import Color
 import Element.Background.Styled as Background
 import Element.Border.Styled as Border
 import Element.Font.Styled as Font
 import Element.Input.Styled as Input
 import Element.Styled exposing (..)
-import Skin
 
 
 type DropdownDirection
@@ -66,8 +66,8 @@ rawButton { left, right } { role, enabled, onPress, label } =
             else
                 color
     in
-    withSkin <|
-        \skin ->
+    withStyle <|
+        \style ->
             Debug.todo ""
 
 
@@ -104,12 +104,12 @@ dropdownButton { direction, menu, label, open, toggleMsg, onPress } =
                         []
                    )
     in
-    withSkin
+    withStyle
         (\skin ->
             row
                 attrs
                 [ Input.button
-                    [ Background.color skin.primaryColor
+                    [ Background.color skin.primary
                     , Border.roundEach
                         { topLeft = 5
                         , bottomLeft = 5
@@ -125,7 +125,7 @@ dropdownButton { direction, menu, label, open, toggleMsg, onPress } =
                             , Font.size <|
                                 round <|
                                     scaled 1
-                            , Font.color Skin.white
+                            , Font.color Color.white
                             , Font.center
                             ]
                         <|
@@ -133,7 +133,7 @@ dropdownButton { direction, menu, label, open, toggleMsg, onPress } =
                     , onPress = onPress
                     }
                 , Input.button
-                    [ Background.color skin.primaryColor
+                    [ Background.color skin.primary
                     , Border.roundEach
                         { topLeft = 0
                         , bottomLeft = 0

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/PublishButton.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/PublishButton.elm
@@ -13,8 +13,8 @@ import Html exposing (Html)
 import Html.Attributes as HA
 import Json.Decode as Decode exposing (Value)
 import NonEmpty
-import Persona exposing (Persona, PersonaData, SaveState(..))
-import Skin exposing (Skin)
+import Old.Persona as Persona exposing (Persona, PersonaData, SaveState(..))
+import Old.Skin as Skin exposing (Skin)
 import Time exposing (Posix)
 import Url exposing (Url)
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/RatingView.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/RatingView.elm
@@ -8,7 +8,7 @@ import Element.Font as Font
 import Element.Input as Input
 import Html exposing (Html)
 import Html.Attributes as HA
-import Skin exposing (Skin)
+import Old.Skin as Skin exposing (Skin)
 
 
 main =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
@@ -77,13 +77,13 @@ init : { width : Int, height : Int } -> ( Model, Cmd Msg )
 init size =
     let
         ( model, cmd ) =
-            Account.init ()
+            Personas.init ()
     in
     ( { size = size
-      , page = Account model
+      , page = Personas model
       , menuOpen = True
       }
-    , Cmd.map AccountMsg cmd
+    , Cmd.map PersonasMsg cmd
     )
 
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
@@ -8,9 +8,9 @@ import Element.Font as Font
 import Element.Input as Input
 import Elements
 import Html exposing (Html)
+import Old.Skin as Skin exposing (Skin)
 import Settings.Account as Account
 import Settings.Personas as Personas
-import Skin exposing (Skin)
 
 
 main =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Account.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Account.elm
@@ -12,7 +12,7 @@ import Element.Font as Font
 import Element.Input as Input
 import Elements
 import Http
-import Skin exposing (Skin)
+import Old.Skin as Skin exposing (Skin)
 
 
 type alias Model =

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Personas.elm
@@ -20,9 +20,9 @@ import Html exposing (Html, node)
 import Html.Attributes as HA
 import Json.Decode as Decode exposing (Value)
 import NonEmpty
-import Persona exposing (Persona, PersonaData, SaveState(..))
+import Old.Persona as Persona exposing (Persona, PersonaData, SaveState(..))
+import Old.Skin as Skin exposing (Skin)
 import Regex
-import Skin exposing (Skin)
 import String.Extra as String
 import Time
 import Url

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Skin.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Skin.elm
@@ -1,9 +1,11 @@
 port module Skin exposing
     ( Skin
+    , SkinFlags
     , black
     , cssColor
     , decoder
     , default
+    , fromFlags
     , setAlpha
     , skinnedElement
     , white
@@ -79,16 +81,10 @@ setAlpha alpha color =
 
 colorDecoder : Decoder Color
 colorDecoder =
-    Decode.list Decode.int
-        |> Decode.andThen
-            (\channels ->
-                case channels of
-                    [ r, g, b ] ->
-                        Decode.succeed <| rgb255 r g b
-
-                    _ ->
-                        Decode.fail "Expected [r, g, b]"
-            )
+    Decode.map3 rgb255
+        (Decode.field "r" Decode.int)
+        (Decode.field "g" Decode.int)
+        (Decode.field "b" Decode.int)
 
 
 decoder : Decoder Skin

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/SubmitButton.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/SubmitButton.elm
@@ -109,7 +109,8 @@ view skin model =
                     }
                 ]
     in
-    layout
+    layoutWith
+        { options = [ noStaticStyleSheet ] }
         [ Font.size 16
         , width shrink
         ]

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/SubmitButton.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/SubmitButton.elm
@@ -13,8 +13,8 @@ import Html exposing (Html)
 import Html.Attributes as HA
 import Json.Decode as Decode exposing (Value)
 import NonEmpty
-import Persona exposing (Persona, PersonaData, SaveState(..))
-import Skin exposing (Skin)
+import Old.Persona as Persona exposing (Persona, PersonaData, SaveState(..))
+import Old.Skin as Skin exposing (Skin)
 import Time exposing (Posix)
 import Url exposing (Url)
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_elm-ui-shim.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_elm-ui-shim.scss
@@ -1,0 +1,1041 @@
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .s.r > .s {
+    flex-basis: auto !important;
+  }
+  .s.r > .s.ctr {
+    flex-basis: auto !important;
+  }
+}
+
+/* General Input Reset */
+input[type="range"] {
+  -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+  /* width: 100%;  Specific width is required for Firefox. */
+  background: transparent; /* Otherwise white in Chrome */
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 10;
+  width: 100%;
+  outline: dashed 1px;
+  height: 100%;
+  opacity: 0;
+}
+
+/* Hide all syling for track */
+input[type="range"]::-moz-range-track {
+  background: transparent;
+  cursor: pointer;
+}
+input[type="range"]::-ms-track {
+  background: transparent;
+  cursor: pointer;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  background: transparent;
+  cursor: pointer;
+}
+
+/* Thumbs */
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  opacity: 0.5;
+  width: 80px;
+  height: 80px;
+  background-color: black;
+  border: none;
+  border-radius: 5px;
+}
+input[type="range"]::-moz-range-thumb {
+  opacity: 0.5;
+  width: 80px;
+  height: 80px;
+  background-color: black;
+  border: none;
+  border-radius: 5px;
+}
+input[type="range"]::-ms-thumb {
+  opacity: 0.5;
+  width: 80px;
+  height: 80px;
+  background-color: black;
+  border: none;
+  border-radius: 5px;
+}
+input[type="range"][orient="vertical"] {
+  writing-mode: bt-lr; /* IE */
+  -webkit-appearance: slider-vertical; /* WebKit */
+}
+
+.explain {
+  border: 6px solid rgb(174, 121, 15) !important;
+}
+.explain > .s {
+  border: 4px dashed rgb(0, 151, 167) !important;
+}
+
+.ctr {
+  border: none !important;
+}
+.explain > .ctr > .s {
+  border: 4px dashed rgb(0, 151, 167) !important;
+}
+
+html,
+body {
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+.s.e.ic {
+  display: block;
+}
+.s:focus {
+  outline: none;
+}
+.ui {
+  width: 100%;
+  height: auto;
+  min-height: 100%;
+  z-index: 0;
+}
+.ui.s.hf {
+  height: 100%;
+}
+.ui.s.hf > .hf {
+  height: 100%;
+}
+.ui > .fr.nb {
+  position: fixed;
+}
+.nb {
+  position: relative;
+  border: none;
+  display: flex;
+  flex-direction: row;
+  flex-basis: auto;
+}
+.nb.e {
+  display: flex;
+  flex-direction: column;
+  white-space: pre;
+}
+.nb.e.hbh {
+  z-index: 0;
+}
+.nb.e.hbh > .bh {
+  z-index: -1;
+}
+.nb.e.sbt > .t.hf {
+  flex-grow: 0;
+}
+.nb.e.sbt > .t.wf {
+  align-self: auto !important;
+}
+.nb.e > .hc {
+  height: auto;
+}
+.nb.e > .hf {
+  flex-grow: 100000;
+}
+.nb.e > .wf {
+  width: 100%;
+}
+.nb.e > .wc {
+  align-self: flex-start;
+}
+.nb.e.ct {
+  justify-content: flex-start;
+}
+.nb.e > .s.at {
+  margin-bottom: auto !important;
+  margin-top: 0 !important;
+}
+.nb.e.cb {
+  justify-content: flex-end;
+}
+.nb.e > .s.ab {
+  margin-top: auto !important;
+  margin-bottom: 0 !important;
+}
+.nb.e.cr {
+  align-items: flex-end;
+}
+.nb.e > .s.ar {
+  align-self: flex-end;
+}
+.nb.e.cl {
+  align-items: flex-start;
+}
+.nb.e > .s.al {
+  align-self: flex-start;
+}
+.nb.e.ccx {
+  align-items: center;
+}
+.nb.e > .s.cx {
+  align-self: center;
+}
+.nb.e.ccy > .s {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+.nb.e > .s.cy {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+.nb.a {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+  margin: 0 !important;
+  pointer-events: none;
+}
+.nb.a > .hf {
+  height: auto;
+}
+.nb.a > .wf {
+  width: 100%;
+}
+.nb.a > * {
+  pointer-events: auto;
+}
+.nb.b {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 0;
+  width: 100%;
+  z-index: 20;
+  margin: 0 !important;
+  pointer-events: none;
+}
+.nb.b > * {
+  pointer-events: auto;
+}
+.nb.b > .hf {
+  height: auto;
+}
+.nb.or {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  height: 100%;
+  margin: 0 !important;
+  z-index: 20;
+  pointer-events: none;
+}
+.nb.or > * {
+  pointer-events: auto;
+}
+.nb.ol {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  height: 100%;
+  margin: 0 !important;
+  z-index: 20;
+  pointer-events: none;
+}
+.nb.ol > * {
+  pointer-events: auto;
+}
+.nb.fr {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  margin: 0 !important;
+  pointer-events: none;
+}
+.nb.fr > * {
+  pointer-events: auto;
+}
+.nb.bh {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  margin: 0 !important;
+  z-index: 0;
+  pointer-events: none;
+}
+.nb.bh > * {
+  pointer-events: auto;
+}
+.s {
+  position: relative;
+  border: none;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  flex-basis: auto;
+  resize: none;
+  font-feature-settings: inherit;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border-width: 0;
+  border-style: solid;
+  font-size: inherit;
+  color: inherit;
+  font-family: inherit;
+  line-height: 1;
+  font-weight: inherit;
+  text-decoration: none;
+  font-style: inherit;
+}
+.s.wrp {
+  flex-wrap: wrap;
+}
+.s.notxt {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.s.cptr {
+  cursor: pointer;
+}
+.s.ctxt {
+  cursor: text;
+}
+.s.ppe {
+  pointer-events: none !important;
+}
+.s.cpe {
+  pointer-events: auto !important;
+}
+.s.clr {
+  opacity: 0;
+}
+.s.oq {
+  opacity: 1;
+}
+.s.hvclr:hover {
+  opacity: 0;
+}
+.s.hvoq:hover {
+  opacity: 1;
+}
+.s.fcsclr:focus {
+  opacity: 0;
+}
+.s.fcsoq:focus {
+  opacity: 1;
+}
+.s.atvclr:active {
+  opacity: 0;
+}
+.s.atvoq:active {
+  opacity: 1;
+}
+.s.ts {
+  transition: transform 160ms, opacity 160ms, filter 160ms,
+    background-color 160ms, color 160ms, font-size 160ms;
+}
+.s.sb {
+  overflow: auto;
+  flex-shrink: 1;
+}
+.s.sbx {
+  overflow-x: auto;
+}
+.s.sbx.r {
+  flex-shrink: 1;
+}
+.s.sby {
+  overflow-y: auto;
+}
+.s.sby.c {
+  flex-shrink: 1;
+}
+.s.sby.e {
+  flex-shrink: 1;
+}
+.s.cp {
+  overflow: hidden;
+}
+.s.cpx {
+  overflow-x: hidden;
+}
+.s.cpy {
+  overflow-y: hidden;
+}
+.s.wc {
+  width: auto;
+}
+.s.bn {
+  border-width: 0;
+}
+.s.bd {
+  border-style: dashed;
+}
+.s.bdt {
+  border-style: dotted;
+}
+.s.bs {
+  border-style: solid;
+}
+.s.t {
+  white-space: pre;
+  display: inline-block;
+}
+.s.it {
+  line-height: 1.05;
+}
+.s.e {
+  display: flex;
+  flex-direction: column;
+  white-space: pre;
+}
+.s.e.hbh {
+  z-index: 0;
+}
+.s.e.hbh > .bh {
+  z-index: -1;
+}
+.s.e.sbt > .t.hf {
+  flex-grow: 0;
+}
+.s.e.sbt > .t.wf {
+  align-self: auto !important;
+}
+.s.e > .hc {
+  height: auto;
+}
+.s.e > .hf {
+  flex-grow: 100000;
+}
+.s.e > .wf {
+  width: 100%;
+}
+.s.e > .wc {
+  align-self: flex-start;
+}
+.s.e.ct {
+  justify-content: flex-start;
+}
+.s.e > .s.at {
+  margin-bottom: auto !important;
+  margin-top: 0 !important;
+}
+.s.e.cb {
+  justify-content: flex-end;
+}
+.s.e > .s.ab {
+  margin-top: auto !important;
+  margin-bottom: 0 !important;
+}
+.s.e.cr {
+  align-items: flex-end;
+}
+.s.e > .s.ar {
+  align-self: flex-end;
+}
+.s.e.cl {
+  align-items: flex-start;
+}
+.s.e > .s.al {
+  align-self: flex-start;
+}
+.s.e.ccx {
+  align-items: center;
+}
+.s.e > .s.cx {
+  align-self: center;
+}
+.s.e.ccy > .s {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+.s.e > .s.cy {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+.s.r {
+  display: flex;
+  flex-direction: row;
+}
+.s.r > .s {
+  flex-basis: 0%;
+}
+.s.r > .s.we {
+  flex-basis: auto;
+}
+.s.r > .hf {
+  align-self: stretch !important;
+}
+.s.r > .hfp {
+  align-self: stretch !important;
+}
+.s.r > .wf {
+  flex-grow: 100000;
+}
+.s.r > .ctr {
+  flex-grow: 0;
+  flex-basis: auto;
+  align-self: stretch;
+}
+.s.r > u:first-of-type.acr {
+  flex-grow: 1;
+}
+.s.r > s:first-of-type.accx {
+  flex-grow: 1;
+}
+.s.r > s:first-of-type.accx > .cx {
+  margin-left: auto !important;
+}
+.s.r > s:last-of-type.accx {
+  flex-grow: 1;
+}
+.s.r > s:last-of-type.accx > .cx {
+  margin-right: auto !important;
+}
+.s.r > s:only-of-type.accx {
+  flex-grow: 1;
+}
+.s.r > s:only-of-type.accx > .cy {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+.s.r > s:last-of-type.accx ~ u {
+  flex-grow: 0;
+}
+.s.r > u:first-of-type.acr ~ s.accx {
+  flex-grow: 0;
+}
+.s.r.ct {
+  align-items: flex-start;
+}
+.s.r > .s.at {
+  align-self: flex-start;
+}
+.s.r.cb {
+  align-items: flex-end;
+}
+.s.r > .s.ab {
+  align-self: flex-end;
+}
+.s.r.cr {
+  justify-content: flex-end;
+}
+.s.r.cl {
+  justify-content: flex-start;
+}
+.s.r.ccx {
+  justify-content: center;
+}
+.s.r.ccy {
+  align-items: center;
+}
+.s.r > .s.cy {
+  align-self: center;
+}
+.s.r.sev {
+  justify-content: space-between;
+}
+.s.c {
+  display: flex;
+  flex-direction: column;
+}
+.s.c > .hf {
+  flex-grow: 100000;
+}
+.s.c > .wf {
+  width: 100%;
+}
+.s.c > .wfp {
+  width: 100%;
+}
+.s.c > .wc {
+  align-self: flex-start;
+}
+.s.c > u:first-of-type.acb {
+  flex-grow: 1;
+}
+.s.c > s:first-of-type.accy {
+  flex-grow: 1;
+}
+.s.c > s:first-of-type.accy > .cy {
+  margin-top: auto !important;
+  margin-bottom: 0 !important;
+}
+.s.c > s:last-of-type.accy {
+  flex-grow: 1;
+}
+.s.c > s:last-of-type.accy > .cy {
+  margin-bottom: auto !important;
+  margin-top: 0 !important;
+}
+.s.c > s:only-of-type.accy {
+  flex-grow: 1;
+}
+.s.c > s:only-of-type.accy > .cy {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+.s.c > s:last-of-type.accy ~ u {
+  flex-grow: 0;
+}
+.s.c > u:first-of-type.acb ~ s.accy {
+  flex-grow: 0;
+}
+.s.c.ct {
+  justify-content: flex-start;
+}
+.s.c > .s.at {
+  margin-bottom: auto;
+}
+.s.c.cb {
+  justify-content: flex-end;
+}
+.s.c > .s.ab {
+  margin-top: auto;
+}
+.s.c.cr {
+  align-items: flex-end;
+}
+.s.c > .s.ar {
+  align-self: flex-end;
+}
+.s.c.cl {
+  align-items: flex-start;
+}
+.s.c > .s.al {
+  align-self: flex-start;
+}
+.s.c.ccx {
+  align-items: center;
+}
+.s.c > .s.cx {
+  align-self: center;
+}
+.s.c.ccy {
+  justify-content: center;
+}
+.s.c > .ctr {
+  flex-grow: 0;
+  flex-basis: auto;
+  width: 100%;
+  align-self: stretch !important;
+}
+.s.c.sev {
+  justify-content: space-between;
+}
+.s.g {
+  display: -ms-grid;
+}
+.s.g > .gp > .s {
+  width: 100%;
+}
+@supports (display: grid) {
+  .s.g {
+    display: grid;
+  }
+}
+.s.g > .s.at {
+  justify-content: flex-start;
+}
+.s.g > .s.ab {
+  justify-content: flex-end;
+}
+.s.g > .s.ar {
+  align-items: flex-end;
+}
+.s.g > .s.al {
+  align-items: flex-start;
+}
+.s.g > .s.cx {
+  align-items: center;
+}
+.s.g > .s.cy {
+  justify-content: center;
+}
+.s.pg {
+  display: block;
+}
+.s.pg > .s:first-child {
+  margin: 0 !important;
+}
+.s.pg > .s.al:first-child + .s {
+  margin: 0 !important;
+}
+.s.pg > .s.ar:first-child + .s {
+  margin: 0 !important;
+}
+.s.pg > .s.ar {
+  float: right;
+}
+.s.pg > .s.ar::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.s.pg > .s.al {
+  float: left;
+}
+.s.pg > .s.al::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.s.iml {
+  white-space: pre-wrap;
+}
+.s.p {
+  display: block;
+  white-space: normal;
+}
+.s.p.hbh {
+  z-index: 0;
+}
+.s.p.hbh > .bh {
+  z-index: -1;
+}
+.s.p > .t {
+  display: inline;
+  white-space: normal;
+}
+.s.p > .e {
+  display: inline;
+  white-space: normal;
+}
+.s.p > .e.fr {
+  display: flex;
+}
+.s.p > .e.bh {
+  display: flex;
+}
+.s.p > .e.a {
+  display: flex;
+}
+.s.p > .e.b {
+  display: flex;
+}
+.s.p > .e.or {
+  display: flex;
+}
+.s.p > .e.ol {
+  display: flex;
+}
+.s.p > .e > .t {
+  display: inline;
+  white-space: normal;
+}
+.s.p > .r {
+  display: inline-flex;
+}
+.s.p > .c {
+  display: inline-flex;
+}
+.s.p > .g {
+  display: inline-grid;
+}
+.s.p > .s.ar {
+  float: right;
+}
+.s.p > .s.al {
+  float: left;
+}
+.s.hidden {
+  display: none;
+}
+.s.w1 {
+  font-weight: 100;
+}
+.s.w2 {
+  font-weight: 200;
+}
+.s.w3 {
+  font-weight: 300;
+}
+.s.w4 {
+  font-weight: 400;
+}
+.s.w5 {
+  font-weight: 500;
+}
+.s.w6 {
+  font-weight: 600;
+}
+.s.w7 {
+  font-weight: 700;
+}
+.s.w8 {
+  font-weight: 800;
+}
+.s.w9 {
+  font-weight: 900;
+}
+.s.i {
+  font-style: italic;
+}
+.s.sk {
+  text-decoration: line-through;
+}
+.s.u {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+  text-decoration-skip: ink;
+}
+.s.u.sk {
+  text-decoration: line-through underline;
+  text-decoration-skip-ink: auto;
+  text-decoration-skip: ink;
+}
+.s.tun {
+  font-style: normal;
+}
+.s.tj {
+  text-align: justify;
+}
+.s.tja {
+  text-align: justify-all;
+}
+.s.tc {
+  text-align: center;
+}
+.s.tr {
+  text-align: right;
+}
+.s.tl {
+  text-align: left;
+}
+.s.modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.border-0 {
+  border-width: 0px;
+}
+.border-1 {
+  border-width: 1px;
+}
+.border-2 {
+  border-width: 2px;
+}
+.border-3 {
+  border-width: 3px;
+}
+.border-4 {
+  border-width: 4px;
+}
+.border-5 {
+  border-width: 5px;
+}
+.border-6 {
+  border-width: 6px;
+}
+.font-size-8 {
+  font-size: 8px;
+}
+.font-size-9 {
+  font-size: 9px;
+}
+.font-size-10 {
+  font-size: 10px;
+}
+.font-size-11 {
+  font-size: 11px;
+}
+.font-size-12 {
+  font-size: 12px;
+}
+.font-size-13 {
+  font-size: 13px;
+}
+.font-size-14 {
+  font-size: 14px;
+}
+.font-size-15 {
+  font-size: 15px;
+}
+.font-size-16 {
+  font-size: 16px;
+}
+.font-size-17 {
+  font-size: 17px;
+}
+.font-size-18 {
+  font-size: 18px;
+}
+.font-size-19 {
+  font-size: 19px;
+}
+.font-size-20 {
+  font-size: 20px;
+}
+.font-size-21 {
+  font-size: 21px;
+}
+.font-size-22 {
+  font-size: 22px;
+}
+.font-size-23 {
+  font-size: 23px;
+}
+.font-size-24 {
+  font-size: 24px;
+}
+.font-size-25 {
+  font-size: 25px;
+}
+.font-size-26 {
+  font-size: 26px;
+}
+.font-size-27 {
+  font-size: 27px;
+}
+.font-size-28 {
+  font-size: 28px;
+}
+.font-size-29 {
+  font-size: 29px;
+}
+.font-size-30 {
+  font-size: 30px;
+}
+.font-size-31 {
+  font-size: 31px;
+}
+.font-size-32 {
+  font-size: 32px;
+}
+.p-0 {
+  padding: 0px;
+}
+.p-1 {
+  padding: 1px;
+}
+.p-2 {
+  padding: 2px;
+}
+.p-3 {
+  padding: 3px;
+}
+.p-4 {
+  padding: 4px;
+}
+.p-5 {
+  padding: 5px;
+}
+.p-6 {
+  padding: 6px;
+}
+.p-7 {
+  padding: 7px;
+}
+.p-8 {
+  padding: 8px;
+}
+.p-9 {
+  padding: 9px;
+}
+.p-10 {
+  padding: 10px;
+}
+.p-11 {
+  padding: 11px;
+}
+.p-12 {
+  padding: 12px;
+}
+.p-13 {
+  padding: 13px;
+}
+.p-14 {
+  padding: 14px;
+}
+.p-15 {
+  padding: 15px;
+}
+.p-16 {
+  padding: 16px;
+}
+.p-17 {
+  padding: 17px;
+}
+.p-18 {
+  padding: 18px;
+}
+.p-19 {
+  padding: 19px;
+}
+.p-20 {
+  padding: 20px;
+}
+.p-21 {
+  padding: 21px;
+}
+.p-22 {
+  padding: 22px;
+}
+.p-23 {
+  padding: 23px;
+}
+.p-24 {
+  padding: 24px;
+}
+.v-smcp {
+  font-variant: small-caps;
+}
+.v-smcp-off {
+  font-variant: normal;
+}
+.v-zero {
+  font-feature-settings: "zero";
+}
+.v-zero-off {
+  font-feature-settings: "zero" 0;
+}
+.v-onum {
+  font-feature-settings: "onum";
+}
+.v-onum-off {
+  font-feature-settings: "onum" 0;
+}
+.v-liga {
+  font-feature-settings: "liga";
+}
+.v-liga-off {
+  font-feature-settings: "liga" 0;
+}
+.v-dlig {
+  font-feature-settings: "dlig";
+}
+.v-dlig-off {
+  font-feature-settings: "dlig" 0;
+}
+.v-ordn {
+  font-feature-settings: "ordn";
+}
+.v-ordn-off {
+  font-feature-settings: "ordn" 0;
+}
+.v-tnum {
+  font-feature-settings: "tnum";
+}
+.v-tnum-off {
+  font-feature-settings: "tnum" 0;
+}
+.v-afrc {
+  font-feature-settings: "afrc";
+}
+.v-afrc-off {
+  font-feature-settings: "afrc" 0;
+}
+.v-frac {
+  font-feature-settings: "frac";
+}
+.v-frac-off {
+  font-feature-settings: "frac" 0;
+}


### PR DESCRIPTION
Fixes #2695 

It is now possible, via a button in the need overview, to add or remove a persona.

Caveats:

* Currently the button state does not get updated correctly, because it depends on the `jsonld` content of a need, which is not updated
* This PR contains a large wrapper around `Element` which, after some thought, will be removed and made more specific.
* The current state representation in Elm only supports a very narrow part of our needs
* All of the created backend needs a design pass so it will be generally usable.
* In this PR I ran into #2778