### PR TITLE
remove saving closed connuris in localstorage and use the correct state from the backend (Feat lds uris by connstate)

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -162,6 +162,14 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
+    "group by msg.parentURI having max(msg.creationDate) > :resumeDate)")
+  Slice<Connection> getConnectionsAfterByActivityDate(
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
+
 
 
   /**

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -229,6 +229,16 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
+    "group by msg.parentURI having max(msg.creationDate) < :resumeDate)")
+  Slice<Connection> getConnectionsBeforeByActivityDate(
+    @Param("need") URI needURI,
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
+
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
     "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
@@ -240,6 +250,16 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
+    "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
+    "group by msg.parentURI having max(msg.creationDate) < :resumeDate)")
+  Slice<Connection> getConnectionsBeforeByActivityDate(
+    @Param("need") URI needURI,
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("messageType") WonMessageType messageType,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
 
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
@@ -252,11 +272,33 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
+    "group by msg.parentURI having max(msg.creationDate) > :resumeDate)")
+  Slice<Connection> getConnectionsAfterByActivityDate(
+    @Param("need") URI needURI,
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
+
+
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
     "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
     "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
   Slice<URI> getConnectionURIsAfterByActivityDate(
+    @Param("need") URI needURI,
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("messageType") WonMessageType messageType,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
+
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
+    "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
+    "group by msg.parentURI having max(msg.creationDate) > :resumeDate)")
+  Slice<Connection> getConnectionsAfterByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("messageType") WonMessageType messageType,

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -146,6 +146,13 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
+    "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
+    "group by msg.parentURI having max(msg.creationDate) < :resumeDate)")
+  Slice<Connection> getConnectionsBeforeByActivityDate(
+    @Param("resumeDate") Date resumeEventDate,
+    @Param("referenceDate") Date referenceDate,
+    Pageable pageable);
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -59,20 +59,13 @@ public interface ConnectionRepository extends WonRepository<Connection>
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select con from Connection con where needURI = :needUri and remoteNeedURI = :remoteNeedUri and facetURI = :facetUri and remoteFacetURI is null")
   Optional<Connection> findOneByNeedURIAndRemoteNeedURIAndFacetURIAndNullRemoteFacetForUpdate(@Param("needUri") URI needURI, @Param("remoteNeedUri") URI remoteNeedURI, @Param("facetUri") URI facetUri);
- 
-  
+
   List<Connection> findByNeedURI(URI URI);
-
-  Slice<Connection> findByNeedURI(URI URI, Pageable pageable);
-
-  List<Connection> findByNeedURIAndRemoteNeedURI(URI needURI, URI remoteNeedURI);
 
   List<Connection> findByNeedURIAndStateAndTypeURI(URI needURI, ConnectionState connectionState, URI facetType);
   
   List<Connection> findByFacetURIAndState(URI facetURI, ConnectionState connectionState);
 
-  List<Connection> findByNeedURIAndRemoteNeedURIAndState(URI needURI, URI remoteNeedURI, ConnectionState connectionState);
-  
   long countByNeedURIAndState(URI needURI, ConnectionState connectionState);
 
   @Query("select connectionURI from Connection")
@@ -81,24 +74,12 @@ public interface ConnectionRepository extends WonRepository<Connection>
   @Query("select conn from Connection conn")
   List<Connection> getAllConnections();
 
-  @Query("select connectionURI from Connection")
-  Slice<URI> getAllConnectionURIs(Pageable pageable);
-
   @Query("select connectionURI from Connection where needURI = ?1")
   List<URI> getAllConnectionURIsForNeedURI(URI needURI);
-
-  @Query("select connectionURI from Connection where needURI = ?1")
-  Slice<URI> getAllConnectionURIsForNeedURI(URI needURI, Pageable pageable);
-
-  @Query("select connectionURI from Connection where needURI = ?1 and state != ?2")
-  List<URI> getConnectionURIsByNeedURIAndNotInState(URI needURI, ConnectionState connectionState);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select c from Connection c where c.needURI = ?1 and c.state != ?2")
   List<Connection> getConnectionsByNeedURIAndNotInStateForUpdate(URI needURI, ConnectionState connectionState);
-
-  @Query("select connectionURI from Connection where lastUpdate > :modifiedAfter")
-  List<URI> findModifiedConnectionURIsAfter(@Param("modifiedAfter") Date modifiedAfter);
 
   @Query("select conn from Connection conn where lastUpdate > :modifiedAfter")
   List<Connection> findModifiedConnectionsAfter(@Param("modifiedAfter") Date modifiedAfter);
@@ -140,27 +121,10 @@ public interface ConnectionRepository extends WonRepository<Connection>
   Slice<Connection> getConnectionsByActivityDate(
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
-    "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByActivityDate(
-    @Param("resumeDate") Date resumeEventDate,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
   @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
     "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
     "group by msg.parentURI having max(msg.creationDate) < :resumeDate)")
   Slice<Connection> getConnectionsBeforeByActivityDate(
-    @Param("resumeDate") Date resumeEventDate,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where ((msg.senderURI = msg.parentURI or msg.receiverURI = msg.parentURI) and (msg.creationDate < :referenceDate))" +
-    "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByActivityDate(
     @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
@@ -256,17 +220,6 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("need") URI needURI,
     @Param("messageType") WonMessageType messageType, Pageable pageable);
 
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
-    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
-    "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByActivityDate(
-    @Param("need") URI needURI,
-    @Param("resumeDate") Date resumeEventDate,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
   @Query("select conn from Connection conn where conn.connectionURI in (select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
@@ -274,17 +227,6 @@ public interface ConnectionRepository extends WonRepository<Connection>
   Slice<Connection> getConnectionsBeforeByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
-    "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
-    "group by msg.parentURI having max(msg.creationDate) < :resumeDate")
-  Slice<URI> getConnectionURIsBeforeByActivityDate(
-    @Param("need") URI needURI,
-    @Param("resumeDate") Date resumeEventDate,
-    @Param("messageType") WonMessageType messageType,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
@@ -296,17 +238,6 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
     @Param("messageType") WonMessageType messageType,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
-    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate))" +
-    "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByActivityDate(
-    @Param("need") URI needURI,
-    @Param("resumeDate") Date resumeEventDate,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 
@@ -317,18 +248,6 @@ public interface ConnectionRepository extends WonRepository<Connection>
   Slice<Connection> getConnectionsAfterByActivityDate(
     @Param("need") URI needURI,
     @Param("resumeDate") Date resumeEventDate,
-    @Param("referenceDate") Date referenceDate,
-    Pageable pageable);
-
-
-  @Query("select msg.parentURI from MessageEventPlaceholder msg " +
-    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
-    "   and (msg.creationDate < :referenceDate) and (msg.messageType = :messageType))" +
-    "group by msg.parentURI having max(msg.creationDate) > :resumeDate")
-  Slice<URI> getConnectionURIsAfterByActivityDate(
-    @Param("need") URI needURI,
-    @Param("resumeDate") Date resumeEventDate,
-    @Param("messageType") WonMessageType messageType,
     @Param("referenceDate") Date referenceDate,
     Pageable pageable);
 

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -100,6 +100,9 @@ public interface ConnectionRepository extends WonRepository<Connection>
   @Query("select connectionURI from Connection where lastUpdate > :modifiedAfter")
   List<URI> findModifiedConnectionURIsAfter(@Param("modifiedAfter") Date modifiedAfter);
 
+  @Query("select conn from Connection conn where lastUpdate > :modifiedAfter")
+  List<Connection> findModifiedConnectionsAfter(@Param("modifiedAfter") Date modifiedAfter);
+
   /**
    * Obtains connectionURIs grouped by the connectionURI itself and with message properties attached. The paging
    * request therefore can use criteria based on aggregated messages properties of the connection,

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -152,11 +152,33 @@ public interface ConnectionRepository extends WonRepository<Connection>
     "group by msg.parentURI")
   Slice<URI> getConnectionURIByActivityDate(@Param("need") URI needURI, Pageable pageable);
 
+  /**
+   * Obtains connections of the provided Need grouped by the connectionURI itself and with message properties
+   * attached. The paging request therefore can use criteria based on aggregated messages properties of the connection,
+   * such as min(msg.creationDate). For example:
+   * <code>new PageRequest(0, 1, Sort.Direction.DESC, "min(msg.creationDate)"))</code>
+   *
+   * @param needURI
+   * @param pageable
+   * @return
+   */
+  @Query("select conn from Connection conn where conn.connectionURI in (select distinct(msg.parentURI) from MessageEventPlaceholder msg " +
+    "where (msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI))")
+  Slice<Connection> getConnectionsByActivityDate(@Param("need") URI needURI, Pageable pageable);
+
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate)) " +
     "group by msg.parentURI")
   Slice<URI> getConnectionURIByActivityDate(
+    @Param("need") URI needURI,
+    @Param("referenceDate") Date referenceDate, Pageable pageable);
+
+  @Query("select conn from Connection conn where conn.connectionURI in (select distinct(msg.parentURI) from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate)))")
+  Slice<Connection> getConnectionsByActivityDate(
     @Param("need") URI needURI,
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
@@ -170,6 +192,15 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("messageType") WonMessageType messageType,
     @Param("referenceDate") Date referenceDate, Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select distinct(msg.parentURI) from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) and (msg.creationDate < :referenceDate)" +
+    "   and (msg.messageType = :messageType)))")
+  Slice<Connection> getConnectionsByActivityDate(
+    @Param("need") URI needURI,
+    @Param("messageType") WonMessageType messageType,
+    @Param("referenceDate") Date referenceDate, Pageable pageable);
+
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +
     "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
     "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
@@ -179,6 +210,13 @@ public interface ConnectionRepository extends WonRepository<Connection>
     @Param("need") URI needURI,
     @Param("messageType") WonMessageType messageType, Pageable pageable);
 
