### PR TITLE
Removed dependency that was not used

### DIFF
--- a/webofneeds/pom.xml
+++ b/webofneeds/pom.xml
@@ -663,11 +663,6 @@
                 <version>${net.sf.ehcache.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>${commons-fileupload.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${com.google.guava.version}</version>
@@ -990,7 +985,6 @@
         <aspectj.version>1.5.4</aspectj.version>
         <bouncycastle.version>1.52</bouncycastle.version>
         <commons-collections.version>3.2.1</commons-collections.version>
-        <commons-fileupload.version>1.2.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <de.uni_koblenz.aggrimm.icp.version>1.0.1</de.uni_koblenz.aggrimm.icp.version>
         <camel.version>2.12.1</camel.version>

--- a/webofneeds/won-owner-webapp/pom.xml
+++ b/webofneeds/won-owner-webapp/pom.xml
@@ -58,13 +58,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- apache commons -->
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <scope>${dependencies.scope}</scope>
-        </dependency>
-
         <!-- JSTL/Servlet-->
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
Removes apache.commons fileupload, was never used anyway -> and resulted in a visible vulnerability in github