### PR TITLE
fix textfield focus color to be browser independent (fixes #1813) 

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -114,6 +114,10 @@ input[type="email"] {
   border-radius: 0.19rem;
   border: $thinGrayBorder;
   font-size: 16px;
+
+  &:focus {
+    outline-color: $won-secondary-color;
+  }
 }
 
 .clickable {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -114,7 +114,17 @@ input[type="email"] {
   border-radius: 0.19rem;
   border: $thinGrayBorder;
   font-size: 16px;
+}
 
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="date"],
+input[type="time"],
+input[type="url"],
+input[type="number"],
+select,
+textarea {
   &:focus {
     outline-color: $won-secondary-color;
   }


### PR DESCRIPTION
add :focus outline color to be won-secondary-color by default (should overwrite any browser specific focus behaviour)