+  @Query("select conn from Connection conn where conn.connectionURI in (select distinct(msg.parentURI) from MessageEventPlaceholder msg " +
+    "where (((msg.senderNeedURI = :need and msg.senderURI = msg.parentURI) " +
+    "   or (msg.receiverNeedURI = :need and msg.receiverURI = msg.parentURI)) " +
+    "   and (msg.messageType = :messageType)))")
+  Slice<Connection> getConnectionsByActivityDate(
+    @Param("need") URI needURI,
+    @Param("messageType") WonMessageType messageType, Pageable pageable);
 
 
   @Query("select msg.parentURI from MessageEventPlaceholder msg " +

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/NeedRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/NeedRepository.java
@@ -63,6 +63,9 @@ public interface NeedRepository extends WonRepository<Need> {
     @Query("select state, count(*) from Connection where needURI = :need group by state")
     List<Object[]> getCountsPerConnectionState(@Param("need") URI needURI);
 
+    @Query("select state, connectionURI from Connection where needURI = :need")
+    List<Object[]> getConnectionUrisAndState(@Param("need") URI needUri);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select need from Need need where needURI= :uri")
     Need findOneByNeedURIForUpdate(@Param("uri") URI uri);

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -125,6 +125,18 @@ public interface LinkedDataService {
     public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException;
 
     /**
+     * Returns container dataset containing all connections. If deep is true,
+     * the resource data of those connection uris is also part of the returned
+     * resource.
+     *
+     * @param deep
+     * @return
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final boolean deep) throws NoSuchConnectionException;
+
+    /**
      * Returns container dataset containing all connection URIs that where modified
      * after a certain date.
      *
@@ -151,6 +163,22 @@ public interface LinkedDataService {
      */
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page,
                                                                                  final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+
+    /**
+     * Returns a resource containing connections at given page. If deep is true,
+     * the resource data of those connection uris is also part of the returned
+     * resource. If page >0, paging is used and the respective page is returned.
+     *
+     * @param page
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param deep
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final int page,
+                                                                                     final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
     /**
      * Returns a resource containing connection uris that precede (by time of their

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -16,466 +16,404 @@
 
 package won.protocol.service;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Date;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.springframework.context.NoSuchMessageException;
-
 import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchNeedException;
 import won.protocol.message.WonMessageType;
+import won.protocol.model.Connection;
 import won.protocol.model.DataWithEtag;
 import won.protocol.model.NeedState;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
 
 /**
  * User: fkleedorfer Date: 26.11.12
  */
 public interface LinkedDataService {
 
-	/**
-	 * Returns a model containing all need URIs.
-	 * 
-	 * @return
-	 */
-	public Dataset listNeedURIs();
+    /**
+     * Returns a model containing all need URIs.
+     *
+     * @return
+     */
+    public Dataset listNeedURIs();
 
-	/**
-	 * Returns a model containing all need URIs. If page >= 0, paging is used and
-	 * the respective page is returned.
-	 * 
-	 * @param page
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int page);
+    /**
+     * Returns a model containing all need URIs. If page >= 0, paging is used and
+     * the respective page is returned.
+     *
+     * @param page
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int page);
 
-	/**
-	 * Returns a model containing all need URIs that are in the specified state. If
-	 * page >= 0, paging is used and the respective page is returned.
-	 * 
-	 * @param page
-	 * @param preferedSize
-	 *            preferred number of need uris per page (null means use default)
-	 * @param needState
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int page, final Integer preferedSize,
-			NeedState needState);
+    /**
+     * Returns a model containing all need URIs that are in the specified state. If
+     * page >= 0, paging is used and the respective page is returned.
+     *
+     * @param page
+     * @param preferedSize preferred number of need uris per page (null means use default)
+     * @param needState
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int page, final Integer preferedSize,
+                                                                           NeedState needState);
 
-	/**
-	 * Return all need URIs that where created before the provided need
-	 * 
-	 * @param need
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(final URI need);
+    /**
+     * Return all need URIs that where created before the provided need
+     *
+     * @param need
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(final URI need);
 
-	/**
-	 * Return all need URIs that where created after the provided need
-	 * 
-	 * @param need
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(final URI need);
+    /**
+     * Return all need URIs that where created after the provided need
+     *
+     * @param need
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(final URI need);
 
-	/**
-	 * Return all need URIs that where created after the provided need and that are
-	 * in the specified state
-	 * 
-	 * @param need
-	 * @param preferedSize
-	 *            preferred number of need uris per page (null means use default)
-	 * @param needState
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(final URI need,
-			final Integer preferedSize, NeedState needState);
+    /**
+     * Return all need URIs that where created after the provided need and that are
+     * in the specified state
+     *
+     * @param need
+     * @param preferedSize preferred number of need uris per page (null means use default)
+     * @param needState
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(final URI need,
+                                                                                 final Integer preferedSize, NeedState needState);
 
-	/**
-	 * Return all need URIs that where created after the provided need and that are
-	 * in the specified state
-	 * 
-	 * @param need
-	 * @param preferedSize
-	 *            preferred number of need uris per page (null means use default)
-	 * @param needState
-	 * @return
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(final URI need,
-			final Integer preferedSize, NeedState needState);
+    /**
+     * Return all need URIs that where created after the provided need and that are
+     * in the specified state
+     *
+     * @param need
+     * @param preferedSize preferred number of need uris per page (null means use default)
+     * @param needState
+     * @return
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(final URI need,
+                                                                                final Integer preferedSize, NeedState needState);
 
-	/**
-	 * Returns container dataset containing all needs that have been modified after
-	 * a certain date
-	 * 
-	 * @param modifiedDate
-	 *            modification date of needs
-	 * @return
-	 */
-	public Dataset listModifiedNeedURIsAfter(Date modifiedDate);
+    /**
+     * Returns container dataset containing all needs that have been modified after
+     * a certain date
+     *
+     * @param modifiedDate modification date of needs
+     * @return
+     */
+    public Dataset listModifiedNeedURIsAfter(Date modifiedDate);
 
-	/**
-	 * Returns container dataset containing all connection URIs. If deep is true,
-	 * the resource data of those connection uris is also part of the returned
-	 * resource.
-	 * 
-	 * @param deep
-	 * @return
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException;
+    /**
+     * Returns container dataset containing all connection URIs. If deep is true,
+     * the resource data of those connection uris is also part of the returned
+     * resource.
+     *
+     * @param deep
+     * @return
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException;
 
-	/**
-	 * Returns container dataset containing all connection URIs that where modified
-	 * after a certain date.
-	 * 
-	 * @param modifiedAfter
-	 *            modification date
-	 * @param deep
-	 *            If deep is true, the resource data of those connection uris is
-	 *            also part of the returned resource.
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
+    /**
+     * Returns container dataset containing all connection URIs that where modified
+     * after a certain date.
+     *
+     * @param modifiedAfter modification date
+     * @param deep          If deep is true, the resource data of those connection uris is
+     *                      also part of the returned resource.
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
 
-	/**
-	 * Returns a resource containing connection uris at given page. If deep is true,
-	 * the resource data of those connection uris is also part of the returned
-	 * resource. If page >0, paging is used and the respective page is returned.
-	 * 
-	 * @param page
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param deep
-	 * @return
-	 * @throws NoSuchNeedException
-	 * @throws NoSuchConnectionException
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page,
-			final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+    /**
+     * Returns a resource containing connection uris at given page. If deep is true,
+     * the resource data of those connection uris is also part of the returned
+     * resource. If page >0, paging is used and the respective page is returned.
+     *
+     * @param page
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param deep
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page,
+                                                                                 final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
-	/**
-	 * Returns a resource containing connection uris that precede (by time of their
-	 * latest event activities) the given connection as of state that was at the
-	 * specified time.
-	 *
-	 * @param beforeConnURI
-	 *            a connection the preceding connections of which we are interested
-	 *            in
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param timeSpot
-	 *            date and time that specifies the connections and events state of
-	 *            interest
-	 * @param deep
-	 *            if true, the resource data of those connection uris is also part
-	 *            of the resource
-	 * @return
-	 * @throws NoSuchNeedException
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI beforeConnURI,
-			final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+    /**
+     * Returns a resource containing connection uris that precede (by time of their
+     * latest event activities) the given connection as of state that was at the
+     * specified time.
+     *
+     * @param beforeConnURI a connection the preceding connections of which we are interested
+     *                      in
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param timeSpot      date and time that specifies the connections and events state of
+     *                      interest
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI beforeConnURI,
+                                                                                       final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
-	/**
-	 * Returns a resource containing connection uris that follow (by time of their
-	 * latest event activities) the given connection as of state that was at the
-	 * specified time.
-	 *
-	 * @param afterConnURI
-	 *            a connection the following connections of which we are interested
-	 *            in
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param timeSpot
-	 *            date and time that specifies the connections and events state of
-	 *            interest
-	 * @param deep
-	 *            if true, the resource data of those connection uris is also part
-	 *            of the resource
-	 * @return
-	 * @throws NoSuchNeedException
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI afterConnURI,
-			final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+    /**
+     * Returns a resource containing connection uris that follow (by time of their
+     * latest event activities) the given connection as of state that was at the
+     * specified time.
+     *
+     * @param afterConnURI  a connection the following connections of which we are interested
+     *                      in
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param timeSpot      date and time that specifies the connections and events state of
+     *                      interest
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI afterConnURI,
+                                                                                      final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
-	/**
-	 * Returns a model containing all connection uris belonging to the specified
-	 * need.
-	 * 
-	 * @param needURI
-	 * @param addMetadata
-	 *            - if true, a metadata graph is added to the dataset containing
-	 *            counts by connection state
-	 * @param deep
-	 *            - if true, connection data is added (not only connection URIs)
-	 * @return
-	 * @throws NoSuchNeedException
-	 */
-	public Dataset listConnectionURIs(final URI needURI, boolean deep, final boolean addMetadata)
-			throws NoSuchNeedException, NoSuchConnectionException;
+    /**
+     * Returns a model containing all connection uris belonging to the specified
+     * need.
+     *
+     * @param needURI
+     * @param addMetadata - if true, a metadata graph is added to the dataset containing
+     *                    counts by connection state
+     * @param deep        - if true, connection data is added (not only connection URIs)
+     * @return
+     * @throws NoSuchNeedException
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionURIs(final URI needURI, boolean deep, final boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
 
-	/**
-	 * Returns paged resource containing all connection uris belonging to the
-	 * specified need.
-	 *
-	 * @param page
-	 *            number
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param needURI
-	 *            local need the connections of which are retrieved
-	 * @param messageType
-	 *            the event type that should be used for defining connection latest
-	 *            activity; null => all event types
-	 * @param timeSpot
-	 *            time at which we want the list state to be fixed
-	 * @param deep
-	 *            if true, the resource data of those connection uris is also part
-	 *            of the resource
-	 * @param addMetadata
-	 *            - if true, a metadata graph is added to the dataset containing
-	 *            counts by connection state
-	 * @return
-	 * @throws NoSuchNeedException
-	 *             when specified need is not found
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(int page, URI needURI,
-			Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-			throws NoSuchNeedException, NoSuchConnectionException;
+    /**
+     * Returns paged resource containing all connection uris belonging to the
+     * specified need.
+     *
+     * @param page          number
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param needURI       local need the connections of which are retrieved
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(int page, URI needURI,
+                                                                                 Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
 
-	/**
-	 * Returns paged resource containing all connection uris belonging to the
-	 * specified need that precede the given connection URI from the point of view
-	 * of their latest events.
-	 *
-	 * 
-	 * @param needURI
-	 *            local need the connections of which are retrieved
-	 * @param resumeConnURI
-	 *            the returned slice connections precede (in time of their latest
-	 *            events) this connection uri
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param messageType
-	 *            the event type that should be used for defining connection latest
-	 *            activity; null => all event types
-	 * @param timeSpot
-	 *            time at which we want the list state to be fixed
-	 * @param deep
-	 *            if true, the resource data of those connection uris is also part
-	 *            of the resource
-	 * @param addMetadata
-	 *            - if true, a metadata graph is added to the dataset containing
-	 *            counts by connection state
-	 * @return
-	 * @throws NoSuchNeedException
-	 *             when specified need is not found
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI needURI, URI resumeConnURI,
-			Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-			throws NoSuchNeedException, NoSuchConnectionException;
+    /**
+     * Returns paged resource containing all connection uris belonging to the
+     * specified need that precede the given connection URI from the point of view
+     * of their latest events.
+     *
+     * @param needURI       local need the connections of which are retrieved
+     * @param resumeConnURI the returned slice connections precede (in time of their latest
+     *                      events) this connection uri
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI needURI, URI resumeConnURI,
+                                                                                       Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
 
-	/**
-	 * Returns paged resource containing all connection uris belonging to the
-	 * specified need that follows the given connection URI from the point of view
-	 * of their latest events.
-	 *
-	 * @param needURI
-	 *            local need the connections of which are retrieved
-	 * @param resumeConnURI
-	 *            the returned slice connections follow (in time of their latest
-	 *            events) this connection uri
-	 * @param preferredSize
-	 *            preferred number of connection uris per page (null means use
-	 *            default)
-	 * @param messageType
-	 *            the event type that should be used for defining connection latest
-	 *            activity; null => all event types
-	 * @param timeSpot
-	 *            time at which we want the list state to be fixed
-	 * @param deep
-	 *            if true, the resource data of those connection uris is also part
-	 *            of the resource
-	 * @param addMetadata
-	 *            - if true, a metadata graph is added to the dataset containing
-	 *            counts by connection state
-	 * @return
-	 * @throws NoSuchNeedException
-	 *             when specified need is not found
-	 * @throws NoSuchConnectionException
-	 *             only in case deep is set to true and connection data for a member
-	 *             connection uri cannot be retrieved.
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI needURI, URI resumeConnURI,
-			Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-			throws NoSuchNeedException, NoSuchConnectionException;
+    /**
+     * Returns paged resource containing all connection uris belonging to the
+     * specified need that follows the given connection URI from the point of view
+     * of their latest events.
+     *
+     * @param needURI       local need the connections of which are retrieved
+     * @param resumeConnURI the returned slice connections follow (in time of their latest
+     *                      events) this connection uri
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI needURI, URI resumeConnURI,
+                                                                                      Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
 
-	/**
-	 * Returns a dataset describing the need, if the etag indicates that it has
-	 * changed.
-	 * 
-	 * @param needUri
-	 * @param etag
-	 * @return dataset with etag describing the need or null if not found
-	 */
-	public DataWithEtag<Dataset> getNeedDataset(final URI needUri, String etag);
+    /**
+     * Returns a dataset describing the need, if the etag indicates that it has
+     * changed.
+     *
+     * @param needUri
+     * @param etag
+     * @return dataset with etag describing the need or null if not found
+     */
+    public DataWithEtag<Dataset> getNeedDataset(final URI needUri, String etag);
 
-	/**
-	 * Returns a dataset describing the need with the specified URI. If the need is
-	 * in state ACTIVE, 'deep' data is added if requested.
-	 * 
-	 * @param needUri
-	 * @param deep
-	 *            - include need's connections datasets and each connection's
-	 *            events' datasets
-	 * @param deepLayerSize
-	 *            - number of connections and events to include in the deep need
-	 *            dataset
-	 * @return
-	 * @throws NoSuchNeedException
-	 */
-	public Dataset getNeedDataset(final URI needUri, final boolean deep, final Integer deepLayerSize)
-			throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException;
+    /**
+     * Returns a dataset describing the need with the specified URI. If the need is
+     * in state ACTIVE, 'deep' data is added if requested.
+     *
+     * @param needUri
+     * @param deep          - include need's connections datasets and each connection's
+     *                      events' datasets
+     * @param deepLayerSize - number of connections and events to include in the deep need
+     *                      dataset
+     * @return
+     * @throws NoSuchNeedException
+     */
+    public Dataset getNeedDataset(final URI needUri, final boolean deep, final Integer deepLayerSize)
+            throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException;
 
-	/**
-	 * Returns a dataset describing the connection, if the etag indicates that it
-	 * has changed.
-	 * 
-	 * @param connectionUri
-	 * @param includeEventContainer
-	 * @param etag
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	DataWithEtag<Dataset> getConnectionDataset(URI connectionUri, boolean includeEventContainer, String etag);
+    /**
+     * Returns a dataset describing the connection, if the etag indicates that it
+     * has changed.
+     *
+     * @param connectionUri
+     * @param includeEventContainer
+     * @param etag
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    DataWithEtag<Dataset> getConnectionDataset(URI connectionUri, boolean includeEventContainer, String etag);
 
-	/**
-	 * Returns a dataset containing all event uris belonging to the specified
-	 * connection.
-	 * 
-	 * @param connectionUri
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public Dataset listConnectionEventURIs(final URI connectionUri) throws NoSuchConnectionException;
+    /**
+     * Returns a dataset containing all event uris belonging to the specified
+     * connection.
+     *
+     * @param connectionUri
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public Dataset listConnectionEventURIs(final URI connectionUri) throws NoSuchConnectionException;
 
-	/**
-	 * Returns a dataset containing all event uris belonging to the specified
-	 * connection.
-	 * 
-	 * @param connectionUri
-	 * @param deep
-	 *            - include events dataset
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public Dataset listConnectionEventURIs(final URI connectionUri, final boolean deep)
-			throws NoSuchConnectionException;
+    /**
+     * Returns a dataset containing all event uris belonging to the specified
+     * connection.
+     *
+     * @param connectionUri
+     * @param deep          - include events dataset
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public Dataset listConnectionEventURIs(final URI connectionUri, final boolean deep)
+            throws NoSuchConnectionException;
 
-	/**
-	 * Returns paged resource containing all event uris belonging to the specified
-	 * connection. If deep is true, the event dataset is added to the result.
-	 * 
-	 * @param connectionUri
-	 *            connection parent of the events
-	 * @param pageNum
-	 *            number of the page to be returned
-	 * @param preferedSize
-	 *            preferred number of uris per page, null means use default
-	 * @param messageType
-	 *            message type, null means all types
-	 * @param deep
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIs(final URI connectionUri,
-			final int pageNum, Integer preferedSize, WonMessageType messageType, boolean deep)
-			throws NoSuchConnectionException;
+    /**
+     * Returns paged resource containing all event uris belonging to the specified
+     * connection. If deep is true, the event dataset is added to the result.
+     *
+     * @param connectionUri connection parent of the events
+     * @param pageNum       number of the page to be returned
+     * @param preferedSize  preferred number of uris per page, null means use default
+     * @param messageType   message type, null means all types
+     * @param deep
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIs(final URI connectionUri,
+                                                                                      final int pageNum, Integer preferedSize, WonMessageType messageType, boolean deep)
+            throws NoSuchConnectionException;
 
-	/**
-	 * Returns a dataset containing all event uris belonging to the specified
-	 * connection that were created after the specified event uri. If deep is true,
-	 * the event dataset is added to the result.
-	 * 
-	 * @param connectionUri
-	 *            connection parent of the events
-	 * @param msgURI
-	 *            message to follow (in message creation time)
-	 * @param preferedSize
-	 *            preferred number of uris per page, null means use default
-	 * @param msgType
-	 *            message type, null means all types
-	 * @param deep
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsAfter(final URI connectionUri,
-			final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep)
-			throws NoSuchConnectionException;
+    /**
+     * Returns a dataset containing all event uris belonging to the specified
+     * connection that were created after the specified event uri. If deep is true,
+     * the event dataset is added to the result.
+     *
+     * @param connectionUri connection parent of the events
+     * @param msgURI        message to follow (in message creation time)
+     * @param preferedSize  preferred number of uris per page, null means use default
+     * @param msgType       message type, null means all types
+     * @param deep
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsAfter(final URI connectionUri,
+                                                                                           final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep)
+            throws NoSuchConnectionException;
 
-	/**
-	 * Returns a dataset containing all event uris belonging to the specified
-	 * connection that were created before the specified event uri. If deep is true,
-	 * the event dataset is added to the result.
-	 * 
-	 * @param connectionUri
-	 *            connection parent of the events
-	 * @param msgURI
-	 *            message to precede (in message creation time)
-	 * @param preferedSize
-	 *            preferred number of uris per page, null means use default
-	 * @param msgType
-	 *            message type, null means all types
-	 * @param deep
-	 * @return
-	 * @throws NoSuchConnectionException
-	 */
-	public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsBefore(final URI connectionUri,
-			final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep)
-			throws NoSuchConnectionException;
+    /**
+     * Returns a dataset containing all event uris belonging to the specified
+     * connection that were created before the specified event uri. If deep is true,
+     * the event dataset is added to the result.
+     *
+     * @param connectionUri connection parent of the events
+     * @param msgURI        message to precede (in message creation time)
+     * @param preferedSize  preferred number of uris per page, null means use default
+     * @param msgType       message type, null means all types
+     * @param deep
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsBefore(final URI connectionUri,
+                                                                                            final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep)
+            throws NoSuchConnectionException;
 
-	public Dataset getNodeDataset();
+    public Dataset getNodeDataset();
 
-	/**
-	 * returns a dataset of the (message) event with the specified URI, with a value
-	 * that can be used for an etag. If the current etag is the same as the
-	 * specified one, the dataset is null, indicating no change.
-	 * 
-	 * @param eventURI
-	 */
-	public DataWithEtag<Dataset> getDatasetForUri(final URI eventURI, String etag);
+    /**
+     * returns a dataset of the (message) event with the specified URI, with a value
+     * that can be used for an etag. If the current etag is the same as the
+     * specified one, the dataset is null, indicating no change.
+     *
+     * @param eventURI
+     */
+    public DataWithEtag<Dataset> getDatasetForUri(final URI eventURI, String etag);
 
-	
-	/**
-	 * Returns a model specifying the number of messages and their latest and earliest timestamp found per connection
-	 * after the specified lastSeenMessageURI, or the total message count and respective timestamps for a connection 
-	 * for which no lastSeenMessageURI is specified.  
-	 * @param needURI
-	 * @param lastSeenMessageURIs
-	 * @return
-	 */
-	Model getUnreadInformationForNeed(URI needURI, Collection<URI> lastSeenMessageURIs);
+
+    /**
+     * Returns a model specifying the number of messages and their latest and earliest timestamp found per connection
+     * after the specified lastSeenMessageURI, or the total message count and respective timestamps for a connection
+     * for which no lastSeenMessageURI is specified.
+     *
+     * @param needURI
+     * @param lastSeenMessageURIs
+     * @return
+     */
+    Model getUnreadInformationForNeed(URI needURI, Collection<URI> lastSeenMessageURIs);
 
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -244,6 +244,26 @@ public interface LinkedDataService {
                                                                                       final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
     /**
+     * Returns a resource containing connections that follow (by time of their
+     * latest event activities) the given connection as of state that was at the
+     * specified time.
+     *
+     * @param afterConnURI  a connection the following connections of which we are interested
+     *                      in
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param timeSpot      date and time that specifies the connections and events state of
+     *                      interest
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsAfter(URI afterConnURI,
+                                                                                      final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+    /**
      * Returns a model containing all connection uris belonging to the specified
      * need.
      *

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -281,6 +281,32 @@ public interface LinkedDataService {
             throws NoSuchNeedException, NoSuchConnectionException;
 
     /**
+     * Returns paged resource containing all connections belonging to the
+     * specified need that precede the given connection URI from the point of view
+     * of their latest events.
+     *
+     * @param needURI       local need the connections of which are retrieved
+     * @param resumeConnURI the returned slice connections precede (in time of their latest
+     *                      events) this connection uri
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(URI needURI, URI resumeConnURI,
+                                                                                       Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
+
+    /**
      * Returns paged resource containing all connection uris belonging to the
      * specified need that follows the given connection URI from the point of view
      * of their latest events.
@@ -303,6 +329,32 @@ public interface LinkedDataService {
      *                                   connection uri cannot be retrieved.
      */
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI needURI, URI resumeConnURI,
+                                                                                      Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
+
+    /**
+     * Returns paged resource containing all connections belonging to the
+     * specified need that follows the given connection URI from the point of view
+     * of their latest events.
+     *
+     * @param needURI       local need the connections of which are retrieved
+     * @param resumeConnURI the returned slice connections follow (in time of their latest
+     *                      events) this connection uri
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsAfter(URI needURI, URI resumeConnURI,
                                                                                       Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException;
 

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -149,6 +149,18 @@ public interface LinkedDataService {
     public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
 
     /**
+     * Returns container dataset containing all connection URIs that where modified
+     * after a certain date.
+     *
+     * @param modifiedAfter modification date
+     * @param deep          If deep is true, the resource data of those connection uris is
+     *                      also part of the returned resource.
+     * @return
+     * @throws NoSuchConnectionException
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listModifiedConnectionsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
+
+    /**
      * Returns a resource containing connection uris at given page. If deep is true,
      * the resource data of those connection uris is also part of the returned
      * resource. If page >0, paging is used and the respective page is returned.

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -202,6 +202,27 @@ public interface LinkedDataService {
                                                                                        final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
     /**
+     * Returns a resource containing connection uris that precede (by time of their
+     * latest event activities) the given connection as of state that was at the
+     * specified time.
+     *
+     * @param beforeConnURI a connection the preceding connections of which we are interested
+     *                      in
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param timeSpot      date and time that specifies the connections and events state of
+     *                      interest
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @return
+     * @throws NoSuchNeedException
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(URI beforeConnURI,
+                                                                                       final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
+
+    /**
      * Returns a resource containing connection uris that follow (by time of their
      * latest event activities) the given connection as of state that was at the
      * specified time.

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -205,7 +205,7 @@ public interface LinkedDataService {
      * @return
      * @throws NoSuchNeedException
      */
-    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionURIs(final URI needURI, boolean deep, final boolean addMetadata)
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final URI needURI, boolean deep, final boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException;
 
     /**
@@ -231,7 +231,29 @@ public interface LinkedDataService {
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(int page, URI needURI,
                                                                                  Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException;
-
+    /**
+     * Returns paged resource containing all connections belonging to the
+     * specified need.
+     *
+     * @param page          number
+     * @param preferredSize preferred number of connection uris per page (null means use
+     *                      default)
+     * @param needURI       local need the connections of which are retrieved
+     * @param messageType   the event type that should be used for defining connection latest
+     *                      activity; null => all event types
+     * @param timeSpot      time at which we want the list state to be fixed
+     * @param deep          if true, the resource data of those connection uris is also part
+     *                      of the resource
+     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
+     *                      counts by connection state
+     * @return
+     * @throws NoSuchNeedException       when specified need is not found
+     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
+     *                                   connection uri cannot be retrieved.
+     */
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(int page, URI needURI,
+                                                                                        Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException;
     /**
      * Returns paged resource containing all connection uris belonging to the
      * specified need that precede the given connection URI from the point of view

--- a/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/LinkedDataService.java
@@ -113,18 +113,6 @@ public interface LinkedDataService {
     public Dataset listModifiedNeedURIsAfter(Date modifiedDate);
 
     /**
-     * Returns container dataset containing all connection URIs. If deep is true,
-     * the resource data of those connection uris is also part of the returned
-     * resource.
-     *
-     * @param deep
-     * @return
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
-    public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException;
-
-    /**
      * Returns container dataset containing all connections. If deep is true,
      * the resource data of those connection uris is also part of the returned
      * resource.
@@ -146,35 +134,7 @@ public interface LinkedDataService {
      * @return
      * @throws NoSuchConnectionException
      */
-    public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
-
-    /**
-     * Returns container dataset containing all connection URIs that where modified
-     * after a certain date.
-     *
-     * @param modifiedAfter modification date
-     * @param deep          If deep is true, the resource data of those connection uris is
-     *                      also part of the returned resource.
-     * @return
-     * @throws NoSuchConnectionException
-     */
     public NeedInformationService.PagedResource<Dataset, Connection> listModifiedConnectionsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException;
-
-    /**
-     * Returns a resource containing connection uris at given page. If deep is true,
-     * the resource data of those connection uris is also part of the returned
-     * resource. If page >0, paging is used and the respective page is returned.
-     *
-     * @param page
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param deep
-     * @return
-     * @throws NoSuchNeedException
-     * @throws NoSuchConnectionException
-     */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page,
-                                                                                 final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
     /**
      * Returns a resource containing connections at given page. If deep is true,
@@ -210,50 +170,8 @@ public interface LinkedDataService {
      * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
      *                                   connection uri cannot be retrieved.
      */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI beforeConnURI,
-                                                                                       final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
-
-    /**
-     * Returns a resource containing connection uris that precede (by time of their
-     * latest event activities) the given connection as of state that was at the
-     * specified time.
-     *
-     * @param beforeConnURI a connection the preceding connections of which we are interested
-     *                      in
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param timeSpot      date and time that specifies the connections and events state of
-     *                      interest
-     * @param deep          if true, the resource data of those connection uris is also part
-     *                      of the resource
-     * @return
-     * @throws NoSuchNeedException
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
     public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(URI beforeConnURI,
                                                                                        final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
-
-    /**
-     * Returns a resource containing connection uris that follow (by time of their
-     * latest event activities) the given connection as of state that was at the
-     * specified time.
-     *
-     * @param afterConnURI  a connection the following connections of which we are interested
-     *                      in
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param timeSpot      date and time that specifies the connections and events state of
-     *                      interest
-     * @param deep          if true, the resource data of those connection uris is also part
-     *                      of the resource
-     * @return
-     * @throws NoSuchNeedException
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI afterConnURI,
-                                                                                      final Integer preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException;
 
     /**
      * Returns a resource containing connections that follow (by time of their
@@ -290,29 +208,6 @@ public interface LinkedDataService {
             throws NoSuchNeedException, NoSuchConnectionException;
 
     /**
-     * Returns paged resource containing all connection uris belonging to the
-     * specified need.
-     *
-     * @param page          number
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param needURI       local need the connections of which are retrieved
-     * @param messageType   the event type that should be used for defining connection latest
-     *                      activity; null => all event types
-     * @param timeSpot      time at which we want the list state to be fixed
-     * @param deep          if true, the resource data of those connection uris is also part
-     *                      of the resource
-     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
-     *                      counts by connection state
-     * @return
-     * @throws NoSuchNeedException       when specified need is not found
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(int page, URI needURI,
-                                                                                 Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException;
-    /**
      * Returns paged resource containing all connections belonging to the
      * specified need.
      *
@@ -334,31 +229,6 @@ public interface LinkedDataService {
      */
     public NeedInformationService.PagedResource<Dataset, Connection> listConnections(int page, URI needURI,
                                                                                         Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException;
-    /**
-     * Returns paged resource containing all connection uris belonging to the
-     * specified need that precede the given connection URI from the point of view
-     * of their latest events.
-     *
-     * @param needURI       local need the connections of which are retrieved
-     * @param resumeConnURI the returned slice connections precede (in time of their latest
-     *                      events) this connection uri
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param messageType   the event type that should be used for defining connection latest
-     *                      activity; null => all event types
-     * @param timeSpot      time at which we want the list state to be fixed
-     * @param deep          if true, the resource data of those connection uris is also part
-     *                      of the resource
-     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
-     *                      counts by connection state
-     * @return
-     * @throws NoSuchNeedException       when specified need is not found
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(URI needURI, URI resumeConnURI,
-                                                                                       Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException;
 
     /**
@@ -385,32 +255,6 @@ public interface LinkedDataService {
      */
     public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(URI needURI, URI resumeConnURI,
                                                                                        Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException;
-
-    /**
-     * Returns paged resource containing all connection uris belonging to the
-     * specified need that follows the given connection URI from the point of view
-     * of their latest events.
-     *
-     * @param needURI       local need the connections of which are retrieved
-     * @param resumeConnURI the returned slice connections follow (in time of their latest
-     *                      events) this connection uri
-     * @param preferredSize preferred number of connection uris per page (null means use
-     *                      default)
-     * @param messageType   the event type that should be used for defining connection latest
-     *                      activity; null => all event types
-     * @param timeSpot      time at which we want the list state to be fixed
-     * @param deep          if true, the resource data of those connection uris is also part
-     *                      of the resource
-     * @param addMetadata   - if true, a metadata graph is added to the dataset containing
-     *                      counts by connection state
-     * @return
-     * @throws NoSuchNeedException       when specified need is not found
-     * @throws NoSuchConnectionException only in case deep is set to true and connection data for a member
-     *                                   connection uri cannot be retrieved.
-     */
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(URI needURI, URI resumeConnURI,
-                                                                                      Integer preferredSize, WonMessageType messageType, Date timeSpot, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException;
 
     /**
@@ -475,16 +319,6 @@ public interface LinkedDataService {
      * @throws NoSuchConnectionException
      */
     DataWithEtag<Dataset> getConnectionDataset(URI connectionUri, boolean includeEventContainer, String etag);
-
-    /**
-     * Returns a dataset containing all event uris belonging to the specified
-     * connection.
-     *
-     * @param connectionUri
-     * @return
-     * @throws NoSuchConnectionException
-     */
-    public Dataset listConnectionEventURIs(final URI connectionUri) throws NoSuchConnectionException;
 
     /**
      * Returns a dataset containing all event uris belonging to the specified

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -96,6 +96,13 @@ public interface NeedInformationService {
     public Collection<URI> listConnectionURIs();
 
     /**
+     * Retrieves all connections (regardless of state).
+     *
+     * @return a collection of connections.
+     */
+    public Collection<Connection> listConnections();
+
+    /**
      * Retrieves all connection URIs that were modified (by adding events) after a certain date
      *
      * @param modifiedAfter modification date
@@ -113,6 +120,17 @@ public interface NeedInformationService {
      * @return a slice connection URIs.
      */
     public Slice<URI> listConnectionURIs(int page, Integer preferredSize, Date timeSpot);
+
+    /**
+     * Retrieves slice of the connection URIs list for a given page number
+     *
+     * @param page the page number
+     * @param preferredSize preferred number of members per page or null; null => use default
+     * @param timeSpot time at which we want the list state to be fixed, if null - current state
+     *
+     * @return a slice connection URIs.
+     */
+    public Slice<Connection> listConnections(int page, Integer preferredSize, Date timeSpot);
 
     /**
      * Retrieves slice of the connection URIs that precede the given connection URI from the point of view of their

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -111,6 +111,14 @@ public interface NeedInformationService {
     public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter);
 
     /**
+     * Retrieves all connections that were modified (by adding events) after a certain date
+     *
+     * @param modifiedAfter modification date
+     * @return
+     */
+    public Collection<Connection> listModifiedConnectionsAfter(Date modifiedAfter);
+
+    /**
      * Retrieves slice of the connection URIs list for a given page number
      *
      * @param page the page number

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -146,6 +146,19 @@ public interface NeedInformationService {
       final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
 
     /**
+     * Retrieves slice of the connections that precede the given connection URI from the point of view of their
+     * latest events.
+     *
+     * @param resumeConnURI the returned slice connections precede (in time of their latest events) this connection uri
+     * @param preferredPageSize preferred number of members per page or null; null => use default
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
+     *
+     * @return a slice of connection URIs.
+     */
+    public Slice<Connection> listConnectionsBefore(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
+
+    /**
      * Retrieves slice of the connection URIs that follows the given connection URI from the point of view of their
      * latest events.
      *

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -209,6 +209,21 @@ public interface NeedInformationService {
       URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
 
     /**
+     * Retrieves slice of the connections  for the specified local need URI that precede the given connection URI
+     * from the point of view of their latest events.
+     *
+     * @param resumeConnURI the returned slice connections precede (in time of their latest events) this connection uri
+     * @param preferredPageSize preferred number of members per page or null; null => use default
+     * @param messageType event type that should be used for defining connection latest activity; null => all event
+     *                    types
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
+     *
+     * @return a slice of connection URIs.
+     */
+    public Slice listConnectionsBefore(
+            URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
+
+    /**
      * Retrieves slice of the connection URIs that follows the given connection URI from the point of view of their
      * latest events.
      *
@@ -220,8 +235,23 @@ public interface NeedInformationService {
      *
      * @return a slice of connection URIs.
      */
-    public Slice  listConnectionURIsAfter(
+    public Slice listConnectionURIsAfter(
       URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
+
+    /**
+     * Retrieves slice of the connections that follows the given connection URI from the point of view of their
+     * latest events.
+     *
+     * @param resumeConnURI the returned slice connections follow (in time of their latest events) this connection uri
+     * @param preferredPageSize preferred number of members per page or null; null => use default
+     * @param messageType event type that should be used for defining connection latest activity; null => all event
+     *                    types
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
+     *
+     * @return a slice of connection URIs.
+     */
+    public Slice  listConnectionsAfter(
+            URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
 
     /**
      * Read general information about the need.

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -407,41 +407,6 @@ public interface NeedInformationService {
     URI connectionUri, URI msgURI, Integer preferredPageSize, WonMessageType msgType);
 
 
-  @Deprecated
-  public static class Page<T>{
-    private Collection<T> content;
-    private boolean hasNext;
-    private T resumeBefore = null;
-    private T resumeAfter = null;
-
-    public Page(final Collection<T> content, final T resumeBefore, final T resumeAfter) {
-      this.content = content;
-      this.resumeBefore = resumeBefore;
-      this.resumeAfter = resumeAfter;
-    }
-
-    public Collection<T> getContent() {
-      return content;
-    }
-
-    public boolean hasNext() {
-      return resumeAfter != null;
-    }
-
-    public T getResumeAfter() {
-      return this.resumeAfter;
-    }
-
-    public boolean hasPrevious() {
-      return resumeBefore != null;
-    }
-
-    public T getResumeBefore() {
-      return resumeBefore;
-    }
-  }
-
-
   public static class PagedResource<T,E>{
     private T content;
     private E resumeBefore = null;

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -152,6 +152,16 @@ public interface NeedInformationService {
     public Collection<URI> listConnectionURIs(URI needURI) throws NoSuchNeedException;
 
     /**
+     * Retrieves all connections (regardless of state) for the specified local need URI.
+     *
+     * @param needURI the URI of the need
+     * @return a collection of connections.
+     * @throws won.protocol.exception.NoSuchNeedException
+     *          if needURI is not a known need URI
+     */
+    public Collection<Connection> listConnections(URI needURI) throws NoSuchNeedException;
+
+    /**
      * Retrieves slice of the list of connection URIs for the specified local need URI.
      *
      * @param needURI the URI of the need

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -103,14 +103,6 @@ public interface NeedInformationService {
     public Collection<Connection> listConnections();
 
     /**
-     * Retrieves all connection URIs that were modified (by adding events) after a certain date
-     *
-     * @param modifiedAfter modification date
-     * @return
-     */
-    public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter);
-
-    /**
      * Retrieves all connections that were modified (by adding events) after a certain date
      *
      * @param modifiedAfter modification date
@@ -141,19 +133,6 @@ public interface NeedInformationService {
     public Slice<Connection> listConnections(int page, Integer preferredSize, Date timeSpot);
 
     /**
-     * Retrieves slice of the connection URIs that precede the given connection URI from the point of view of their
-     * latest events.
-     *
-     * @param resumeConnURI the returned slice connections precede (in time of their latest events) this connection uri
-     * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param timeSpot time at which we want the list state to be fixed, cannot be null
-     *
-     * @return a slice of connection URIs.
-     */
-    public Slice<URI> listConnectionURIsBefore(
-      final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
-
-    /**
      * Retrieves slice of the connections that precede the given connection URI from the point of view of their
      * latest events.
      *
@@ -165,19 +144,6 @@ public interface NeedInformationService {
      */
     public Slice<Connection> listConnectionsBefore(
             final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
-
-    /**
-     * Retrieves slice of the connection URIs that follows the given connection URI from the point of view of their
-     * latest events.
-     *
-     * @param resumeConnURI the returned slice connections follow (in time of their latest events) this connection uri
-     * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param timeSpot time at which we want the list state to be fixed, cannot be null
-     *
-     * @return a slice of connection URIs.
-     */
-    public Slice<URI> listConnectionURIsAfter(
-      final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
 
     /**
      * Retrieves slice of the connections that follows the given connection URI from the point of view of their
@@ -245,21 +211,6 @@ public interface NeedInformationService {
             URI needURI, int page, Integer preferredSize, WonMessageType messageType, Date timeSpot);
 
     /**
-     * Retrieves slice of the connection URIs  for the specified local need URI that precede the given connection URI
-     * from the point of view of their latest events.
-     *
-     * @param resumeConnURI the returned slice connections precede (in time of their latest events) this connection uri
-     * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param messageType event type that should be used for defining connection latest activity; null => all event
-     *                    types
-     * @param timeSpot time at which we want the list state to be fixed, cannot be null
-     *
-     * @return a slice of connection URIs.
-     */
-    public Slice listConnectionURIsBefore(
-      URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
-
-    /**
      * Retrieves slice of the connections  for the specified local need URI that precede the given connection URI
      * from the point of view of their latest events.
      *
@@ -273,21 +224,6 @@ public interface NeedInformationService {
      */
     public Slice listConnectionsBefore(
             URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
-
-    /**
-     * Retrieves slice of the connection URIs that follows the given connection URI from the point of view of their
-     * latest events.
-     *
-     * @param resumeConnURI the returned slice connections follow (in time of their latest events) this connection uri
-     * @param preferredPageSize preferred number of members per page or null; null => use default
-     * @param messageType event type that should be used for defining connection latest activity; null => all event
-     *                    types
-     * @param timeSpot time at which we want the list state to be fixed, cannot be null
-     *
-     * @return a slice of connection URIs.
-     */
-    public Slice listConnectionURIsAfter(
-      URI needURI, URI resumeConnURI, Integer preferredPageSize, WonMessageType messageType, Date timeSpot);
 
     /**
      * Retrieves slice of the connections that follows the given connection URI from the point of view of their
@@ -368,39 +304,7 @@ public interface NeedInformationService {
   public Slice<MessageEventPlaceholder> listConnectionEvents(
     URI connectionUri, int page, Integer preferredPageSize, WonMessageType messageType);
 
-
-  /**
-   * Retrieves list of event uris of the specified connection that where created earlier than the given
-   * event (specified by event message uri) and  that have a given message type, with number of uris per page
-   * preference.
-   *
-   * @param connectionUri
-   * @param msgURI before which the messages should be returned (created before this message msgURI)
-   * @param preferredPageSize preferred number of members per page, null => use default
-   * @param msgType null => all types
-   * @return a collection of all event URIs.
-   */
-  @Deprecated
-  public Slice<URI> listConnectionEventURIsBefore(
-      URI connectionUri, URI msgURI, Integer preferredPageSize, WonMessageType msgType);
-
   public Slice<MessageEventPlaceholder> listConnectionEventsBefore(
-    URI connectionUri, URI msgURI, Integer preferredPageSize, WonMessageType msgType);
-
-
-  /**
-   * Retrieves list of event uris of the specified connection that where created later than the given
-   * event (specified by event message uri) and  that have a given message type, with number of uris per page
-   * preference.
-   *
-   * @param connectionUri
-   * @param msgURI after which the messages should be returned (created after this message msgURI)
-   * @param preferredPageSize preferred number of members per page, null => use default
-   * @param msgType null => all types
-   * @return a collection of all event URIs.
-   */
-  @Deprecated
-    public Slice<URI> listConnectionEventURIsAfter(
     URI connectionUri, URI msgURI, Integer preferredPageSize, WonMessageType msgType);
 
   public Slice<MessageEventPlaceholder> listConnectionEventsAfter(

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -178,6 +178,22 @@ public interface NeedInformationService {
       URI needURI, int page, Integer preferredSize, WonMessageType messageType, Date timeSpot);
 
     /**
+     * Retrieves slice of the list of connections for the specified local need URI.
+     *
+     * @param needURI the URI of the need
+     * @param page the page number
+     * @param preferredSize preferred number of members per page or null; null => use default
+     * @param messageType event type that should be used for defining connection latest activity; null => all event
+     *                    types
+     * @param timeSpot time at which we want the list state to be fixed, if null - current state
+     * @return a collection of connections.
+     * @throws won.protocol.exception.NoSuchNeedException
+     *          if needURI is not a known need URI
+     */
+    public Slice<Connection> listConnections(
+            URI needURI, int page, Integer preferredSize, WonMessageType messageType, Date timeSpot);
+
+    /**
      * Retrieves slice of the connection URIs  for the specified local need URI that precede the given connection URI
      * from the point of view of their latest events.
      *

--- a/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/NeedInformationService.java
@@ -171,6 +171,18 @@ public interface NeedInformationService {
     public Slice<URI> listConnectionURIsAfter(
       final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
 
+    /**
+     * Retrieves slice of the connections that follows the given connection URI from the point of view of their
+     * latest events.
+     *
+     * @param resumeConnURI the returned slice connections follow (in time of their latest events) this connection uri
+     * @param preferredPageSize preferred number of members per page or null; null => use default
+     * @param timeSpot time at which we want the list state to be fixed, cannot be null
+     *
+     * @return a slice of connection URIs.
+     */
+    public Slice<Connection> listConnectionsAfter(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot);
 
     /**
      * Retrieves all connection URIs (regardless of state) for the specified local need URI.

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -184,13 +184,6 @@ public class WON {
     public static final Property HAS_DELETED_COUNT = m.createProperty(BASE_URI,
             "hasDeletedCount");
 
-    public static final Property SUGGESTED = m.createProperty(BASE_URI, "suggested");
-    public static final Property REQUEST_RECEIVED = m.createProperty(BASE_URI, "requestReceived");
-    public static final Property REQUEST_SENT = m.createProperty(BASE_URI, "requestSent");
-    public static final Property CONNECTED = m.createProperty(BASE_URI, "connected");
-    public static final Property CLOSED = m.createProperty(BASE_URI, "closed");
-    public static final Property DELETED = m.createProperty(BASE_URI, "deleted");
-    
     //adds a flag to a need
     public static final Property HAS_FLAG = m.createProperty(BASE_URI + "hasFlag");
 

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -181,6 +181,15 @@ public class WON {
             "hasConnectedCount");
     public static final Property HAS_CLOSED_COUNT = m.createProperty(BASE_URI,
             "hasClosedCount");
+    public static final Property HAS_DELETED_COUNT = m.createProperty(BASE_URI,
+            "hasDeletedCount");
+
+    public static final Property SUGGESTED = m.createProperty(BASE_URI, "suggested");
+    public static final Property REQUEST_RECEIVED = m.createProperty(BASE_URI, "requestReceived");
+    public static final Property REQUEST_SENT = m.createProperty(BASE_URI, "requestSent");
+    public static final Property CONNECTED = m.createProperty(BASE_URI, "connected");
+    public static final Property CLOSED = m.createProperty(BASE_URI, "closed");
+    public static final Property DELETED = m.createProperty(BASE_URI, "deleted");
     
     //adds a flag to a need
     public static final Property HAS_FLAG = m.createProperty(BASE_URI + "hasFlag");

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -439,7 +439,9 @@ public class LinkedDataWebController {
                 // all the connections of the need; does not support type and date filtering for
                 // clients that do not support
                 // paging
-                rdfDataset = linkedDataService.listConnectionURIs(needURI, deep, true);
+                rdfDataset = linkedDataService
+                        .listConnectionURIs(needURI, deep, true)
+                        .getContent();
             }
             model.addAttribute("rdfDataset", rdfDataset);
             model.addAttribute("resourceURI",
@@ -793,7 +795,7 @@ public class LinkedDataWebController {
             @PathVariable(value = "identifier") String identifier,
             @RequestParam(value = "lastSeenMessageUris", required = false) List<URI> lastSeenMessageUris) {
         /*
-		 * information we want: need-level: unread count, date of first unread, date of
+         * information we want: need-level: unread count, date of first unread, date of
 		 * last unread per connection: connection uri, unread count, date of first
 		 * unread, date of last unread
 		 */
@@ -1123,7 +1125,9 @@ public class LinkedDataWebController {
             if (preferedSize == null) {
                 // does not support date and type filtering for clients that do not support
                 // paging
-                rdfDataset = linkedDataService.listConnectionURIs(needUri, deep, true);
+                rdfDataset = linkedDataService
+                        .listConnectionURIs(needUri, deep, true)
+                        .getContent();
                 // if no page or resume parameter is specified, display the latest connections:
             } else if (page == null && beforeId == null && afterId == null) {
                 //TODO: Change to include ConnectionData

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -374,19 +374,19 @@ public class LinkedDataWebController {
             DateParameter dateParam = new DateParameter(timestamp);
             Dataset rdfDataset;
             if (page != null) {
-                rdfDataset = linkedDataService.listConnectionURIs(page, null, dateParam.getDate(), deep).getContent();
+                rdfDataset = linkedDataService.listConnections(page, null, dateParam.getDate(), deep).getContent();
             } else if (beforeId != null) {
                 URI connURI = uriService.createConnectionURIForId(beforeId);
-                rdfDataset = linkedDataService.listConnectionURIsBefore(connURI, null, dateParam.getDate(), deep)
+                rdfDataset = linkedDataService.listConnectionsBefore(connURI, null, dateParam.getDate(), deep)
                         .getContent();
             } else if (afterId != null) {
                 URI connURI = uriService.createConnectionURIForId(afterId);
-                rdfDataset = linkedDataService.listConnectionURIsAfter(connURI, null, dateParam.getDate(), deep)
+                rdfDataset = linkedDataService.listConnectionsAfter(connURI, null, dateParam.getDate(), deep)
                         .getContent();
             } else {
                 // all the connections; does not support date filtering for clients that do not
                 // support paging
-                rdfDataset = linkedDataService.listConnectionURIs(deep);
+                rdfDataset = linkedDataService.listConnections(deep).getContent();
             }
             model.addAttribute("rdfDataset", rdfDataset);
             model.addAttribute("resourceURI",
@@ -680,8 +680,6 @@ public class LinkedDataWebController {
                                                       @RequestParam(value = "timeof", required = false) String timestamp,
                                                       @RequestParam(value = "modifiedafter", required = false) String modifiedAfter,
                                                       @RequestParam(value = "deep", defaultValue = "false") boolean deep) {
-
-        logger.debug("listConnectionURIs() called");
         Dataset rdfDataset;
         HttpHeaders headers = new HttpHeaders();
         Integer preferedSize = getPreferredSize(request);
@@ -699,27 +697,27 @@ public class LinkedDataWebController {
             if (preferedSize == null && modifiedAfter == null) {
                 // all connections; does not support date filtering for clients that do not
                 // support paging
-                rdfDataset = linkedDataService.listConnectionURIs(deep);
+                rdfDataset = linkedDataService.listConnections(deep).getContent();
             } else if (modifiedAfter != null) {
                 // paging is not implemented for modified connections for now!
                 rdfDataset = linkedDataService
                         .listModifiedConnectionURIsAfter(new DateParameter(modifiedAfter).getDate(), deep);
             } else if (page != null) {
                 // return latest by the given timestamp
-                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(page,
+                NeedInformationService.PagedResource<Dataset, Connection> resource = linkedDataService.listConnections(page,
                         preferedSize, dateParam.getDate(), deep);
                 rdfDataset = resource.getContent();
-                addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource, page,
+                addPagedConnectionResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource, page,
                         passableMap);
 
                 // resume before parameter specified - display the connections with activities
                 // before the specified event id
             } else if (beforeId == null && afterId == null) {
                 // return latest by the given timestamp
-                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(1,
+                NeedInformationService.PagedResource<Dataset, Connection> resource = linkedDataService.listConnections(1,
                         preferedSize, dateParam.getDate(), deep);
                 rdfDataset = resource.getContent();
-                addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                addPagedConnectionResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
                         passableMap);
 
                 // resume before parameter specified - display the connections with activities
@@ -727,20 +725,20 @@ public class LinkedDataWebController {
             } else {
                 if (beforeId != null) {
                     URI resumeConnURI = uriService.createConnectionURIForId(beforeId);
-                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-                            .listConnectionURIsBefore(resumeConnURI, preferedSize, dateParam.getDate(), deep);
+                    NeedInformationService.PagedResource<Dataset, Connection> resource = linkedDataService
+                            .listConnectionsBefore(resumeConnURI, preferedSize, dateParam.getDate(), deep);
                     rdfDataset = resource.getContent();
-                    addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                    addPagedConnectionResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
                             passableMap);
 
                     // resume after parameter specified - display the connections with activities
                     // after the specified event id:
                 } else { // if (afterId != null)
                     URI resumeConnURI = uriService.createConnectionURIForId(afterId);
-                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-                            .listConnectionURIsAfter(resumeConnURI, preferedSize, dateParam.getDate(), deep);
+                    NeedInformationService.PagedResource<Dataset, Connection> resource = linkedDataService
+                            .listConnectionsAfter(resumeConnURI, preferedSize, dateParam.getDate(), deep);
                     rdfDataset = resource.getContent();
-                    addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                    addPagedConnectionResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
                             passableMap);
 
                 }

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -921,10 +921,7 @@ public class LinkedDataWebController {
             } else if (beforeId == null && afterId == null) {
                 //if page == null -> return page with latest events
                 NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-                        .listConnectionEventURIs(connectionUri, page != null ? page : 1, preferedSize, msgType, deep); // TODO: does not
-                // respect
-                // preferredSize if
-                // deep is used
+                        .listConnectionEventURIs(connectionUri, page != null ? page : 1, preferedSize, msgType, deep); //FIXME: does not respect preferredSize if deep is used
                 rdfDataset = resource.getContent();
                 if (page == null) {
                     addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -508,17 +508,6 @@ public class LinkedDataWebController {
         return requestUri;
     }
 
-    private String getRequestUriWithAddedQuery(final HttpServletRequest request, String query) {
-        String requestUri = request.getRequestURI();
-        String queryString = request.getQueryString();
-        if (queryString == null || queryString.length() <= 2) {
-            requestUri += "?" + query;
-        } else {
-            requestUri += "?" + queryString + "&" + query;
-        }
-        return requestUri;
-    }
-
     /**
      * If the HTTP 'Accept' header is 'text/html' (as listed in the 'produces' value
      * of the RequestMapping annotation), a redirect to a page uri is sent.

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -16,29 +16,6 @@
 
 package won.node.web;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.Property;
@@ -63,7 +40,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.HandlerMapping;
-
 import won.cryptography.service.RegistrationServer;
 import won.node.service.impl.URIService;
 import won.protocol.exception.IncorrectPropertyCountException;
@@ -80,6 +56,20 @@ import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.CNT;
 import won.protocol.vocabulary.HTTP;
 import won.protocol.vocabulary.WONMSG;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * TODO: check the working draft here and see to conformance:
@@ -123,1412 +113,1410 @@ import won.protocol.vocabulary.WONMSG;
 @Controller
 @RequestMapping("/")
 public class LinkedDataWebController {
-	private final Logger logger = LoggerFactory.getLogger(getClass());
-	// full prefix of a need resource
-	private String needResourceURIPrefix;
-	// path of a need resource
-	private String needResourceURIPath;
-	// full prefix of a connection resource
-	private String connectionResourceURIPrefix;
-	// path of a connection resource
-	private String connectionResourceURIPath;
-	// prefix for URISs of RDF data
-	private String dataURIPrefix;
-	// prefix for URIs referring to real-world things
-	private String resourceURIPrefix;
-	// prefix for human readable pages
-	private String pageURIPrefix;
-	private String nodeResourceURIPrefix;
-
-	@Autowired
-	private LinkedDataService linkedDataService;
-
-	@Autowired
-	private RegistrationServer registrationServer;
-
-	// date format for Expires header (rfc 1123)
-	private static final String DATE_FORMAT_RFC_1123 = "EEE, dd MMM yyyy HH:mm:ss z";
-
-	// timeout for resources that clients may cache for a short term
-	private static final int SHORT_TERM_CACHE_TIMEOUT_SECONDS = 600;
-
-	@Autowired
-	private URIService uriService;
-
-	@RequestMapping(value = "/", method = RequestMethod.GET)
-	public String showIndexPage() {
-		return "index";
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.need}/{identifier}")
-	public String showNeedPage(@PathVariable String identifier, Model model, HttpServletResponse response) {
-
-		URI needURI = uriService.createNeedURIForId(identifier);
-		Dataset rdfDataset = linkedDataService.getNeedDataset(needURI, null).getData();
-
-		if (rdfDataset == null) {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-
-		model.addAttribute("rdfDataset", rdfDataset);
-		model.addAttribute("resourceURI", needURI.toString());
-		model.addAttribute("dataURI", uriService.toDataURIIfPossible(needURI).toString());
-		return "rdfDatasetView";
-	}
-
-	/**
-	 * This request URL should be protected by WebID filter because the result
-	 * contains events data - which is data with restricted access. See
-	 * filterChainProxy in node-context.xml.
-	 *
-	 * @param identifier
-	 * @param model
-	 * @param response
-	 * @return
-	 */
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.need}/{identifier}/deep")
-	public String showDeepNeedPage(@PathVariable String identifier, Model model, HttpServletResponse response,
-			@RequestParam(value = "layer-size", required = false) Integer layerSize) {
-		try {
-			URI needURI = uriService.createNeedURIForId(identifier);
-			Dataset rdfDataset = linkedDataService.getNeedDataset(needURI, true, layerSize);
-			model.addAttribute("rdfDataset", rdfDataset);
-			model.addAttribute("resourceURI", needURI.toString());
-			model.addAttribute("dataURI", uriService.toDataURIIfPossible(needURI).toString());
-			return "rdfDatasetView";
-		} catch (NoSuchNeedException | NoSuchConnectionException | NoSuchMessageException e) {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.connection}/{identifier}")
-	public String showConnectionPage(@PathVariable String identifier, Model model, HttpServletResponse response) {
-		URI connectionURI = uriService.createConnectionURIForId(identifier);
-		DataWithEtag<Dataset> rdfDataset = linkedDataService.getConnectionDataset(connectionURI, true, null);
-		if (rdfDataset.isNotFound()) {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-		model.addAttribute("rdfDataset", rdfDataset.getData());
-		model.addAttribute("resourceURI", connectionURI.toString());
-		model.addAttribute("dataURI", uriService.toDataURIIfPossible(connectionURI).toString());
-		return "rdfDatasetView";
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.connection}/{identifier}/events")
-	public String showConnectionEventsPage(@PathVariable String identifier,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "type", required = false) String type,
-			@RequestParam(value = "deep", required = false, defaultValue = "false") boolean deep, Model model,
-			HttpServletResponse response) {
-
-		try {
-
-			URI connectionURI = uriService.createConnectionURIForId(identifier);
-			String eventsURI = connectionURI.toString() + "/events";
-			Dataset rdfDataset;
-			WonMessageType msgType = getMessageType(type);
-
-			if (page == null && beforeId == null && afterId == null) {
-				// all events, does not support type filtering for clients that do not support
-				// paging
-				rdfDataset = linkedDataService.listConnectionEventURIs(connectionURI, deep);
-
-			} else if (page != null) {
-				// a page having particular page number is requested
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIs(connectionURI, page, null, msgType, deep);
-				rdfDataset = resource.getContent();
-
-			} else if (beforeId != null) {
-				// a page that precedes the item identified by the beforeId is requested
-
-				URI referenceEvent = uriService.createEventURIForId(beforeId);
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIsBefore(connectionURI, referenceEvent, null, msgType, deep);
-				rdfDataset = resource.getContent();
-
-			} else {
-				// a page that follows the item identified by the afterId is requested
-
-				URI referenceEvent = uriService.createEventURIForId(afterId);
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIsAfter(connectionURI, referenceEvent, null, msgType, deep);
-				rdfDataset = resource.getContent();
-
-			}
-			model.addAttribute("rdfDataset", rdfDataset);
-			model.addAttribute("resourceURI", eventsURI);
-			model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(eventsURI)).toString());
-			return "rdfDatasetView";
-		} catch (NoSuchConnectionException e) {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-	}
-
-	/**
-	 * This request URL should be protected by WebID filter because the result
-	 * contains events data - which is data with restricted access. See
-	 * filterChainProxy in node-context.xml.
-	 *
-	 * @param identifier
-	 * @param model
-	 * @param response
-	 * @return
-	 */
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.event}/{identifier}")
-	public String showEventPage(@PathVariable(value = "identifier") String identifier, Model model,
-			HttpServletResponse response) {
-		URI eventURI = uriService.createEventURIForId(identifier);
-
-		DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(eventURI, null);
-		if (model != null && !data.isNotFound()) {
-			model.addAttribute("rdfDataset", data.getData());
-			model.addAttribute("resourceURI", eventURI.toString());
-			model.addAttribute("dataURI", uriService.toDataURIIfPossible(eventURI).toString());
-			return "rdfDatasetView";
-		} else {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.attachment}/{identifier}")
-	public String showAttachmentPage(@PathVariable(value = "identifier") String identifier, Model model,
-			HttpServletResponse response) {
-		URI attachmentURI = uriService.createAttachmentURIForId(identifier);
-		DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(attachmentURI, null);
-		if (model != null && !data.isNotFound()) {
-			model.addAttribute("rdfDataset", data.getData());
-			model.addAttribute("resourceURI", attachmentURI.toString());
-			model.addAttribute("dataURI", uriService.toDataURIIfPossible(attachmentURI).toString());
-			return "rdfDatasetView";
-		} else {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		}
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.need}")
-	public String showNeedURIListPage(@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "state", required = false) String state, HttpServletRequest request, Model model,
-			HttpServletResponse response) throws IOException {
-
-		Dataset rdfDataset;
-		NeedState needState = getNeedState(state);
-
-		if (page == null && beforeId == null && afterId == null) {
-			// all needs, does not support need state filtering for clients that do not
-			// support paging
-			rdfDataset = linkedDataService.listNeedURIs();
-		} else if (page != null) {
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(page, null,
-					needState);
-			rdfDataset = resource.getContent();
-		} else if (beforeId != null) {
-
-			URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + beforeId);
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-					.listNeedURIsBefore(referenceNeed, null, needState);
-			rdfDataset = resource.getContent();
-		} else { // afterId != null
-			URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + afterId);
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-					.listNeedURIsAfter(referenceNeed, null, needState);
-			rdfDataset = resource.getContent();
-		}
-
-		model.addAttribute("rdfDataset", rdfDataset);
-		model.addAttribute("resourceURI",
-				uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
-		model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
-		return "rdfDatasetView";
-
-	}
-
-	@RequestMapping("${uri.path.page}")
-	public String showNodeInformationPage(HttpServletRequest request, Model model, HttpServletResponse response) {
-		Dataset rdfDataset = linkedDataService.getNodeDataset();
-		model.addAttribute("rdfDataset", rdfDataset);
-		model.addAttribute("resourceURI",
-				uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
-		model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
-		return "rdfDatasetView";
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.connection}")
-	public String showConnectionURIListPage(@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "deep", defaultValue = "false") boolean deep,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "timeof", required = false) String timestamp, HttpServletRequest request, Model model,
-			HttpServletResponse response) {
-
-		try {
-			DateParameter dateParam = new DateParameter(timestamp);
-			Dataset rdfDataset;
-			if (page != null) {
-				rdfDataset = linkedDataService.listConnectionURIs(page, null, dateParam.getDate(), deep).getContent();
-			} else if (beforeId != null) {
-				URI connURI = uriService.createConnectionURIForId(beforeId);
-				rdfDataset = linkedDataService.listConnectionURIsBefore(connURI, null, dateParam.getDate(), deep)
-						.getContent();
-			} else if (afterId != null) {
-				URI connURI = uriService.createConnectionURIForId(afterId);
-				rdfDataset = linkedDataService.listConnectionURIsAfter(connURI, null, dateParam.getDate(), deep)
-						.getContent();
-			} else {
-				// all the connections; does not support date filtering for clients that do not
-				// support paging
-				rdfDataset = linkedDataService.listConnectionURIs(deep);
-			}
-			model.addAttribute("rdfDataset", rdfDataset);
-			model.addAttribute("resourceURI",
-					uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
-			model.addAttribute("dataURI",
-					uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
-			return "rdfDatasetView";
-		} catch (ParseException e) {
-			model.addAttribute("error", "could not parse timestamp parameter");
-			return "notFoundView";
-		} catch (NoSuchConnectionException e) {
-			model.addAttribute("error", "could not add connection data for " + e.getUnknownConnectionURI().toString());
-			return "notFoundView";
-		}
-	}
-
-	// webmvc controller method
-	@RequestMapping("${uri.path.page.need}/{identifier}/connections")
-	public String showConnectionURIListPage(@PathVariable String identifier,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "deep", defaultValue = "false") boolean deep,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "type", required = false) String type,
-			@RequestParam(value = "timeof", required = false) String timestamp, HttpServletRequest request, Model model,
-			HttpServletResponse response) {
-
-		URI needURI = uriService.createNeedURIForId(identifier);
-		try {
-			DateParameter dateParam = new DateParameter(timestamp);
-			WonMessageType eventsType = getMessageType(type);
-			Dataset rdfDataset;
-			if (page != null) {
-				rdfDataset = linkedDataService
-						.listConnectionURIs(page, needURI, null, eventsType, dateParam.getDate(), deep, true)
-						.getContent();
-			} else if (beforeId != null) {
-				URI connURI = uriService.createConnectionURIForId(beforeId);
-				rdfDataset = linkedDataService
-						.listConnectionURIsBefore(needURI, connURI, null, eventsType, dateParam.getDate(), deep, true)
-						.getContent();
-			} else if (afterId != null) {
-				URI connURI = uriService.createConnectionURIForId(afterId);
-				rdfDataset = linkedDataService
-						.listConnectionURIsAfter(needURI, connURI, null, eventsType, dateParam.getDate(), deep, true)
-						.getContent();
-			} else {
-				// all the connections of the need; does not support type and date filtering for
-				// clients that do not support
-				// paging
-				rdfDataset = linkedDataService.listConnectionURIs(needURI, deep, true);
-			}
-			model.addAttribute("rdfDataset", rdfDataset);
-			model.addAttribute("resourceURI",
-					uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
-			model.addAttribute("dataURI",
-					uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
-			return "rdfDatasetView";
-		} catch (ParseException e) {
-			model.addAttribute("error", "could not parse timestamp parameter");
-			return "notFoundView";
-		} catch (NoSuchNeedException e) {
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			return "notFoundView";
-		} catch (NoSuchConnectionException e) {
-			logger.warn("did not find connection that should be connected to need. connection:{}",
-					e.getUnknownConnectionURI());
-			return "notFoundView"; // TODO: should display an error view
-		}
-	}
-
-	/**
-	 * If the HTTP 'Accept' header is an RDF MIME type (as listed in the 'produces'
-	 * value of the RequestMapping annotation), a redirect to a data uri is sent.
-	 *
-	 * @param request
-	 * @return
-	 */
-	@RequestMapping(value = "${uri.path.resource}/**", method = RequestMethod.GET, produces = { "application/ld+json",
-			"application/trig", "application/n-quads", "*/*" })
-	public ResponseEntity<String> redirectToData(HttpServletRequest request, HttpServletResponse response)
-			throws IOException {
-		URI resourceUriPrefix = URI.create(this.resourceURIPrefix);
-		URI dataUri = URI.create(this.dataURIPrefix);
-		String requestUri = getRequestUriWithQueryString(request);
-		String redirectToURI = requestUri.replaceFirst(resourceUriPrefix.getPath(), dataUri.getPath());
-		logger.debug("resource URI requested with data mime type. redirecting from {} to {}", requestUri,
-				redirectToURI);
-		if (redirectToURI.equals(requestUri)) {
-			logger.debug("redirecting to same URI avoided, sending status 500 instead");
-			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-
-		// TODO: actually the expiry information should be the same as that of the
-		// resource that is redirected to
-		HttpHeaders headers = new HttpHeaders();
-		headers = addExpiresHeadersBasedOnRequestURI(headers, requestUri);
-		// headers.setLocation(URI.create(redirectToURI));
-		addCORSHeader(headers);
-		setResponseHeaders(response, headers);
-		response.sendRedirect(redirectToURI);
-		return null;
-	}
-
-	public void setResponseHeaders(final HttpServletResponse response, final HttpHeaders headers) {
-		for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
-			for (String value : entry.getValue()) {
-				response.setHeader(entry.getKey(), value);
-			}
-		}
-	}
-
-	private String getRequestUriWithQueryString(final HttpServletRequest request) {
-		String requestUri = request.getRequestURI();
-		String queryString = request.getQueryString();
-		if (queryString != null) {
-			requestUri += "?" + queryString;
-		}
-		return requestUri;
-	}
-
-	private String getRequestUriWithAddedQuery(final HttpServletRequest request, String query) {
-		String requestUri = request.getRequestURI();
-		String queryString = request.getQueryString();
-		if (queryString == null || queryString.length() <= 2) {
-			requestUri += "?" + query;
-		} else {
-			requestUri += "?" + queryString + "&" + query;
-		}
-		return requestUri;
-	}
-
-	/**
-	 * If the HTTP 'Accept' header is 'text/html' (as listed in the 'produces' value
-	 * of the RequestMapping annotation), a redirect to a page uri is sent.
-	 *
-	 * @param request
-	 * @return
-	 */
-	@RequestMapping(value = "${uri.path.resource}/**", method = RequestMethod.GET, produces = "text/html")
-	public ResponseEntity<String> redirectToPage(HttpServletRequest request, HttpServletResponse response)
-			throws IOException {
-		URI resourceUriPrefix = URI.create(this.resourceURIPrefix);
-		URI pageUriPrefix = URI.create(this.pageURIPrefix);
-		String requestUri = getRequestUriWithQueryString(request);
-		String redirectToURI = requestUri.replaceFirst(resourceUriPrefix.getPath(), pageUriPrefix.getPath());
-		logger.debug("resource URI requested with page mime type. redirecting from {} to {}", requestUri,
-				redirectToURI);
-		if (redirectToURI.equals(requestUri)) {
-			logger.debug("redirecting to same URI avoided, sending status 500 instead");
-			return new ResponseEntity<>("\"Could not redirect to linked data page\"", HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-		// TODO: actually the expiry information should be the same as that of the
-		// resource that is redirected to
-		HttpHeaders headers = new HttpHeaders();
-		headers = addExpiresHeadersBasedOnRequestURI(headers, requestUri);
-		addCORSHeader(headers);
-		// add a location header
-		// headers.add("Location",redirectToURI);
-		setResponseHeaders(response, headers);
-		response.sendRedirect(redirectToURI);
-		return null;
-	}
-
-	/**
-	 * If the request URI is the URI of a list page (list of needs, list of
-	 * connections), or a need uri, it gets the header that says 'already expired' so that crawlers
-	 * re-download these data. For other URIs, the 'never expires' header is added.
-	 *
-	 * @param headers
-	 * @param requestUri
-	 * @return
-	 */
-	public HttpHeaders addExpiresHeadersBasedOnRequestURI(HttpHeaders headers, final String requestUri) {
-		// now, we want to suppress the 'never expires' header information
-		// for /resource/need and resource/connection so that crawlers always re-fetch
-		// these data
-		URI requestUriAsURI = URI.create(requestUri);
-		String requestPath = requestUriAsURI.getPath();
-		if (uriService.isConnectionEventsURI(requestUriAsURI) || uriService.isNeedEventsURI(requestUriAsURI) || uriService.isNeedURI(requestUriAsURI)) {
-			addMutableResourceHeaders(headers);
-		} else {
-			addImmutableResourceHeaders(headers);
-		}
-		return headers;
-	}
-
-	@RequestMapping(value = "${uri.path.data.need}", method = RequestMethod.GET, produces = { "application/ld+json",
-			"application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> listNeedURIs(HttpServletRequest request, HttpServletResponse response,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "modifiedafter", required = false) String modifiedAfter,
-			@RequestParam(value = "state", required = false) String state) throws IOException, ParseException {
-		logger.debug("listNeedURIs() for page " + page + " called");
-
-		Dataset rdfDataset;
-		HttpHeaders headers = new HttpHeaders();
-		Integer preferedSize = getPreferredSize(request);
-		String passableQuery = getPassableQueryMap("state", state);
-		NeedState needState = getNeedState(state);
-
-		if (preferedSize == null && modifiedAfter == null) {
-			// client doesn not support paging - return all needs; does not support need
-			// state filtering for clients that do
-			// not support paging
-			rdfDataset = linkedDataService.listNeedURIs();
-
-		} else if (page == null && beforeId == null && afterId == null && modifiedAfter == null) {
-			// return latest needs
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(1,
-					preferedSize, needState);
-			rdfDataset = resource.getContent();
-			addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
-
-			// resume before parameter specified - display the connections with activities
-			// before the specified event id
-		} else if (page != null) {
-
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(page,
-					preferedSize, needState);
-			rdfDataset = resource.getContent();
-			addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, page,
-					passableQuery);
-
-		} else if (beforeId != null) {
-
-			URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + beforeId);
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-					.listNeedURIsBefore(referenceNeed, preferedSize, needState);
-			rdfDataset = resource.getContent();
-			addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
-		} else if (afterId != null) {
-
-			URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + afterId);
-			NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-					.listNeedURIsAfter(referenceNeed, preferedSize, needState);
-			rdfDataset = resource.getContent();
-			addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
-		} else { // modifiedafter != null
-
-			// do not support paging for modified needs for now
-			DateParameter modifiedDate = new DateParameter(modifiedAfter);
-			rdfDataset = linkedDataService.listModifiedNeedURIsAfter(modifiedDate.getDate());
-		}
-
-		addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
-				URI.create(this.needResourceURIPrefix));
-		addMutableResourceHeaders(headers);
-		addCORSHeader(headers);
-
-		return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
-	}
-
-	private NeedState getNeedState(final String state) {
-		if (state != null) {
-			return NeedState.parseString(state);
-		} else {
-			return null;
-		}
-	}
-
-	private Integer getPreferredSize(final HttpServletRequest request) {
-
-		Integer preferedSize = null;
-		Enumeration<String> preferValue = request.getHeaders("Prefer");
-		if (preferValue != null) {
-			// TODO share prefer pattern between methods, check the supported syntax
-			// according to HTTP protocol, and take
-			// into account that client preference can also include max-triple-count and
-			// max-kbyte-count:
-			Pattern pattern = Pattern.compile("(return=representation; max-member-count=)(\"?)([0-9]+)(\"?)");
-			while (preferValue.hasMoreElements() && preferedSize == null) {
-				String value = preferValue.nextElement();
-				Matcher matcher = pattern.matcher(value);
-				if (matcher.find()) {
-					preferedSize = Integer.valueOf(matcher.group(3));
-				}
-			}
-		}
-		return preferedSize;
-	}
-
-	@RequestMapping(value = "${uri.path.data.connection}", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> listConnectionURIs(HttpServletRequest request,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "timeof", required = false) String timestamp,
-			@RequestParam(value = "modifiedafter", required = false) String modifiedAfter,
-			@RequestParam(value = "deep", defaultValue = "false") boolean deep) {
-
-		logger.debug("listConnectionURIs() called");
-		Dataset rdfDataset;
-		HttpHeaders headers = new HttpHeaders();
-		Integer preferedSize = getPreferredSize(request);
-
-		try {
-			// even when the timestamp is not provided (null), we need to fix the time (if
-			// null, then to current),
-			// because we will return prev/next links which make no sense if the time is not
-			// fixed
-			DateParameter dateParam = new DateParameter(timestamp);
-			String passableMap = getPassableQueryMap("timeof", dateParam.getTimestamp(), "deep",
-					Boolean.toString(deep));
-			// if no preferred size provided by the client => the client does not support
-			// paging, return everything:
-			if (preferedSize == null && modifiedAfter == null) {
-				// all connections; does not support date filtering for clients that do not
-				// support paging
-				rdfDataset = linkedDataService.listConnectionURIs(deep);
-			} else if (modifiedAfter != null) {
-				// paging is not implemented for modified connections for now!
-				rdfDataset = linkedDataService
-						.listModifiedConnectionURIsAfter(new DateParameter(modifiedAfter).getDate(), deep);
-			} else if (page != null) {
-				// return latest by the given timestamp
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(page,
-						preferedSize, dateParam.getDate(), deep);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource, page,
-						passableMap);
-
-				// resume before parameter specified - display the connections with activities
-				// before the specified event id
-			} else if (beforeId == null && afterId == null) {
-				// return latest by the given timestamp
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(1,
-						preferedSize, dateParam.getDate(), deep);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
-						passableMap);
-
-				// resume before parameter specified - display the connections with activities
-				// before the specified event id
-			} else {
-				if (beforeId != null) {
-					URI resumeConnURI = uriService.createConnectionURIForId(beforeId);
-					NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-							.listConnectionURIsBefore(resumeConnURI, preferedSize, dateParam.getDate(), deep);
-					rdfDataset = resource.getContent();
-					addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
-							passableMap);
-
-					// resume after parameter specified - display the connections with activities
-					// after the specified event id:
-				} else { // if (afterId != null)
-					URI resumeConnURI = uriService.createConnectionURIForId(afterId);
-					NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-							.listConnectionURIsAfter(resumeConnURI, preferedSize, dateParam.getDate(), deep);
-					rdfDataset = resource.getContent();
-					addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
-							passableMap);
-
-				}
-			}
-		} catch (ParseException e) {
-			logger.warn("could not parse timestamp into Date:{}", timestamp);
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		} catch (NoSuchConnectionException e) {
-			logger.warn("did not find connection that should be connected to need. connection:{}",
-					e.getUnknownConnectionURI());
-			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-		addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
-				URI.create(this.connectionResourceURIPrefix));
-		addMutableResourceHeaders(headers);
-		addCORSHeader(headers);
-		return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
-	}
-
-	@RequestMapping(value = "${uri.path.data.need}/{identifier}", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readNeed(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier) {
-
-		logger.debug("readNeed() called");
-		return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
-			@Override
-			public URI createUriForIdentifier(final String identifier) {
-				return URI.create(needResourceURIPrefix + "/" + identifier);
-			}
-
-			@Override
-			public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
-				return linkedDataService.getNeedDataset(uri, etag);
-			}
-
-			@Override
-			public void addHeaders(final HttpHeaders headers) {
-				addCORSHeader(headers);
-				addPublicHeaders(headers);
-			}
-		});
-	}
-
-	@RequestMapping(value = "${uri.path.data.need}/{identifier}/unread", method = RequestMethod.POST, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<org.apache.jena.rdf.model.Model> readUnreadInformationPost(
-			@PathVariable(value = "identifier") String identifier,
-			@RequestParam(value = "lastSeenMessageUris", required = false) List<URI> lastSeenMessageUris) {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    // full prefix of a need resource
+    private String needResourceURIPrefix;
+    // path of a need resource
+    private String needResourceURIPath;
+    // full prefix of a connection resource
+    private String connectionResourceURIPrefix;
+    // path of a connection resource
+    private String connectionResourceURIPath;
+    // prefix for URISs of RDF data
+    private String dataURIPrefix;
+    // prefix for URIs referring to real-world things
+    private String resourceURIPrefix;
+    // prefix for human readable pages
+    private String pageURIPrefix;
+    private String nodeResourceURIPrefix;
+
+    @Autowired
+    private LinkedDataService linkedDataService;
+
+    @Autowired
+    private RegistrationServer registrationServer;
+
+    // date format for Expires header (rfc 1123)
+    private static final String DATE_FORMAT_RFC_1123 = "EEE, dd MMM yyyy HH:mm:ss z";
+
+    // timeout for resources that clients may cache for a short term
+    private static final int SHORT_TERM_CACHE_TIMEOUT_SECONDS = 600;
+
+    @Autowired
+    private URIService uriService;
+
+    @RequestMapping(value = "/", method = RequestMethod.GET)
+    public String showIndexPage() {
+        return "index";
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.need}/{identifier}")
+    public String showNeedPage(@PathVariable String identifier, Model model, HttpServletResponse response) {
+
+        URI needURI = uriService.createNeedURIForId(identifier);
+        Dataset rdfDataset = linkedDataService.getNeedDataset(needURI, null).getData();
+
+        if (rdfDataset == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+
+        model.addAttribute("rdfDataset", rdfDataset);
+        model.addAttribute("resourceURI", needURI.toString());
+        model.addAttribute("dataURI", uriService.toDataURIIfPossible(needURI).toString());
+        return "rdfDatasetView";
+    }
+
+    /**
+     * This request URL should be protected by WebID filter because the result
+     * contains events data - which is data with restricted access. See
+     * filterChainProxy in node-context.xml.
+     *
+     * @param identifier
+     * @param model
+     * @param response
+     * @return
+     */
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.need}/{identifier}/deep")
+    public String showDeepNeedPage(@PathVariable String identifier, Model model, HttpServletResponse response,
+                                   @RequestParam(value = "layer-size", required = false) Integer layerSize) {
+        try {
+            URI needURI = uriService.createNeedURIForId(identifier);
+            Dataset rdfDataset = linkedDataService.getNeedDataset(needURI, true, layerSize);
+            model.addAttribute("rdfDataset", rdfDataset);
+            model.addAttribute("resourceURI", needURI.toString());
+            model.addAttribute("dataURI", uriService.toDataURIIfPossible(needURI).toString());
+            return "rdfDatasetView";
+        } catch (NoSuchNeedException | NoSuchConnectionException | NoSuchMessageException e) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.connection}/{identifier}")
+    public String showConnectionPage(@PathVariable String identifier, Model model, HttpServletResponse response) {
+        URI connectionURI = uriService.createConnectionURIForId(identifier);
+        DataWithEtag<Dataset> rdfDataset = linkedDataService.getConnectionDataset(connectionURI, true, null);
+        if (rdfDataset.isNotFound()) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+        model.addAttribute("rdfDataset", rdfDataset.getData());
+        model.addAttribute("resourceURI", connectionURI.toString());
+        model.addAttribute("dataURI", uriService.toDataURIIfPossible(connectionURI).toString());
+        return "rdfDatasetView";
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.connection}/{identifier}/events")
+    public String showConnectionEventsPage(@PathVariable String identifier,
+                                           @RequestParam(value = "p", required = false) Integer page,
+                                           @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                           @RequestParam(value = "resumeafter", required = false) String afterId,
+                                           @RequestParam(value = "type", required = false) String type,
+                                           @RequestParam(value = "deep", required = false, defaultValue = "false") boolean deep, Model model,
+                                           HttpServletResponse response) {
+
+        try {
+
+            URI connectionURI = uriService.createConnectionURIForId(identifier);
+            String eventsURI = connectionURI.toString() + "/events";
+            Dataset rdfDataset;
+            WonMessageType msgType = getMessageType(type);
+
+            if (page == null && beforeId == null && afterId == null) {
+                // all events, does not support type filtering for clients that do not support
+                // paging
+                rdfDataset = linkedDataService.listConnectionEventURIs(connectionURI, deep);
+
+            } else if (page != null) {
+                // a page having particular page number is requested
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIs(connectionURI, page, null, msgType, deep);
+                rdfDataset = resource.getContent();
+
+            } else if (beforeId != null) {
+                // a page that precedes the item identified by the beforeId is requested
+
+                URI referenceEvent = uriService.createEventURIForId(beforeId);
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIsBefore(connectionURI, referenceEvent, null, msgType, deep);
+                rdfDataset = resource.getContent();
+
+            } else {
+                // a page that follows the item identified by the afterId is requested
+
+                URI referenceEvent = uriService.createEventURIForId(afterId);
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIsAfter(connectionURI, referenceEvent, null, msgType, deep);
+                rdfDataset = resource.getContent();
+
+            }
+            model.addAttribute("rdfDataset", rdfDataset);
+            model.addAttribute("resourceURI", eventsURI);
+            model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(eventsURI)).toString());
+            return "rdfDatasetView";
+        } catch (NoSuchConnectionException e) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+    }
+
+    /**
+     * This request URL should be protected by WebID filter because the result
+     * contains events data - which is data with restricted access. See
+     * filterChainProxy in node-context.xml.
+     *
+     * @param identifier
+     * @param model
+     * @param response
+     * @return
+     */
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.event}/{identifier}")
+    public String showEventPage(@PathVariable(value = "identifier") String identifier, Model model,
+                                HttpServletResponse response) {
+        URI eventURI = uriService.createEventURIForId(identifier);
+
+        DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(eventURI, null);
+        if (model != null && !data.isNotFound()) {
+            model.addAttribute("rdfDataset", data.getData());
+            model.addAttribute("resourceURI", eventURI.toString());
+            model.addAttribute("dataURI", uriService.toDataURIIfPossible(eventURI).toString());
+            return "rdfDatasetView";
+        } else {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.attachment}/{identifier}")
+    public String showAttachmentPage(@PathVariable(value = "identifier") String identifier, Model model,
+                                     HttpServletResponse response) {
+        URI attachmentURI = uriService.createAttachmentURIForId(identifier);
+        DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(attachmentURI, null);
+        if (model != null && !data.isNotFound()) {
+            model.addAttribute("rdfDataset", data.getData());
+            model.addAttribute("resourceURI", attachmentURI.toString());
+            model.addAttribute("dataURI", uriService.toDataURIIfPossible(attachmentURI).toString());
+            return "rdfDatasetView";
+        } else {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        }
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.need}")
+    public String showNeedURIListPage(@RequestParam(value = "p", required = false) Integer page,
+                                      @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                      @RequestParam(value = "resumeafter", required = false) String afterId,
+                                      @RequestParam(value = "state", required = false) String state, HttpServletRequest request, Model model,
+                                      HttpServletResponse response) throws IOException {
+
+        Dataset rdfDataset;
+        NeedState needState = getNeedState(state);
+
+        if (page == null && beforeId == null && afterId == null) {
+            // all needs, does not support need state filtering for clients that do not
+            // support paging
+            rdfDataset = linkedDataService.listNeedURIs();
+        } else if (page != null) {
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(page, null,
+                    needState);
+            rdfDataset = resource.getContent();
+        } else if (beforeId != null) {
+
+            URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + beforeId);
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                    .listNeedURIsBefore(referenceNeed, null, needState);
+            rdfDataset = resource.getContent();
+        } else { // afterId != null
+            URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + afterId);
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                    .listNeedURIsAfter(referenceNeed, null, needState);
+            rdfDataset = resource.getContent();
+        }
+
+        model.addAttribute("rdfDataset", rdfDataset);
+        model.addAttribute("resourceURI",
+                uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
+        model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
+        return "rdfDatasetView";
+
+    }
+
+    @RequestMapping("${uri.path.page}")
+    public String showNodeInformationPage(HttpServletRequest request, Model model, HttpServletResponse response) {
+        Dataset rdfDataset = linkedDataService.getNodeDataset();
+        model.addAttribute("rdfDataset", rdfDataset);
+        model.addAttribute("resourceURI",
+                uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
+        model.addAttribute("dataURI", uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
+        return "rdfDatasetView";
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.connection}")
+    public String showConnectionURIListPage(@RequestParam(value = "p", required = false) Integer page,
+                                            @RequestParam(value = "deep", defaultValue = "false") boolean deep,
+                                            @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                            @RequestParam(value = "resumeafter", required = false) String afterId,
+                                            @RequestParam(value = "timeof", required = false) String timestamp, HttpServletRequest request, Model model,
+                                            HttpServletResponse response) {
+
+        try {
+            DateParameter dateParam = new DateParameter(timestamp);
+            Dataset rdfDataset;
+            if (page != null) {
+                rdfDataset = linkedDataService.listConnectionURIs(page, null, dateParam.getDate(), deep).getContent();
+            } else if (beforeId != null) {
+                URI connURI = uriService.createConnectionURIForId(beforeId);
+                rdfDataset = linkedDataService.listConnectionURIsBefore(connURI, null, dateParam.getDate(), deep)
+                        .getContent();
+            } else if (afterId != null) {
+                URI connURI = uriService.createConnectionURIForId(afterId);
+                rdfDataset = linkedDataService.listConnectionURIsAfter(connURI, null, dateParam.getDate(), deep)
+                        .getContent();
+            } else {
+                // all the connections; does not support date filtering for clients that do not
+                // support paging
+                rdfDataset = linkedDataService.listConnectionURIs(deep);
+            }
+            model.addAttribute("rdfDataset", rdfDataset);
+            model.addAttribute("resourceURI",
+                    uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
+            model.addAttribute("dataURI",
+                    uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
+            return "rdfDatasetView";
+        } catch (ParseException e) {
+            model.addAttribute("error", "could not parse timestamp parameter");
+            return "notFoundView";
+        } catch (NoSuchConnectionException e) {
+            model.addAttribute("error", "could not add connection data for " + e.getUnknownConnectionURI().toString());
+            return "notFoundView";
+        }
+    }
+
+    // webmvc controller method
+    @RequestMapping("${uri.path.page.need}/{identifier}/connections")
+    public String showConnectionURIListPage(@PathVariable String identifier,
+                                            @RequestParam(value = "p", required = false) Integer page,
+                                            @RequestParam(value = "deep", defaultValue = "false") boolean deep,
+                                            @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                            @RequestParam(value = "resumeafter", required = false) String afterId,
+                                            @RequestParam(value = "type", required = false) String type,
+                                            @RequestParam(value = "timeof", required = false) String timestamp, HttpServletRequest request, Model model,
+                                            HttpServletResponse response) {
+
+        URI needURI = uriService.createNeedURIForId(identifier);
+        try {
+            DateParameter dateParam = new DateParameter(timestamp);
+            WonMessageType eventsType = getMessageType(type);
+            Dataset rdfDataset;
+            if (page != null) {
+                //TODO: Change to include ConnectionData
+                rdfDataset = linkedDataService
+                        .listConnectionURIs(page, needURI, null, eventsType, dateParam.getDate(), deep, true)
+                        .getContent();
+            } else if (beforeId != null) {
+                //TODO: Change to include ConnectionData
+                URI connURI = uriService.createConnectionURIForId(beforeId);
+                rdfDataset = linkedDataService
+                        .listConnectionURIsBefore(needURI, connURI, null, eventsType, dateParam.getDate(), deep, true)
+                        .getContent();
+            } else if (afterId != null) {
+                //TODO: Change to include ConnectionData
+                URI connURI = uriService.createConnectionURIForId(afterId);
+                rdfDataset = linkedDataService
+                        .listConnectionURIsAfter(needURI, connURI, null, eventsType, dateParam.getDate(), deep, true)
+                        .getContent();
+            } else {
+                // all the connections of the need; does not support type and date filtering for
+                // clients that do not support
+                // paging
+                rdfDataset = linkedDataService.listConnectionURIs(needURI, deep, true);
+            }
+            model.addAttribute("rdfDataset", rdfDataset);
+            model.addAttribute("resourceURI",
+                    uriService.toResourceURIIfPossible(URI.create(request.getRequestURI())).toString());
+            model.addAttribute("dataURI",
+                    uriService.toDataURIIfPossible(URI.create(request.getRequestURI())).toString());
+            return "rdfDatasetView";
+        } catch (ParseException e) {
+            model.addAttribute("error", "could not parse timestamp parameter");
+            return "notFoundView";
+        } catch (NoSuchNeedException e) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return "notFoundView";
+        } catch (NoSuchConnectionException e) {
+            logger.warn("did not find connection that should be connected to need. connection:{}",
+                    e.getUnknownConnectionURI());
+            return "notFoundView"; // TODO: should display an error view
+        }
+    }
+
+    /**
+     * If the HTTP 'Accept' header is an RDF MIME type (as listed in the 'produces'
+     * value of the RequestMapping annotation), a redirect to a data uri is sent.
+     *
+     * @param request
+     * @return
+     */
+    @RequestMapping(value = "${uri.path.resource}/**", method = RequestMethod.GET, produces = {"application/ld+json",
+            "application/trig", "application/n-quads", "*/*"})
+    public ResponseEntity<String> redirectToData(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        URI resourceUriPrefix = URI.create(this.resourceURIPrefix);
+        URI dataUri = URI.create(this.dataURIPrefix);
+        String requestUri = getRequestUriWithQueryString(request);
+        String redirectToURI = requestUri.replaceFirst(resourceUriPrefix.getPath(), dataUri.getPath());
+        logger.debug("resource URI requested with data mime type. redirecting from {} to {}", requestUri,
+                redirectToURI);
+        if (redirectToURI.equals(requestUri)) {
+            logger.debug("redirecting to same URI avoided, sending status 500 instead");
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        // TODO: actually the expiry information should be the same as that of the
+        // resource that is redirected to
+        HttpHeaders headers = new HttpHeaders();
+        headers = addExpiresHeadersBasedOnRequestURI(headers, requestUri);
+        // headers.setLocation(URI.create(redirectToURI));
+        addCORSHeader(headers);
+        setResponseHeaders(response, headers);
+        response.sendRedirect(redirectToURI);
+        return null;
+    }
+
+    public void setResponseHeaders(final HttpServletResponse response, final HttpHeaders headers) {
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            for (String value : entry.getValue()) {
+                response.setHeader(entry.getKey(), value);
+            }
+        }
+    }
+
+    private String getRequestUriWithQueryString(final HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String queryString = request.getQueryString();
+        if (queryString != null) {
+            requestUri += "?" + queryString;
+        }
+        return requestUri;
+    }
+
+    private String getRequestUriWithAddedQuery(final HttpServletRequest request, String query) {
+        String requestUri = request.getRequestURI();
+        String queryString = request.getQueryString();
+        if (queryString == null || queryString.length() <= 2) {
+            requestUri += "?" + query;
+        } else {
+            requestUri += "?" + queryString + "&" + query;
+        }
+        return requestUri;
+    }
+
+    /**
+     * If the HTTP 'Accept' header is 'text/html' (as listed in the 'produces' value
+     * of the RequestMapping annotation), a redirect to a page uri is sent.
+     *
+     * @param request
+     * @return
+     */
+    @RequestMapping(value = "${uri.path.resource}/**", method = RequestMethod.GET, produces = "text/html")
+    public ResponseEntity<String> redirectToPage(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        URI resourceUriPrefix = URI.create(this.resourceURIPrefix);
+        URI pageUriPrefix = URI.create(this.pageURIPrefix);
+        String requestUri = getRequestUriWithQueryString(request);
+        String redirectToURI = requestUri.replaceFirst(resourceUriPrefix.getPath(), pageUriPrefix.getPath());
+        logger.debug("resource URI requested with page mime type. redirecting from {} to {}", requestUri,
+                redirectToURI);
+        if (redirectToURI.equals(requestUri)) {
+            logger.debug("redirecting to same URI avoided, sending status 500 instead");
+            return new ResponseEntity<>("\"Could not redirect to linked data page\"", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        // TODO: actually the expiry information should be the same as that of the
+        // resource that is redirected to
+        HttpHeaders headers = new HttpHeaders();
+        headers = addExpiresHeadersBasedOnRequestURI(headers, requestUri);
+        addCORSHeader(headers);
+        // add a location header
+        // headers.add("Location",redirectToURI);
+        setResponseHeaders(response, headers);
+        response.sendRedirect(redirectToURI);
+        return null;
+    }
+
+    /**
+     * If the request URI is the URI of a list page (list of needs, list of
+     * connections), or a need uri, it gets the header that says 'already expired' so that crawlers
+     * re-download these data. For other URIs, the 'never expires' header is added.
+     *
+     * @param headers
+     * @param requestUri
+     * @return
+     */
+    public HttpHeaders addExpiresHeadersBasedOnRequestURI(HttpHeaders headers, final String requestUri) {
+        // now, we want to suppress the 'never expires' header information
+        // for /resource/need and resource/connection so that crawlers always re-fetch
+        // these data
+        URI requestUriAsURI = URI.create(requestUri);
+        String requestPath = requestUriAsURI.getPath();
+        if (uriService.isConnectionEventsURI(requestUriAsURI) || uriService.isNeedEventsURI(requestUriAsURI) || uriService.isNeedURI(requestUriAsURI)) {
+            addMutableResourceHeaders(headers);
+        } else {
+            addImmutableResourceHeaders(headers);
+        }
+        return headers;
+    }
+
+    @RequestMapping(value = "${uri.path.data.need}", method = RequestMethod.GET, produces = {"application/ld+json",
+            "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> listNeedURIs(HttpServletRequest request, HttpServletResponse response,
+                                                @RequestParam(value = "p", required = false) Integer page,
+                                                @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                                @RequestParam(value = "resumeafter", required = false) String afterId,
+                                                @RequestParam(value = "modifiedafter", required = false) String modifiedAfter,
+                                                @RequestParam(value = "state", required = false) String state) throws IOException, ParseException {
+        logger.debug("listNeedURIs() for page " + page + " called");
+
+        Dataset rdfDataset;
+        HttpHeaders headers = new HttpHeaders();
+        Integer preferedSize = getPreferredSize(request);
+        String passableQuery = getPassableQueryMap("state", state);
+        NeedState needState = getNeedState(state);
+
+        if (preferedSize == null && modifiedAfter == null) {
+            // client doesn not support paging - return all needs; does not support need
+            // state filtering for clients that do
+            // not support paging
+            rdfDataset = linkedDataService.listNeedURIs();
+
+        } else if (page == null && beforeId == null && afterId == null && modifiedAfter == null) {
+            // return latest needs
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(1,
+                    preferedSize, needState);
+            rdfDataset = resource.getContent();
+            addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
+
+            // resume before parameter specified - display the connections with activities
+            // before the specified event id
+        } else if (page != null) {
+
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listNeedURIs(page,
+                    preferedSize, needState);
+            rdfDataset = resource.getContent();
+            addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, page,
+                    passableQuery);
+
+        } else if (beforeId != null) {
+
+            URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + beforeId);
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                    .listNeedURIsBefore(referenceNeed, preferedSize, needState);
+            rdfDataset = resource.getContent();
+            addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
+        } else if (afterId != null) {
+
+            URI referenceNeed = URI.create(this.needResourceURIPrefix + "/" + afterId);
+            NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                    .listNeedURIsAfter(referenceNeed, preferedSize, needState);
+            rdfDataset = resource.getContent();
+            addPagedResourceInSequenceHeader(headers, URI.create(this.needResourceURIPrefix), resource, passableQuery);
+        } else { // modifiedafter != null
+
+            // do not support paging for modified needs for now
+            DateParameter modifiedDate = new DateParameter(modifiedAfter);
+            rdfDataset = linkedDataService.listModifiedNeedURIsAfter(modifiedDate.getDate());
+        }
+
+        addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
+                URI.create(this.needResourceURIPrefix));
+        addMutableResourceHeaders(headers);
+        addCORSHeader(headers);
+
+        return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
+    }
+
+    private NeedState getNeedState(final String state) {
+        if (state != null) {
+            return NeedState.parseString(state);
+        } else {
+            return null;
+        }
+    }
+
+    private Integer getPreferredSize(final HttpServletRequest request) {
+
+        Integer preferedSize = null;
+        Enumeration<String> preferValue = request.getHeaders("Prefer");
+        if (preferValue != null) {
+            // TODO share prefer pattern between methods, check the supported syntax
+            // according to HTTP protocol, and take
+            // into account that client preference can also include max-triple-count and
+            // max-kbyte-count:
+            Pattern pattern = Pattern.compile("(return=representation; max-member-count=)(\"?)([0-9]+)(\"?)");
+            while (preferValue.hasMoreElements() && preferedSize == null) {
+                String value = preferValue.nextElement();
+                Matcher matcher = pattern.matcher(value);
+                if (matcher.find()) {
+                    preferedSize = Integer.valueOf(matcher.group(3));
+                }
+            }
+        }
+        return preferedSize;
+    }
+
+    @RequestMapping(value = "${uri.path.data.connection}", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> listConnectionURIs(HttpServletRequest request,
+                                                      @RequestParam(value = "p", required = false) Integer page,
+                                                      @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                                      @RequestParam(value = "resumeafter", required = false) String afterId,
+                                                      @RequestParam(value = "timeof", required = false) String timestamp,
+                                                      @RequestParam(value = "modifiedafter", required = false) String modifiedAfter,
+                                                      @RequestParam(value = "deep", defaultValue = "false") boolean deep) {
+
+        logger.debug("listConnectionURIs() called");
+        Dataset rdfDataset;
+        HttpHeaders headers = new HttpHeaders();
+        Integer preferedSize = getPreferredSize(request);
+
+        try {
+            // even when the timestamp is not provided (null), we need to fix the time (if
+            // null, then to current),
+            // because we will return prev/next links which make no sense if the time is not
+            // fixed
+            DateParameter dateParam = new DateParameter(timestamp);
+            String passableMap = getPassableQueryMap("timeof", dateParam.getTimestamp(), "deep",
+                    Boolean.toString(deep));
+            // if no preferred size provided by the client => the client does not support
+            // paging, return everything:
+            if (preferedSize == null && modifiedAfter == null) {
+                // all connections; does not support date filtering for clients that do not
+                // support paging
+                rdfDataset = linkedDataService.listConnectionURIs(deep);
+            } else if (modifiedAfter != null) {
+                // paging is not implemented for modified connections for now!
+                rdfDataset = linkedDataService
+                        .listModifiedConnectionURIsAfter(new DateParameter(modifiedAfter).getDate(), deep);
+            } else if (page != null) {
+                // return latest by the given timestamp
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(page,
+                        preferedSize, dateParam.getDate(), deep);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource, page,
+                        passableMap);
+
+                // resume before parameter specified - display the connections with activities
+                // before the specified event id
+            } else if (beforeId == null && afterId == null) {
+                // return latest by the given timestamp
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(1,
+                        preferedSize, dateParam.getDate(), deep);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                        passableMap);
+
+                // resume before parameter specified - display the connections with activities
+                // before the specified event id
+            } else {
+                if (beforeId != null) {
+                    URI resumeConnURI = uriService.createConnectionURIForId(beforeId);
+                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                            .listConnectionURIsBefore(resumeConnURI, preferedSize, dateParam.getDate(), deep);
+                    rdfDataset = resource.getContent();
+                    addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                            passableMap);
+
+                    // resume after parameter specified - display the connections with activities
+                    // after the specified event id:
+                } else { // if (afterId != null)
+                    URI resumeConnURI = uriService.createConnectionURIForId(afterId);
+                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                            .listConnectionURIsAfter(resumeConnURI, preferedSize, dateParam.getDate(), deep);
+                    rdfDataset = resource.getContent();
+                    addPagedResourceInSequenceHeader(headers, URI.create(this.connectionResourceURIPrefix), resource,
+                            passableMap);
+
+                }
+            }
+        } catch (ParseException e) {
+            logger.warn("could not parse timestamp into Date:{}", timestamp);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (NoSuchConnectionException e) {
+            logger.warn("did not find connection that should be connected to need. connection:{}",
+                    e.getUnknownConnectionURI());
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
+                URI.create(this.connectionResourceURIPrefix));
+        addMutableResourceHeaders(headers);
+        addCORSHeader(headers);
+        return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "${uri.path.data.need}/{identifier}", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readNeed(HttpServletRequest request,
+                                            @PathVariable(value = "identifier") String identifier) {
+
+        logger.debug("readNeed() called");
+        return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
+            @Override
+            public URI createUriForIdentifier(final String identifier) {
+                return URI.create(needResourceURIPrefix + "/" + identifier);
+            }
+
+            @Override
+            public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
+                return linkedDataService.getNeedDataset(uri, etag);
+            }
+
+            @Override
+            public void addHeaders(final HttpHeaders headers) {
+                addCORSHeader(headers);
+                addPublicHeaders(headers);
+            }
+        });
+    }
+
+    @RequestMapping(value = "${uri.path.data.need}/{identifier}/unread", method = RequestMethod.POST, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<org.apache.jena.rdf.model.Model> readUnreadInformationPost(
+            @PathVariable(value = "identifier") String identifier,
+            @RequestParam(value = "lastSeenMessageUris", required = false) List<URI> lastSeenMessageUris) {
+        /*
+		 * information we want: need-level: unread count, date of first unread, date of
+		 * last unread per connection: connection uri, unread count, date of first
+		 * unread, date of last unread
+		 */
+        URI needURI = URI.create(needResourceURIPrefix + "/" + identifier);
+        org.apache.jena.rdf.model.Model unreadInfo = this.linkedDataService.getUnreadInformationForNeed(needURI,
+                lastSeenMessageUris);
+        return new ResponseEntity<>(unreadInfo, HttpStatus.OK);
+
+    }
+
+    @RequestMapping(value = "${uri.path.data.need}/{identifier}/unread", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<org.apache.jena.rdf.model.Model> readUnreadInformationGet(
+            @PathVariable(value = "identifier") String identifier,
+            @RequestParam(value = "lastSeenMessageUris", required = false) List<URI> lastSeenMessageUris) {
 		/*
 		 * information we want: need-level: unread count, date of first unread, date of
 		 * last unread per connection: connection uri, unread count, date of first
 		 * unread, date of last unread
 		 */
-		URI needURI = URI.create(needResourceURIPrefix + "/" + identifier);
-		org.apache.jena.rdf.model.Model unreadInfo = this.linkedDataService.getUnreadInformationForNeed(needURI,
-				lastSeenMessageUris);
-		return new ResponseEntity<>(unreadInfo, HttpStatus.OK);
+        URI needURI = URI.create(needResourceURIPrefix + "/" + identifier);
+        org.apache.jena.rdf.model.Model unreadInfo = this.linkedDataService.getUnreadInformationForNeed(needURI,
+                lastSeenMessageUris);
+        return new ResponseEntity<>(unreadInfo, HttpStatus.OK);
 
-	}
+    }
 
-	@RequestMapping(value = "${uri.path.data.need}/{identifier}/unread", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<org.apache.jena.rdf.model.Model> readUnreadInformationGet(
-			@PathVariable(value = "identifier") String identifier,
-			@RequestParam(value = "lastSeenMessageUris", required = false) List<URI> lastSeenMessageUris) {
-		/*
-		 * information we want: need-level: unread count, date of first unread, date of
-		 * last unread per connection: connection uri, unread count, date of first
-		 * unread, date of last unread
-		 */
-		URI needURI = URI.create(needResourceURIPrefix + "/" + identifier);
-		org.apache.jena.rdf.model.Model unreadInfo = this.linkedDataService.getUnreadInformationForNeed(needURI,
-				lastSeenMessageUris);
-		return new ResponseEntity<>(unreadInfo, HttpStatus.OK);
+    /**
+     * This request URL should be protected by WebID filter because the result
+     * contains events data - which is data with restricted access. See
+     * filterChainProxy in node-context.xml.
+     *
+     * @param request
+     * @param identifier
+     * @return
+     */
+    @RequestMapping(value = "${uri.path.data.need}/{identifier}/deep", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readNeedDeep(HttpServletRequest request,
+                                                @PathVariable(value = "identifier") String identifier,
+                                                @RequestParam(value = "layer-size", required = false) Integer layerSize) {
+        logger.debug("readNeed() called");
+        URI needUri = URI.create(this.needResourceURIPrefix + "/" + identifier);
+        try {
+            Dataset dataset = linkedDataService.getNeedDataset(needUri, true, layerSize);
+            // TODO: need information does change over time. The immutable need information
+            // should never expire, the mutable should
+            HttpHeaders headers = new HttpHeaders();
+            addCORSHeader(headers);
+            return new ResponseEntity<>(dataset, headers, HttpStatus.OK);
+        } catch (NoSuchNeedException | NoSuchConnectionException | NoSuchMessageException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
-	}
+    }
 
-	/**
-	 * This request URL should be protected by WebID filter because the result
-	 * contains events data - which is data with restricted access. See
-	 * filterChainProxy in node-context.xml.
-	 *
-	 * @param request
-	 * @param identifier
-	 * @return
-	 */
-	@RequestMapping(value = "${uri.path.data.need}/{identifier}/deep", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readNeedDeep(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier,
-			@RequestParam(value = "layer-size", required = false) Integer layerSize) {
-		logger.debug("readNeed() called");
-		URI needUri = URI.create(this.needResourceURIPrefix + "/" + identifier);
-		try {
-			Dataset dataset = linkedDataService.getNeedDataset(needUri, true, layerSize);
-			// TODO: need information does change over time. The immutable need information
-			// should never expire, the mutable should
-			HttpHeaders headers = new HttpHeaders();
-			addCORSHeader(headers);
-			return new ResponseEntity<>(dataset, headers, HttpStatus.OK);
-		} catch (NoSuchNeedException | NoSuchConnectionException | NoSuchMessageException e) {
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
+    @RequestMapping(value = "${uri.path.data}", method = RequestMethod.GET, produces = {"application/ld+json",
+            "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readNode(HttpServletRequest request) {
+        logger.debug("readNode() called");
+        // URI nodeUri = URI.create(this.nodeResourceURIPrefix);
+        Dataset model = linkedDataService.getNodeDataset();
+        // TODO: need information does change over time. The immutable need information
+        // should never expire, the mutable should
+        HttpHeaders headers = new HttpHeaders();
+        addCORSHeader(headers);
+        addHeadersForShortTermCaching(headers);
+        headers.add(HttpHeaders.CACHE_CONTROL, "public");
+        return new ResponseEntity<>(model, headers, HttpStatus.OK);
+    }
 
-	}
+    @RequestMapping(value = "${uri.path.data.connection}/{identifier}", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readConnection(HttpServletRequest request,
+                                                  @PathVariable(value = "identifier") String identifier) {
+        logger.debug("readConnection() called");
+        return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
+            @Override
+            public URI createUriForIdentifier(final String identifier) {
+                return URI.create(connectionResourceURIPrefix + "/" + identifier);
+            }
 
-	@RequestMapping(value = "${uri.path.data}", method = RequestMethod.GET, produces = { "application/ld+json",
-			"application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readNode(HttpServletRequest request) {
-		logger.debug("readNode() called");
-		// URI nodeUri = URI.create(this.nodeResourceURIPrefix);
-		Dataset model = linkedDataService.getNodeDataset();
-		// TODO: need information does change over time. The immutable need information
-		// should never expire, the mutable should
-		HttpHeaders headers = new HttpHeaders();
-		addCORSHeader(headers);
-		addHeadersForShortTermCaching(headers);
-		headers.add(HttpHeaders.CACHE_CONTROL, "public");
-		return new ResponseEntity<>(model, headers, HttpStatus.OK);
-	}
+            @Override
+            public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
+                return linkedDataService.getConnectionDataset(uri, true, etag);
+            }
 
-	@RequestMapping(value = "${uri.path.data.connection}/{identifier}", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readConnection(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier) {
-		logger.debug("readConnection() called");
-		return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
-			@Override
-			public URI createUriForIdentifier(final String identifier) {
-				return URI.create(connectionResourceURIPrefix + "/" + identifier);
-			}
+            @Override
+            public void addHeaders(final HttpHeaders headers) {
+                addCORSHeader(headers);
+                addPublicHeaders(headers);
+            }
+        });
+    }
 
-			@Override
-			public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
-				return linkedDataService.getConnectionDataset(uri, true, etag);
-			}
+    @RequestMapping(value = "${uri.path.data.connection}/{identifier}/events", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readConnectionEvents(HttpServletRequest request,
+                                                        @PathVariable(value = "identifier") String identifier,
+                                                        @RequestParam(value = "p", required = false) Integer page,
+                                                        @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                                        @RequestParam(value = "resumeafter", required = false) String afterId,
+                                                        @RequestParam(value = "type", required = false) String type,
+                                                        @RequestParam(value = "deep", required = false, defaultValue = "false") boolean deep) {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        logger.debug("readConnection() called");
+        Dataset rdfDataset;
+        HttpHeaders headers = new HttpHeaders();
+        Integer preferedSize = getPreferredSize(request);
+        URI connectionUri = URI.create(this.connectionResourceURIPrefix + "/" + identifier);
+        URI connectionEventsURI = URI.create(connectionUri.toString() + "/" + "events");
+        WonMessageType msgType = getMessageType(type);
 
-			@Override
-			public void addHeaders(final HttpHeaders headers) {
-				addCORSHeader(headers);
-				addPublicHeaders(headers);
-			}
-		});
-	}
+        try {
+            String passableMap = getPassableQueryMap("type", type);
 
-	@RequestMapping(value = "${uri.path.data.connection}/{identifier}/events", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readConnectionEvents(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "type", required = false) String type,
-			@RequestParam(value = "deep", required = false, defaultValue = "false") boolean deep) {
-		StopWatch stopWatch = new StopWatch();
-		stopWatch.start();
-		logger.debug("readConnection() called");
-		Dataset rdfDataset;
-		HttpHeaders headers = new HttpHeaders();
-		Integer preferedSize = getPreferredSize(request);
-		URI connectionUri = URI.create(this.connectionResourceURIPrefix + "/" + identifier);
-		URI connectionEventsURI = URI.create(connectionUri.toString() + "/" + "events");
-		WonMessageType msgType = getMessageType(type);
-
-		try {
-			String passableMap = getPassableQueryMap("type", type);
-
-			if (preferedSize == null) {
-				// client doesn't not support paging - return all members; does not support type
-				// filtering for clients that do
-				// not support paging
-				rdfDataset = linkedDataService.listConnectionEventURIs(connectionUri, deep);
-			} else if (beforeId == null && afterId == null) {
-				//if page == null -> return page with latest events
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIs(connectionUri, page != null? page : 1, preferedSize, msgType, deep); // TODO: does not
-																									// respect
-																									// preferredSize if
-																									// deep is used
-				rdfDataset = resource.getContent();
+            if (preferedSize == null) {
+                // client doesn't not support paging - return all members; does not support type
+                // filtering for clients that do
+                // not support paging
+                rdfDataset = linkedDataService.listConnectionEventURIs(connectionUri, deep);
+            } else if (beforeId == null && afterId == null) {
+                //if page == null -> return page with latest events
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIs(connectionUri, page != null ? page : 1, preferedSize, msgType, deep); // TODO: does not
+                // respect
+                // preferredSize if
+                // deep is used
+                rdfDataset = resource.getContent();
                 if (page == null) {
                     addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
                 } else {
                     addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, page, passableMap);
                 }
-			} else if (beforeId != null) {
-				// a page that precedes the item identified by the beforeId is requested
+            } else if (beforeId != null) {
+                // a page that precedes the item identified by the beforeId is requested
 
-				URI referenceEvent = uriService.createEventURIForId(beforeId);
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIsBefore(connectionUri, referenceEvent, preferedSize, msgType, deep);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
+                URI referenceEvent = uriService.createEventURIForId(beforeId);
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIsBefore(connectionUri, referenceEvent, preferedSize, msgType, deep);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
 
-			} else {
-				// a page that follows the item identified by the afterId is requested
+            } else {
+                // a page that follows the item identified by the afterId is requested
 
-				URI referenceEvent = uriService.createEventURIForId(afterId);
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIsAfter(connectionUri, referenceEvent, preferedSize, msgType, deep);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
+                URI referenceEvent = uriService.createEventURIForId(afterId);
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                        .listConnectionEventURIsAfter(connectionUri, referenceEvent, preferedSize, msgType, deep);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
 
-			}
+            }
 
-		} catch (NoSuchConnectionException e) {
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
+        } catch (NoSuchConnectionException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
-		// TODO: events list information does change over time, unless the connection is
-		// closed and cannot be reopened.
-		// The events list of immutable connection information should never expire, the
-		// mutable should
-		addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
-				URI.create(this.connectionResourceURIPrefix));
-		addMutableResourceHeaders(headers);
-		addCORSHeader(headers);
-		stopWatch.stop();
-		logger.debug("readConnectionEvents took " + stopWatch.getLastTaskTimeMillis() + " millis");
-		return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
+        // TODO: events list information does change over time, unless the connection is
+        // closed and cannot be reopened.
+        // The events list of immutable connection information should never expire, the
+        // mutable should
+        addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()),
+                URI.create(this.connectionResourceURIPrefix));
+        addMutableResourceHeaders(headers);
+        addCORSHeader(headers);
+        stopWatch.stop();
+        logger.debug("readConnectionEvents took " + stopWatch.getLastTaskTimeMillis() + " millis");
+        return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
 
-	}
+    }
 
-	private WonMessageType getMessageType(final String type) {
-		if (type != null) {
-			return WonMessageType.valueOf(type);
-		} else {
-			return null;
-		}
-	}
+    private WonMessageType getMessageType(final String type) {
+        if (type != null) {
+            return WonMessageType.valueOf(type);
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * This request URL should be protected by WebID filter because the result
-	 * contains events data - which is data with restricted access. See
-	 * filterChainProxy in node-context.xml.
-	 *
-	 * @param request
-	 * @param identifier
-	 * @return
-	 */
-	@RequestMapping(value = "${uri.path.data.event}/{identifier}", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readEvent(@PathVariable(value = "identifier") String identifier,
-			HttpServletRequest request, HttpServletResponse response) {
-		// get etag from headers, extract version identifier
-		logger.debug("readConnectionEvent() called");
-		return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
-			@Override
-			public URI createUriForIdentifier(final String identifier) {
-				return uriService.createEventURIForId(identifier);
-			}
+    /**
+     * This request URL should be protected by WebID filter because the result
+     * contains events data - which is data with restricted access. See
+     * filterChainProxy in node-context.xml.
+     *
+     * @param request
+     * @param identifier
+     * @return
+     */
+    @RequestMapping(value = "${uri.path.data.event}/{identifier}", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readEvent(@PathVariable(value = "identifier") String identifier,
+                                             HttpServletRequest request, HttpServletResponse response) {
+        // get etag from headers, extract version identifier
+        logger.debug("readConnectionEvent() called");
+        return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
+            @Override
+            public URI createUriForIdentifier(final String identifier) {
+                return uriService.createEventURIForId(identifier);
+            }
 
-			@Override
-			public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
-				return linkedDataService.getDatasetForUri(uri, etag);
-			}
+            @Override
+            public DataWithEtag<Dataset> loadDataWithEtag(final URI uri, final String etag) {
+                return linkedDataService.getDatasetForUri(uri, etag);
+            }
 
-			@Override
-			public void addHeaders(final HttpHeaders headers) {
-				addCORSHeader(headers);
-				addPrivateHeaders(headers);
-				addImmutableResourceHeaders(headers);
-			}
-		});
-	}
+            @Override
+            public void addHeaders(final HttpHeaders headers) {
+                addCORSHeader(headers);
+                addPrivateHeaders(headers);
+                addImmutableResourceHeaders(headers);
+            }
+        });
+    }
 
-	private <T> ResponseEntity<T> getResponseEntity(String identifier, final HttpServletRequest request,
-			EtagSupportingDataLoader<T> loader) {
-		HttpHeaders requestHeaders = getHttpHeaders(request);
-		WonEtagHelper requestEtagHelper = WonEtagHelper.fromHeaderIfCompatibleWithAcceptHeader(requestHeaders);
+    private <T> ResponseEntity<T> getResponseEntity(String identifier, final HttpServletRequest request,
+                                                    EtagSupportingDataLoader<T> loader) {
+        HttpHeaders requestHeaders = getHttpHeaders(request);
+        WonEtagHelper requestEtagHelper = WonEtagHelper.fromHeaderIfCompatibleWithAcceptHeader(requestHeaders);
 
-		String versionIdentifier = WonEtagHelper.getVersionIdentifier(requestEtagHelper);
-		// fetch the data if required
-		logger.debug("using version identifier {}", versionIdentifier);
-		URI entityUri = loader.createUriForIdentifier(identifier);
-		DataWithEtag<T> dataWithEtag = loader.loadDataWithEtag(entityUri, versionIdentifier);
+        String versionIdentifier = WonEtagHelper.getVersionIdentifier(requestEtagHelper);
+        // fetch the data if required
+        logger.debug("using version identifier {}", versionIdentifier);
+        URI entityUri = loader.createUriForIdentifier(identifier);
+        DataWithEtag<T> dataWithEtag = loader.loadDataWithEtag(entityUri, versionIdentifier);
 
-		// prepare the response headers
-		HttpHeaders headers = new HttpHeaders();
-		loader.addHeaders(headers);
-		// set the etag headers
-		setEtagHeaderForResponse(headers, dataWithEtag, requestEtagHelper);
+        // prepare the response headers
+        HttpHeaders headers = new HttpHeaders();
+        loader.addHeaders(headers);
+        // set the etag headers
+        setEtagHeaderForResponse(headers, dataWithEtag, requestEtagHelper);
 
-		// return the response
-		return getResponseEntityForPossiblyNotModifiedResult(dataWithEtag, headers);
-	}
+        // return the response
+        return getResponseEntityForPossiblyNotModifiedResult(dataWithEtag, headers);
+    }
 
-	@RequestMapping(value = "${uri.path.data.attachment}/{identifier}", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads", "*/*" })
-	public ResponseEntity<Dataset> readAttachment(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier) {
-		logger.debug("readAttachment() called");
+    @RequestMapping(value = "${uri.path.data.attachment}/{identifier}", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads", "*/*"})
+    public ResponseEntity<Dataset> readAttachment(HttpServletRequest request,
+                                                  @PathVariable(value = "identifier") String identifier) {
+        logger.debug("readAttachment() called");
 
-		URI attachmentURI = uriService.createAttachmentURIForId(identifier);
-		DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(attachmentURI, null);
-		if (!data.isNotFound()) {
-			HttpHeaders headers = new HttpHeaders();
-			addCORSHeader(headers);
-			String mimeTypeOfResponse = RdfUtils.findFirst(data.getData(), model -> {
-				String content = getObjectOfPropertyAsString(model, CNT.BYTES);
-				if (content == null)
-					return null;
-				return getObjectOfPropertyAsString(model, WONMSG.CONTENT_TYPE);
-			});
-			if (mimeTypeOfResponse != null) {
-				// we found a base64 encoded attachment, we obtained its contentType, so we set
-				// it as the
-				// contentType of the response.
-				Set<MediaType> producibleMediaTypes = new HashSet<>();
-				producibleMediaTypes.add(MediaType.valueOf(mimeTypeOfResponse));
-				request.setAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE, producibleMediaTypes);
-			}
-			return new ResponseEntity<>(data.getData(), headers, HttpStatus.OK);
-		} else {
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
-	}
+        URI attachmentURI = uriService.createAttachmentURIForId(identifier);
+        DataWithEtag<Dataset> data = linkedDataService.getDatasetForUri(attachmentURI, null);
+        if (!data.isNotFound()) {
+            HttpHeaders headers = new HttpHeaders();
+            addCORSHeader(headers);
+            String mimeTypeOfResponse = RdfUtils.findFirst(data.getData(), model -> {
+                String content = getObjectOfPropertyAsString(model, CNT.BYTES);
+                if (content == null)
+                    return null;
+                return getObjectOfPropertyAsString(model, WONMSG.CONTENT_TYPE);
+            });
+            if (mimeTypeOfResponse != null) {
+                // we found a base64 encoded attachment, we obtained its contentType, so we set
+                // it as the
+                // contentType of the response.
+                Set<MediaType> producibleMediaTypes = new HashSet<>();
+                producibleMediaTypes.add(MediaType.valueOf(mimeTypeOfResponse));
+                request.setAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE, producibleMediaTypes);
+            }
+            return new ResponseEntity<>(data.getData(), headers, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
 
-	private String getObjectOfPropertyAsString(org.apache.jena.rdf.model.Model model, Property property) {
-		NodeIterator nodeIteratr = model.listObjectsOfProperty(property);
-		if (!nodeIteratr.hasNext())
-			return null;
-		String ret = nodeIteratr.next().asLiteral().getString();
-		if (nodeIteratr.hasNext()) {
-			throw new IncorrectPropertyCountException("found more than one property of cnt:bytes", 1, 2);
-		}
-		return ret;
-	}
+    private String getObjectOfPropertyAsString(org.apache.jena.rdf.model.Model model, Property property) {
+        NodeIterator nodeIteratr = model.listObjectsOfProperty(property);
+        if (!nodeIteratr.hasNext())
+            return null;
+        String ret = nodeIteratr.next().asLiteral().getString();
+        if (nodeIteratr.hasNext()) {
+            throw new IncorrectPropertyCountException("found more than one property of cnt:bytes", 1, 2);
+        }
+        return ret;
+    }
 
-	/**
-	 * Get the RDF for the connections of the specified need.
-	 *
-	 * @param request
-	 * @param identifier
-	 * @param deep
-	 *            If true, connection data is added to the model (not only
-	 *            connection URIs). Default: false.
-	 * @param page
-	 *            taken into account only if client supports paging; in that case
-	 *            the specified page is returned
-	 * @param beforeId
-	 *            taken into account only if client supports paging; in that case
-	 *            the page with connections URIs that precede the connection having
-	 *            beforeId is returned
-	 * @param afterId
-	 *            taken into account only if client supports paging; in that case
-	 *            the page with connections URIs that follow the connection having
-	 *            afterId are returned
-	 * @param type
-	 *            only connection events of the given type are considered when
-	 *            ordering returned connections. Default: all event types.
-	 * @param timestamp
-	 *            only connection events that where created before the given time
-	 *            are considered when ordering returned connections. Default:
-	 *            current time.
-	 * @return
-	 */
-	@RequestMapping(value = "${uri.path.data.need}/{identifier}/connections", method = RequestMethod.GET, produces = {
-			"application/ld+json", "application/trig", "application/n-quads" })
-	public ResponseEntity<Dataset> readConnectionsOfNeed(HttpServletRequest request,
-			@PathVariable(value = "identifier") String identifier,
-			@RequestParam(value = "deep", defaultValue = "false") boolean deep,
-			@RequestParam(value = "p", required = false) Integer page,
-			@RequestParam(value = "resumebefore", required = false) String beforeId,
-			@RequestParam(value = "resumeafter", required = false) String afterId,
-			@RequestParam(value = "type", required = false) String type,
-			@RequestParam(value = "timeof", required = false) String timestamp) {
+    /**
+     * Get the RDF for the connections of the specified need.
+     *
+     * @param request
+     * @param identifier
+     * @param deep       If true, connection data is added to the model (not only
+     *                   connection URIs). Default: false.
+     * @param page       taken into account only if client supports paging; in that case
+     *                   the specified page is returned
+     * @param beforeId   taken into account only if client supports paging; in that case
+     *                   the page with connections URIs that precede the connection having
+     *                   beforeId is returned
+     * @param afterId    taken into account only if client supports paging; in that case
+     *                   the page with connections URIs that follow the connection having
+     *                   afterId are returned
+     * @param type       only connection events of the given type are considered when
+     *                   ordering returned connections. Default: all event types.
+     * @param timestamp  only connection events that where created before the given time
+     *                   are considered when ordering returned connections. Default:
+     *                   current time.
+     * @return
+     */
+    @RequestMapping(value = "${uri.path.data.need}/{identifier}/connections", method = RequestMethod.GET, produces = {
+            "application/ld+json", "application/trig", "application/n-quads"})
+    public ResponseEntity<Dataset> readConnectionsOfNeed(HttpServletRequest request,
+                                                         @PathVariable(value = "identifier") String identifier,
+                                                         @RequestParam(value = "deep", defaultValue = "false") boolean deep,
+                                                         @RequestParam(value = "p", required = false) Integer page,
+                                                         @RequestParam(value = "resumebefore", required = false) String beforeId,
+                                                         @RequestParam(value = "resumeafter", required = false) String afterId,
+                                                         @RequestParam(value = "type", required = false) String type,
+                                                         @RequestParam(value = "timeof", required = false) String timestamp) {
 
-		logger.debug("readConnectionsOfNeed() called");
-		URI needUri = URI.create(this.needResourceURIPrefix + "/" + identifier);
-		Dataset rdfDataset;
-		HttpHeaders headers = new HttpHeaders();
-		Integer preferedSize = getPreferredSize(request);
-		URI connectionsURI = URI.create(needUri.toString() + "/connections");
+        logger.debug("readConnectionsOfNeed() called");
+        URI needUri = URI.create(this.needResourceURIPrefix + "/" + identifier);
+        Dataset rdfDataset;
+        HttpHeaders headers = new HttpHeaders();
+        Integer preferedSize = getPreferredSize(request);
+        URI connectionsURI = URI.create(needUri.toString() + "/connections");
 
-		try {
-			WonMessageType eventsType = getMessageType(type);
-			DateParameter dateParam = new DateParameter(timestamp);
-			String passableQuery = getPassableQueryMap("type", type, "timeof", dateParam.getTimestamp(), "deep",
-					Boolean.toString(deep));
-			// if no preferred size provided by the client => the client does not support
-			// paging, return everything:
-			if (preferedSize == null) {
-				// does not support date and type filtering for clients that do not support
-				// paging
-				rdfDataset = linkedDataService.listConnectionURIs(needUri, deep, true);
-				// if no page or resume parameter is specified, display the latest connections:
-			} else if (page == null && beforeId == null && afterId == null) {
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(1,
-						needUri, preferedSize, eventsType, dateParam.getDate(), deep, true);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
-			} else if (page != null) {
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(page,
-						needUri, preferedSize, eventsType, dateParam.getDate(), deep, true);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionsURI, resource, page, passableQuery);
-			} else {
-				// resume before parameter specified - display the connections with activities
-				// before the specified event id:
-				if (beforeId != null) {
-					URI resumeConnURI = uriService.createConnectionURIForId(beforeId);
-					NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-							.listConnectionURIsBefore(needUri, resumeConnURI, preferedSize, eventsType,
-									dateParam.getDate(), deep, true);
-					rdfDataset = resource.getContent();
-					addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
+        try {
+            WonMessageType eventsType = getMessageType(type);
+            DateParameter dateParam = new DateParameter(timestamp);
+            String passableQuery = getPassableQueryMap("type", type, "timeof", dateParam.getTimestamp(), "deep",
+                    Boolean.toString(deep));
+            // if no preferred size provided by the client => the client does not support
+            // paging, return everything:
+            if (preferedSize == null) {
+                // does not support date and type filtering for clients that do not support
+                // paging
+                rdfDataset = linkedDataService.listConnectionURIs(needUri, deep, true);
+                // if no page or resume parameter is specified, display the latest connections:
+            } else if (page == null && beforeId == null && afterId == null) {
+                //TODO: Change to include ConnectionData
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(1,
+                        needUri, preferedSize, eventsType, dateParam.getDate(), deep, true);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
+            } else if (page != null) {
+                //TODO: Change to include ConnectionData
+                NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService.listConnectionURIs(page,
+                        needUri, preferedSize, eventsType, dateParam.getDate(), deep, true);
+                rdfDataset = resource.getContent();
+                addPagedResourceInSequenceHeader(headers, connectionsURI, resource, page, passableQuery);
+            } else {
+                // resume before parameter specified - display the connections with activities
+                // before the specified event id:
+                if (beforeId != null) {
+                    //TODO: Change to include ConnectionData
+                    URI resumeConnURI = uriService.createConnectionURIForId(beforeId);
+                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                            .listConnectionURIsBefore(needUri, resumeConnURI, preferedSize, eventsType,
+                                    dateParam.getDate(), deep, true);
+                    rdfDataset = resource.getContent();
+                    addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
 
-					// resume after parameter specified - display the connections with activities
-					// after the specified event id:
-				} else { // if (afterId != null)
-					URI resumeConnURI = uriService.createConnectionURIForId(afterId);
-					NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-							.listConnectionURIsAfter(needUri, resumeConnURI, preferedSize, eventsType,
-									dateParam.getDate(), deep, true);
-					rdfDataset = resource.getContent();
-					addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
-				}
-			}
+                    // resume after parameter specified - display the connections with activities
+                    // after the specified event id:
+                } else { // if (afterId != null)
+                    //TODO: Change to include ConnectionData
+                    URI resumeConnURI = uriService.createConnectionURIForId(afterId);
+                    NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
+                            .listConnectionURIsAfter(needUri, resumeConnURI, preferedSize, eventsType,
+                                    dateParam.getDate(), deep, true);
+                    rdfDataset = resource.getContent();
+                    addPagedResourceInSequenceHeader(headers, connectionsURI, resource, passableQuery);
+                }
+            }
 
-			// append the required headers
-			addMutableResourceHeaders(headers);
-			addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()), connectionsURI);
-			addCORSHeader(headers);
-			return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
+            // append the required headers
+            addMutableResourceHeaders(headers);
+            addLocationHeaderIfNecessary(headers, URI.create(request.getRequestURI()), connectionsURI);
+            addCORSHeader(headers);
+            return new ResponseEntity<>(rdfDataset, headers, HttpStatus.OK);
 
-		} catch (ParseException e) {
-			logger.warn("could not parse timestamp into Date:{}", timestamp);
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		} catch (NoSuchNeedException e) {
-			logger.warn("did not find need {}", e.getUnknownNeedURI());
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		} catch (NoSuchConnectionException e) {
-			logger.warn("did not find connection that should be connected to need. connection:{}",
-					e.getUnknownConnectionURI());
-			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-	}
+        } catch (ParseException e) {
+            logger.warn("could not parse timestamp into Date:{}", timestamp);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (NoSuchNeedException e) {
+            logger.warn("did not find need {}", e.getUnknownNeedURI());
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (NoSuchConnectionException e) {
+            logger.warn("did not find connection that should be connected to need. connection:{}",
+                    e.getUnknownConnectionURI());
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
-	/**
-	 * Checks if the actual URI is the same as the canonical URI; if not, adds a
-	 * Location header to the response builder indicating the canonical URI.
-	 *
-	 * @param headers
-	 * @param actualURI
-	 * @param canonicalURI
-	 * @return the headers map with added header values
-	 */
-	private HttpHeaders addLocationHeaderIfNecessary(HttpHeaders headers, URI actualURI, URI canonicalURI) {
-		if (!canonicalURI.resolve(actualURI).equals(canonicalURI)) {
-			// the request URI is the canonical URI, it may be a DNS alias or relative
-			// according to http://www.w3.org/TR/ldp/#general we have to include
-			// the canonical URI in the lcoation header here
-			headers.add(HTTP.HEADER_LOCATION, canonicalURI.toString());
-		}
-		return headers;
-	}
+    /**
+     * Checks if the actual URI is the same as the canonical URI; if not, adds a
+     * Location header to the response builder indicating the canonical URI.
+     *
+     * @param headers
+     * @param actualURI
+     * @param canonicalURI
+     * @return the headers map with added header values
+     */
+    private HttpHeaders addLocationHeaderIfNecessary(HttpHeaders headers, URI actualURI, URI canonicalURI) {
+        if (!canonicalURI.resolve(actualURI).equals(canonicalURI)) {
+            // the request URI is the canonical URI, it may be a DNS alias or relative
+            // according to http://www.w3.org/TR/ldp/#general we have to include
+            // the canonical URI in the lcoation header here
+            headers.add(HTTP.HEADER_LOCATION, canonicalURI.toString());
+        }
+        return headers;
+    }
 
-	/**
-	 * Adds headers describing the paged resource according to
-	 * https://www.w3.org/TR/ldp-paging/ (here implemented version is
-	 * http://www.w3.org/TR/2015/NOTE-ldp-paging-20150630/) that inform the client
-	 * about the following properties of the pages resource:
-	 * <p>
-	 * Link: <uri>; rel="canonical"; etag="tag" - which resource it is a page of,
-	 * and current tag of the resource Link: <http://www.w3.org/ns/ldp#Page>;
-	 * rel="type" - that this is one in-sequence page resource Link:
-	 * <http://www.w3.org/ns/ldp#Resource>; rel="type" - that this is a LDP Resource
-	 * (should be Container in our case?) Link: <uri?p=x>; rel="next" - that the
-	 * next in-sequence page resource exists and is retrievable at the given uri
-	 *
-	 * @param headers
-	 *            headers to which paged resource headers should be added
-	 * @param canonicalURI
-	 *            uri of the LDP Resource
-	 * @param page
-	 *            page of the Paged LDP Resource
-	 * @return the headers map with added header values
-	 */
-	private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
-			final NeedInformationService.PagedResource<Dataset, URI> resource, final int page, String queryPart) {
+    /**
+     * Adds headers describing the paged resource according to
+     * https://www.w3.org/TR/ldp-paging/ (here implemented version is
+     * http://www.w3.org/TR/2015/NOTE-ldp-paging-20150630/) that inform the client
+     * about the following properties of the pages resource:
+     * <p>
+     * Link: <uri>; rel="canonical"; etag="tag" - which resource it is a page of,
+     * and current tag of the resource Link: <http://www.w3.org/ns/ldp#Page>;
+     * rel="type" - that this is one in-sequence page resource Link:
+     * <http://www.w3.org/ns/ldp#Resource>; rel="type" - that this is a LDP Resource
+     * (should be Container in our case?) Link: <uri?p=x>; rel="next" - that the
+     * next in-sequence page resource exists and is retrievable at the given uri
+     *
+     * @param headers      headers to which paged resource headers should be added
+     * @param canonicalURI uri of the LDP Resource
+     * @param page         page of the Paged LDP Resource
+     * @return the headers map with added header values
+     */
+    private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
+                                                  final NeedInformationService.PagedResource<Dataset, URI> resource, final int page, String queryPart) {
 
-		headers.add("Link",
-				"<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
-		// Link: <http://example.org/customer-relations?p=2>; rel="next"
-		if (resource.hasNext()) {
-			int nextPage = page + 1;
-			headers.add("Link", "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
-		}
-		if (resource.hasPrevious() && page > 1) {
-			int prevPage = page - 1;
-			headers.add("Link", "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
-		}
-		headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
-	}
+        headers.add("Link",
+                "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
+        // Link: <http://example.org/customer-relations?p=2>; rel="next"
+        if (resource.hasNext()) {
+            int nextPage = page + 1;
+            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
+        }
+        if (resource.hasPrevious() && page > 1) {
+            int prevPage = page - 1;
+            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
+        }
+        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+    }
 
-	private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
-			final NeedInformationService.PagedResource<Dataset, URI> resource, String queryPart) {
+    private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
+                                                  final NeedInformationService.PagedResource<Dataset, URI> resource, String queryPart) {
 
-		headers.add("Link",
-				"<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
-		if (resource.hasNext()) {
-			String id = extractResourceLocalId(resource.getResumeAfter());
-			headers.add("Link", "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
-		}
-		if (resource.hasPrevious()) {
-			String id = extractResourceLocalId(resource.getResumeBefore());
-			headers.add("Link", "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
-		}
-		headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+        headers.add("Link",
+                "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
+        if (resource.hasNext()) {
+            String id = extractResourceLocalId(resource.getResumeAfter());
+            headers.add("Link", "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
+        }
+        if (resource.hasPrevious()) {
+            String id = extractResourceLocalId(resource.getResumeBefore());
+            headers.add("Link", "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
+        }
+        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
 
-	}
+    }
 
-	private String getPassableQueryMap(String... nameValue) {
-		String queryPart = "";
-		for (int i = 0; i < nameValue.length; i++) {
-			if (nameValue[i + 1] != null) {
-				queryPart = queryPart + "&" + nameValue[i] + "=" + nameValue[i + 1];
-			}
-			i++;
-		}
-		return queryPart;
-	}
+    private String getPassableQueryMap(String... nameValue) {
+        String queryPart = "";
+        for (int i = 0; i < nameValue.length; i++) {
+            if (nameValue[i + 1] != null) {
+                queryPart = queryPart + "&" + nameValue[i] + "=" + nameValue[i + 1];
+            }
+            i++;
+        }
+        return queryPart;
+    }
 
-	private String extractResourceLocalId(final URI uri) {
-		int startIdAfter = uri.toString().replaceAll("/$", "").lastIndexOf("/");
-		return uri.toString().substring(startIdAfter + 1);
-	}
+    private String extractResourceLocalId(final URI uri) {
+        int startIdAfter = uri.toString().replaceAll("/$", "").lastIndexOf("/");
+        return uri.toString().substring(startIdAfter + 1);
+    }
 
-	/**
-	 * Headers: types of resources * public immutable * public mutable * private
-	 * immutable * private mutable * public short-term cacheable * privet short-term
-	 * cacheable
-	 */
+    /**
+     * Headers: types of resources * public immutable * public mutable * private
+     * immutable * private mutable * public short-term cacheable * privet short-term
+     * cacheable
+     */
 
-	private void addPrivateHeaders(HttpHeaders headers) {
-		headers.add(HttpHeaders.CACHE_CONTROL, "private");
-		// with no-store, the items don't survive a browser reload - but if the browser
-		// is closed, the items are gone
-		// headers.add(HttpHeaders.CACHE_CONTROL, "no-store");
-	}
+    private void addPrivateHeaders(HttpHeaders headers) {
+        headers.add(HttpHeaders.CACHE_CONTROL, "private");
+        // with no-store, the items don't survive a browser reload - but if the browser
+        // is closed, the items are gone
+        // headers.add(HttpHeaders.CACHE_CONTROL, "no-store");
+    }
 
-	private void addPublicHeaders(HttpHeaders headers) {
-		headers.add(HttpHeaders.CACHE_CONTROL, "public");
-	}
+    private void addPublicHeaders(HttpHeaders headers) {
+        headers.add(HttpHeaders.CACHE_CONTROL, "public");
+    }
 
-	private void addImmutableResourceHeaders(HttpHeaders headers) {
-		headers.add(HttpHeaders.CACHE_CONTROL, "max-age=31536000");
-		SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
-		headers.add(HTTP.HEADER_EXPIRES, dateFormat.format(getNeverExpiresDate()));
-		headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
-	}
+    private void addImmutableResourceHeaders(HttpHeaders headers) {
+        headers.add(HttpHeaders.CACHE_CONTROL, "max-age=31536000");
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
+        headers.add(HTTP.HEADER_EXPIRES, dateFormat.format(getNeverExpiresDate()));
+        headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
+    }
 
-	private void addMutableResourceHeaders(HttpHeaders headers) {
-		headers.add(HttpHeaders.CACHE_CONTROL, "max-age=0");
-		headers.add(HttpHeaders.CACHE_CONTROL, "must-revalidate");
-		SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
-		headers.add(HTTP.HEADER_EXPIRES, "0");
-		headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
-	}
+    private void addMutableResourceHeaders(HttpHeaders headers) {
+        headers.add(HttpHeaders.CACHE_CONTROL, "max-age=0");
+        headers.add(HttpHeaders.CACHE_CONTROL, "must-revalidate");
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
+        headers.add(HTTP.HEADER_EXPIRES, "0");
+        headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
+    }
 
-	/**
-	 * Sets the Expires and Cache-Control header fields such that the response will
-	 * be cached for a few minutes. Useful for data that might change during a
-	 * server reconfiguration but is otherwise quite stable.
-	 *
-	 * @param headers
-	 * @return the headers map with added header values
-	 */
-	private HttpHeaders addHeadersForShortTermCaching(HttpHeaders headers) {
-		SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
-		Calendar cal = Calendar.getInstance();
-		cal.setTime(new Date());
-		cal.add(Calendar.SECOND, SHORT_TERM_CACHE_TIMEOUT_SECONDS);
-		headers.add(HTTP.HEADER_EXPIRES, dateFormat.format(cal.getTime()));
-		headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
-		headers.add(HttpHeaders.CACHE_CONTROL, "max-age=" + SHORT_TERM_CACHE_TIMEOUT_SECONDS);
-		return headers;
-	}
+    /**
+     * Sets the Expires and Cache-Control header fields such that the response will
+     * be cached for a few minutes. Useful for data that might change during a
+     * server reconfiguration but is otherwise quite stable.
+     *
+     * @param headers
+     * @return the headers map with added header values
+     */
+    private HttpHeaders addHeadersForShortTermCaching(HttpHeaders headers) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_RFC_1123, Locale.ENGLISH);
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.SECOND, SHORT_TERM_CACHE_TIMEOUT_SECONDS);
+        headers.add(HTTP.HEADER_EXPIRES, dateFormat.format(cal.getTime()));
+        headers.add(HTTP.HEADER_DATE, dateFormat.format(new Date()));
+        headers.add(HttpHeaders.CACHE_CONTROL, "max-age=" + SHORT_TERM_CACHE_TIMEOUT_SECONDS);
+        return headers;
+    }
 
-	// Calculates a date that, according to http spec, means 'never expires'
-	// See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-	private Date getNeverExpiresDate() {
-		Calendar cal = Calendar.getInstance();
-		cal.setTime(new Date());
-		cal.set(Calendar.YEAR, cal.get(Calendar.YEAR) + 1);
-		return cal.getTime();
-	}
+    // Calculates a date that, according to http spec, means 'never expires'
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+    private Date getNeverExpiresDate() {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.set(Calendar.YEAR, cal.get(Calendar.YEAR) + 1);
+        return cal.getTime();
+    }
 
-	/**
-	 * Adds the CORS headers required for client side cross-site requests. See
-	 * http://www.w3.org/TR/cors/
-	 *
-	 * @param headers
-	 */
-	private void addCORSHeader(final HttpHeaders headers) {
-		headers.add("Access-Control-Allow-Origin", "*");
-	}
+    /**
+     * Adds the CORS headers required for client side cross-site requests. See
+     * http://www.w3.org/TR/cors/
+     *
+     * @param headers
+     */
+    private void addCORSHeader(final HttpHeaders headers) {
+        headers.add("Access-Control-Allow-Origin", "*");
+    }
 
-	private HttpHeaders getHttpHeaders(final HttpServletResponse response) {
-		ServletServerHttpResponse servletResponse = new ServletServerHttpResponse(response);
-		return servletResponse.getHeaders();
-	}
+    private HttpHeaders getHttpHeaders(final HttpServletResponse response) {
+        ServletServerHttpResponse servletResponse = new ServletServerHttpResponse(response);
+        return servletResponse.getHeaders();
+    }
 
-	private HttpHeaders getHttpHeaders(final HttpServletRequest request) {
-		ServletServerHttpRequest servletRequest = new ServletServerHttpRequest(request);
-		return servletRequest.getHeaders();
-	}
+    private HttpHeaders getHttpHeaders(final HttpServletRequest request) {
+        ServletServerHttpRequest servletRequest = new ServletServerHttpRequest(request);
+        return servletRequest.getHeaders();
+    }
 
-	private <T> ResponseEntity<T> getResponseEntityForPossiblyNotModifiedResult(final DataWithEtag<T> datasetWithEtag,
-			final HttpHeaders headers) {
+    private <T> ResponseEntity<T> getResponseEntityForPossiblyNotModifiedResult(final DataWithEtag<T> datasetWithEtag,
+                                                                                final HttpHeaders headers) {
 
-		if (datasetWithEtag != null) {
-		    if (datasetWithEtag.isDeleted()) {
+        if (datasetWithEtag != null) {
+            if (datasetWithEtag.isDeleted()) {
                 return new ResponseEntity<>(headers, HttpStatus.GONE);
             } else if (datasetWithEtag.isChanged()) {
-				return new ResponseEntity<>(datasetWithEtag.getData(), headers, HttpStatus.OK);
-			} else {
-				return new ResponseEntity<>(headers, HttpStatus.NOT_MODIFIED);
-			}
-			
-		} else {
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
-	}
+                return new ResponseEntity<>(datasetWithEtag.getData(), headers, HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(headers, HttpStatus.NOT_MODIFIED);
+            }
 
-	/**
-	 * Depending on whether the data has changed, use the old etag or create a new
-	 * one.
-	 *
-	 * @param headers
-	 * @param datasetWithEtag
-	 * @param requestEtagHelper
-	 */
-	private <T> void setEtagHeaderForResponse(final HttpHeaders headers, final DataWithEtag<T> datasetWithEtag,
-			final WonEtagHelper requestEtagHelper) {
-		// check if the data has changed
-		if (datasetWithEtag.isChanged()) {
-			logger.debug("ETAG comparison shows that data has changed or no etag was present");
-			// data has changed: create a new etag and put it into the header
-			WonEtagHelper responseEtagHelper = WonEtagHelper.forVersion(datasetWithEtag.getEtag());
-			if (responseEtagHelper != null) {
-				WonEtagHelper.setEtagHeader(responseEtagHelper, headers);
-			}
-		} else {
-			// data has not changed: use the old etag value for the response ETag header
-			WonEtagHelper.setEtagHeader(requestEtagHelper, headers);
-		}
-	}
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
 
-	public void setLinkedDataService(final LinkedDataService linkedDataService) {
-		this.linkedDataService = linkedDataService;
-	}
+    /**
+     * Depending on whether the data has changed, use the old etag or create a new
+     * one.
+     *
+     * @param headers
+     * @param datasetWithEtag
+     * @param requestEtagHelper
+     */
+    private <T> void setEtagHeaderForResponse(final HttpHeaders headers, final DataWithEtag<T> datasetWithEtag,
+                                              final WonEtagHelper requestEtagHelper) {
+        // check if the data has changed
+        if (datasetWithEtag.isChanged()) {
+            logger.debug("ETAG comparison shows that data has changed or no etag was present");
+            // data has changed: create a new etag and put it into the header
+            WonEtagHelper responseEtagHelper = WonEtagHelper.forVersion(datasetWithEtag.getEtag());
+            if (responseEtagHelper != null) {
+                WonEtagHelper.setEtagHeader(responseEtagHelper, headers);
+            }
+        } else {
+            // data has not changed: use the old etag value for the response ETag header
+            WonEtagHelper.setEtagHeader(requestEtagHelper, headers);
+        }
+    }
 
-	public void setRegistrationServer(final RegistrationServer registrationServer) {
-		this.registrationServer = registrationServer;
-	}
+    public void setLinkedDataService(final LinkedDataService linkedDataService) {
+        this.linkedDataService = linkedDataService;
+    }
 
-	public void setUriService(final URIService uriService) {
-		this.uriService = uriService;
-	}
+    public void setRegistrationServer(final RegistrationServer registrationServer) {
+        this.registrationServer = registrationServer;
+    }
 
-	public void setNeedResourceURIPrefix(String needResourceURIPrefix) {
-		this.needResourceURIPrefix = needResourceURIPrefix;
-	}
+    public void setUriService(final URIService uriService) {
+        this.uriService = uriService;
+    }
 
-	public void setConnectionResourceURIPrefix(String connectionResourceURIPrefix) {
-		this.connectionResourceURIPrefix = connectionResourceURIPrefix;
-	}
+    public void setNeedResourceURIPrefix(String needResourceURIPrefix) {
+        this.needResourceURIPrefix = needResourceURIPrefix;
+    }
 
-	public void setDataURIPrefix(String dataURIPrefix) {
-		this.dataURIPrefix = dataURIPrefix;
-	}
+    public void setConnectionResourceURIPrefix(String connectionResourceURIPrefix) {
+        this.connectionResourceURIPrefix = connectionResourceURIPrefix;
+    }
 
-	public void setResourceURIPrefix(final String resourceURIPrefix) {
-		this.resourceURIPrefix = resourceURIPrefix;
-	}
+    public void setDataURIPrefix(String dataURIPrefix) {
+        this.dataURIPrefix = dataURIPrefix;
+    }
 
-	public void setPageURIPrefix(final String pageURIPrefix) {
-		this.pageURIPrefix = pageURIPrefix;
-	}
+    public void setResourceURIPrefix(final String resourceURIPrefix) {
+        this.resourceURIPrefix = resourceURIPrefix;
+    }
 
-	public String getNodeResourceURIPrefix() {
-		return nodeResourceURIPrefix;
-	}
+    public void setPageURIPrefix(final String pageURIPrefix) {
+        this.pageURIPrefix = pageURIPrefix;
+    }
 
-	public void setNodeResourceURIPrefix(String nodeResourceURIPrefix) {
-		this.nodeResourceURIPrefix = nodeResourceURIPrefix;
-	}
+    public String getNodeResourceURIPrefix() {
+        return nodeResourceURIPrefix;
+    }
 
-	public void setNeedResourceURIPath(final String needResourceURIPath) {
-		this.needResourceURIPath = needResourceURIPath;
-	}
+    public void setNodeResourceURIPrefix(String nodeResourceURIPrefix) {
+        this.nodeResourceURIPrefix = nodeResourceURIPrefix;
+    }
 
-	public void setConnectionResourceURIPath(final String connectionResourceURIPath) {
-		this.connectionResourceURIPath = connectionResourceURIPath;
-	}
+    public void setNeedResourceURIPath(final String needResourceURIPath) {
+        this.needResourceURIPath = needResourceURIPath;
+    }
 
-	@RequestMapping(value = "${uri.path.resource}", method = RequestMethod.POST, produces = { "text/plain" })
-	public ResponseEntity<String> register(@RequestParam("register") String registeredType, HttpServletRequest request)
-			throws CertificateException, UnsupportedEncodingException {
-		logger.debug("REGISTERING " + registeredType);
-		PreAuthenticatedAuthenticationToken authentication = (PreAuthenticatedAuthenticationToken) SecurityContextHolder
-				.getContext().getAuthentication();
+    public void setConnectionResourceURIPath(final String connectionResourceURIPath) {
+        this.connectionResourceURIPath = connectionResourceURIPath;
+    }
 
-		if (!(authentication instanceof PreAuthenticatedAuthenticationToken)) {
-			throw new BadCredentialsException("Could not register: PreAuthenticatedAuthenticationToken expected");
-		}
-		// Object principal = authentication.getPrincipal();
+    @RequestMapping(value = "${uri.path.resource}", method = RequestMethod.POST, produces = {"text/plain"})
+    public ResponseEntity<String> register(@RequestParam("register") String registeredType, HttpServletRequest request)
+            throws CertificateException, UnsupportedEncodingException {
+        logger.debug("REGISTERING " + registeredType);
+        PreAuthenticatedAuthenticationToken authentication = (PreAuthenticatedAuthenticationToken) SecurityContextHolder
+                .getContext().getAuthentication();
 
-		Object credentials = authentication.getCredentials();
-		X509Certificate cert;
-		if (credentials instanceof X509Certificate) {
-			cert = (X509Certificate) credentials;
-		} else {
-			throw new BadCredentialsException("Could not register: expected to find a X509Certificate in the request");
-		}
-		try {
-			if ("owner".equals(registeredType)) {
-				String result = registrationServer.registerOwner(cert);
-				logger.debug("successfully registered owner");
-				return new ResponseEntity<>(result, HttpStatus.OK);
-			}
-			if ("node".equals(registeredType)) {
-				String result = registrationServer.registerNode(cert);
-				logger.debug("successfully registered node");
-				return new ResponseEntity<>(result, HttpStatus.OK);
-			} else {
-				String supportedTypesMsg = "Request parameter error; supported 'register' parameter values: 'owner', 'node'";
-				logger.debug(supportedTypesMsg);
-				return new ResponseEntity<>(supportedTypesMsg, HttpStatus.BAD_REQUEST);
-			}
-		} catch (WonProtocolException e) {
-			logger.info("Could not register " + registeredType, e);
-			return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
-		}
-	}
+        if (!(authentication instanceof PreAuthenticatedAuthenticationToken)) {
+            throw new BadCredentialsException("Could not register: PreAuthenticatedAuthenticationToken expected");
+        }
+        // Object principal = authentication.getPrincipal();
 
-	private class DateParameter {
-		private String timestamp;
-		private Date date;
+        Object credentials = authentication.getCredentials();
+        X509Certificate cert;
+        if (credentials instanceof X509Certificate) {
+            cert = (X509Certificate) credentials;
+        } else {
+            throw new BadCredentialsException("Could not register: expected to find a X509Certificate in the request");
+        }
+        try {
+            if ("owner".equals(registeredType)) {
+                String result = registrationServer.registerOwner(cert);
+                logger.debug("successfully registered owner");
+                return new ResponseEntity<>(result, HttpStatus.OK);
+            }
+            if ("node".equals(registeredType)) {
+                String result = registrationServer.registerNode(cert);
+                logger.debug("successfully registered node");
+                return new ResponseEntity<>(result, HttpStatus.OK);
+            } else {
+                String supportedTypesMsg = "Request parameter error; supported 'register' parameter values: 'owner', 'node'";
+                logger.debug(supportedTypesMsg);
+                return new ResponseEntity<>(supportedTypesMsg, HttpStatus.BAD_REQUEST);
+            }
+        } catch (WonProtocolException e) {
+            logger.info("Could not register " + registeredType, e);
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
 
-		/**
-		 * Creates date parameter from String timestamp, assumes timestamp format is ISO
-		 * 8601. If timestamp is null, the parameter is assigned current time value.
-		 *
-		 * @param timestamp
-		 */
-		public DateParameter(final String timestamp) throws ParseException {
+    private class DateParameter {
+        private String timestamp;
+        private Date date;
 
-			// timestamp string is expected in ISO 8601 format (UTC)
-			DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-			format.setTimeZone(TimeZone.getTimeZone("UTC"));
-			if (timestamp == null) {
-				this.date = new Date();
-				this.timestamp = format.format(date);
-			} else {
-				this.date = format.parse(timestamp);
-				this.timestamp = timestamp;
-			}
-		}
+        /**
+         * Creates date parameter from String timestamp, assumes timestamp format is ISO
+         * 8601. If timestamp is null, the parameter is assigned current time value.
+         *
+         * @param timestamp
+         */
+        public DateParameter(final String timestamp) throws ParseException {
 
-		/**
-		 * Gets time from String timestamp.
-		 *
-		 * @return
-		 */
-		public Date getDate() {
-			return date;
-		}
+            // timestamp string is expected in ISO 8601 format (UTC)
+            DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            format.setTimeZone(TimeZone.getTimeZone("UTC"));
+            if (timestamp == null) {
+                this.date = new Date();
+                this.timestamp = format.format(date);
+            } else {
+                this.date = format.parse(timestamp);
+                this.timestamp = timestamp;
+            }
+        }
 
-		/**
-		 * Gets String timestamp.
-		 *
-		 * @return
-		 */
-		public String getTimestamp() {
-			return timestamp;
-		}
-	}
+        /**
+         * Gets time from String timestamp.
+         *
+         * @return
+         */
+        public Date getDate() {
+            return date;
+        }
+
+        /**
+         * Gets String timestamp.
+         *
+         * @return
+         */
+        public String getTimestamp() {
+            return timestamp;
+        }
+    }
 }

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -690,7 +690,7 @@ public class LinkedDataWebController {
             } else if (modifiedAfter != null) {
                 // paging is not implemented for modified connections for now!
                 rdfDataset = linkedDataService
-                        .listModifiedConnectionURIsAfter(new DateParameter(modifiedAfter).getDate(), deep);
+                        .listModifiedConnectionsAfter(new DateParameter(modifiedAfter).getDate(), deep).getContent();
             } else if (page != null) {
                 // return latest by the given timestamp
                 NeedInformationService.PagedResource<Dataset, Connection> resource = linkedDataService.listConnections(page,

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -47,6 +47,7 @@ import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchNeedException;
 import won.protocol.exception.WonProtocolException;
 import won.protocol.message.WonMessageType;
+import won.protocol.model.Connection;
 import won.protocol.model.DataWithEtag;
 import won.protocol.model.NeedState;
 import won.protocol.rest.WonEtagHelper;
@@ -419,9 +420,8 @@ public class LinkedDataWebController {
             WonMessageType eventsType = getMessageType(type);
             Dataset rdfDataset;
             if (page != null) {
-                //TODO: Change to include ConnectionData
                 rdfDataset = linkedDataService
-                        .listConnectionURIs(page, needURI, null, eventsType, dateParam.getDate(), deep, true)
+                        .listConnections(page, needURI, null, eventsType, dateParam.getDate(), deep, true)
                         .getContent();
             } else if (beforeId != null) {
                 //TODO: Change to include ConnectionData
@@ -440,7 +440,7 @@ public class LinkedDataWebController {
                 // clients that do not support
                 // paging
                 rdfDataset = linkedDataService
-                        .listConnectionURIs(needURI, deep, true)
+                        .listConnections(needURI, deep, true)
                         .getContent();
             }
             model.addAttribute("rdfDataset", rdfDataset);
@@ -1126,7 +1126,7 @@ public class LinkedDataWebController {
                 // does not support date and type filtering for clients that do not support
                 // paging
                 rdfDataset = linkedDataService
-                        .listConnectionURIs(needUri, deep, true)
+                        .listConnections(needUri, deep, true)
                         .getContent();
                 // if no page or resume parameter is specified, display the latest connections:
             } else if (page == null && beforeId == null && afterId == null) {

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -923,25 +923,19 @@ public class LinkedDataWebController {
 				// filtering for clients that do
 				// not support paging
 				rdfDataset = linkedDataService.listConnectionEventURIs(connectionUri, deep);
-			} else if (page == null && beforeId == null && afterId == null) {
-				// client supports paging but didn't specify which page to return - return page
-				// with latest events
+			} else if (beforeId == null && afterId == null) {
+				//if page == null -> return page with latest events
 				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIs(connectionUri, 1, preferedSize, msgType, deep); // TODO: does not
+						.listConnectionEventURIs(connectionUri, page != null? page : 1, preferedSize, msgType, deep); // TODO: does not
 																									// respect
 																									// preferredSize if
 																									// deep is used
 				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
-
-			} else if (page != null) {
-				// a page having particular page number is requested
-
-				NeedInformationService.PagedResource<Dataset, URI> resource = linkedDataService
-						.listConnectionEventURIs(connectionUri, page, preferedSize, msgType, deep);
-				rdfDataset = resource.getContent();
-				addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, page, passableMap);
-
+                if (page == null) {
+                    addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, passableMap);
+                } else {
+                    addPagedResourceInSequenceHeader(headers, connectionEventsURI, resource, page, passableMap);
+                }
 			} else if (beforeId != null) {
 				// a page that precedes the item identified by the beforeId is requested
 

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -212,7 +212,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         String newEtag = data.getEtag();
 
         // load the dataset from storage
-        boolean isDeleted = !!(need.getState() == NeedState.DELETED);
+        boolean isDeleted = (need.getState() == NeedState.DELETED);
         Dataset dataset = isDeleted ? DatasetFactory.createGeneral() : need.getDatatsetHolder().getDataset();
         Model metaModel = needModelMapper.toModel(need);
 
@@ -791,9 +791,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             NoSuchConnectionException {
         Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEvents(connectionUri, pageNum,
                 preferedSize, msgType);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(
-                this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
-        return containerPage;
+        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
     }
 
 
@@ -804,11 +802,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             NoSuchConnectionException {
         Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsAfter(
                 connectionUri, msgURI, preferedSize, msgType);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(this.uriService
-                        .createEventsURIForConnection
-                                (connectionUri).toString(),
-                slice, deep);
-        return containerPage;
+        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
     }
 
     @Override
@@ -819,9 +813,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
         Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsBefore(
                 connectionUri, msgURI, preferedSize, msgType);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(this.uriService.createEventsURIForConnection
-                (connectionUri).toString(), slice, deep);
-        return containerPage;
+        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
     }
 
     private Dataset setDefaults(Dataset dataset) {
@@ -969,9 +961,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         }
         Dataset dataset = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
         addBaseUriAndDefaultPrefixes(dataset);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = new NeedInformationService.PagedResource
-                (dataset, resumeBefore, resumeAfter);
-        return containerPage;
+        return new NeedInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
     }
 
     private NeedInformationService.PagedResource<Dataset, Connection> toConnectionsContainerPage(String containerUri, Slice<Connection> slice) {
@@ -1005,8 +995,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         }
         Dataset dataset = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
         addBaseUriAndDefaultPrefixes(dataset);
-        NeedInformationService.PagedResource<Dataset, Connection> containerPage = new NeedInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
-        return containerPage;
+        return new NeedInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
     }
 
     /**
@@ -1055,9 +1044,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         Dataset dataset = aggregator.aggregate();
         dataset.addNamedModel(createDataGraphUriFromResource(needListPageResource), model);
         addBaseUriAndDefaultPrefixes(dataset);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = new NeedInformationService.PagedResource
-                (dataset, resumeBefore, resumeAfter);
-        return containerPage;
+        return new NeedInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
     }
 
     public void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) throws NoSuchConnectionException {

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -443,6 +443,23 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final boolean deep) throws NoSuchConnectionException {
+        List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections());
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
+                this.connectionResourceURIPrefix + "/", new SliceImpl<Connection>(connections));
+        if (deep) {
+            List<URI> uris = connections
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
     public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
         List<URI> uris = new ArrayList<URI>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
         NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
@@ -465,6 +482,24 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             addDeepConnectionData(containerPage.getContent(), slice.getContent());
         }
         return containerPage;
+    }
+
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final int page, final Integer
+            preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnections(page, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
+                this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        return connectionsContainerPage;
     }
 
     @Override

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -1047,7 +1047,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         return new NeedInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
     }
 
-    public void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) throws NoSuchConnectionException {
+    private void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) {
         //add the connection model for each connection URI
         for (URI connectionURI : connectionURIs) {
             DataWithEtag<Dataset> connectionDataset =

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -373,7 +373,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
      *
      * @param connectionUri
      * @param includeEventContainer
-     * @param includeLatestEvent
+     * @param includeEventContainer
      * @param etag
      * @return
      */
@@ -578,6 +578,30 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(final URI needURI, URI
+            beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
+                                                                                       boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnectionsBefore(
+                needURI, beforeEventURI, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(connectionsUri.toString(), slice);
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        if (addMetadata) {
+            addConnectionMetadata(connectionsContainerPage.getContent(), needURI, connectionsUri);
+        }
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(final URI needURI, URI
             resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
                                                                                       boolean addMetadata)
@@ -594,6 +618,31 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
         }
         return containerPage;
+    }
+
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsAfter(final URI needURI, URI
+            resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
+                                                                                      boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnectionsAfter(
+                needURI, resumeConnURI, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
+                connectionsUri.toString(), slice);
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        if (addMetadata) {
+            addConnectionMetadata(connectionsContainerPage.getContent(), needURI, connectionsUri);
+        }
+        return connectionsContainerPage;
     }
 
     private void addConnectionMetadata(final Dataset content, URI needURI, URI containerURI) {

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -121,10 +121,8 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     public Dataset listNeedURIs() {
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource needListPageResource = null;
-        Collection<URI> uris = null;
-        uris = needInformationService.listNeedURIs();
-        needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
+        Collection<URI> uris = needInformationService.listNeedURIs();
+        Resource needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
 
         for (URI needURI : uris) {
             model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
@@ -180,10 +178,8 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource needListPageResource = null;
-        Collection<URI> uris = null;
-        uris = needInformationService.listModifiedNeedURIsAfter(modifiedDate);
-        needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
+        Collection<URI> uris = needInformationService.listModifiedNeedURIsAfter(modifiedDate);
+        Resource needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
 
         for (URI needURI : uris) {
             model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
@@ -196,7 +192,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     @Transactional
     public DataWithEtag<Dataset> getNeedDataset(final URI needUri, String etag) {
 
-        DataWithEtag<Need> data = null;
+        DataWithEtag<Need> data;
         try {
             data = needInformationService.readNeed(needUri, etag);
         } catch (NoSuchNeedException e) {
@@ -318,8 +314,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     public Dataset getNodeDataset() {
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource showNodePageResource = null;
-        showNodePageResource = model.createResource(this.resourceURIPrefix);
+        Resource showNodePageResource = model.createResource(this.resourceURIPrefix);
         addNeedList(model, showNodePageResource);
         addProtocolEndpoints(model, showNodePageResource);
         Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(showNodePageResource), model);
@@ -379,19 +374,15 @@ public class LinkedDataServiceImpl implements LinkedDataService {
      */
     @Override
     @Transactional
-    public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final String etag)
-
-    {
-        DataWithEtag<Connection> data = null;
-        Connection connection = null;
-        data = needInformationService.readConnection(connectionUri, etag);
+    public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final String etag) {
+        DataWithEtag<Connection> data = needInformationService.readConnection(connectionUri, etag);
         if (data.isNotFound()) {
             return DataWithEtag.dataNotFound();
         }
         if (!data.isChanged()) {
             return DataWithEtag.dataNotChanged(data);
         }
-        connection = data.getData();
+        Connection connection = data.getData();
         if (connection == null) {
             return DataWithEtag.dataNotFound();
         }
@@ -431,9 +422,9 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     @Override
     @Transactional
     public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException {
-        List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs());
+        List<URI> uris = new ArrayList<>(needInformationService.listConnectionURIs());
         NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
+                this.connectionResourceURIPrefix + "/", new SliceImpl<>(uris));
         if (deep) {
             addDeepConnectionData(containerPage.getContent(), uris);
         }
@@ -444,13 +435,13 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     @Override
     @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final boolean deep) throws NoSuchConnectionException {
-        List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections());
+        List<Connection> connections = new ArrayList<>(needInformationService.listConnections());
         NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
-                this.connectionResourceURIPrefix + "/", new SliceImpl<Connection>(connections));
+                this.connectionResourceURIPrefix + "/", new SliceImpl<>(connections));
         if (deep) {
             List<URI> uris = connections
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -461,9 +452,9 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     @Override
     @Transactional
     public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
-        List<URI> uris = new ArrayList<URI>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
+        List<URI> uris = new ArrayList<>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
         NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
+                this.connectionResourceURIPrefix + "/", new SliceImpl<>(uris));
         if (deep) {
             addDeepConnectionData(containerPage.getContent(), uris);
         }
@@ -495,7 +486,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -524,7 +515,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -555,7 +546,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -566,14 +557,14 @@ public class LinkedDataServiceImpl implements LinkedDataService {
     @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final URI needURI, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException {
-        List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections(needURI));
+        List<Connection> connections = new ArrayList<>(needInformationService.listConnections(needURI));
         URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
         NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(connectionsUri.toString(), new
-                SliceImpl<Connection>(connections));
+                SliceImpl<>(connections));
         if (deep) {
             List<URI> uris = connections
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
 
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
@@ -598,7 +589,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -660,7 +651,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -705,7 +696,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             List<URI> uris = slice
                     .getContent()
                     .stream()
-                    .map(conn -> conn.getConnectionURI())
+                    .map(Connection::getConnectionURI)
                     .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
@@ -831,13 +822,13 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         if (datasetHolder == null) {
             return DataWithEtag.dataNotFound();
         }
-        if (version.intValue() == datasetHolder.getVersion()) {
+        if (version == datasetHolder.getVersion()) {
             return DataWithEtag.dataNotChanged(etag);
         }
         Dataset dataset = datasetHolder.getDataset();
         DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
         addBaseUriAndDefaultPrefixes(dataset);
-        return new DataWithEtag<Dataset>(dataset, Integer.toString(datasetHolder.getVersion()), etag);
+        return new DataWithEtag<>(dataset, Integer.toString(datasetHolder.getVersion()), etag);
     }
 
 
@@ -891,10 +882,9 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         model.add(model.createStatement(containerPageResource, RDF.type, LDP.PAGE));
         model.add(model.createStatement(containerPageResource, LDP.PAGE_OF, containerResource));
         model.add(model.createStatement(containerPageResource, RDF.type, LDP.CONTAINER));
-        Resource containerNextPageResource = null;
         //assume last page if we didn't fetch pageSize uris
         if (page.hasNext()) {
-            containerNextPageResource = model.createResource(addPageQueryString(containerURI, pageNum + 1));
+            Resource containerNextPageResource = model.createResource(addPageQueryString(containerURI, pageNum + 1));
             model.add(model.createStatement(containerPageResource, LDP.NEXT_PAGE, containerNextPageResource));
         }
 
@@ -952,9 +942,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource needListPageResource = null;
-
-        needListPageResource = model.createResource(containerUri);
+        Resource needListPageResource = model.createResource(containerUri);
 
         for (URI needURI : uris) {
             model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
@@ -985,9 +973,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource needListPageResource = null;
-
-        needListPageResource = model.createResource(containerUri);
+        Resource needListPageResource = model.createResource(containerUri);
 
         for (Connection conn : connections) {
             model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(conn.getConnectionURI().toString())));
@@ -1030,9 +1016,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
         Model model = ModelFactory.createDefaultModel();
         setNsPrefixes(model);
-        Resource needListPageResource = null;
-
-        needListPageResource = model.createResource(containerUri);
+        Resource needListPageResource = model.createResource(containerUri);
 
         DatasetHolderAggregator aggregator = new DatasetHolderAggregator();
         for (MessageEventPlaceholder event : events) {

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -546,6 +546,24 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsAfter(
+            URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnectionsAfter(afterConnURI, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
+                this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final URI needURI, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException {
         List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections(needURI));

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
  * TODO: conform to: https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp-paging.html, especially for sorting
  */
 public class LinkedDataServiceImpl implements LinkedDataService {
-    final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     //prefix of a need resource
     private String needResourceURIPrefix;

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -600,6 +600,18 @@ public class LinkedDataServiceImpl implements LinkedDataService
       }
       containerResource.addProperty(countProperty, Integer.toString(count.intValue()), XSDDatatype.XSDint);
     }
+
+    List<Object[]> connectionUrisWithState = needRepository.getConnectionUrisAndState(needURI);
+    for (Object[] connUriWithState : connectionUrisWithState) {
+        ConnectionState stateName = (ConnectionState) connUriWithState[0];
+        URI connectionUri = (URI) connUriWithState[1];
+        Property stateUrisProperty = getRdfPropertyForStateUris(stateName);
+        if (stateUrisProperty == null) {
+            logger.warn("did not recognize connection state " + stateName);
+            continue;
+        }
+        containerResource.addProperty(stateUrisProperty, connectionUri.toString(), XSDDatatype.XSDID);
+    }
   }
 
   private Property getRdfPropertyForState(ConnectionState state) {
@@ -609,6 +621,19 @@ public class LinkedDataServiceImpl implements LinkedDataService
       case REQUEST_SENT: return WON.HAS_REQUEST_SENT_COUNT;
       case CONNECTED: return WON.HAS_CONNECTED_COUNT;
       case CLOSED: return WON.HAS_CLOSED_COUNT;
+      case DELETED: return WON.HAS_DELETED_COUNT;
+    }
+    return null;
+  }
+
+  private Property getRdfPropertyForStateUris(ConnectionState state) {
+    switch (state){
+      case SUGGESTED: return WON.SUGGESTED;
+      case REQUEST_RECEIVED: return WON.REQUEST_RECEIVED;
+      case REQUEST_SENT: return WON.REQUEST_SENT;
+      case CONNECTED: return WON.CONNECTED;
+      case CLOSED: return WON.CLOSED;
+      case DELETED: return WON.DELETED;
     }
     return null;
   }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -516,6 +516,23 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(
+            URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnectionsBefore(beforeConnURI, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(
             URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
         Slice<URI> slice = needInformationService.listConnectionURIsAfter(afterConnURI, preferredSize, timeSpot);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -16,14 +16,6 @@
 
 package won.node.service.impl;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
@@ -41,22 +33,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
-
 import won.cryptography.rdfsign.WonKeysReaderWriter;
 import won.cryptography.service.CryptographyService;
 import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchNeedException;
 import won.protocol.message.WonMessageType;
-import won.protocol.model.Connection;
-import won.protocol.model.ConnectionModelMapper;
-import won.protocol.model.ConnectionState;
-import won.protocol.model.DataWithEtag;
-import won.protocol.model.DatasetHolder;
-import won.protocol.model.DatasetHolderAggregator;
-import won.protocol.model.MessageEventPlaceholder;
-import won.protocol.model.Need;
-import won.protocol.model.NeedModelMapper;
-import won.protocol.model.NeedState;
+import won.protocol.model.*;
 import won.protocol.model.unread.UnreadMessageInfo;
 import won.protocol.model.unread.UnreadMessageInfoForNeed;
 import won.protocol.repository.DatasetHolderRepository;
@@ -71,948 +53,913 @@ import won.protocol.vocabulary.LDP;
 import won.protocol.vocabulary.RDFG;
 import won.protocol.vocabulary.WON;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
 /**
  * Creates rdf models from the relational database.
  * TODO: conform to: https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp-paging.html, especially for sorting
  */
-public class LinkedDataServiceImpl implements LinkedDataService
-{
-  final Logger logger = LoggerFactory.getLogger(getClass());
+public class LinkedDataServiceImpl implements LinkedDataService {
+    final Logger logger = LoggerFactory.getLogger(getClass());
 
-  //prefix of a need resource
-  private String needResourceURIPrefix;
-  //prefix of a connection resource
-  private String connectionResourceURIPrefix;
-  //prefix of a event resource
-  private String eventResourceURIPrefix;
-  //prefix for URISs of RDF data
-  private String dataURIPrefix;
-  //prefix for URIs referring to real-world things
-  private String resourceURIPrefix;
-  //prefix for human readable pages
-  private String pageURIPrefix;
-
-
-  @Autowired
-  private MessageEventRepository messageEventRepository;
-  @Autowired
-  private NeedRepository needRepository;
-  @Autowired
-  private DatasetHolderRepository datasetHolderRepository;
-
-  //TODO: used to access/create event URIs for connection model rendering. Could be removed if events knew their URIs.
-  private URIService uriService;
-  @Autowired
-  private NeedModelMapper needModelMapper;
-  @Autowired
-  private ConnectionModelMapper connectionModelMapper;
-
-  @Autowired
-  private CryptographyService cryptographyService;
-  
-  @Autowired 
-  private UnreadInformationService unreadInformationService;
-  
-
-  private String needProtocolEndpoint;
-  private String matcherProtocolEndpoint;
-  private String ownerProtocolEndpoint;
-
-  private NeedInformationService needInformationService;
+    //prefix of a need resource
+    private String needResourceURIPrefix;
+    //prefix of a connection resource
+    private String connectionResourceURIPrefix;
+    //prefix of a event resource
+    private String eventResourceURIPrefix;
+    //prefix for URISs of RDF data
+    private String dataURIPrefix;
+    //prefix for URIs referring to real-world things
+    private String resourceURIPrefix;
+    //prefix for human readable pages
+    private String pageURIPrefix;
 
 
-  private String activeMqEndpoint;
-  private String activeMqNeedProtcolQueueName;
-  private String activeMqOwnerProtcolQueueName;
-  private String activeMqMatcherPrtotocolQueueName;
-  private String activeMqMatcherProtocolTopicNameNeedCreated;
-  private String activeMqMatcherProtocolTopicNameNeedActivated;
-  private String activeMqMatcherProtocolTopicNameNeedDeactivated;
-  private String activeMqMatcherProtocolTopicNameNeedDeleted;
+    @Autowired
+    private MessageEventRepository messageEventRepository;
+    @Autowired
+    private NeedRepository needRepository;
+    @Autowired
+    private DatasetHolderRepository datasetHolderRepository;
+
+    //TODO: used to access/create event URIs for connection model rendering. Could be removed if events knew their URIs.
+    private URIService uriService;
+    @Autowired
+    private NeedModelMapper needModelMapper;
+    @Autowired
+    private ConnectionModelMapper connectionModelMapper;
+
+    @Autowired
+    private CryptographyService cryptographyService;
+
+    @Autowired
+    private UnreadInformationService unreadInformationService;
 
 
-  @Transactional
-  public Dataset listNeedURIs()
-  {
-    Model model = ModelFactory.createDefaultModel();
-    setNsPrefixes(model);
-    Resource needListPageResource = null;
-    Collection<URI> uris = null;
-    uris = needInformationService.listNeedURIs();
-    needListPageResource = model.createResource(this.needResourceURIPrefix+"/");
+    private String needProtocolEndpoint;
+    private String matcherProtocolEndpoint;
+    private String ownerProtocolEndpoint;
 
-    for (URI needURI : uris) {
-      model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
-    }
-    Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
-    addBaseUriAndDefaultPrefixes(ret);
-    return ret;
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listNeedURIs(final int pageNum)
-  {
-    return listNeedURIs(pageNum, null, null);
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsBefore(final URI need)
-  {
-    return listNeedURIsBefore(need, null, null);
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsAfter(final URI need)
-  {
-    return listNeedURIsAfter(need, null, null);
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listNeedURIs(final int pageNum, final Integer preferedSize,
-                                                                    NeedState needState) {
-    Slice<URI> slice = needInformationService.listNeedURIs(pageNum, preferedSize, needState);
-    return toContainerPage(this.needResourceURIPrefix + "/", slice);
-
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listNeedURIsBefore(
-    final URI need, final Integer preferedSize, NeedState needState) {
-
-    Slice<URI> slice = needInformationService.listNeedURIsBefore(need, preferedSize, needState);
-    return toContainerPage(this.needResourceURIPrefix + "/", slice);
-
-  }
-
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(
-    final URI need, final Integer preferedSize, NeedState needState) {
-
-    Slice<URI> slice = needInformationService.listNeedURIsAfter(need, preferedSize, needState);
-    return toContainerPage(this.needResourceURIPrefix + "/", slice);
-
-  }
-
-  @Transactional
-  public Dataset listModifiedNeedURIsAfter(Date modifiedDate) {
-
-      Model model = ModelFactory.createDefaultModel();
-      setNsPrefixes(model);
-      Resource needListPageResource = null;
-      Collection<URI> uris = null;
-      uris = needInformationService.listModifiedNeedURIsAfter(modifiedDate);
-      needListPageResource = model.createResource(this.needResourceURIPrefix+"/");
-
-      for (URI needURI : uris) {
-          model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
-      }
-      Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
-      addBaseUriAndDefaultPrefixes(ret);
-      return ret;
-  }
-
-  @Transactional
-  public DataWithEtag<Dataset> getNeedDataset(final URI needUri, String etag) {
-
-      DataWithEtag<Need> data = null;
-      try {
-          data = needInformationService.readNeed(needUri, etag);
-      } catch (NoSuchNeedException e) {
-          return DataWithEtag.dataNotFound();
-      }
-      if (data.isNotFound()) {
-          return DataWithEtag.dataNotFound();
-      }
-      if (!data.isChanged()){
-          return DataWithEtag.dataNotChanged(data);
-      }
-      Need need = data.getData();
-      String newEtag = data.getEtag();
-
-    // load the dataset from storage
-    boolean isDeleted = !!(need.getState() == NeedState.DELETED);
-    Dataset dataset = isDeleted? DatasetFactory.createGeneral() : need.getDatatsetHolder().getDataset();
-    Model metaModel = needModelMapper.toModel(need);
-
-    Resource needResource = metaModel.getResource(needUri.toString());
-    String needMetaInformationURI = uriService.createNeedSysInfoGraphURI(needUri).toString();
-    Resource needMetaInformationResource = metaModel.getResource(needMetaInformationURI);
-    
-    //link needMetaInformationURI to need via rdfg:subGraphOf
-    needMetaInformationResource.addProperty(RDFG.SUBGRAPH_OF, needResource);
-
-    // add connections
-    Resource connectionsContainer = metaModel.createResource(need.getNeedURI().toString() + "/connections");
-    metaModel.add(metaModel.createStatement(needResource, WON.HAS_CONNECTIONS, connectionsContainer));
-
-    // add need event container
-    Resource needEventContainer = metaModel.createResource(need.getNeedURI().toString()+"#events", WON.EVENT_CONTAINER);
-    metaModel.add(metaModel.createStatement(needResource, WON.HAS_EVENT_CONTAINER, needEventContainer));
-
-    // add need event URIs
-    Collection<MessageEventPlaceholder> messageEvents = need.getEventContainer().getEvents();
-    for (MessageEventPlaceholder messageEvent : messageEvents) {
-    metaModel.add(metaModel.createStatement(needEventContainer,
-                                            RDFS.member,
-                                            metaModel.getResource(messageEvent.getMessageURI().toString())));
-    }
-
-    // add WON node link
-    needResource.addProperty(WON.HAS_WON_NODE, metaModel.createResource(this.resourceURIPrefix));
-
-    // link all need graphs taken from the create message to need uri:
-    Iterator<String> namesIt = dataset.listNames();
-    while(namesIt.hasNext()) {
-    	String name = namesIt.next();
-    	Resource needGraphResource = metaModel.getResource(name);
-    	needResource.addProperty(WON.HAS_CONTENT_GRAPH, needGraphResource);
-    }
-    
-    // add meta model to dataset
-    dataset.addNamedModel(needMetaInformationURI, metaModel);
-    addBaseUriAndDefaultPrefixes(dataset);
-
-    return new DataWithEtag<>(dataset ,newEtag, etag, isDeleted);
-  }
+    private NeedInformationService needInformationService;
 
 
+    private String activeMqEndpoint;
+    private String activeMqNeedProtcolQueueName;
+    private String activeMqOwnerProtcolQueueName;
+    private String activeMqMatcherPrtotocolQueueName;
+    private String activeMqMatcherProtocolTopicNameNeedCreated;
+    private String activeMqMatcherProtocolTopicNameNeedActivated;
+    private String activeMqMatcherProtocolTopicNameNeedDeactivated;
+    private String activeMqMatcherProtocolTopicNameNeedDeleted;
 
-  @Override
-  @Transactional
-  public Dataset getNeedDataset(final URI needUri, boolean deep, Integer deepLayerSize
-                                ) throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException {
-    Dataset dataset = getNeedDataset(needUri, null).getData();
-    if (deep) {
-      Need need = needInformationService.readNeed(needUri);
-      if (need.getState() == NeedState.ACTIVE) {
-        //only add deep data if need is active
-        Slice<URI> slice = needInformationService.listConnectionURIs(needUri, 1, deepLayerSize, null, null);
-        NeedInformationService.PagedResource<Dataset, URI> connectionsResource = toContainerPage(
-                this.uriService.createConnectionsURIForNeed(needUri).toString(), slice);
-        addDeepConnectionData(connectionsResource.getContent(), slice.getContent());
-        RdfUtils.addDatasetToDataset(dataset, connectionsResource.getContent());
-        for (URI connectionUri : slice.getContent()) {
-          NeedInformationService.PagedResource<Dataset, URI> eventsResource = listConnectionEventURIs(
-                  connectionUri, 1, deepLayerSize, null, true);
-          RdfUtils.addDatasetToDataset(dataset, eventsResource.getContent());
+
+    @Transactional
+    public Dataset listNeedURIs() {
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
+        Resource needListPageResource = null;
+        Collection<URI> uris = null;
+        uris = needInformationService.listNeedURIs();
+        needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
+
+        for (URI needURI : uris) {
+            model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
         }
-      }
+        Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
+        addBaseUriAndDefaultPrefixes(ret);
+        return ret;
     }
-    return dataset;
-  }
 
-  @Override
-@Transactional
-  public Model getUnreadInformationForNeed(URI needURI, Collection<URI> lastSeenMessageURIs) {
-		UnreadMessageInfoForNeed unreadInfo = this.unreadInformationService.getUnreadInformation(needURI, lastSeenMessageURIs);
-		Model ret = ModelFactory.createDefaultModel();
-		Resource needRes = ret.createResource(needURI.toString());
-		addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_SUGGESTED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.SUGGESTED));
-		addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_CONNECTED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.CONNECTED));
-		addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_REQUEST_SENT, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.REQUEST_SENT));
-		addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_REQUEST_RECEIVED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.REQUEST_RECEIVED));
-		addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_CLOSED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.CLOSED));
-		unreadInfo.getUnreadMessageInfoForConnections().forEach(info -> {
-			Resource connRes = ret.createResource(info.getConnectionURI().toString());
-			addUnreadInfoWithProperty(ret, connRes, null, info.getUnreadInformation());
-		});
-		return ret;
-  }
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int pageNum) {
+        return listNeedURIs(pageNum, null, null);
+    }
 
-	private void addUnreadInfoWithProperty(Model ret, Resource subject, Property property, UnreadMessageInfo info) {
-		if (info != null) {
-			if (property != null) {
-				//if we are given a property, make a blank node and connect it to the subject using the property
-				Resource node = ret.createResource();
-				subject.addProperty(property, node);
-				subject = node;
-			} 
-			subject.addLiteral(WON.HAS_UNREAD_COUNT, info.getCount());
-			subject.addLiteral(WON.HAS_UNREAD_OLDEST_TIMESTAMP, info.getOldestTimestamp().getTime());
-			subject.addLiteral(WON.HAS_UNREAD_NEWEST_TIMESTAMP, info.getNewestTimestamp().getTime());
-		}
-	}
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(final URI need) {
+        return listNeedURIsBefore(need, null, null);
+    }
 
-  @Transactional
-  public Dataset getNodeDataset()
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(final URI need) {
+        return listNeedURIsAfter(need, null, null);
+    }
+
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIs(final int pageNum, final Integer preferedSize,
+                                                                           NeedState needState) {
+        Slice<URI> slice = needInformationService.listNeedURIs(pageNum, preferedSize, needState);
+        return toContainerPage(this.needResourceURIPrefix + "/", slice);
+
+    }
+
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsBefore(
+            final URI need, final Integer preferedSize, NeedState needState) {
+
+        Slice<URI> slice = needInformationService.listNeedURIsBefore(need, preferedSize, needState);
+        return toContainerPage(this.needResourceURIPrefix + "/", slice);
+
+    }
+
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listNeedURIsAfter(
+            final URI need, final Integer preferedSize, NeedState needState) {
+
+        Slice<URI> slice = needInformationService.listNeedURIsAfter(need, preferedSize, needState);
+        return toContainerPage(this.needResourceURIPrefix + "/", slice);
+
+    }
+
+    @Transactional
+    public Dataset listModifiedNeedURIsAfter(Date modifiedDate) {
+
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
+        Resource needListPageResource = null;
+        Collection<URI> uris = null;
+        uris = needInformationService.listModifiedNeedURIsAfter(modifiedDate);
+        needListPageResource = model.createResource(this.needResourceURIPrefix + "/");
+
+        for (URI needURI : uris) {
+            model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
+        }
+        Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
+        addBaseUriAndDefaultPrefixes(ret);
+        return ret;
+    }
+
+    @Transactional
+    public DataWithEtag<Dataset> getNeedDataset(final URI needUri, String etag) {
+
+        DataWithEtag<Need> data = null;
+        try {
+            data = needInformationService.readNeed(needUri, etag);
+        } catch (NoSuchNeedException e) {
+            return DataWithEtag.dataNotFound();
+        }
+        if (data.isNotFound()) {
+            return DataWithEtag.dataNotFound();
+        }
+        if (!data.isChanged()) {
+            return DataWithEtag.dataNotChanged(data);
+        }
+        Need need = data.getData();
+        String newEtag = data.getEtag();
+
+        // load the dataset from storage
+        boolean isDeleted = !!(need.getState() == NeedState.DELETED);
+        Dataset dataset = isDeleted ? DatasetFactory.createGeneral() : need.getDatatsetHolder().getDataset();
+        Model metaModel = needModelMapper.toModel(need);
+
+        Resource needResource = metaModel.getResource(needUri.toString());
+        String needMetaInformationURI = uriService.createNeedSysInfoGraphURI(needUri).toString();
+        Resource needMetaInformationResource = metaModel.getResource(needMetaInformationURI);
+
+        //link needMetaInformationURI to need via rdfg:subGraphOf
+        needMetaInformationResource.addProperty(RDFG.SUBGRAPH_OF, needResource);
+
+        // add connections
+        Resource connectionsContainer = metaModel.createResource(need.getNeedURI().toString() + "/connections");
+        metaModel.add(metaModel.createStatement(needResource, WON.HAS_CONNECTIONS, connectionsContainer));
+
+        // add need event container
+        Resource needEventContainer = metaModel.createResource(need.getNeedURI().toString() + "#events", WON.EVENT_CONTAINER);
+        metaModel.add(metaModel.createStatement(needResource, WON.HAS_EVENT_CONTAINER, needEventContainer));
+
+        // add need event URIs
+        Collection<MessageEventPlaceholder> messageEvents = need.getEventContainer().getEvents();
+        for (MessageEventPlaceholder messageEvent : messageEvents) {
+            metaModel.add(metaModel.createStatement(needEventContainer,
+                    RDFS.member,
+                    metaModel.getResource(messageEvent.getMessageURI().toString())));
+        }
+
+        // add WON node link
+        needResource.addProperty(WON.HAS_WON_NODE, metaModel.createResource(this.resourceURIPrefix));
+
+        // link all need graphs taken from the create message to need uri:
+        Iterator<String> namesIt = dataset.listNames();
+        while (namesIt.hasNext()) {
+            String name = namesIt.next();
+            Resource needGraphResource = metaModel.getResource(name);
+            needResource.addProperty(WON.HAS_CONTENT_GRAPH, needGraphResource);
+        }
+
+        // add meta model to dataset
+        dataset.addNamedModel(needMetaInformationURI, metaModel);
+        addBaseUriAndDefaultPrefixes(dataset);
+
+        return new DataWithEtag<>(dataset, newEtag, etag, isDeleted);
+    }
+
+
+    @Override
+    @Transactional
+    public Dataset getNeedDataset(final URI needUri, boolean deep, Integer deepLayerSize
+    ) throws NoSuchNeedException, NoSuchConnectionException, NoSuchMessageException {
+        Dataset dataset = getNeedDataset(needUri, null).getData();
+        if (deep) {
+            Need need = needInformationService.readNeed(needUri);
+            if (need.getState() == NeedState.ACTIVE) {
+                //only add deep data if need is active
+                Slice<URI> slice = needInformationService.listConnectionURIs(needUri, 1, deepLayerSize, null, null);
+                NeedInformationService.PagedResource<Dataset, URI> connectionsResource = toContainerPage(
+                        this.uriService.createConnectionsURIForNeed(needUri).toString(), slice);
+                addDeepConnectionData(connectionsResource.getContent(), slice.getContent());
+                RdfUtils.addDatasetToDataset(dataset, connectionsResource.getContent());
+                for (URI connectionUri : slice.getContent()) {
+                    NeedInformationService.PagedResource<Dataset, URI> eventsResource = listConnectionEventURIs(
+                            connectionUri, 1, deepLayerSize, null, true);
+                    RdfUtils.addDatasetToDataset(dataset, eventsResource.getContent());
+                }
+            }
+        }
+        return dataset;
+    }
+
+    @Override
+    @Transactional
+    public Model getUnreadInformationForNeed(URI needURI, Collection<URI> lastSeenMessageURIs) {
+        UnreadMessageInfoForNeed unreadInfo = this.unreadInformationService.getUnreadInformation(needURI, lastSeenMessageURIs);
+        Model ret = ModelFactory.createDefaultModel();
+        Resource needRes = ret.createResource(needURI.toString());
+        addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_SUGGESTED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.SUGGESTED));
+        addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_CONNECTED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.CONNECTED));
+        addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_REQUEST_SENT, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.REQUEST_SENT));
+        addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_REQUEST_RECEIVED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.REQUEST_RECEIVED));
+        addUnreadInfoWithProperty(ret, needRes, WON.HAS_UNREAD_CLOSED, unreadInfo.getUnreadInfoByConnectionState().get(ConnectionState.CLOSED));
+        unreadInfo.getUnreadMessageInfoForConnections().forEach(info -> {
+            Resource connRes = ret.createResource(info.getConnectionURI().toString());
+            addUnreadInfoWithProperty(ret, connRes, null, info.getUnreadInformation());
+        });
+        return ret;
+    }
+
+    private void addUnreadInfoWithProperty(Model ret, Resource subject, Property property, UnreadMessageInfo info) {
+        if (info != null) {
+            if (property != null) {
+                //if we are given a property, make a blank node and connect it to the subject using the property
+                Resource node = ret.createResource();
+                subject.addProperty(property, node);
+                subject = node;
+            }
+            subject.addLiteral(WON.HAS_UNREAD_COUNT, info.getCount());
+            subject.addLiteral(WON.HAS_UNREAD_OLDEST_TIMESTAMP, info.getOldestTimestamp().getTime());
+            subject.addLiteral(WON.HAS_UNREAD_NEWEST_TIMESTAMP, info.getNewestTimestamp().getTime());
+        }
+    }
+
+    @Transactional
+    public Dataset getNodeDataset() {
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
+        Resource showNodePageResource = null;
+        showNodePageResource = model.createResource(this.resourceURIPrefix);
+        addNeedList(model, showNodePageResource);
+        addProtocolEndpoints(model, showNodePageResource);
+        Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(showNodePageResource), model);
+        addBaseUriAndDefaultPrefixes(ret);
+        addPublicKey(model, showNodePageResource);
+        return ret;
+    }
+
+    private void addNeedList(Model model, Resource res) {
+        res.addProperty(WON.HAS_NEED_LIST, model.createResource(this.needResourceURIPrefix));
+    }
+
+    private void addPublicKey(Model model, Resource res) {
+        WonKeysReaderWriter keyWriter = new WonKeysReaderWriter();
+        try {
+            keyWriter.writeToModel(model, res, cryptographyService.getPublicKey(res.getURI()));
+        } catch (Exception e) {
+            logger.warn("No public key could be added to RDF for " + res.getURI());
+        }
+    }
+
+    //TODO: protocol endpoint specification in RDF model needs refactoring!
+    private void addProtocolEndpoints(Model model, Resource res) {
+        Resource blankNodeActiveMq = model.createResource();
+        res.addProperty(WON.SUPPORTS_WON_PROTOCOL_IMPL, blankNodeActiveMq);
+        blankNodeActiveMq
+                .addProperty(RDF.type, WON.WON_OVER_ACTIVE_MQ)
+                .addProperty(WON.HAS_BROKER_URI, model.createResource(this.activeMqEndpoint))
+                .addProperty(WON.HAS_ACTIVEMQ_OWNER_PROTOCOL_QUEUE_NAME, this.activeMqOwnerProtcolQueueName, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_NEED_PROTOCOL_QUEUE_NAME, this.activeMqNeedProtcolQueueName, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_QUEUE_NAME, this.activeMqMatcherPrtotocolQueueName, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_ACTIVATED_TOPIC_NAME,
+                        this.activeMqMatcherProtocolTopicNameNeedActivated, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_DEACTIVATED_TOPIC_NAME, this.activeMqMatcherProtocolTopicNameNeedDeactivated, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_DELETED_TOPIC_NAME, this.activeMqMatcherProtocolTopicNameNeedDeleted, XSDDatatype.XSDstring)
+                .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_CREATED_TOPIC_NAME, this.activeMqMatcherProtocolTopicNameNeedCreated, XSDDatatype.XSDstring)
+        ;
+
+        Resource blankNodeUriSpec = model.createResource();
+        res.addProperty(WON.HAS_URI_PATTERN_SPECIFICATION, blankNodeUriSpec);
+        blankNodeUriSpec.addProperty(WON.HAS_NEED_URI_PREFIX,
+                model.createLiteral(this.needResourceURIPrefix));
+        blankNodeUriSpec.addProperty(WON.HAS_CONNECTION_URI_PREFIX,
+                model.createLiteral(this.connectionResourceURIPrefix));
+        blankNodeUriSpec.addProperty(WON.HAS_EVENT_URI_PREFIX, model.createLiteral(this.eventResourceURIPrefix));
+    }
+
+    /**
+     * ETag-aware method for obtaining connection data. Currently does not take into account new events, only changes
+     * to the connection itself.
+     *
+     * @param connectionUri
+     * @param includeEventContainer
+     * @param includeLatestEvent
+     * @param etag
+     * @return
+     */
+    @Override
+    @Transactional
+    public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final String etag)
+
     {
-      Model model = ModelFactory.createDefaultModel();
-      setNsPrefixes(model);
-      Resource showNodePageResource = null;
-      showNodePageResource = model.createResource(this.resourceURIPrefix);
-      addNeedList(model, showNodePageResource);
-      addProtocolEndpoints(model, showNodePageResource);
-      Dataset ret = newDatasetWithNamedModel(createDataGraphUriFromResource(showNodePageResource), model);
-      addBaseUriAndDefaultPrefixes(ret);
-      addPublicKey(model, showNodePageResource);
-      return ret;
+        DataWithEtag<Connection> data = null;
+        Connection connection = null;
+        data = needInformationService.readConnection(connectionUri, etag);
+        if (data.isNotFound()) {
+            return DataWithEtag.dataNotFound();
+        }
+        if (!data.isChanged()) {
+            return DataWithEtag.dataNotChanged(data);
+        }
+        connection = data.getData();
+        if (connection == null) {
+            return DataWithEtag.dataNotFound();
+        }
+        String newEtag = data.getEtag();
+
+        // load the model from storage
+        Model model = connectionModelMapper.toModel(connection);
+        Model additionalData = connection.getDatasetHolder() == null ? null : connection.getDatasetHolder().getDataset().getDefaultModel();
+        setNsPrefixes(model);
+        if (additionalData != null) {
+            model.add(additionalData);
+        }
+        //model.setNsPrefix("", connection.getConnectionURI().toString());
+
+        //create connection member
+        Resource connectionResource = model.getResource(connection.getConnectionURI().toString());
+
+        // add WON node link
+        connectionResource.addProperty(WON.HAS_WON_NODE, model.createResource(this.resourceURIPrefix));
+        if (includeEventContainer) {
+            //create event container and attach it to the member
+            Resource eventContainer = model.createResource(connection.getConnectionURI().toString() + "/events");
+            connectionResource.addProperty(WON.HAS_EVENT_CONTAINER, eventContainer);
+            eventContainer.addProperty(RDF.type, WON.EVENT_CONTAINER);
+            DatasetHolder datasetHolder = connection.getDatasetHolder();
+            if (datasetHolder != null) {
+                addAdditionalData(model, datasetHolder.getDataset().getDefaultModel(), connectionResource);
+            }
+        }
+
+        Dataset connectionDataset = addBaseUriAndDefaultPrefixes(newDatasetWithNamedModel(createDataGraphUriFromResource
+                (connectionResource), model));
+        return new DataWithEtag<>(connectionDataset, newEtag, etag);
     }
 
-  private void addNeedList(Model model, Resource res) {
-    res.addProperty(WON.HAS_NEED_LIST, model.createResource(this.needResourceURIPrefix));
-  }
 
-  private void addPublicKey(Model model, Resource res) {
-    WonKeysReaderWriter keyWriter = new WonKeysReaderWriter();
-    try {
-      keyWriter.writeToModel(model, res, cryptographyService.getPublicKey(res.getURI()));
-    } catch (Exception e) {
-      logger.warn("No public key could be added to RDF for " + res.getURI());
-    }
-  }
+    @Override
+    @Transactional
+    public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException {
+        List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs());
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
+                this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), uris);
+        }
 
-  //TODO: protocol endpoint specification in RDF model needs refactoring!
-  private void addProtocolEndpoints(Model model, Resource res)
-  {
-      Resource blankNodeActiveMq = model.createResource();
-      res.addProperty(WON.SUPPORTS_WON_PROTOCOL_IMPL, blankNodeActiveMq);
-      blankNodeActiveMq
-              .addProperty(RDF.type, WON.WON_OVER_ACTIVE_MQ)
-              .addProperty(WON.HAS_BROKER_URI, model.createResource(this.activeMqEndpoint))
-              .addProperty(WON.HAS_ACTIVEMQ_OWNER_PROTOCOL_QUEUE_NAME,this.activeMqOwnerProtcolQueueName,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_NEED_PROTOCOL_QUEUE_NAME,this.activeMqNeedProtcolQueueName,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_QUEUE_NAME,this.activeMqMatcherPrtotocolQueueName,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_ACTIVATED_TOPIC_NAME,
-                           this.activeMqMatcherProtocolTopicNameNeedActivated,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_DEACTIVATED_TOPIC_NAME,this.activeMqMatcherProtocolTopicNameNeedDeactivated,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_DELETED_TOPIC_NAME,this.activeMqMatcherProtocolTopicNameNeedDeleted,XSDDatatype.XSDstring)
-              .addProperty(WON.HAS_ACTIVEMQ_MATCHER_PROTOCOL_OUT_NEED_CREATED_TOPIC_NAME,this.activeMqMatcherProtocolTopicNameNeedCreated,XSDDatatype.XSDstring)
-      ;
-
-      Resource blankNodeUriSpec = model.createResource();
-      res.addProperty(WON.HAS_URI_PATTERN_SPECIFICATION, blankNodeUriSpec);
-      blankNodeUriSpec.addProperty(WON.HAS_NEED_URI_PREFIX,
-                                   model.createLiteral(this.needResourceURIPrefix));
-      blankNodeUriSpec.addProperty(WON.HAS_CONNECTION_URI_PREFIX,
-                                   model.createLiteral(this.connectionResourceURIPrefix));
-      blankNodeUriSpec.addProperty(WON.HAS_EVENT_URI_PREFIX, model.createLiteral(this.eventResourceURIPrefix));
-  }
-
-  /***
-   * ETag-aware method for obtaining connection data. Currently does not take into account new events, only changes
-   * to the connection itself.
-   * @param connectionUri
-   * @param includeEventContainer
-   * @param includeLatestEvent
-   * @param etag
-   * @return
-   */
-  @Override
-  @Transactional
-  public DataWithEtag<Dataset> getConnectionDataset(final URI connectionUri, final boolean includeEventContainer, final String etag)
-
-  {
-    DataWithEtag<Connection> data = null;
-    Connection connection = null;
-    data = needInformationService.readConnection(connectionUri, etag);
-    if (data.isNotFound()) {
-      return DataWithEtag.dataNotFound();
-    }
-    if (!data.isChanged()){
-      return DataWithEtag.dataNotChanged(data);
-    }
-    connection = data.getData();
-    if(connection == null) {
-      return DataWithEtag.dataNotFound();
-    }
-    String newEtag = data.getEtag();
-
-    // load the model from storage
-    Model model = connectionModelMapper.toModel(connection);
-    Model additionalData = connection.getDatasetHolder() == null ? null : connection.getDatasetHolder().getDataset().getDefaultModel();
-    setNsPrefixes(model);
-    if (additionalData != null) {
-      model.add(additionalData);
-    }
-    //model.setNsPrefix("", connection.getConnectionURI().toString());
-
-    //create connection member
-    Resource connectionResource = model.getResource(connection.getConnectionURI().toString());
-
-    // add WON node link
-    connectionResource.addProperty(WON.HAS_WON_NODE, model.createResource(this.resourceURIPrefix));
-    if (includeEventContainer) {
-      //create event container and attach it to the member
-      Resource eventContainer = model.createResource(connection.getConnectionURI().toString()+"/events");
-      connectionResource.addProperty(WON.HAS_EVENT_CONTAINER, eventContainer);
-      eventContainer.addProperty(RDF.type, WON.EVENT_CONTAINER);
-      DatasetHolder datasetHolder = connection.getDatasetHolder();
-      if (datasetHolder != null) {
-        addAdditionalData(model, datasetHolder.getDataset().getDefaultModel(), connectionResource);
-      }
+        return containerPage.getContent();
     }
 
-    Dataset connectionDataset = addBaseUriAndDefaultPrefixes(newDatasetWithNamedModel(createDataGraphUriFromResource
-                                                                       (connectionResource), model));
-    return new DataWithEtag<>(connectionDataset,newEtag, etag);
-  }
+    @Override
+    @Transactional
+    public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
+        List<URI> uris = new ArrayList<URI>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
+                this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), uris);
+        }
 
-
-  @Override
-  @Transactional
-  public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException {
-    List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs());
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-      this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), uris);
+        return containerPage.getContent();
     }
 
-    return containerPage.getContent();
-  }
-
-  @Override
-  @Transactional
-  public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
-      List<URI> uris = new ArrayList<URI>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
-      NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-              this.connectionResourceURIPrefix + "/", new SliceImpl<URI>(uris));
-      if (deep) {
-          addDeepConnectionData(containerPage.getContent(), uris);
-      }
-
-      return containerPage.getContent();
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page, final Integer
-    preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIs(page, preferredSize, timeSpot);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-      this.connectionResourceURIPrefix + "/", slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page, final Integer
+            preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIs(page, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
+                this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        return containerPage;
     }
-    return containerPage;
-  }
 
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(
-    URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIsBefore(beforeConnURI, preferredSize, timeSpot);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(this.connectionResourceURIPrefix + "/", slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(
+            URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIsBefore(beforeConnURI, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        return containerPage;
     }
-    return containerPage;
-  }
 
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(
-    URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIsAfter(afterConnURI, preferredSize, timeSpot);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-      this.connectionResourceURIPrefix + "/", slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(
+            URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIsAfter(afterConnURI, preferredSize, timeSpot);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
+                this.connectionResourceURIPrefix + "/", slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        return containerPage;
     }
-    return containerPage;
-  }
 
     @Override
     @Transactional
     public Dataset listConnectionURIs(final URI needURI, boolean deep, boolean addMetadata)
-    throws NoSuchNeedException, NoSuchConnectionException {
-    List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs(needURI));
-    URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), new
-      SliceImpl<URI>(uris));
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), uris);
-    }
-    if (addMetadata){
-      addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-    }
-    return containerPage.getContent();
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(
-    final int page, final URI needURI, final Integer preferredSize, final WonMessageType messageType, final Date
-    timeSpot, boolean deep, boolean addMetadata)
-    throws NoSuchNeedException, NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIs(needURI, page, preferredSize, messageType, timeSpot);
-    URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
-    }
-    if (addMetadata){
-      addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-    }
-    return containerPage;
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(final URI needURI, URI
-    beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
-                                                                                     boolean addMetadata)
-    throws NoSuchNeedException, NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIsBefore(
-      needURI, beforeEventURI, preferredSize, messageType, timeSpot);
-    URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
-    }
-    if (addMetadata){
-      addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-    }
-    return containerPage;
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(final URI needURI, URI
-    resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
-                                                                                    boolean addMetadata)
-    throws NoSuchNeedException, NoSuchConnectionException {
-    Slice<URI> slice = needInformationService.listConnectionURIsAfter(
-      needURI, resumeConnURI, preferredSize, messageType, timeSpot);
-    URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-    NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-      connectionsUri.toString(), slice);
-    if (deep) {
-      addDeepConnectionData(containerPage.getContent(), slice.getContent());
-    }
-    if (addMetadata){
-      addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-    }
-    return containerPage;
-  }
-
-  private void addConnectionMetadata(final Dataset content, URI needURI, URI containerURI) {
-    Model model = content.getNamedModel(createDataGraphUriFromUri(containerURI) );
-    List<Object[]> connectionCountsPerState =  needRepository.getCountsPerConnectionState(needURI);
-    Resource containerResource = model.getResource(containerURI.toString());
-    for (Object[] countForState : connectionCountsPerState){
-      ConnectionState stateName = (ConnectionState) countForState[0];
-      Long count = (Long) countForState[1];
-      Property countProperty = getRdfPropertyForState(stateName);
-      if (countProperty == null) {
-        logger.warn("did not recognize connection state " + stateName);
-        continue;
-      }
-      containerResource.addProperty(countProperty, Integer.toString(count.intValue()), XSDDatatype.XSDint);
-    }
-
-    List<Object[]> connectionUrisWithState = needRepository.getConnectionUrisAndState(needURI);
-    for (Object[] connUriWithState : connectionUrisWithState) {
-        ConnectionState stateName = (ConnectionState) connUriWithState[0];
-        URI connectionUri = (URI) connUriWithState[1];
-        Property stateUrisProperty = getRdfPropertyForStateUris(stateName);
-        if (stateUrisProperty == null) {
-            logger.warn("did not recognize connection state " + stateName);
-            continue;
+            throws NoSuchNeedException, NoSuchConnectionException {
+        List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections(needURI));
+        List<URI> uris = new ArrayList<URI>(needInformationService.listConnectionURIs(needURI));
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), new
+                SliceImpl<URI>(uris));
+        // TODO: IMPL THIS: NeedInformationService.PagedResource<Dataset, Connection> containerPage = toContainerPage(connectionsUri.toString(), new
+        // SliceImpl<Connection>(connections));
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), uris);
         }
-        containerResource.addProperty(stateUrisProperty, connectionUri.toString(), XSDDatatype.XSDID);
-    }
-  }
-
-  private Property getRdfPropertyForState(ConnectionState state) {
-    switch (state){
-      case SUGGESTED: return WON.HAS_SUGGESTED_COUNT;
-      case REQUEST_RECEIVED: return WON.HAS_REQUEST_RECEIVED_COUNT;
-      case REQUEST_SENT: return WON.HAS_REQUEST_SENT_COUNT;
-      case CONNECTED: return WON.HAS_CONNECTED_COUNT;
-      case CLOSED: return WON.HAS_CLOSED_COUNT;
-      case DELETED: return WON.HAS_DELETED_COUNT;
-    }
-    return null;
-  }
-
-  private Property getRdfPropertyForStateUris(ConnectionState state) {
-    switch (state){
-      case SUGGESTED: return WON.SUGGESTED;
-      case REQUEST_RECEIVED: return WON.REQUEST_RECEIVED;
-      case REQUEST_SENT: return WON.REQUEST_SENT;
-      case CONNECTED: return WON.CONNECTED;
-      case CLOSED: return WON.CLOSED;
-      case DELETED: return WON.DELETED;
-    }
-    return null;
-  }
-
-
-  @Override
-  @Transactional
-  public Dataset listConnectionEventURIs(final URI connectionUri) throws
-    NoSuchConnectionException
-  {
-    return  listConnectionEventURIs(connectionUri, false);
-  }
-
-  @Override
-  @Transactional
-  public Dataset listConnectionEventURIs(final URI connectionUri, boolean deep) throws
-    NoSuchConnectionException
-  {
-
-    Model model = ModelFactory.createDefaultModel();
-    setNsPrefixes(model);
-
-    Connection connection = needInformationService.readConnection(connectionUri);
-    Resource eventContainer = model.createResource(connection.getConnectionURI().toString() + "/events",
-                                                   WON.EVENT_CONTAINER);
-    // add the events with the new format (only the URI, no content)
-    List<MessageEventPlaceholder> connectionEvents = messageEventRepository.findByParentURI(connectionUri);
-    Dataset eventsContainerDataset = newDatasetWithNamedModel(createDataGraphUriFromResource(eventContainer), model);
-    addBaseUriAndDefaultPrefixes(eventsContainerDataset);
-    for (MessageEventPlaceholder event : connectionEvents) {
-      model.add(model.createStatement(eventContainer,
-                                      RDFS.member,
-                                      model.getResource(event.getMessageURI().toString())));
-      if (deep) {
-        Dataset eventDataset = event.getDatasetHolder().getDataset();
-        RdfUtils.addDatasetToDataset(eventsContainerDataset, eventDataset);
-      }
-    }
-
-    return eventsContainerDataset;
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIs(final URI connectionUri, final int
-    pageNum, Integer preferedSize, WonMessageType msgType, boolean deep) throws
-    NoSuchConnectionException
-  {
-    Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEvents(connectionUri, pageNum,
-                                                                      preferedSize, msgType);
-    NeedInformationService.PagedResource<Dataset,URI> containerPage = eventsToContainerPage(
-      this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
-    return containerPage;
-  }
-
-
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsAfter(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
-    NoSuchConnectionException
-  {
-    Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsAfter(
-      connectionUri, msgURI, preferedSize, msgType);
-    NeedInformationService.PagedResource<Dataset,URI> containerPage = eventsToContainerPage(this.uriService
-                                                                                        .createEventsURIForConnection
-                                                                                          (connectionUri).toString(),
-                                                                                      slice, deep);
-    return containerPage;
-  }
-
-  @Override
-  @Transactional
-  public NeedInformationService.PagedResource<Dataset,URI> listConnectionEventURIsBefore(
-    final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
-    NoSuchConnectionException
-  {
-
-    Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsBefore(
-      connectionUri, msgURI, preferedSize, msgType);
-    NeedInformationService.PagedResource<Dataset,URI> containerPage = eventsToContainerPage(this.uriService.createEventsURIForConnection
-      (connectionUri).toString(), slice, deep);
-    return containerPage;
-  }
-
-  private Dataset setDefaults(Dataset dataset) {
-    if (dataset == null) return null;
-    DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
-    addBaseUriAndDefaultPrefixes(dataset);
-    return dataset;
-  }
-
-  @Override
-  @Transactional
-  public DataWithEtag<Dataset> getDatasetForUri(URI datasetUri, String etag) {
-    Integer version = etag == null ? -1: Integer.valueOf(etag);
-    DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(datasetUri);
-    if (datasetHolder == null) {
-      return DataWithEtag.dataNotFound();
-    }
-    if (version.intValue() == datasetHolder.getVersion()){
-      return DataWithEtag.dataNotChanged(etag);
-    }
-    Dataset dataset = datasetHolder.getDataset();
-    DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
-    addBaseUriAndDefaultPrefixes(dataset);
-    return new DataWithEtag<Dataset>(dataset, Integer.toString(datasetHolder.getVersion()), etag);
-  }
-
-
-  private String createDataGraphUriFromResource(Resource needListPageResource) {
-    URI uri = URI.create(needListPageResource.getURI());
-    return createDataGraphUriFromUri(uri);
-  }
-
-  private String createDataGraphUriFromUri(final URI uri) {
-    try {
-      URI ret = new URI(uri.getScheme(), uri.getHost(), uri.getPath(), uri.getQuery(), "data");
-      return ret.toString();
-    } catch (URISyntaxException e) {
-      return uri.toString() + "#data";
-    }
-  }
-
-  private Dataset newDatasetWithNamedModel(String graphUri, Model model) {
-    Dataset dataset = DatasetFactory.createGeneral();
-    dataset.addNamedModel(graphUri, model);
-    return dataset;
-  }
-
-  private void addAdditionalData(final Model targetModel, Model fromModel, final Resource targetResource) {
-    if (fromModel != null && fromModel.size() > 0) {
-      Resource additionalData = fromModel.createResource();
-      //TODO: check if the statement below is now necessary
-      //RdfUtils.replaceBaseResource(additionalDataModel, additionalData);
-      targetModel.add(targetModel.createStatement(targetResource, WON.HAS_ADDITIONAL_DATA, additionalData));
-      targetModel.add(fromModel);
-    }
-  }
-
-
-
-  private String addPageQueryString(String uri, int page)
-  {
-    //TODO: simple implementation for adding page number to uri - breaks as soon as other query strings are present!
-    return uri + "?page=" + page;
-  }
-
-  /**
-   * @deprecated  the method returns the paged resource description according to Linked Data Platform Draft 2013
-   * https://www.w3.org/TR/2013/WD-ldp-20130730/. As of state Feb 2016 (https://www.w3.org/TR/2015/REC-ldp-20150226/)
-   * the paged resource should not contain any paging information as part of resource description, this information
-   * is conveyed vie HEADERs. Therefore, this method should no longer be used.
-   */
-  @Deprecated
-  private Resource createPage(final Model model, final String containerURI, final int pageNum, NeedInformationService.Page page)
-  {
-    String containerPageURI = addPageQueryString(containerURI, pageNum);
-    Resource containerPageResource = model.createResource(containerPageURI);
-    Resource containerResource = model.createResource(containerURI);
-    model.add(model.createStatement(containerPageResource, RDF.type, LDP.PAGE));
-    model.add(model.createStatement(containerPageResource, LDP.PAGE_OF, containerResource));
-    model.add(model.createStatement(containerPageResource, RDF.type, LDP.CONTAINER));
-    Resource containerNextPageResource = null;
-    //assume last page if we didn't fetch pageSize uris
-    if (page.hasNext()) {
-      containerNextPageResource = model.createResource(addPageQueryString(containerURI, pageNum + 1));
-      model.add(model.createStatement(containerPageResource, LDP.NEXT_PAGE, containerNextPageResource));
-    }
-
-    return containerPageResource;
-  }
-
-  private void setNsPrefixes(final Model model)
-  {
-    DefaultPrefixUtils.setDefaultPrefixes(model);
-  }
-
-  /**
-   * Adds the specified URI as the default prefix for each model in the dataset and
-   * return the dataset.
-   * @param dataset
-   * @return
-   */
-  private Dataset addBaseUriAndDefaultPrefixes(Dataset dataset){
-    setNsPrefixes(dataset.getDefaultModel());
-    addPrefixForSpecialResources(dataset, "local", this.resourceURIPrefix);
-    addPrefixForSpecialResources(dataset, "need", this.needResourceURIPrefix);
-    addPrefixForSpecialResources(dataset, "event", this.eventResourceURIPrefix);
-    addPrefixForSpecialResources(dataset, "conn", this.connectionResourceURIPrefix);
-    return dataset;
-  }
-
-  private void addPrefixForSpecialResources(Dataset dataset, String prefix, String uri) {
-    if (uri == null) return; //ignore if no uri specified
-    //the prefix (prefix of all local URIs must end with a slash or a hash, otherwise,
-    //it will never be used by RDF serializations. Force that.
-    if (!uri.endsWith("/") && !uri.endsWith("#")) {
-      uri += "/";
-    }
-    dataset.getDefaultModel().getGraph().getPrefixMapping().setNsPrefix(prefix, uri);
-  }
-
-  private NeedInformationService.PagedResource<Dataset,URI> toContainerPage(String containerUri, Slice<URI>
-  slice) {
-
-  List<URI> uris = slice.getContent();
-  URI resumeBefore = null;
-  URI resumeAfter = null;
-  if (slice.getSort() != null && !uris.isEmpty()) {
-    Iterator<Sort.Order> sortOrders = slice.getSort().iterator();
-    if (sortOrders.hasNext()) {
-      Sort.Order sortOrder = sortOrders.next();
-      if (sortOrder.getDirection() == Sort.Direction.ASC) {
-        resumeBefore = uris.get(0);
-        resumeAfter = uris.get(uris.size() - 1);
-      } else {
-        resumeBefore = uris.get(uris.size() - 1);
-        resumeAfter = uris.get(0);
-      }
-    }
-  }
-
-  Model model = ModelFactory.createDefaultModel();
-  setNsPrefixes(model);
-  Resource needListPageResource = null;
-
-  needListPageResource = model.createResource(containerUri);
-
-  for (URI needURI : uris) {
-    model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
-  }
-  Dataset dataset = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
-  addBaseUriAndDefaultPrefixes(dataset);
-  NeedInformationService.PagedResource<Dataset,URI> containerPage = new NeedInformationService.PagedResource
-    (dataset, resumeBefore, resumeAfter);
-  return containerPage;
-}
-
-  /**
-   * Returns a container resource with the messageUris of all MessageEventPlaceholder objects in the slice.
-   * If deep == true, the event datasets are added, too.
-   * @param containerUri
-   * @param slice
-   * @param deep
-   * @return
-   */
-  private NeedInformationService.PagedResource<Dataset,URI> eventsToContainerPage(String containerUri,
-                                                                             Slice<MessageEventPlaceholder>
-    slice, boolean deep) {
-
-    List<MessageEventPlaceholder> events = slice.getContent();
-    URI resumeBefore = null;
-    URI resumeAfter = null;
-    if (slice.getSort() != null && !events.isEmpty()) {
-      Iterator<Sort.Order> sortOrders = slice.getSort().iterator();
-      if (sortOrders.hasNext()) {
-        Sort.Order sortOrder = sortOrders.next();
-        if (sortOrder.getDirection() == Sort.Direction.ASC) {
-          resumeBefore = events.get(0).getMessageURI();
-          resumeAfter = events.get(events.size() - 1).getMessageURI();
-        } else {
-          resumeBefore = events.get(events.size() - 1).getMessageURI();
-          resumeAfter = events.get(0).getMessageURI();
+        if (addMetadata) {
+            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
         }
-      }
+        return containerPage.getContent();
     }
 
-    Model model = ModelFactory.createDefaultModel();
-    setNsPrefixes(model);
-    Resource needListPageResource = null;
-
-    needListPageResource = model.createResource(containerUri);
-
-    DatasetHolderAggregator aggregator = new DatasetHolderAggregator();
-    for (MessageEventPlaceholder event : events) {
-      model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(event.getMessageURI().toString())));
-      if (deep) {
-        aggregator.appendDataset(event.getDatasetHolder());
-      }
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(
+            final int page, final URI needURI, final Integer preferredSize, final WonMessageType messageType, final Date
+            timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIs(needURI, page, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        if (addMetadata) {
+            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
+        }
+        return containerPage;
     }
-    Dataset dataset = aggregator.aggregate();
-    dataset.addNamedModel(createDataGraphUriFromResource(needListPageResource), model);
-    addBaseUriAndDefaultPrefixes(dataset);
-    NeedInformationService.PagedResource<Dataset,URI> containerPage = new NeedInformationService.PagedResource
-      (dataset, resumeBefore, resumeAfter);
-    return containerPage;
-  }
 
-  public void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) throws NoSuchConnectionException {
-    //add the connection model for each connection URI
-    for (URI connectionURI : connectionURIs) {
-      DataWithEtag<Dataset> connectionDataset =
-        getConnectionDataset(connectionURI, true, null);
-      RdfUtils.addDatasetToDataset(dataset, connectionDataset.getData());
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(final URI needURI, URI
+            beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
+                                                                                       boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIsBefore(
+                needURI, beforeEventURI, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        if (addMetadata) {
+            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
+        }
+        return containerPage;
     }
-  }
 
-  public void setNeedResourceURIPrefix(final String needResourceURIPrefix)
-  {
-    this.needResourceURIPrefix = needResourceURIPrefix;
-  }
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(final URI needURI, URI
+            resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
+                                                                                      boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<URI> slice = needInformationService.listConnectionURIsAfter(
+                needURI, resumeConnURI, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
+                connectionsUri.toString(), slice);
+        if (deep) {
+            addDeepConnectionData(containerPage.getContent(), slice.getContent());
+        }
+        if (addMetadata) {
+            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
+        }
+        return containerPage;
+    }
 
-  public void setConnectionResourceURIPrefix(final String connectionResourceURIPrefix)
-  {
-    this.connectionResourceURIPrefix = connectionResourceURIPrefix;
-  }
+    private void addConnectionMetadata(final Dataset content, URI needURI, URI containerURI) {
+        Model model = content.getNamedModel(createDataGraphUriFromUri(containerURI));
+        List<Object[]> connectionCountsPerState = needRepository.getCountsPerConnectionState(needURI);
+        Resource containerResource = model.getResource(containerURI.toString());
+        for (Object[] countForState : connectionCountsPerState) {
+            ConnectionState stateName = (ConnectionState) countForState[0];
+            Long count = (Long) countForState[1];
+            Property countProperty = getRdfPropertyForState(stateName);
+            if (countProperty == null) {
+                logger.warn("did not recognize connection state " + stateName);
+                continue;
+            }
+            containerResource.addProperty(countProperty, Integer.toString(count.intValue()), XSDDatatype.XSDint);
+        }
+    }
 
-  public void setEventResourceURIPrefix(final String eventResourceURIPrefix) {
-    this.eventResourceURIPrefix = eventResourceURIPrefix;
-  }
+    private Property getRdfPropertyForState(ConnectionState state) {
+        switch (state) {
+            case SUGGESTED:
+                return WON.HAS_SUGGESTED_COUNT;
+            case REQUEST_RECEIVED:
+                return WON.HAS_REQUEST_RECEIVED_COUNT;
+            case REQUEST_SENT:
+                return WON.HAS_REQUEST_SENT_COUNT;
+            case CONNECTED:
+                return WON.HAS_CONNECTED_COUNT;
+            case CLOSED:
+                return WON.HAS_CLOSED_COUNT;
+            case DELETED:
+                return WON.HAS_DELETED_COUNT;
+        }
+        return null;
+    }
 
-  public void setDataURIPrefix(final String dataURIPrefix)
-  {
-    this.dataURIPrefix = dataURIPrefix;
-  }
+    @Override
+    @Transactional
+    public Dataset listConnectionEventURIs(final URI connectionUri) throws
+            NoSuchConnectionException {
+        return listConnectionEventURIs(connectionUri, false);
+    }
 
-  public void setResourceURIPrefix(final String resourceURIPrefix)
-  {
-    this.resourceURIPrefix = resourceURIPrefix;
-  }
+    @Override
+    @Transactional
+    public Dataset listConnectionEventURIs(final URI connectionUri, boolean deep) throws
+            NoSuchConnectionException {
 
-  public void setNeedInformationService(final NeedInformationService needInformationService)
-  {
-    this.needInformationService = needInformationService;
-  }
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
 
-  public void setNeedProtocolEndpoint(final String needProtocolEndpoint)
-  {
-    this.needProtocolEndpoint = needProtocolEndpoint;
-  }
+        Connection connection = needInformationService.readConnection(connectionUri);
+        Resource eventContainer = model.createResource(connection.getConnectionURI().toString() + "/events",
+                WON.EVENT_CONTAINER);
+        // add the events with the new format (only the URI, no content)
+        List<MessageEventPlaceholder> connectionEvents = messageEventRepository.findByParentURI(connectionUri);
+        Dataset eventsContainerDataset = newDatasetWithNamedModel(createDataGraphUriFromResource(eventContainer), model);
+        addBaseUriAndDefaultPrefixes(eventsContainerDataset);
+        for (MessageEventPlaceholder event : connectionEvents) {
+            model.add(model.createStatement(eventContainer,
+                    RDFS.member,
+                    model.getResource(event.getMessageURI().toString())));
+            if (deep) {
+                Dataset eventDataset = event.getDatasetHolder().getDataset();
+                RdfUtils.addDatasetToDataset(eventsContainerDataset, eventDataset);
+            }
+        }
 
-  public void setMatcherProtocolEndpoint(final String matcherProtocolEndpoint)
-  {
-    this.matcherProtocolEndpoint = matcherProtocolEndpoint;
-  }
+        return eventsContainerDataset;
+    }
 
-  public void setOwnerProtocolEndpoint(final String ownerProtocolEndpoint)
-  {
-    this.ownerProtocolEndpoint = ownerProtocolEndpoint;
-  }
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIs(final URI connectionUri, final int
+            pageNum, Integer preferedSize, WonMessageType msgType, boolean deep) throws
+            NoSuchConnectionException {
+        Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEvents(connectionUri, pageNum,
+                preferedSize, msgType);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(
+                this.uriService.createEventsURIForConnection(connectionUri).toString(), slice, deep);
+        return containerPage;
+    }
 
-  public void setPageURIPrefix(final String pageURIPrefix)
-  {
-    this.pageURIPrefix = pageURIPrefix;
-  }
 
-  public void setUriService(URIService uriService) {
-    this.uriService = uriService;
-  }
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsAfter(
+            final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
+            NoSuchConnectionException {
+        Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsAfter(
+                connectionUri, msgURI, preferedSize, msgType);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(this.uriService
+                        .createEventsURIForConnection
+                                (connectionUri).toString(),
+                slice, deep);
+        return containerPage;
+    }
 
-  public void setActiveMqOwnerProtcolQueueName(String activeMqOwnerProtcolQueueName) {
-      this.activeMqOwnerProtcolQueueName = activeMqOwnerProtcolQueueName;
-  }
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, URI> listConnectionEventURIsBefore(
+            final URI connectionUri, final URI msgURI, Integer preferedSize, WonMessageType msgType, boolean deep) throws
+            NoSuchConnectionException {
 
-  public void setActiveMqNeedProtcolQueueName(String activeMqNeedProtcolQueueName) {
-      this.activeMqNeedProtcolQueueName = activeMqNeedProtcolQueueName;
-  }
-  public void setActiveMqMatcherPrtotocolQueueName(String activeMqMatcherPrtotocolQueueName) {
-      this.activeMqMatcherPrtotocolQueueName = activeMqMatcherPrtotocolQueueName;
-  }
-  public void setActiveMqEndpoint(String activeMqEndpoint) {
-      this.activeMqEndpoint = activeMqEndpoint;
-  }
+        Slice<MessageEventPlaceholder> slice = needInformationService.listConnectionEventsBefore(
+                connectionUri, msgURI, preferedSize, msgType);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = eventsToContainerPage(this.uriService.createEventsURIForConnection
+                (connectionUri).toString(), slice, deep);
+        return containerPage;
+    }
 
-  public void setActiveMqMatcherProtocolTopicNameNeedCreated(final String activeMqMatcherProtocolTopicNameNeedCreated) {
-    this.activeMqMatcherProtocolTopicNameNeedCreated = activeMqMatcherProtocolTopicNameNeedCreated;
-  }
+    private Dataset setDefaults(Dataset dataset) {
+        if (dataset == null) return null;
+        DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
+        addBaseUriAndDefaultPrefixes(dataset);
+        return dataset;
+    }
 
-  public void setActiveMqMatcherProtocolTopicNameNeedActivated(final String activeMqMatcherProtocolTopicNameNeedActivated) {
-    this.activeMqMatcherProtocolTopicNameNeedActivated = activeMqMatcherProtocolTopicNameNeedActivated;
-  }
+    @Override
+    @Transactional
+    public DataWithEtag<Dataset> getDatasetForUri(URI datasetUri, String etag) {
+        Integer version = etag == null ? -1 : Integer.valueOf(etag);
+        DatasetHolder datasetHolder = datasetHolderRepository.findOneByUri(datasetUri);
+        if (datasetHolder == null) {
+            return DataWithEtag.dataNotFound();
+        }
+        if (version.intValue() == datasetHolder.getVersion()) {
+            return DataWithEtag.dataNotChanged(etag);
+        }
+        Dataset dataset = datasetHolder.getDataset();
+        DefaultPrefixUtils.setDefaultPrefixes(dataset.getDefaultModel());
+        addBaseUriAndDefaultPrefixes(dataset);
+        return new DataWithEtag<Dataset>(dataset, Integer.toString(datasetHolder.getVersion()), etag);
+    }
 
-  public void setActiveMqMatcherProtocolTopicNameNeedDeactivated(final String activeMqMatcherProtocolTopicNameNeedDeactivated) {
-    this.activeMqMatcherProtocolTopicNameNeedDeactivated = activeMqMatcherProtocolTopicNameNeedDeactivated;
-  }
-  
-  public void setActiveMqMatcherProtocolTopicNameNeedDeleted(final String activeMqMatcherProtocolTopicNameNeedDeleted) {
-      this.activeMqMatcherProtocolTopicNameNeedDeleted = activeMqMatcherProtocolTopicNameNeedDeleted;
+
+    private String createDataGraphUriFromResource(Resource needListPageResource) {
+        URI uri = URI.create(needListPageResource.getURI());
+        return createDataGraphUriFromUri(uri);
+    }
+
+    private String createDataGraphUriFromUri(final URI uri) {
+        try {
+            URI ret = new URI(uri.getScheme(), uri.getHost(), uri.getPath(), uri.getQuery(), "data");
+            return ret.toString();
+        } catch (URISyntaxException e) {
+            return uri.toString() + "#data";
+        }
+    }
+
+    private Dataset newDatasetWithNamedModel(String graphUri, Model model) {
+        Dataset dataset = DatasetFactory.createGeneral();
+        dataset.addNamedModel(graphUri, model);
+        return dataset;
+    }
+
+    private void addAdditionalData(final Model targetModel, Model fromModel, final Resource targetResource) {
+        if (fromModel != null && fromModel.size() > 0) {
+            Resource additionalData = fromModel.createResource();
+            //TODO: check if the statement below is now necessary
+            //RdfUtils.replaceBaseResource(additionalDataModel, additionalData);
+            targetModel.add(targetModel.createStatement(targetResource, WON.HAS_ADDITIONAL_DATA, additionalData));
+            targetModel.add(fromModel);
+        }
+    }
+
+
+    private String addPageQueryString(String uri, int page) {
+        //TODO: simple implementation for adding page number to uri - breaks as soon as other query strings are present!
+        return uri + "?page=" + page;
+    }
+
+    /**
+     * @deprecated the method returns the paged resource description according to Linked Data Platform Draft 2013
+     * https://www.w3.org/TR/2013/WD-ldp-20130730/. As of state Feb 2016 (https://www.w3.org/TR/2015/REC-ldp-20150226/)
+     * the paged resource should not contain any paging information as part of resource description, this information
+     * is conveyed vie HEADERs. Therefore, this method should no longer be used.
+     */
+    @Deprecated
+    private Resource createPage(final Model model, final String containerURI, final int pageNum, NeedInformationService.Page page) {
+        String containerPageURI = addPageQueryString(containerURI, pageNum);
+        Resource containerPageResource = model.createResource(containerPageURI);
+        Resource containerResource = model.createResource(containerURI);
+        model.add(model.createStatement(containerPageResource, RDF.type, LDP.PAGE));
+        model.add(model.createStatement(containerPageResource, LDP.PAGE_OF, containerResource));
+        model.add(model.createStatement(containerPageResource, RDF.type, LDP.CONTAINER));
+        Resource containerNextPageResource = null;
+        //assume last page if we didn't fetch pageSize uris
+        if (page.hasNext()) {
+            containerNextPageResource = model.createResource(addPageQueryString(containerURI, pageNum + 1));
+            model.add(model.createStatement(containerPageResource, LDP.NEXT_PAGE, containerNextPageResource));
+        }
+
+        return containerPageResource;
+    }
+
+    private void setNsPrefixes(final Model model) {
+        DefaultPrefixUtils.setDefaultPrefixes(model);
+    }
+
+    /**
+     * Adds the specified URI as the default prefix for each model in the dataset and
+     * return the dataset.
+     *
+     * @param dataset
+     * @return
+     */
+    private Dataset addBaseUriAndDefaultPrefixes(Dataset dataset) {
+        setNsPrefixes(dataset.getDefaultModel());
+        addPrefixForSpecialResources(dataset, "local", this.resourceURIPrefix);
+        addPrefixForSpecialResources(dataset, "need", this.needResourceURIPrefix);
+        addPrefixForSpecialResources(dataset, "event", this.eventResourceURIPrefix);
+        addPrefixForSpecialResources(dataset, "conn", this.connectionResourceURIPrefix);
+        return dataset;
+    }
+
+    private void addPrefixForSpecialResources(Dataset dataset, String prefix, String uri) {
+        if (uri == null) return; //ignore if no uri specified
+        //the prefix (prefix of all local URIs must end with a slash or a hash, otherwise,
+        //it will never be used by RDF serializations. Force that.
+        if (!uri.endsWith("/") && !uri.endsWith("#")) {
+            uri += "/";
+        }
+        dataset.getDefaultModel().getGraph().getPrefixMapping().setNsPrefix(prefix, uri);
+    }
+
+    private NeedInformationService.PagedResource<Dataset, URI> toContainerPage(String containerUri, Slice<URI> slice) {
+
+        List<URI> uris = slice.getContent();
+        URI resumeBefore = null;
+        URI resumeAfter = null;
+        if (slice.getSort() != null && !uris.isEmpty()) {
+            Iterator<Sort.Order> sortOrders = slice.getSort().iterator();
+            if (sortOrders.hasNext()) {
+                Sort.Order sortOrder = sortOrders.next();
+                if (sortOrder.getDirection() == Sort.Direction.ASC) {
+                    resumeBefore = uris.get(0);
+                    resumeAfter = uris.get(uris.size() - 1);
+                } else {
+                    resumeBefore = uris.get(uris.size() - 1);
+                    resumeAfter = uris.get(0);
+                }
+            }
+        }
+
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
+        Resource needListPageResource = null;
+
+        needListPageResource = model.createResource(containerUri);
+
+        for (URI needURI : uris) {
+            model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(needURI.toString())));
+        }
+        Dataset dataset = newDatasetWithNamedModel(createDataGraphUriFromResource(needListPageResource), model);
+        addBaseUriAndDefaultPrefixes(dataset);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = new NeedInformationService.PagedResource
+                (dataset, resumeBefore, resumeAfter);
+        return containerPage;
+    }
+
+    /**
+     * Returns a container resource with the messageUris of all MessageEventPlaceholder objects in the slice.
+     * If deep == true, the event datasets are added, too.
+     *
+     * @param containerUri
+     * @param slice
+     * @param deep
+     * @return
+     */
+    private NeedInformationService.PagedResource<Dataset, URI> eventsToContainerPage(String containerUri,
+                                                                                     Slice<MessageEventPlaceholder>
+                                                                                             slice, boolean deep) {
+
+        List<MessageEventPlaceholder> events = slice.getContent();
+        URI resumeBefore = null;
+        URI resumeAfter = null;
+        if (slice.getSort() != null && !events.isEmpty()) {
+            Iterator<Sort.Order> sortOrders = slice.getSort().iterator();
+            if (sortOrders.hasNext()) {
+                Sort.Order sortOrder = sortOrders.next();
+                if (sortOrder.getDirection() == Sort.Direction.ASC) {
+                    resumeBefore = events.get(0).getMessageURI();
+                    resumeAfter = events.get(events.size() - 1).getMessageURI();
+                } else {
+                    resumeBefore = events.get(events.size() - 1).getMessageURI();
+                    resumeAfter = events.get(0).getMessageURI();
+                }
+            }
+        }
+
+        Model model = ModelFactory.createDefaultModel();
+        setNsPrefixes(model);
+        Resource needListPageResource = null;
+
+        needListPageResource = model.createResource(containerUri);
+
+        DatasetHolderAggregator aggregator = new DatasetHolderAggregator();
+        for (MessageEventPlaceholder event : events) {
+            model.add(model.createStatement(needListPageResource, RDFS.member, model.createResource(event.getMessageURI().toString())));
+            if (deep) {
+                aggregator.appendDataset(event.getDatasetHolder());
+            }
+        }
+        Dataset dataset = aggregator.aggregate();
+        dataset.addNamedModel(createDataGraphUriFromResource(needListPageResource), model);
+        addBaseUriAndDefaultPrefixes(dataset);
+        NeedInformationService.PagedResource<Dataset, URI> containerPage = new NeedInformationService.PagedResource
+                (dataset, resumeBefore, resumeAfter);
+        return containerPage;
+    }
+
+    public void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) throws NoSuchConnectionException {
+        //add the connection model for each connection URI
+        for (URI connectionURI : connectionURIs) {
+            DataWithEtag<Dataset> connectionDataset =
+                    getConnectionDataset(connectionURI, true, null);
+            RdfUtils.addDatasetToDataset(dataset, connectionDataset.getData());
+        }
+    }
+
+    public void setNeedResourceURIPrefix(final String needResourceURIPrefix) {
+        this.needResourceURIPrefix = needResourceURIPrefix;
+    }
+
+    public void setConnectionResourceURIPrefix(final String connectionResourceURIPrefix) {
+        this.connectionResourceURIPrefix = connectionResourceURIPrefix;
+    }
+
+    public void setEventResourceURIPrefix(final String eventResourceURIPrefix) {
+        this.eventResourceURIPrefix = eventResourceURIPrefix;
+    }
+
+    public void setDataURIPrefix(final String dataURIPrefix) {
+        this.dataURIPrefix = dataURIPrefix;
+    }
+
+    public void setResourceURIPrefix(final String resourceURIPrefix) {
+        this.resourceURIPrefix = resourceURIPrefix;
+    }
+
+    public void setNeedInformationService(final NeedInformationService needInformationService) {
+        this.needInformationService = needInformationService;
+    }
+
+    public void setNeedProtocolEndpoint(final String needProtocolEndpoint) {
+        this.needProtocolEndpoint = needProtocolEndpoint;
+    }
+
+    public void setMatcherProtocolEndpoint(final String matcherProtocolEndpoint) {
+        this.matcherProtocolEndpoint = matcherProtocolEndpoint;
+    }
+
+    public void setOwnerProtocolEndpoint(final String ownerProtocolEndpoint) {
+        this.ownerProtocolEndpoint = ownerProtocolEndpoint;
+    }
+
+    public void setPageURIPrefix(final String pageURIPrefix) {
+        this.pageURIPrefix = pageURIPrefix;
+    }
+
+    public void setUriService(URIService uriService) {
+        this.uriService = uriService;
+    }
+
+    public void setActiveMqOwnerProtcolQueueName(String activeMqOwnerProtcolQueueName) {
+        this.activeMqOwnerProtcolQueueName = activeMqOwnerProtcolQueueName;
+    }
+
+    public void setActiveMqNeedProtcolQueueName(String activeMqNeedProtcolQueueName) {
+        this.activeMqNeedProtcolQueueName = activeMqNeedProtcolQueueName;
+    }
+
+    public void setActiveMqMatcherPrtotocolQueueName(String activeMqMatcherPrtotocolQueueName) {
+        this.activeMqMatcherPrtotocolQueueName = activeMqMatcherPrtotocolQueueName;
+    }
+
+    public void setActiveMqEndpoint(String activeMqEndpoint) {
+        this.activeMqEndpoint = activeMqEndpoint;
+    }
+
+    public void setActiveMqMatcherProtocolTopicNameNeedCreated(final String activeMqMatcherProtocolTopicNameNeedCreated) {
+        this.activeMqMatcherProtocolTopicNameNeedCreated = activeMqMatcherProtocolTopicNameNeedCreated;
+    }
+
+    public void setActiveMqMatcherProtocolTopicNameNeedActivated(final String activeMqMatcherProtocolTopicNameNeedActivated) {
+        this.activeMqMatcherProtocolTopicNameNeedActivated = activeMqMatcherProtocolTopicNameNeedActivated;
+    }
+
+    public void setActiveMqMatcherProtocolTopicNameNeedDeactivated(final String activeMqMatcherProtocolTopicNameNeedDeactivated) {
+        this.activeMqMatcherProtocolTopicNameNeedDeactivated = activeMqMatcherProtocolTopicNameNeedDeactivated;
+    }
+
+    public void setActiveMqMatcherProtocolTopicNameNeedDeleted(final String activeMqMatcherProtocolTopicNameNeedDeleted) {
+        this.activeMqMatcherProtocolTopicNameNeedDeleted = activeMqMatcherProtocolTopicNameNeedDeleted;
     }
 }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -464,6 +464,23 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listModifiedConnectionsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
+        List<Connection> connections = new ArrayList<>(needInformationService.listModifiedConnectionsAfter(modifiedAfter));
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
+                this.connectionResourceURIPrefix + "/", new SliceImpl<>(connections));
+        if (deep) {
+            List<URI> uris = connections
+                    .stream()
+                    .map(Connection::getConnectionURI)
+                    .collect(Collectors.toList());
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
     public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page, final Integer
             preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
         Slice<URI> slice = needInformationService.listConnectionURIs(page, preferredSize, timeSpot);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -756,29 +756,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         return uri + "?page=" + page;
     }
 
-    /**
-     * @deprecated the method returns the paged resource description according to Linked Data Platform Draft 2013
-     * https://www.w3.org/TR/2013/WD-ldp-20130730/. As of state Feb 2016 (https://www.w3.org/TR/2015/REC-ldp-20150226/)
-     * the paged resource should not contain any paging information as part of resource description, this information
-     * is conveyed vie HEADERs. Therefore, this method should no longer be used.
-     */
-    @Deprecated
-    private Resource createPage(final Model model, final String containerURI, final int pageNum, NeedInformationService.Page page) {
-        String containerPageURI = addPageQueryString(containerURI, pageNum);
-        Resource containerPageResource = model.createResource(containerPageURI);
-        Resource containerResource = model.createResource(containerURI);
-        model.add(model.createStatement(containerPageResource, RDF.type, LDP.PAGE));
-        model.add(model.createStatement(containerPageResource, LDP.PAGE_OF, containerResource));
-        model.add(model.createStatement(containerPageResource, RDF.type, LDP.CONTAINER));
-        //assume last page if we didn't fetch pageSize uris
-        if (page.hasNext()) {
-            Resource containerNextPageResource = model.createResource(addPageQueryString(containerURI, pageNum + 1));
-            model.add(model.createStatement(containerPageResource, LDP.NEXT_PAGE, containerNextPageResource));
-        }
-
-        return containerPageResource;
-    }
-
     private void setNsPrefixes(final Model model) {
         DefaultPrefixUtils.setDefaultPrefixes(model);
     }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -494,7 +494,7 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
-    public NeedInformationService.PagedResource<Dataset, Connection> listConnectionURIs(final URI needURI, boolean deep, boolean addMetadata)
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final URI needURI, boolean deep, boolean addMetadata)
             throws NoSuchNeedException, NoSuchConnectionException {
         List<Connection> connections = new ArrayList<Connection>(needInformationService.listConnections(needURI));
         URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
@@ -506,6 +506,30 @@ public class LinkedDataServiceImpl implements LinkedDataService {
                     .map(conn -> conn.getConnectionURI())
                     .collect(Collectors.toList());
 
+            addDeepConnectionData(connectionsContainerPage.getContent(), uris);
+        }
+        if (addMetadata) {
+            addConnectionMetadata(connectionsContainerPage.getContent(), needURI, connectionsUri);
+        }
+        return connectionsContainerPage;
+    }
+
+    @Override
+    @Transactional
+    public NeedInformationService.PagedResource<Dataset, Connection> listConnections(
+            final int page, final URI needURI, final Integer preferredSize, final WonMessageType messageType, final Date
+            timeSpot, boolean deep, boolean addMetadata)
+            throws NoSuchNeedException, NoSuchConnectionException {
+        Slice<Connection> slice = needInformationService.listConnections(needURI, page, preferredSize, messageType, timeSpot);
+        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
+        NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(connectionsUri.toString(), slice);
+
+        if (deep) {
+            List<URI> uris = slice
+                    .getContent()
+                    .stream()
+                    .map(conn -> conn.getConnectionURI())
+                    .collect(Collectors.toList());
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
         if (addMetadata) {

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -421,19 +421,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
-    public Dataset listConnectionURIs(final boolean deep) throws NoSuchConnectionException {
-        List<URI> uris = new ArrayList<>(needInformationService.listConnectionURIs());
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", new SliceImpl<>(uris));
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), uris);
-        }
-
-        return containerPage.getContent();
-    }
-
-    @Override
-    @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnections(final boolean deep) throws NoSuchConnectionException {
         List<Connection> connections = new ArrayList<>(needInformationService.listConnections());
         NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
@@ -451,19 +438,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
-    public Dataset listModifiedConnectionURIsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
-        List<URI> uris = new ArrayList<>(needInformationService.listModifiedConnectionURIsAfter(modifiedAfter));
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", new SliceImpl<>(uris));
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), uris);
-        }
-
-        return containerPage.getContent();
-    }
-
-    @Override
-    @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listModifiedConnectionsAfter(Date modifiedAfter, boolean deep) throws NoSuchConnectionException {
         List<Connection> connections = new ArrayList<>(needInformationService.listModifiedConnectionsAfter(modifiedAfter));
         NeedInformationService.PagedResource<Dataset, Connection> connectionsContainerPage = toConnectionsContainerPage(
@@ -477,19 +451,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         }
 
         return connectionsContainerPage;
-    }
-
-    @Override
-    @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(final int page, final Integer
-            preferredSize, Date timeSpot, final boolean deep) throws NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIs(page, preferredSize, timeSpot);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", slice);
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        return containerPage;
     }
 
     @Override
@@ -512,18 +473,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(
-            URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIsBefore(beforeConnURI, preferredSize, timeSpot);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(this.connectionResourceURIPrefix + "/", slice);
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        return containerPage;
-    }
-
-    @Override
-    @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(
             URI beforeConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
         Slice<Connection> slice = needInformationService.listConnectionsBefore(beforeConnURI, preferredSize, timeSpot);
@@ -537,19 +486,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             addDeepConnectionData(connectionsContainerPage.getContent(), uris);
         }
         return connectionsContainerPage;
-    }
-
-    @Override
-    @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(
-            URI afterConnURI, final Integer preferredSize, Date timeSpot, boolean deep) throws NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIsAfter(afterConnURI, preferredSize, timeSpot);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                this.connectionResourceURIPrefix + "/", slice);
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        return containerPage;
     }
 
     @Override
