### PR TITLE
Not displaying export without verification.

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/pojo/RestStatusResponse.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/pojo/RestStatusResponse.java
@@ -36,7 +36,7 @@ public enum RestStatusResponse {
     TOS_ACCEPT_SUCCESS(6200, "Successfully accepted Terms Of Service", HttpStatus.OK),
 
     EXPORT_SUCCESS(7200, "Successfully started exporting user", HttpStatus.OK),
-    EXPORT_IS_ANONYMOUS(7403, "To export with an anonymous user you need to provide an email address", HttpStatus.BAD_REQUEST);
+    EXPORT_NOT_VERIFIED(7403, "You need a verified account to export your data", HttpStatus.BAD_REQUEST);
 
     private final int code;
     private final String message;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
@@ -425,18 +425,16 @@ public class RestUserController {
             value = "/exportAccount",
             method = RequestMethod.POST
     )
-    public ResponseEntity exportAccount(@RequestParam(name = "email", required = false) String responseEmail, @RequestParam(name="keyStorePassword", required = false) String keyStorePassword) {
+    public ResponseEntity exportAccount(@RequestParam(name="keyStorePassword", required = false) String keyStorePassword) {
 
         SecurityContext securityContext = SecurityContextHolder.getContext();
         User authUser = ((KeystoreEnabledUserDetails) securityContext.getAuthentication().getPrincipal()).getUser();
         User user = userService.getByUsername(authUser.getUsername());
-
-        if(responseEmail == null) {
-            if(user.isAnonymous()) {
-                return generateStatusResponse(RestStatusResponse.EXPORT_IS_ANONYMOUS);
-            } else {
-                responseEmail = user.getEmail();
-            }
+        String responseEmail = null;
+        if(user.isEmailVerified()) {
+            responseEmail = user.getEmail();
+        } else {
+            return generateStatusResponse(RestStatusResponse.EXPORT_NOT_VERIFIED);
         }
 
         eventPublisher.publishEvent(new OnExportUserEvent(securityContext.getAuthentication(), keyStorePassword, responseEmail));

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
@@ -6,6 +6,7 @@ import {
   getOwnedPersonas,
   currentSkin,
 } from "../../selectors/general-selectors.js";
+import { getIn } from "../../utils";
 
 function genComponentConf($ngRedux) {
   return {
@@ -39,12 +40,16 @@ function genComponentConf($ngRedux) {
       }
 
       const disconnect = $ngRedux.connect(state => {
-        return { personas: getOwnedPersonas(state) };
+        return {
+          personas: getOwnedPersonas(state),
+          isVerified: getIn(state, ["account", "emailVerified"] || false),
+        };
       })(state => {
         if (!state.personas) {
           return;
         }
         elmApp.ports.personaIn.send(state.personas.toJS());
+        elmApp.ports.isVerified.send(state.isVerified);
       });
 
       const disconnectSkin = $ngRedux.connect(state => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
@@ -42,7 +42,7 @@ function genComponentConf($ngRedux) {
       const disconnect = $ngRedux.connect(state => {
         return {
           personas: getOwnedPersonas(state),
-          isVerified: getIn(state, ["account", "emailVerified"] || false),
+          isVerified: getIn(state, ["account", "emailVerified"]) || false,
         };
       })(state => {
         if (!state.personas) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
@@ -34,6 +34,12 @@ function genComponentConf($ngRedux) {
         }
       });
 
+      elmApp.ports.getVerified.subscribe(() => {
+        const isVerified =
+          getIn($ngRedux.getState(), ["account", "emailVerified"]) || false;
+        elmApp.ports.isVerified.send(isVerified);
+      });
+
       const personas = getOwnedPersonas($ngRedux.getState());
       if (personas) {
         elmApp.ports.personaIn.send(personas.toJS());
@@ -45,10 +51,9 @@ function genComponentConf($ngRedux) {
           isVerified: getIn(state, ["account", "emailVerified"]) || false,
         };
       })(state => {
-        if (!state.personas) {
-          return;
+        if (state.personas) {
+          elmApp.ports.personaIn.send(state.personas.toJS());
         }
-        elmApp.ports.personaIn.send(state.personas.toJS());
         elmApp.ports.isVerified.send(state.isVerified);
       });
 
@@ -62,6 +67,7 @@ function genComponentConf($ngRedux) {
 
       scope.$on("$destroy", () => {
         elmApp.ports.personaOut.unsubscribe();
+        elmApp.ports.getVerified.unsubscribe();
         disconnectSkin();
         disconnect();
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -368,7 +368,7 @@ won.RESPONSECODE = Object.freeze({
   SETTINGS_CREATED: 5200,
   TOS_ACCEPT_SUCCESS: 6200,
   EXPORT_SUCCESS: 7200,
-  EXPORT_IS_ANONYMOUS: 7403,
+  EXPORT_NOT_VERIFIED: 7403,
 
   PRIVATEID_NOT_FOUND: 666, //this one is not defined in RestStatusResponse.java
 });

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
@@ -9,7 +9,7 @@ import Element.Input as Input
 import Elements
 import Html exposing (Html)
 import Old.Skin as Skin exposing (Skin)
-import Settings.Account as Account
+import Settings.Export as Export
 import Settings.Personas as Personas
 
 
@@ -55,12 +55,12 @@ type alias Model =
 
 type Page
     = Personas Personas.Model
-    | Account Account.Model
+    | Export Export.Model
 
 
 type Route
     = PersonasR
-    | AccountR
+    | ExportR
 
 
 toRoute : Page -> Route
@@ -69,8 +69,8 @@ toRoute page =
         Personas _ ->
             PersonasR
 
-        Account _ ->
-            AccountR
+        Export _ ->
+            ExportR
 
 
 init : { width : Int, height : Int } -> ( Model, Cmd Msg )
@@ -100,7 +100,7 @@ subInit toPage toMsg ( subModel, cmd ) =
 
 type Msg
     = PersonasMsg Personas.Msg
-    | AccountMsg Account.Msg
+    | ExportMsg Export.Msg
     | ChangeRoute Route
     | Resized Size
     | Back
@@ -113,9 +113,9 @@ update msg model =
             Personas.update subMsg subModel
                 |> updateWith Personas PersonasMsg model
 
-        ( AccountMsg subMsg, Account subModel ) ->
-            Account.update subMsg subModel
-                |> updateWith Account AccountMsg model
+        ( ExportMsg subMsg, Export subModel ) ->
+            Export.update subMsg subModel
+                |> updateWith Export ExportMsg model
 
         ( ChangeRoute newRoute, _ ) ->
             if toRoute model.page == newRoute then
@@ -151,8 +151,8 @@ changeRoute route model =
     let
         ( newPage, cmd ) =
             case route of
-                AccountR ->
-                    subInit Account AccountMsg (Account.init ())
+                ExportR ->
+                    subInit Export ExportMsg (Export.init ())
 
                 PersonasR ->
                     subInit Personas PersonasMsg (Personas.init ())
@@ -234,8 +234,8 @@ view skin model =
             Personas subModel ->
                 viewPage PersonasMsg Personas.view subModel
 
-            Account subModel ->
-                viewPage AccountMsg Account.view subModel
+            Export subModel ->
+                viewPage ExportMsg Export.view subModel
 
 
 navigation : DeviceClass -> Skin -> Route -> Element Msg
@@ -275,16 +275,16 @@ navigation deviceClass skin route =
     in
     column
         attrs
-        [ navItem AccountR
-        , navItem PersonasR
+        [ navItem PersonasR
+        , navItem ExportR
         ]
 
 
 routeLabel : Route -> String
 routeLabel route =
     case route of
-        AccountR ->
-            "Account"
+        ExportR ->
+            "Export"
 
         PersonasR ->
             "Personas"
@@ -301,9 +301,9 @@ subSubscriptions page =
             Personas.subscriptions subModel
                 |> Sub.map PersonasMsg
 
-        Account _ ->
-            Account.subscriptions
-                |> Sub.map AccountMsg
+        Export _ ->
+            Export.subscriptions
+                |> Sub.map ExportMsg
 
 
 subscriptions : Model -> Sub Msg

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings.elm
@@ -302,7 +302,8 @@ subSubscriptions page =
                 |> Sub.map PersonasMsg
 
         Account _ ->
-            Sub.none
+            Account.subscriptions
+                |> Sub.map AccountMsg
 
 
 subscriptions : Model -> Sub Msg

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Account.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Account.elm
@@ -42,7 +42,7 @@ init () =
     ( { exportState = EnteringPassword ""
       , isVerified = False
       }
-    , Cmd.none
+    , getVerified ()
     )
 
 
@@ -240,6 +240,9 @@ view skin model =
 
 
 port isVerified : (Bool -> msg) -> Sub msg
+
+
+port getVerified : () -> Cmd msg
 
 
 subscriptions : Sub Msg

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Export.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Export.elm
@@ -1,4 +1,4 @@
-port module Settings.Account exposing
+port module Settings.Export exposing
     ( Model
     , Msg
     , init
@@ -148,10 +148,10 @@ exportView skin model =
                     , spacing 10
                     ]
                     [ paragraph [ width fill ]
-                        [ text "All your account data will be sent to your email address"
+                        [ text "All your account data will be sent to your email address."
                         ]
                     , paragraph [ width fill ]
-                        [ text "Your private keys will be encrypted."
+                        [ text "You can type in any password you like below and your keys will be encrypted using that password."
                         ]
                     ]
                 , row
@@ -226,6 +226,9 @@ view skin model =
         , Font.size 16
         ]
         [ el [ Font.size 24 ] <| text "Account data export"
+        , paragraph [ width fill ]
+            [ text "Here you can export the data associated with your account, including posts, connections and the keys that prove you are the owner of your posts."
+            ]
         , if model.isVerified then
             exportView skin model
 


### PR DESCRIPTION
Fixes #2608
Fixes #2607

Progress:

- [x] Don't display export interface when user is not verified
- [x] Change rest endpoint to not allow unverified users to export data
- [x] Add a call to action for signing up to the message

    https://github.com/researchstudio-sat/webofneeds/blob/f9dc42cfc75b5ac9bcac4aa70270e4f5d830de60/webofneeds/won-owner-webapp/src/main/webapp/elm/Settings/Account.elm#L234