@@ -618,44 +554,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
 
     @Override
     @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIs(
-            final int page, final URI needURI, final Integer preferredSize, final WonMessageType messageType, final Date
-            timeSpot, boolean deep, boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIs(needURI, page, preferredSize, messageType, timeSpot);
-        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
-
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        if (addMetadata) {
-            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-        }
-        return containerPage;
-    }
-
-    @Override
-    @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsBefore(final URI needURI, URI
-            beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
-                                                                                       boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIsBefore(
-                needURI, beforeEventURI, preferredSize, messageType, timeSpot);
-        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(connectionsUri.toString(), slice);
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        if (addMetadata) {
-            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-        }
-        return containerPage;
-    }
-
-    @Override
-    @Transactional
     public NeedInformationService.PagedResource<Dataset, Connection> listConnectionsBefore(final URI needURI, URI
             beforeEventURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
                                                                                        boolean addMetadata)
@@ -676,26 +574,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
             addConnectionMetadata(connectionsContainerPage.getContent(), needURI, connectionsUri);
         }
         return connectionsContainerPage;
-    }
-
-    @Override
-    @Transactional
-    public NeedInformationService.PagedResource<Dataset, URI> listConnectionURIsAfter(final URI needURI, URI
-            resumeConnURI, final Integer preferredSize, final WonMessageType messageType, final Date timeSpot, boolean deep,
-                                                                                      boolean addMetadata)
-            throws NoSuchNeedException, NoSuchConnectionException {
-        Slice<URI> slice = needInformationService.listConnectionURIsAfter(
-                needURI, resumeConnURI, preferredSize, messageType, timeSpot);
-        URI connectionsUri = this.uriService.createConnectionsURIForNeed(needURI);
-        NeedInformationService.PagedResource<Dataset, URI> containerPage = toContainerPage(
-                connectionsUri.toString(), slice);
-        if (deep) {
-            addDeepConnectionData(containerPage.getContent(), slice.getContent());
-        }
-        if (addMetadata) {
-            addConnectionMetadata(containerPage.getContent(), needURI, connectionsUri);
-        }
-        return containerPage;
     }
 
     @Override
@@ -755,13 +633,6 @@ public class LinkedDataServiceImpl implements LinkedDataService {
                 return WON.HAS_DELETED_COUNT;
         }
         return null;
-    }
-
-    @Override
-    @Transactional
-    public Dataset listConnectionEventURIs(final URI connectionUri) throws
-            NoSuchConnectionException {
-        return listConnectionEventURIs(connectionUri, false);
     }
 
     @Override

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -236,6 +236,32 @@ public class NeedInformationServiceImpl implements NeedInformationService {
 
     @Override
     @Deprecated
+    public Slice<Connection> listConnections(final URI needURI, int page, Integer preferedPageSize, WonMessageType
+            messageType, Date timeSpot) {
+        Slice<Connection> slice = null;
+        int pageSize = getPageSize(preferedPageSize);
+        int pageNum = page - 1;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)");
+        if (messageType == null) {
+            if (timeSpot == null) {
+                slice = connectionRepository.getConnectionsByActivityDate(needURI, pageRequest);
+            } else {
+                slice = connectionRepository.getConnectionsByActivityDate(needURI, timeSpot, pageRequest);
+            }
+        } else {
+            if (timeSpot == null) {
+                slice = connectionRepository.getConnectionsByActivityDate(needURI, messageType, pageRequest);
+            } else {
+                slice = connectionRepository.getConnectionsByActivityDate(needURI, messageType, timeSpot, pageRequest);
+            }
+        }
+        return slice;
+    }
+
+    @Override
+    @Deprecated
     public Slice listConnectionURIsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
                                           WonMessageType messageType, final Date timeSpot) {
 

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -235,7 +235,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
-    @Deprecated
     public Slice<Connection> listConnections(final URI needURI, int page, Integer preferedPageSize, WonMessageType
             messageType, Date timeSpot) {
         Slice<Connection> slice = null;
@@ -286,6 +285,29 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
+    public Slice<Connection> listConnectionsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
+                                          WonMessageType messageType, final Date timeSpot) {
+        Date resume;
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<Connection> slice;
+        if (messageType == null) {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsBeforeByActivityDate(
+                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        } else {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsBeforeByActivityDate(
+                    needURI, resume, messageType, timeSpot, new PageRequest(
+                            0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+    @Override
     @Deprecated
     public Slice listConnectionURIsAfter(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
                                          final WonMessageType messageType, final Date timeSpot) {
@@ -304,6 +326,29 @@ public class NeedInformationServiceImpl implements NeedInformationService {
 
             // use 'min(msg.creationDate)' to keep a constant connection order over requests
             slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+                    needURI, resume, messageType, timeSpot, new PageRequest(
+                            0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+    @Override
+    public Slice<Connection> listConnectionsAfter(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
+                                         final WonMessageType messageType, final Date timeSpot) {
+        Date resume;
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<Connection> slice;
+        if (messageType == null) {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsAfterByActivityDate(
+                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        } else {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsAfterByActivityDate(
                     needURI, resume, messageType, timeSpot, new PageRequest(
                             0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
         }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -146,11 +146,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
-    public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter) {
-        return connectionRepository.findModifiedConnectionURIsAfter(modifiedAfter);
-    }
-
-    @Override
     public Collection<Connection> listModifiedConnectionsAfter(Date modifiedAfter) {
         return connectionRepository.findModifiedConnectionsAfter(modifiedAfter);
     }
@@ -197,21 +192,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
-    @Deprecated
-    public Slice<URI> listConnectionURIsBefore(
-            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
-
-        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-        slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-        return slice;
-    }
-
-    @Override
     public Slice<Connection> listConnectionsBefore(
             final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
 
@@ -222,21 +202,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
         // use 'min(msg.creationDate)' to keep a constant connection order over requests
         slice = connectionRepository.getConnectionsBeforeByActivityDate(
                 resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-        return slice;
-    }
-
-    @Override
-    @Deprecated
-    public Slice<URI> listConnectionURIsAfter(
-            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
-
-        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-        slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
         return slice;
     }
 
@@ -318,31 +283,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
-    @Deprecated
-    public Slice listConnectionURIsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
-                                          WonMessageType messageType, final Date timeSpot) {
-
-        Date resume = null;
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-        if (messageType == null) {
-            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-
-            // use 'min(msg.creationDate)' to keep a constant connection order over requests
-            slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-        } else {
-            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-
-            // use 'min(msg.creationDate)' to keep a constant connection order over requests
-            slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-                    needURI, resume, messageType, timeSpot, new PageRequest(
-                            0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-        }
-        return slice;
-    }
-
-    @Override
     public Slice<Connection> listConnectionsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
                                           WonMessageType messageType, final Date timeSpot) {
         Date resume;
@@ -361,31 +301,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
             slice = connectionRepository.getConnectionsBeforeByActivityDate(
                     needURI, resume, messageType, timeSpot, new PageRequest(
                             0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-        }
-        return slice;
-    }
-
-    @Override
-    @Deprecated
-    public Slice listConnectionURIsAfter(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
-                                         final WonMessageType messageType, final Date timeSpot) {
-
-        Date resume = null;
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-        if (messageType == null) {
-            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-
-            // use 'min(msg.creationDate)' to keep a constant connection order over requests
-            slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
-        } else {
-            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-
-            // use 'min(msg.creationDate)' to keep a constant connection order over requests
-            slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-                    needURI, resume, messageType, timeSpot, new PageRequest(
-                            0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
         }
         return slice;
     }
@@ -486,24 +401,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
-    @Deprecated
-    public Slice<URI> listConnectionEventURIsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
-                                                   WonMessageType msgType) {
-        MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
-        Date referenceDate = referenceMsg.getCreationDate();
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-        if (msgType == null) {
-            slice = messageEventRepository.getMessageURIsByParentURIAfter(
-                    connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-        } else {
-            slice = messageEventRepository.getMessageURIsByParentURIAfter(
-                    connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-        }
-        return slice;
-    }
-
-    @Override
     public Slice<MessageEventPlaceholder> listConnectionEventsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
                                                                     WonMessageType msgType) {
         MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
@@ -516,24 +413,6 @@ public class NeedInformationServiceImpl implements NeedInformationService {
         } else {
             slice = messageEventRepository.findByParentURIAndTypeAfter(
                     connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-        }
-        return slice;
-    }
-
-    @Override
-    @Deprecated
-    public Slice<URI> listConnectionEventURIsBefore(final URI connectionUri, final URI msgURI, final Integer
-            preferredPageSize, final WonMessageType msgType) {
-        MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
-        Date referenceDate = referenceMsg.getCreationDate();
-        int pageSize = getPageSize(preferredPageSize);
-        Slice<URI> slice = null;
-        if (msgType == null) {
-            slice = messageEventRepository.getMessageURIsByParentURIBefore(
-                    connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
-        } else {
-            slice = messageEventRepository.getMessageURIsByParentURIBefore(
-                    connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
         }
         return slice;
     }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -151,6 +151,11 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
+    public Collection<Connection> listModifiedConnectionsAfter(Date modifiedAfter) {
+        return connectionRepository.findModifiedConnectionsAfter(modifiedAfter);
+    }
+
+    @Override
     @Deprecated
     public Slice<URI> listConnectionURIs(int page, Integer preferedPageSize, Date timeSpot) {
         int pageSize = getPageSize(preferedPageSize);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -141,6 +141,11 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
+    public Collection<Connection> listConnections() {
+        return connectionRepository.getAllConnections();
+    }
+
+    @Override
     public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter) {
         return connectionRepository.findModifiedConnectionURIsAfter(modifiedAfter);
     }
@@ -160,6 +165,26 @@ public class NeedInformationServiceImpl implements NeedInformationService {
 
             // use 'min(msg.creationDate)' to keep a constant connection order over requests
             slice = connectionRepository.getConnectionURIByActivityDate(
+                    timeSpot,
+                    new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+    @Override
+    public Slice<Connection> listConnections(int page, Integer preferedPageSize, Date timeSpot) {
+        int pageSize = getPageSize(preferedPageSize);
+        int pageNum = page - 1;
+        Slice<Connection> slice;
+        if (timeSpot == null) {
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsByActivityDate(
+                    new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        } else {
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionsByActivityDate(
                     timeSpot,
                     new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
         }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -236,6 +236,20 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
+    public Slice<Connection> listConnectionsAfter(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
+
+        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<Connection> slice;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        slice = connectionRepository.getConnectionsAfterByActivityDate(
+                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        return slice;
+    }
+
+    @Override
     @Deprecated
     public Collection<URI> listConnectionURIs(final URI needURI) throws NoSuchNeedException {
         return connectionRepository.getAllConnectionURIsForNeedURI(needURI);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -16,10 +16,6 @@
 
 package won.node.service.impl;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Date;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,282 +23,276 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
-
 import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchNeedException;
 import won.protocol.message.WonMessageType;
-import won.protocol.model.Connection;
-import won.protocol.model.DataWithEtag;
-import won.protocol.model.MessageEventPlaceholder;
-import won.protocol.model.Need;
-import won.protocol.model.NeedState;
+import won.protocol.model.*;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.repository.MessageEventRepository;
 import won.protocol.repository.NeedRepository;
 import won.protocol.service.NeedInformationService;
 import won.protocol.util.DataAccessUtils;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+
 /**
  * User: fkleedorfer
  * Date: 02.11.12
  */
 @Component
-public class NeedInformationServiceImpl implements NeedInformationService
-{
+public class NeedInformationServiceImpl implements NeedInformationService {
 
-  @Autowired
-  private NeedRepository needRepository;
-  @Autowired
-  private ConnectionRepository connectionRepository;
-  @Autowired
-  private MessageEventRepository messageEventRepository;
-  @Autowired
-  private URIService uriService;
+    @Autowired
+    private NeedRepository needRepository;
+    @Autowired
+    private ConnectionRepository connectionRepository;
+    @Autowired
+    private MessageEventRepository messageEventRepository;
+    @Autowired
+    private URIService uriService;
 
-  private static final int DEFAULT_PAGE_SIZE = 500;
+    private static final int DEFAULT_PAGE_SIZE = 500;
 
-  private int pageSize = DEFAULT_PAGE_SIZE;
-
-  @Override
-  public Collection<URI> listNeedURIs()
-  {
-    return needRepository.getAllNeedURIs();
-  }
-
-  @Override
-  public Slice<URI> listNeedURIs(int page, Integer preferedPageSize, NeedState needState)
-  {
-    int pageSize = this.pageSize;
-    int pageNum = page - 1;
-    if (preferedPageSize != null && preferedPageSize < this.pageSize) {
-      pageSize = preferedPageSize;
-    }
-    Slice<URI> slice = null;
-    if (needState == null) {
-
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
-    } else {
-
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getAllNeedURIs(needState, new PageRequest(pageNum, pageSize, Sort.Direction.DESC,
-                                                                       "creationDate"));
-    }
-    return slice;
-  }
-
-  @Override
-  public Slice<URI> listNeedURIsBefore(URI needURI, Integer preferedPageSize, NeedState needState)
-  {
-    Need referenceNeed = needRepository.findOneByNeedURI(needURI);
-    Date referenceDate = referenceNeed.getCreationDate();
-    int pageSize = this.pageSize;
-    if (preferedPageSize != null && preferedPageSize < this.pageSize) {
-      pageSize = preferedPageSize;
-    }
-    Slice<URI> slice = null;
-    if (needState == null) {
-
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getNeedURIsBefore(referenceDate, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "creationDate"));
-    } else {
-
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getNeedURIsBefore(referenceDate, needState, new PageRequest(0, pageSize, Sort
-        .Direction.DESC, "creationDate"));
-    }
-    return slice;
-  }
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     @Override
-    public Collection<URI> listModifiedNeedURIsAfter(Date modifiedAfter)
-    {
+    public Collection<URI> listNeedURIs() {
+        return needRepository.getAllNeedURIs();
+    }
+
+    @Override
+    public Slice<URI> listNeedURIs(int page, Integer preferedPageSize, NeedState needState) {
+        int pageSize = this.pageSize;
+        int pageNum = page - 1;
+        if (preferedPageSize != null && preferedPageSize < this.pageSize) {
+            pageSize = preferedPageSize;
+        }
+        Slice<URI> slice = null;
+        if (needState == null) {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getAllNeedURIs(new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
+        } else {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getAllNeedURIs(needState, new PageRequest(pageNum, pageSize, Sort.Direction.DESC,
+                    "creationDate"));
+        }
+        return slice;
+    }
+
+    @Override
+    public Slice<URI> listNeedURIsBefore(URI needURI, Integer preferedPageSize, NeedState needState) {
+        Need referenceNeed = needRepository.findOneByNeedURI(needURI);
+        Date referenceDate = referenceNeed.getCreationDate();
+        int pageSize = this.pageSize;
+        if (preferedPageSize != null && preferedPageSize < this.pageSize) {
+            pageSize = preferedPageSize;
+        }
+        Slice<URI> slice = null;
+        if (needState == null) {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getNeedURIsBefore(referenceDate, new PageRequest(0, pageSize, Sort
+                    .Direction.DESC, "creationDate"));
+        } else {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getNeedURIsBefore(referenceDate, needState, new PageRequest(0, pageSize, Sort
+                    .Direction.DESC, "creationDate"));
+        }
+        return slice;
+    }
+
+    @Override
+    public Collection<URI> listModifiedNeedURIsAfter(Date modifiedAfter) {
         return needRepository.findModifiedNeedURIsAfter(modifiedAfter);
     }
 
-  @Override
-  public Slice<URI> listNeedURIsAfter(URI needURI, Integer preferedPageSize, NeedState needState)
-  {
-    Need referenceNeed = needRepository.findOneByNeedURI(needURI);
-    Date referenceDate = referenceNeed.getCreationDate();
-    int pageSize = this.pageSize;
-    if (preferedPageSize != null && preferedPageSize < this.pageSize) {
-      pageSize = preferedPageSize;
+    @Override
+    public Slice<URI> listNeedURIsAfter(URI needURI, Integer preferedPageSize, NeedState needState) {
+        Need referenceNeed = needRepository.findOneByNeedURI(needURI);
+        Date referenceDate = referenceNeed.getCreationDate();
+        int pageSize = this.pageSize;
+        if (preferedPageSize != null && preferedPageSize < this.pageSize) {
+            pageSize = preferedPageSize;
+        }
+        Slice<URI> slice = null;
+        if (needState == null) {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getNeedURIsAfter(referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC,
+                    "creationDate"));
+        } else {
+
+            // use 'creationDate' to keep a constant need order over requests
+            slice = needRepository.getNeedURIsAfter(referenceDate, needState, new PageRequest(0, pageSize, Sort.Direction.ASC,
+                    "creationDate"));
+        }
+        return slice;
     }
-    Slice<URI> slice = null;
-    if (needState == null) {
 
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getNeedURIsAfter(referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                             "creationDate"));
-    } else {
-
-        // use 'creationDate' to keep a constant need order over requests
-      slice = needRepository.getNeedURIsAfter(referenceDate, needState, new PageRequest(0, pageSize, Sort.Direction.ASC,
-                                                                                        "creationDate"));
-    }
-    return slice;
-  }
-
-
-  @Override
-  public Collection<URI> listConnectionURIs()
-  {
-    return connectionRepository.getAllConnectionURIs();
-  }
-
-  @Override
-  public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter) {
-      return connectionRepository.findModifiedConnectionURIsAfter(modifiedAfter);
-  }
-
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionURIs(int page, Integer preferedPageSize, Date timeSpot)
-  {
-    int pageSize = getPageSize(preferedPageSize);
-    int pageNum = page - 1;
-    Slice<URI> slice;
-    if (timeSpot == null) {
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIByActivityDate(
-        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-    } else {
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIByActivityDate(
-        timeSpot,
-        new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-    }
-    return slice;
-  }
-
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionURIsBefore(
-    final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
-
-    Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<URI> slice = null;
-
-      // use 'min(msg.creationDate)' to keep a constant connection order over requests
-    slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-    return slice;
-  }
-
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionURIsAfter(
-    final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
-
-    Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<URI> slice = null;
-
-      // use 'min(msg.creationDate)' to keep a constant connection order over requests
-    slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-      resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
-    return slice;
-  }
-
-  @Override
-  @Deprecated
-  public Collection<URI> listConnectionURIs(final URI needURI) throws NoSuchNeedException
-  {
-    return connectionRepository.getAllConnectionURIsForNeedURI(needURI);
-  }
-
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionURIs(final URI needURI, int page, Integer preferedPageSize, WonMessageType
-    messageType, Date timeSpot) {
-    Slice<URI> slice = null;
-    int pageSize = getPageSize(preferedPageSize);
-    int pageNum = page - 1;
-
-      // use 'min(msg.creationDate)' to keep a constant connection order over requests
-    PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)");
-    if (messageType == null) {
-      if (timeSpot == null) {
-        slice = connectionRepository.getConnectionURIByActivityDate(needURI, pageRequest);
-      } else {
-        slice = connectionRepository.getConnectionURIByActivityDate(needURI, timeSpot, pageRequest);
-      }
-    } else {
-      if (timeSpot == null) {
-        slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, pageRequest);
-      } else {
-        slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, timeSpot, pageRequest);
-      }
-    }
-    return slice;
-  }
-
-  @Override
-  @Deprecated
-  public Slice listConnectionURIsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
-                                        WonMessageType messageType, final Date timeSpot) {
-
-    Date resume = null;
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<URI> slice = null;
-    if (messageType == null) {
-      resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-    } else {
-      resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-      
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
-        needURI, resume, messageType, timeSpot, new PageRequest(
-          0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
-    }
-    return slice;
-  }
-
-  @Override
-  @Deprecated
-  public Slice listConnectionURIsAfter(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
-                                        final WonMessageType messageType, final Date timeSpot) {
-
-    Date resume = null;
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<URI> slice = null;
-    if (messageType == null) {
-      resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-        needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
-    } else {
-      resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
-
-        // use 'min(msg.creationDate)' to keep a constant connection order over requests
-      slice = connectionRepository.getConnectionURIsAfterByActivityDate(
-        needURI, resume, messageType, timeSpot, new PageRequest(
-          0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
-    }
-    return slice;
-  }
-
-
-  @Override
-  public Need readNeed(final URI needURI) throws NoSuchNeedException
-  {
-    if (needURI == null) throw new IllegalArgumentException("needURI is not set");
-    return (DataAccessUtils.loadNeed(needRepository, needURI));
-  }
 
     @Override
-    public DataWithEtag<Need> readNeed(final URI needURI, String etag) throws NoSuchNeedException
-    {
+    public Collection<URI> listConnectionURIs() {
+        return connectionRepository.getAllConnectionURIs();
+    }
+
+    @Override
+    public Collection<URI> listModifiedConnectionURIsAfter(Date modifiedAfter) {
+        return connectionRepository.findModifiedConnectionURIsAfter(modifiedAfter);
+    }
+
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionURIs(int page, Integer preferedPageSize, Date timeSpot) {
+        int pageSize = getPageSize(preferedPageSize);
+        int pageNum = page - 1;
+        Slice<URI> slice;
+        if (timeSpot == null) {
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIByActivityDate(
+                    new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        } else {
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIByActivityDate(
+                    timeSpot,
+                    new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionURIsBefore(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
+
+        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
+                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        return slice;
+    }
+
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionURIsAfter(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
+
+        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        return slice;
+    }
+
+    @Override
+    @Deprecated
+    public Collection<URI> listConnectionURIs(final URI needURI) throws NoSuchNeedException {
+        return connectionRepository.getAllConnectionURIsForNeedURI(needURI);
+    }
+
+    @Override
+    public Collection<Connection> listConnections(final URI needURI) throws NoSuchNeedException {
+        return connectionRepository.findByNeedURI(needURI);
+    }
+
+
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionURIs(final URI needURI, int page, Integer preferedPageSize, WonMessageType
+            messageType, Date timeSpot) {
+        Slice<URI> slice = null;
+        int pageSize = getPageSize(preferedPageSize);
+        int pageNum = page - 1;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        PageRequest pageRequest = new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "min(msg.creationDate)");
+        if (messageType == null) {
+            if (timeSpot == null) {
+                slice = connectionRepository.getConnectionURIByActivityDate(needURI, pageRequest);
+            } else {
+                slice = connectionRepository.getConnectionURIByActivityDate(needURI, timeSpot, pageRequest);
+            }
+        } else {
+            if (timeSpot == null) {
+                slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, pageRequest);
+            } else {
+                slice = connectionRepository.getConnectionURIByActivityDate(needURI, messageType, timeSpot, pageRequest);
+            }
+        }
+        return slice;
+    }
+
+    @Override
+    @Deprecated
+    public Slice listConnectionURIsBefore(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
+                                          WonMessageType messageType, final Date timeSpot) {
+
+        Date resume = null;
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+        if (messageType == null) {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
+                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        } else {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIsBeforeByActivityDate(
+                    needURI, resume, messageType, timeSpot, new PageRequest(
+                            0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+    @Override
+    @Deprecated
+    public Slice listConnectionURIsAfter(final URI needURI, final URI resumeConnURI, final Integer preferredPageSize,
+                                         final WonMessageType messageType, final Date timeSpot) {
+
+        Date resume = null;
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+        if (messageType == null) {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+                    needURI, resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        } else {
+            resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, messageType, timeSpot);
+
+            // use 'min(msg.creationDate)' to keep a constant connection order over requests
+            slice = connectionRepository.getConnectionURIsAfterByActivityDate(
+                    needURI, resume, messageType, timeSpot, new PageRequest(
+                            0, pageSize, Sort.Direction.ASC, "min(msg.creationDate)"));
+        }
+        return slice;
+    }
+
+
+    @Override
+    public Need readNeed(final URI needURI) throws NoSuchNeedException {
+        if (needURI == null) throw new IllegalArgumentException("needURI is not set");
+        return (DataAccessUtils.loadNeed(needRepository, needURI));
+    }
+
+    @Override
+    public DataWithEtag<Need> readNeed(final URI needURI, String etag) throws NoSuchNeedException {
         if (needURI == null) throw new IllegalArgumentException("needURI is not set");
         Need need = null;
         if (etag == null) {
@@ -312,158 +302,149 @@ public class NeedInformationServiceImpl implements NeedInformationService
             need = needRepository.findOneByNeedURIAndVersionNot(needURI, version);
         }
         boolean isDeleted = need != null && (need.getState() == NeedState.DELETED);
-        
+
         return new DataWithEtag<>(need, need == null ? etag : Integer.toString(need.getVersion()), etag, isDeleted);
     }
 
-  @Override
-  public Model readNeedContent(final URI needURI) throws NoSuchNeedException
-  {
-    if (needURI == null) throw new IllegalArgumentException("needURI is not set");
-    Need need = DataAccessUtils.loadNeed(needRepository, needURI);
-    return (need == null || need.getState() == NeedState.DELETED) ? ModelFactory.createDefaultModel() : need.getDatatsetHolder().getDataset().getDefaultModel();
-  }
-
-  @Override
-  public Connection readConnection(final URI connectionURI) throws NoSuchConnectionException
-  {
-    if (connectionURI == null) throw new IllegalArgumentException("connectionURI is not set");
-    return DataAccessUtils.loadConnection(connectionRepository, connectionURI);
-  }
-
-  @Override
-  public DataWithEtag<Connection> readConnection(final URI connectionURI, String etag)
-  {
-    if (connectionURI == null) throw new IllegalArgumentException("connectionURI is not set");
-    Connection con = null;
-    if (etag == null) {
-      con = connectionRepository.findOneByConnectionURI(connectionURI);
-    } else {
-      Integer version = Integer.valueOf(etag);
-      con = connectionRepository.findOneByConnectionURIAndVersionNot(connectionURI, version);
+    @Override
+    public Model readNeedContent(final URI needURI) throws NoSuchNeedException {
+        if (needURI == null) throw new IllegalArgumentException("needURI is not set");
+        Need need = DataAccessUtils.loadNeed(needRepository, needURI);
+        return (need == null || need.getState() == NeedState.DELETED) ? ModelFactory.createDefaultModel() : need.getDatatsetHolder().getDataset().getDefaultModel();
     }
-    return new DataWithEtag<>(con, con == null ? etag : Integer.toString(con.getVersion()), etag);
-  }
 
-
-  //TODO implement RDF handling!
-  @Override
-  public Model readConnectionContent(final URI connectionURI) throws NoSuchConnectionException
-  {
-    return null;
-  }
-
-
-  @Override
-  public Slice<MessageEventPlaceholder> listConnectionEvents(
-    URI connectionUri, int page, Integer preferedPageSize, WonMessageType messageType)
-  {
-    int pageSize = getPageSize(preferedPageSize);
-    int pageNum = page - 1;
-    Slice<MessageEventPlaceholder> slice = null;
-    if (messageType == null) {
-      slice = messageEventRepository.findByParentURI(
-        connectionUri, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
-    } else {
-      slice = messageEventRepository.findByParentURIAndType(
-        connectionUri, messageType, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
+    @Override
+    public Connection readConnection(final URI connectionURI) throws NoSuchConnectionException {
+        if (connectionURI == null) throw new IllegalArgumentException("connectionURI is not set");
+        return DataAccessUtils.loadConnection(connectionRepository, connectionURI);
     }
-    return slice;
-  }
 
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionEventURIsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
-                                                 WonMessageType msgType) {
-      MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
-      Date referenceDate = referenceMsg.getCreationDate();
-      int pageSize = getPageSize(preferredPageSize);
-      Slice<URI> slice = null;
-      if (msgType == null) {
-        slice = messageEventRepository.getMessageURIsByParentURIAfter(
-          connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-      } else {
-        slice = messageEventRepository.getMessageURIsByParentURIAfter(
-          connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-      }
-      return slice;
-  }
-
-  @Override
-  public Slice<MessageEventPlaceholder> listConnectionEventsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
-                                                 WonMessageType msgType) {
-    MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
-    Date referenceDate = referenceMsg.getCreationDate();
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<MessageEventPlaceholder> slice = null;
-    if (msgType == null) {
-      slice = messageEventRepository.findByParentURIAfter(
-        connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
-    } else {
-      slice = messageEventRepository.findByParentURIAndTypeAfter(
-        connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
+    @Override
+    public DataWithEtag<Connection> readConnection(final URI connectionURI, String etag) {
+        if (connectionURI == null) throw new IllegalArgumentException("connectionURI is not set");
+        Connection con = null;
+        if (etag == null) {
+            con = connectionRepository.findOneByConnectionURI(connectionURI);
+        } else {
+            Integer version = Integer.valueOf(etag);
+            con = connectionRepository.findOneByConnectionURIAndVersionNot(connectionURI, version);
+        }
+        return new DataWithEtag<>(con, con == null ? etag : Integer.toString(con.getVersion()), etag);
     }
-    return slice;
-  }
 
-  @Override
-  @Deprecated
-  public Slice<URI> listConnectionEventURIsBefore(final URI connectionUri, final URI msgURI, final Integer
-    preferredPageSize, final WonMessageType msgType) {
-    MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
-    Date referenceDate = referenceMsg.getCreationDate();
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<URI> slice = null;
-    if (msgType == null) {
-      slice = messageEventRepository.getMessageURIsByParentURIBefore(
-        connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
-    } else {
-      slice = messageEventRepository.getMessageURIsByParentURIBefore(
-        connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+
+    //TODO implement RDF handling!
+    @Override
+    public Model readConnectionContent(final URI connectionURI) throws NoSuchConnectionException {
+        return null;
     }
-    return slice;
-  }
 
-  @Override
-  public Slice<MessageEventPlaceholder> listConnectionEventsBefore(final URI connectionUri, final URI msgURI, final Integer
-    preferredPageSize, final WonMessageType msgType) {
-    int pageSize = getPageSize(preferredPageSize);
-    Slice<MessageEventPlaceholder> slice = null;
-    if (msgType == null) {
-      slice = messageEventRepository.findByParentURIBeforeFetchDatasetEagerly(
-        connectionUri, msgURI, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
-    } else {
-      slice = messageEventRepository.findByParentURIAndTypeBeforeFetchDatasetEagerly(
-        connectionUri, msgURI, msgType, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+
+    @Override
+    public Slice<MessageEventPlaceholder> listConnectionEvents(
+            URI connectionUri, int page, Integer preferedPageSize, WonMessageType messageType) {
+        int pageSize = getPageSize(preferedPageSize);
+        int pageNum = page - 1;
+        Slice<MessageEventPlaceholder> slice = null;
+        if (messageType == null) {
+            slice = messageEventRepository.findByParentURI(
+                    connectionUri, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
+        } else {
+            slice = messageEventRepository.findByParentURIAndType(
+                    connectionUri, messageType, new PageRequest(pageNum, pageSize, Sort.Direction.DESC, "creationDate"));
+        }
+        return slice;
     }
-    return slice;
-  }
 
-  private int getPageSize(final Integer preferredPageSize) {
-    int pageSize = this.pageSize;
-    if (preferredPageSize != null && preferredPageSize < this.pageSize) {
-      pageSize = preferredPageSize;
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionEventURIsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
+                                                   WonMessageType msgType) {
+        MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
+        Date referenceDate = referenceMsg.getCreationDate();
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+        if (msgType == null) {
+            slice = messageEventRepository.getMessageURIsByParentURIAfter(
+                    connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
+        } else {
+            slice = messageEventRepository.getMessageURIsByParentURIAfter(
+                    connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
+        }
+        return slice;
     }
-    return pageSize;
-  }
 
-  public void setNeedRepository(final NeedRepository needRepository)
-  {
-    this.needRepository = needRepository;
-  }
+    @Override
+    public Slice<MessageEventPlaceholder> listConnectionEventsAfter(URI connectionUri, URI msgURI, Integer preferredPageSize,
+                                                                    WonMessageType msgType) {
+        MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
+        Date referenceDate = referenceMsg.getCreationDate();
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<MessageEventPlaceholder> slice = null;
+        if (msgType == null) {
+            slice = messageEventRepository.findByParentURIAfter(
+                    connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
+        } else {
+            slice = messageEventRepository.findByParentURIAndTypeAfter(
+                    connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.ASC, "creationDate"));
+        }
+        return slice;
+    }
 
-  public void setConnectionRepository(final ConnectionRepository connectionRepository)
-  {
-    this.connectionRepository = connectionRepository;
-  }
+    @Override
+    @Deprecated
+    public Slice<URI> listConnectionEventURIsBefore(final URI connectionUri, final URI msgURI, final Integer
+            preferredPageSize, final WonMessageType msgType) {
+        MessageEventPlaceholder referenceMsg = messageEventRepository.findOneByMessageURI(msgURI);
+        Date referenceDate = referenceMsg.getCreationDate();
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<URI> slice = null;
+        if (msgType == null) {
+            slice = messageEventRepository.getMessageURIsByParentURIBefore(
+                    connectionUri, referenceDate, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+        } else {
+            slice = messageEventRepository.getMessageURIsByParentURIBefore(
+                    connectionUri, referenceDate, msgType, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+        }
+        return slice;
+    }
 
-  private boolean isNeedActive(final Need need)
-  {
-    return NeedState.ACTIVE == need.getState();
-  }
+    @Override
+    public Slice<MessageEventPlaceholder> listConnectionEventsBefore(final URI connectionUri, final URI msgURI, final Integer
+            preferredPageSize, final WonMessageType msgType) {
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<MessageEventPlaceholder> slice = null;
+        if (msgType == null) {
+            slice = messageEventRepository.findByParentURIBeforeFetchDatasetEagerly(
+                    connectionUri, msgURI, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+        } else {
+            slice = messageEventRepository.findByParentURIAndTypeBeforeFetchDatasetEagerly(
+                    connectionUri, msgURI, msgType, new PageRequest(0, pageSize, Sort.Direction.DESC, "creationDate"));
+        }
+        return slice;
+    }
 
-  public void setPageSize(int pageSize)
-  {
-    this.pageSize = pageSize;
-  }
+    private int getPageSize(final Integer preferredPageSize) {
+        int pageSize = this.pageSize;
+        if (preferredPageSize != null && preferredPageSize < this.pageSize) {
+            pageSize = preferredPageSize;
+        }
+        return pageSize;
+    }
+
+    public void setNeedRepository(final NeedRepository needRepository) {
+        this.needRepository = needRepository;
+    }
+
+    public void setConnectionRepository(final ConnectionRepository connectionRepository) {
+        this.connectionRepository = connectionRepository;
+    }
+
+    private boolean isNeedActive(final Need need) {
+        return NeedState.ACTIVE == need.getState();
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
 }

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/NeedInformationServiceImpl.java
@@ -207,6 +207,20 @@ public class NeedInformationServiceImpl implements NeedInformationService {
     }
 
     @Override
+    public Slice<Connection> listConnectionsBefore(
+            final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {
+
+        Date resume = messageEventRepository.findMaxActivityDateOfParentAtTime(resumeConnURI, timeSpot);
+        int pageSize = getPageSize(preferredPageSize);
+        Slice<Connection> slice;
+
+        // use 'min(msg.creationDate)' to keep a constant connection order over requests
+        slice = connectionRepository.getConnectionsBeforeByActivityDate(
+                resume, timeSpot, new PageRequest(0, pageSize, Sort.Direction.DESC, "min(msg.creationDate)"));
+        return slice;
+    }
+
+    @Override
     @Deprecated
     public Slice<URI> listConnectionURIsAfter(
             final URI resumeConnURI, final Integer preferredPageSize, final Date timeSpot) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -45,11 +45,11 @@ export function failedCloseNeed(event) {
         */
     won
       .invalidateCacheForNeed(needUri) // mark need and it's connection container dirty
-      .then(() => won.getConnectionUrisOfNeed(needUri))
-      .then(connectionUris =>
+      .then(() => won.getConnectionUrisWithStateOfNeed(needUri))
+      .then(connectionsWithStateOfNeed =>
         Promise.all(
-          connectionUris.map(
-            cnctUri => won.invalidateCacheForNewMessage(cnctUri, needUri) // mark connections dirty
+          connectionsWithStateOfNeed.map(
+            conn => won.invalidateCacheForNewMessage(conn.connectionUri) // mark connections dirty
           )
         )
       )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -1,7 +1,7 @@
 import won from "../../won-es6.js";
 import Immutable from "immutable";
 import { parseConnection } from "./parse-connection.js";
-import { markUriAsRead, markConnUriAsClosed } from "../../won-localstorage.js";
+import { markUriAsRead } from "../../won-localstorage.js";
 
 import { markNeedAsRead } from "./reduce-needs.js";
 import { getIn } from "../../utils.js";
@@ -98,10 +98,6 @@ function addConnectionFull(state, connection) {
         state = state.setIn([needUri, "unread"], true);
       }
 
-      if (parsedConnection.getIn(["data", "state"]) === won.WON.Closed) {
-        markConnUriAsClosed(connectionUri);
-      }
-
       return state.mergeDeepIn(
         [needUri, "connections", connectionUri],
         parsedConnection.get("data")
@@ -195,10 +191,6 @@ export function changeConnectionState(state, connectionUri, newState) {
   }
 
   const needUri = need.get("uri");
-
-  if (newState === won.WON.Closed) {
-    markConnUriAsClosed(connectionUri);
-  }
 
   const connection = getIn(need, ["connections", connectionUri]);
   if (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -21,8 +21,6 @@
 import { is, prefixOfUri, isArray, clone, createArray } from "../utils.js";
 import {
   clearReadUris,
-  clearClosedConnUris,
-  getClosedConnUris,
   clearDisclaimerAccepted,
   isDisclaimerAccepted,
   setDisclaimerAccepted,
@@ -42,8 +40,6 @@ let won = {};
 won.debugmode = false; //if you set this to true, the created needs will get flagged as debug needs in order to get matches and requests from the debugbot
 
 won.clearReadUris = clearReadUris;
-won.clearClosedConnUris = clearClosedConnUris;
-won.getClosedConnUris = getClosedConnUris;
 won.isDisclaimerAccepted = isDisclaimerAccepted;
 won.clearDisclaimerAccepted = clearDisclaimerAccepted;
 won.setDisclaimerAccepted = setDisclaimerAccepted;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-localstorage.js
@@ -2,11 +2,9 @@
  * Created by fsuda on 25.04.2018.
  */
 const READ_URIS = "wonReadUris";
-const CLOSED_CONN_URIS = "wonClosedConnectionUris";
 const DISCLAIMER_ACCEPTED = "disclaimerAccepted";
 
 let readUrisCache;
-let closedConnUrisCache;
 let disclaimerAcceptedCache;
 
 export function markUriAsRead(uri) {
@@ -49,48 +47,6 @@ export function isUriRead(uri) {
 export function clearReadUris() {
   readUrisCache = undefined;
   localStorage.removeItem(READ_URIS);
-}
-
-export function markConnUriAsClosed(uri) {
-  if (!isConnUriClosed(uri)) {
-    closedConnUrisCache = getClosedConnUris();
-    closedConnUrisCache.push(uri);
-    localStorage.setItem(CLOSED_CONN_URIS, JSON.stringify(closedConnUrisCache));
-  }
-}
-
-export function getClosedConnUris() {
-  if (!closedConnUrisCache) {
-    let closedConnUrisString = localStorage.getItem(CLOSED_CONN_URIS);
-
-    if (closedConnUrisString) {
-      try {
-        closedConnUrisCache = JSON.parse(closedConnUrisString);
-      } catch (e) {
-        localStorage.removeItem(CLOSED_CONN_URIS);
-        closedConnUrisCache = [];
-      }
-    } else {
-      closedConnUrisCache = [];
-    }
-  }
-
-  return closedConnUrisCache;
-}
-
-export function isConnUriClosed(uri) {
-  for (const closedUri of getClosedConnUris()) {
-    if (closedUri === uri) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-export function clearClosedConnUris() {
-  closedConnUrisCache = undefined;
-  localStorage.removeItem(CLOSED_CONN_URIS);
 }
 
 export function isDisclaimerAccepted() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -11,7 +11,6 @@ import urljoin from "url-join";
 
 import { getRandomWonId } from "./won-utils.js";
 import * as useCaseUtils from "./usecase-utils.js";
-import { isConnUriClosed } from "./won-localstorage.js";
 import { actionTypes } from "./actions/actions.js";
 
 /**
@@ -712,11 +711,12 @@ export async function fetchDataForOwnedNeeds(ownedNeedUris, dispatch) {
 
 function fetchConnectionsOfNeedAndDispatch(needUri, dispatch) {
   return won
-    .getConnectionUrisOfNeed(needUri, needUri, true)
-    .then(connectionUrisOfNeed => {
-      const activeConnectionUris = connectionUrisOfNeed.filter(
-        connUri => !isConnUriClosed(connUri)
-      );
+    .getConnectionUrisWithStateOfNeed(needUri, needUri, true)
+    .then(connectionsWithStateOfNeed => {
+      const activeConnectionUris = connectionsWithStateOfNeed
+        .filter(conn => conn.connectionState !== won.WON.Closed)
+        .map(conn => conn.connectionUri);
+
       dispatch({
         type: actionTypes.connections.storeActiveUrisInLoading,
         payload: Immutable.fromJS({


### PR DESCRIPTION
fixes #2778 

Frontend changes:
- removes the closedConnUri check from localStorage (closedConnUris wont be stored in localStorage at all)
- implements a new method that retrieves not only the connectionUri but also the state
- only add active Connections based on their real state from the server and not from localStorage

Backend changes:
- removed unused methods
- connectionContainer updates -> do not only give a list of connUris but also their state and facets and additional info

### warning: due to the changes made in the backend i recommend checking if the bots work properly too (at least debugbot and hokifybot)
### warning: testing pr only works if owner is connected to a node that runs from the same codebase (either deploy/connect to a local node, or push the branch to integration-test)

