### PR TITLE
Feat  agree tos private #2537

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -89,3 +89,12 @@ export function getEmailVerificationError(accountState) {
 export function isDisclaimerAccepted(accountState) {
   return !!get(accountState, "acceptedDisclaimer");
 }
+
+/**
+ * Return true if the TermsOfService are already accepted
+ * @param accountState
+ * @returns {boolean}
+ */
+export function isTermsOfServiceAccepted(accountState) {
+  return !!get(accountState, "acceptedTermsOfService");
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -10,7 +10,7 @@ import { get } from "./utils.js";
  * @returns {*|boolean}
  */
 export function isLoggedIn(accountState) {
-  return get(accountState, "loggedIn");
+  return !!get(accountState, "loggedIn");
 }
 
 /**
@@ -19,7 +19,16 @@ export function isLoggedIn(accountState) {
  * @returns {*|boolean}
  */
 export function isAnonymous(accountState) {
-  return get(accountState, "isAnonymous");
+  return !!get(accountState, "isAnonymous");
+}
+
+/**
+ * Determines if the email address of the currently logged in user is verified
+ * @param accountState
+ * @returns {*|boolean}
+ */
+export function isEmailVerified(accountState) {
+  return !!get(accountState, "emailVerified");
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -4,8 +4,8 @@
 
 import { get } from "./utils.js";
 /**
- * Determines if a given connection is a chatConnection
- * @param conn
+ * Determines if a there is currently a user logged in or not
+ * @param accountState
  * @returns {*|boolean}
  */
 export function isLoggedIn(accountState) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -32,11 +32,21 @@ export function isEmailVerified(accountState) {
 }
 
 /**
- * Returns the email of the currentyl logged in user
+ * Returns the email of the currently logged in user
  *
  * @param accountState
  * @returns {*}
  */
 export function getEmail(accountState) {
   return get(accountState, "email");
+}
+
+/**
+ * Returns the privateId of the currently logged in user
+ *
+ * @param accountState
+ * @returns {*}
+ */
+export function getPrivateId(accountState) {
+  return get(accountState, "privateId");
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -1,0 +1,13 @@
+/**
+ * Created by fsuda on 19.03.2019.
+ */
+
+import { get } from "./utils.js";
+/**
+ * Determines if a given connection is a chatConnection
+ * @param conn
+ * @returns {*|boolean}
+ */
+export function isLoggedIn(accountState) {
+  return get(accountState, "loggedIn");
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -50,3 +50,42 @@ export function getEmail(accountState) {
 export function getPrivateId(accountState) {
   return get(accountState, "privateId");
 }
+
+/**
+ * Returns the loginError if present
+ *
+ * @param accountState
+ * @returns {*}
+ */
+export function getLoginError(accountState) {
+  return get(accountState, "loginError");
+}
+
+/**
+ * Returns the registerError if present
+ *
+ * @param accountState
+ * @returns {*}
+ */
+export function getRegisterError(accountState) {
+  return get(accountState, "registerError");
+}
+
+/**
+ * Returns the emailVerificationError if present
+ *
+ * @param accountState
+ * @returns {*}
+ */
+export function getEmailVerificationError(accountState) {
+  return get(accountState, "emailVerificationError");
+}
+
+/**
+ * Return true if the disclaimer is already accepted
+ * @param accountState
+ * @returns {boolean}
+ */
+export function isDisclaimerAccepted(accountState) {
+  return !!get(accountState, "acceptedDisclaimer");
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -3,6 +3,7 @@
  */
 
 import { get } from "./utils.js";
+
 /**
  * Determines if a there is currently a user logged in or not
  * @param accountState
@@ -10,4 +11,23 @@ import { get } from "./utils.js";
  */
 export function isLoggedIn(accountState) {
   return get(accountState, "loggedIn");
+}
+
+/**
+ * Determines if a the currently logged in user is an anonymous one
+ * @param accountState
+ * @returns {*|boolean}
+ */
+export function isAnonymous(accountState) {
+  return get(accountState, "isAnonymous");
+}
+
+/**
+ * Returns the email of the currentyl logged in user
+ *
+ * @param accountState
+ * @returns {*}
+ */
+export function getEmail(accountState) {
+  return get(accountState, "email");
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -66,7 +66,8 @@ export function accountLogin(credentials, redirectToFeed = false) {
 
     const { email } = parseCredentials(credentials);
 
-    const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
+    const accountState = get(state, "account");
+    const isLoggedIn = accountUtils.isLoggedIn(accountState);
     const processingLoginForEmail =
       processUtils.isProcessingLoginForEmail(get(state, "process")) ||
       _loginInProcessFor;
@@ -84,7 +85,7 @@ export function accountLogin(credentials, redirectToFeed = false) {
       isLoggedIn &&
       !processUtils.isProcessingInitialLoad(get(state, "process"))
     ) {
-      const loggedInEmail = state.getIn(["account", "email"]);
+      const loggedInEmail = accountUtils.getEmail(accountState);
 
       if (credentials.email === loggedInEmail) {
         console.debug(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -351,6 +351,7 @@ const actionHierarchy = {
     selectAddMessageContent: INJ_DEFAULT,
     removeAddMessageContent: INJ_DEFAULT,
 
+    showTermsDialog: INJ_DEFAULT,
     showModalDialog: INJ_DEFAULT,
     hideModalDialog: INJ_DEFAULT,
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -9,12 +9,14 @@ import { actionCreators, actionTypes } from "./actions.js";
 import { ensureLoggedIn } from "./account-actions.js";
 
 import {
+  get,
   getIn,
   reverseSearchNominatim,
   nominatim2draftLocation,
 } from "../utils.js";
 
 import { isWhatsAroundNeed, isWhatsNewNeed } from "../need-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 export function needCreate(draft, persona, nodeUri) {
   return (dispatch, getState) => {
@@ -26,7 +28,10 @@ export function needCreate(draft, persona, nodeUri) {
 
     let prevParams = getIn(state, ["router", "prevParams"]);
 
-    if (!state.getIn(["account", "loggedIn"]) && prevParams.privateId) {
+    if (
+      !accountUtils.isLoggedIn(get(state, "account")) &&
+      prevParams.privateId
+    ) {
       /*
              * `ensureLoggedIn` will generate a new privateId. should
              * there be a previous privateId, we don't want to change

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
@@ -1,4 +1,5 @@
 import angular from "angular";
+import Immutable from "immutable";
 import ngAnimate from "angular-animate";
 import compareToModule from "../../directives/compareTo.js";
 import accordionModule from "../accordion.js";
@@ -254,27 +255,17 @@ class AboutController {
     if (this.loggedIn) {
       this.needs__whatsAround();
     } else {
-      const payload = {
-        caption: "FIXME#2537: Attention!",
-        text:
-          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-        buttons: [
-          {
-            caption: "Accept",
-            callback: () => {
-              this.view__hideModalDialog();
-              this.needs__whatsAround();
-            },
+      this.view__showTermsDialog(
+        Immutable.fromJS({
+          acceptCallback: () => {
+            this.view__hideModalDialog();
+            this.needs__whatsAround();
           },
-          {
-            caption: "Cancel",
-            callback: () => {
-              this.view__hideModalDialog();
-            },
+          cancelCallback: () => {
+            this.view__hideModalDialog();
           },
-        ],
-      };
-      this.view__showModalDialog(payload);
+        })
+      );
     }
   }
 
@@ -287,27 +278,17 @@ class AboutController {
     if (this.loggedIn) {
       this.needs__whatsNew();
     } else {
-      const payload = {
-        caption: "FIXME#2537: Attention!",
-        text:
-          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-        buttons: [
-          {
-            caption: "Accept",
-            callback: () => {
-              this.view__hideModalDialog();
-              this.needs__whatsNew();
-            },
+      this.view__showTermsDialog(
+        Immutable.fromJS({
+          acceptCallback: () => {
+            this.view__hideModalDialog();
+            this.needs__whatsNew();
           },
-          {
-            caption: "Cancel",
-            callback: () => {
-              this.view__hideModalDialog();
-            },
+          cancelCallback: () => {
+            this.view__hideModalDialog();
           },
-        ],
-      };
-      this.view__showModalDialog(payload);
+        })
+      );
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
@@ -3,12 +3,13 @@ import ngAnimate from "angular-animate";
 import compareToModule from "../../directives/compareTo.js";
 import accordionModule from "../accordion.js";
 import flexGridModule from "../flexgrid.js";
-import { attach, getIn, toAbsoluteURL } from "../../utils.js";
+import { attach, get, getIn, toAbsoluteURL } from "../../utils.js";
 import { actionCreators } from "../../actions/actions.js";
 import { ownerBaseUrl } from "config";
 import * as srefUtils from "../../sref-utils.js";
 import { getAboutSectionFromRoute } from "../../selectors/general-selectors.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
+import * as accountUtils from "../../account-utils.js";
 
 import "style/_about.scss";
 
@@ -198,6 +199,7 @@ class AboutController {
       const visibleSection = getAboutSectionFromRoute(state);
       const themeName = getIn(state, ["config", "theme", "name"]);
       return {
+        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         themeName,
         visibleSection,
         appTitle: getIn(state, ["config", "theme", "title"]),
@@ -244,14 +246,68 @@ class AboutController {
   }
 
   createWhatsAround() {
-    if (!this.processingPublish) {
+    if (this.processingPublish) {
+      console.debug("publish in process, do not take any action");
+      return;
+    }
+
+    if (this.loggedIn) {
       this.needs__whatsAround();
+    } else {
+      const payload = {
+        caption: "FIXME#2537: Attention!",
+        text:
+          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+        buttons: [
+          {
+            caption: "Accept",
+            callback: () => {
+              this.view__hideModalDialog();
+              this.needs__whatsAround();
+            },
+          },
+          {
+            caption: "Cancel",
+            callback: () => {
+              this.view__hideModalDialog();
+            },
+          },
+        ],
+      };
+      this.view__showModalDialog(payload);
     }
   }
 
   createWhatsNew() {
-    if (!this.processingPublish) {
+    if (this.processingPublish) {
+      console.debug("publish in process, do not take any action");
+      return;
+    }
+
+    if (this.loggedIn) {
       this.needs__whatsNew();
+    } else {
+      const payload = {
+        caption: "FIXME#2537: Attention!",
+        text:
+          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+        buttons: [
+          {
+            caption: "Accept",
+            callback: () => {
+              this.view__hideModalDialog();
+              this.needs__whatsNew();
+            },
+          },
+          {
+            caption: "Cancel",
+            callback: () => {
+              this.view__hideModalDialog();
+            },
+          },
+        ],
+      };
+      this.view__showModalDialog(payload);
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -73,11 +73,15 @@ function genLogoutConf() {
       this.email = "";
       this.password = "";
 
-      const logout = state => ({
-        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
-        email: state.getIn(["account", "email"]),
-        isAnonymous: state.getIn(["account", "isAnonymous"]),
-      });
+      const logout = state => {
+        const accountState = get(state, "account");
+
+        return {
+          loggedIn: accountUtils.isLoggedIn(accountState),
+          email: accountUtils.getEmail(accountState),
+          isAnonymous: accountUtils.isLoggedIn(accountState),
+        };
+      };
 
       connect2Redux(logout, actionCreators, [], this);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/account-menu.js
@@ -2,7 +2,7 @@
  * Created by ksinger on 01.09.2017.
  */
 import angular from "angular";
-import { attach } from "../utils.js";
+import { attach, get } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 
@@ -11,6 +11,8 @@ import loginFormModule from "./login-form.js";
 import loggedInMenuModule from "./logged-in-menu.js";
 
 import * as srefUtils from "../sref-utils.js";
+
+import * as accountUtils from "../account-utils.js";
 
 import "style/_login.scss";
 
@@ -72,7 +74,7 @@ function genLogoutConf() {
       this.password = "";
 
       const logout = state => ({
-        loggedIn: state.getIn(["account", "loggedIn"]),
+        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         email: state.getIn(["account", "email"]),
         isAnonymous: state.getIn(["account", "isAnonymous"]),
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.js
@@ -31,6 +31,7 @@ import labelledHrModule from "./labelled-hr.js";
 import { getHumanReadableStringFromMessage } from "../reducers/need-reducer/parse-message.js";
 import { isChatToGroup } from "../connection-utils.js";
 import submitButtonModule from "./submit-button.js";
+import * as accountUtils from "../account-utils.js";
 
 import "style/_chattextfield.scss";
 import "style/_textfield.scss";
@@ -361,7 +362,7 @@ function genComponentConf() {
           showAddMessageContent: state.getIn(["view", "showAddMessageContent"]),
           selectedDetail,
           selectedDetailComponent: selectedDetail && selectedDetail.component,
-          isLoggedIn: state.getIn(["account", "loggedIn"]),
+          isLoggedIn: accountUtils.isLoggedIn(get(state, "account")),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -2,6 +2,7 @@
  * Created by ksinger on 24.08.2015.
  */
 import angular from "angular";
+import Immutable from "immutable";
 import ngAnimate from "angular-animate";
 
 import "ng-redux";
@@ -328,35 +329,25 @@ function genComponentConf() {
             connectionUri: undefined,
           });
         } else {
-          const payload = {
-            caption: "FIXME#2537: Attention!",
-            text:
-              "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-            buttons: [
-              {
-                caption: "Accept",
-                callback: () => {
-                  this.view__hideModalDialog();
-                  this.connections__connectReactionNeed(
-                    tempConnectToNeedUri,
-                    tempDraft,
-                    persona
-                  );
-                  this.router__stateGoCurrent({
-                    useCase: undefined,
-                    connectionUri: undefined,
-                  });
-                },
+          this.view__showTermsDialog(
+            Immutable.fromJS({
+              acceptCallback: () => {
+                this.view__hideModalDialog();
+                this.connections__connectReactionNeed(
+                  tempConnectToNeedUri,
+                  tempDraft,
+                  persona
+                );
+                this.router__stateGoCurrent({
+                  useCase: undefined,
+                  connectionUri: undefined,
+                });
               },
-              {
-                caption: "Cancel",
-                callback: () => {
-                  this.view__hideModalDialog();
-                },
+              cancelCallback: () => {
+                this.view__hideModalDialog();
               },
-            ],
-          };
-          this.view__showModalDialog(payload);
+            })
+          );
         }
       } else {
         this.draftObject.useCase = get(this.useCase, "identifier");
@@ -376,27 +367,17 @@ function genComponentConf() {
         if (this.loggedIn) {
           this.needs__create(tempDraft, persona, tempDefaultNodeUri);
         } else {
-          const payload = {
-            caption: "FIXME#2537: Attention!",
-            text:
-              "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-            buttons: [
-              {
-                caption: "Accept",
-                callback: () => {
-                  this.view__hideModalDialog();
-                  this.needs__create(tempDraft, persona, tempDefaultNodeUri);
-                },
+          this.view__showTermsDialog(
+            Immutable.fromJS({
+              acceptCallback: () => {
+                this.view__hideModalDialog();
+                this.needs__create(tempDraft, persona, tempDefaultNodeUri);
               },
-              {
-                caption: "Cancel",
-                callback: () => {
-                  this.view__hideModalDialog();
-                },
+              cancelCallback: () => {
+                this.view__hideModalDialog();
               },
-            ],
-          };
-          this.view__showModalDialog(payload);
+            })
+          );
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
@@ -2,6 +2,7 @@
  * Created by ksinger on 24.08.2015.
  */
 import angular from "angular";
+import Immutable from "immutable";
 import ngAnimate from "angular-animate";
 
 import "ng-redux";
@@ -179,27 +180,17 @@ function genComponentConf() {
         if (this.loggedIn) {
           this.needs__create(tempDraft, undefined, tempDefaultNodeUri);
         } else {
-          const payload = {
-            caption: "FIXME#2537: Attention!",
-            text:
-              "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-            buttons: [
-              {
-                caption: "Accept",
-                callback: () => {
-                  this.view__hideModalDialog();
-                  this.needs__create(tempDraft, undefined, tempDefaultNodeUri);
-                },
+          this.view__showTermsDialog(
+            Immutable.fromJS({
+              acceptCallback: () => {
+                this.view__hideModalDialog();
+                this.needs__create(tempDraft, undefined, tempDefaultNodeUri);
               },
-              {
-                caption: "Cancel",
-                callback: () => {
-                  this.view__hideModalDialog();
-                },
+              cancelCallback: () => {
+                this.view__hideModalDialog();
               },
-            ],
-          };
-          this.view__showModalDialog(payload);
+            })
+          );
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
@@ -171,37 +171,35 @@ function genComponentConf() {
     publish() {
       // Post both needs
       if (!this.processingPublish) {
-        if (self.loggedIn) {
-          this.needs__create(
-            this.draftObject,
-            undefined,
-            this.$ngRedux.getState().getIn(["config", "defaultNodeUri"])
-          );
+        const tempDraft = this.draftObject;
+        const tempDefaultNodeUri = this.$ngRedux
+          .getState()
+          .getIn(["config", "defaultNodeUri"]);
+
+        if (this.loggedIn) {
+          this.needs__create(tempDraft, undefined, tempDefaultNodeUri);
         } else {
-          /*TODO: IMPLEMENT MODALDIALOG const payload = {
-           caption: "Attention!",
-           text: "Deleting the Post is irreversible, do you want to proceed?",
-           buttons: [
-           {
-           caption: "YES",
-           callback: () => {
-           this.needs__delete(this.post.get("uri"));
-           this.router__stateGoCurrent({
-           useCase: undefined,
-           postUri: undefined,
-           });
-           this.view__hideModalDialog();
-           },
-           },
-           {
-           caption: "NO",
-           callback: () => {
-           this.view__hideModalDialog();
-           },
-           },
-           ],
-           };
-           this.view__showModalDialog(payload); */
+          const payload = {
+            caption: "FIXME#2537: Attention!",
+            text:
+              "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+            buttons: [
+              {
+                caption: "Accept",
+                callback: () => {
+                  this.view__hideModalDialog();
+                  this.needs__create(tempDraft, undefined, tempDefaultNodeUri);
+                },
+              },
+              {
+                caption: "Cancel",
+                callback: () => {
+                  this.view__hideModalDialog();
+                },
+              },
+            ],
+          };
+          this.view__showModalDialog(payload);
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-search.js
@@ -6,10 +6,13 @@ import ngAnimate from "angular-animate";
 
 import "ng-redux";
 import labelledHrModule from "./labelled-hr.js";
-import { attach } from "../utils.js";
+import { attach, get } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectIsConnected } from "../selectors/general-selectors.js";
+
+import * as accountUtils from "../account-utils.js";
+import * as processUtils from "../process-utils.js";
 
 //TODO can't inject $scope with the angular2-router, preventing redux-cleanup
 const serviceDependencies = [
@@ -105,7 +108,10 @@ function genComponentConf() {
 
       const selectFromState = state => {
         return {
-          processingPublish: state.getIn(["process", "processingPublish"]),
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
+          processingPublish: processUtils.isProcessingPublish(
+            get(state, "process")
+          ),
           connectionHasBeenLost: !selectIsConnected(state),
         };
       };
@@ -165,11 +171,38 @@ function genComponentConf() {
     publish() {
       // Post both needs
       if (!this.processingPublish) {
-        this.needs__create(
-          this.draftObject,
-          undefined,
-          this.$ngRedux.getState().getIn(["config", "defaultNodeUri"])
-        );
+        if (self.loggedIn) {
+          this.needs__create(
+            this.draftObject,
+            undefined,
+            this.$ngRedux.getState().getIn(["config", "defaultNodeUri"])
+          );
+        } else {
+          /*TODO: IMPLEMENT MODALDIALOG const payload = {
+           caption: "Attention!",
+           text: "Deleting the Post is irreversible, do you want to proceed?",
+           buttons: [
+           {
+           caption: "YES",
+           callback: () => {
+           this.needs__delete(this.post.get("uri"));
+           this.router__stateGoCurrent({
+           useCase: undefined,
+           postUri: undefined,
+           });
+           this.view__hideModalDialog();
+           },
+           },
+           {
+           caption: "NO",
+           callback: () => {
+           this.view__hideModalDialog();
+           },
+           },
+           ],
+           };
+           this.view__showModalDialog(payload); */
+        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
@@ -2,11 +2,12 @@
  * Created by ksinger on 20.08.2015.
  */
 import angular from "angular";
-import { attach } from "../utils.js";
+import { attach, get } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 
 import * as srefUtils from "../sref-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 function genComponentConf() {
   let template = `
@@ -52,7 +53,7 @@ function genComponentConf() {
 
       const logout = state => {
         return {
-          loggedIn: state.getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
           email: state.getIn(["account", "email"]),
           isAnonymous: state.getIn(["account", "isAnonymous"]),
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/logged-in-menu.js
@@ -52,10 +52,12 @@ function genComponentConf() {
       this.password = "";
 
       const logout = state => {
+        const accountState = get(state, "account");
+
         return {
-          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
-          email: state.getIn(["account", "email"]),
-          isAnonymous: state.getIn(["account", "isAnonymous"]),
+          loggedIn: accountUtils.isLoggedIn(accountState),
+          email: accountUtils.getEmail(accountState),
+          isAnonymous: accountUtils.isAnonymous(accountState),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
@@ -75,17 +75,22 @@ function genLoginConf() {
       this.password = "";
       this.rememberMe = false;
 
-      const login = state => ({
-        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
-        loginError: state.getIn(["account", "loginError"]),
-        processingResendVerificationEmail: getIn(state, [
-          "process",
-          "processingResendVerificationEmail",
-        ]),
-        isNotVerified:
-          state.getIn(["account", "loginError", "code"]) ==
-          won.RESPONSECODE.USER_NOT_VERIFIED,
-      });
+      const login = state => {
+        const accountState = get(state, "account");
+        const loginError = accountUtils.getLoginError(accountState);
+        const isNotVerified =
+          get(loginError, "code") === won.RESPONSECODE.USER_NOT_VERIFIED;
+
+        return {
+          loggedIn: accountUtils.isLoggedIn(accountState),
+          loginError,
+          processingResendVerificationEmail: getIn(state, [
+            "process",
+            "processingResendVerificationEmail",
+          ]),
+          isNotVerified,
+        };
+      };
 
       connect2Redux(login, actionCreators, [], this);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/login-form.js
@@ -2,13 +2,14 @@
  * Created by ksinger on 01.09.2017.
  */
 import angular from "angular";
-import { attach, getIn } from "../utils.js";
+import { attach, get, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux, parseRestErrorMessage } from "../won-utils.js";
 import won from "../won-es6.js";
 import "angular-marked";
 
 import * as srefUtils from "../sref-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 function genLoginConf() {
   let template = `
@@ -75,7 +76,7 @@ function genLoginConf() {
       this.rememberMe = false;
 
       const login = state => ({
-        loggedIn: state.getIn(["account", "loggedIn"]),
+        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         loginError: state.getIn(["account", "loginError"]),
         processingResendVerificationEmail: getIn(state, [
           "process",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -23,6 +23,7 @@ function genComponentConf() {
              <span class="md__dialog__content__text" ng-if="self.showTerms">
                 This action requires an account. If you want to proceed, we will create an anonymous account for you.
                 <br/>
+                <br/>
                 By clicking 'Yes', you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'aboutSection': 'aboutTermsOfService'}) }}">Terms Of Service(ToS)</a> and anonymous account will be created. Clicking 'No' will just cancel the action.
               </span>
           </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -4,7 +4,7 @@
 
 import angular from "angular";
 import { actionCreators } from "../actions/actions.js";
-import { attach } from "../utils.js";
+import { attach, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 
 import "style/_modal-dialog.scss";
@@ -17,7 +17,9 @@ function genComponentConf() {
              <span class="md__dialog__header__caption">{{self.modalDialogCaption}}</span>
           </div>
           <div class="md__dialog__content">
-             <span class="md__dialog__content__text">{{self.modalDialogText}}</span>
+             <span class="md__dialog__content__text" ng-if="!self.showTerms">{{self.modalDialogText}}</span>
+             <div class="md__dialog__content__terms" ng-if="self.showTerms" ng-include="self.tosTemplate"></div>
+             <div class="md__dialog__content__privacy" ng-if="self.showTerms" ng-include="self.privacyPolicyTemplate"></div>
           </div>
           <div class="md__dialog__footer">
              <button
@@ -40,9 +42,24 @@ function genComponentConf() {
         const modalDialogText = modalDialog && modalDialog.get("text");
         const modalDialogButtons = modalDialog && modalDialog.get("buttons");
 
+        const showTerms = modalDialog && modalDialog.get("showTerms");
+        const themeName =
+          showTerms && getIn(state, ["config", "theme", "name"]);
         return {
           modalDialogCaption,
           modalDialogText,
+          showTerms,
+          tosTemplate:
+            themeName &&
+            "./skin/" +
+              themeName +
+              "/" +
+              getIn(state, ["config", "theme", "tosTemplate"]),
+          privacyPolicyTemplate:
+            "./skin/" +
+            themeName +
+            "/" +
+            getIn(state, ["config", "theme", "privacyPolicyTemplate"]),
           modalDialogButtons:
             modalDialogButtons && modalDialogButtons.toArray(),
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -4,22 +4,30 @@
 
 import angular from "angular";
 import { actionCreators } from "../actions/actions.js";
-import { attach, getIn } from "../utils.js";
+import { attach } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
+import * as srefUtils from "../sref-utils.js";
 
 import "style/_modal-dialog.scss";
 
-const serviceDependencies = ["$scope", "$ngRedux", "$element"];
+const serviceDependencies = ["$scope", "$ngRedux", "$element", "$state"];
 function genComponentConf() {
   let template = `
       <div class="md__dialog">
           <div class="md__dialog__header">
-             <span class="md__dialog__header__caption">{{self.modalDialogCaption}}</span>
+             <span class="md__dialog__header__caption" ng-if="!self.showTerms">{{self.modalDialogCaption}}</span>
+             <span class="md__dialog__header__caption" ng-if="self.showTerms">Attention</span>
           </div>
           <div class="md__dialog__content">
              <span class="md__dialog__content__text" ng-if="!self.showTerms">{{self.modalDialogText}}</span>
-             <div class="md__dialog__content__terms" ng-if="self.showTerms" ng-include="self.tosTemplate"></div>
-             <div class="md__dialog__content__privacy" ng-if="self.showTerms" ng-include="self.privacyPolicyTemplate"></div>
+             <span class="md__dialog__content__text" ng-if="self.showTerms">
+                You are about to create an anoymous Account.
+                <br/>
+                This is only possible if you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'#': 'aboutTermsOfService'}) }}">Terms Of Service</a>.
+                <br/>
+                <br/>
+                Do you want to want to proceed and thus also accept the Terms of Service?
+              </span>
           </div>
           <div class="md__dialog__footer">
              <button
@@ -35,6 +43,7 @@ function genComponentConf() {
   class Controller {
     constructor() {
       attach(this, serviceDependencies, arguments);
+      Object.assign(this, srefUtils); // bind srefUtils to scope
 
       const selectFromState = state => {
         const modalDialog = state.getIn(["view", "modalDialog"]);
@@ -43,23 +52,10 @@ function genComponentConf() {
         const modalDialogButtons = modalDialog && modalDialog.get("buttons");
 
         const showTerms = modalDialog && modalDialog.get("showTerms");
-        const themeName =
-          showTerms && getIn(state, ["config", "theme", "name"]);
         return {
           modalDialogCaption,
           modalDialogText,
           showTerms,
-          tosTemplate:
-            themeName &&
-            "./skin/" +
-              themeName +
-              "/" +
-              getIn(state, ["config", "theme", "tosTemplate"]),
-          privacyPolicyTemplate:
-            "./skin/" +
-            themeName +
-            "/" +
-            getIn(state, ["config", "theme", "privacyPolicyTemplate"]),
           modalDialogButtons:
             modalDialogButtons && modalDialogButtons.toArray(),
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -23,7 +23,7 @@ function genComponentConf() {
              <span class="md__dialog__content__text" ng-if="self.showTerms">
                 You are about to create an anoymous Account.
                 <br/>
-                This is only possible if you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'#': 'aboutTermsOfService'}) }}">Terms Of Service</a>.
+                This is only possible if you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'aboutSection': 'aboutTermsOfService'}) }}">Terms Of Service</a>.
                 <br/>
                 <br/>
                 Do you want to want to proceed and thus also accept the Terms of Service?

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/modal-dialog.js
@@ -16,17 +16,14 @@ function genComponentConf() {
       <div class="md__dialog">
           <div class="md__dialog__header">
              <span class="md__dialog__header__caption" ng-if="!self.showTerms">{{self.modalDialogCaption}}</span>
-             <span class="md__dialog__header__caption" ng-if="self.showTerms">Attention</span>
+             <span class="md__dialog__header__caption" ng-if="self.showTerms">Important Note</span>
           </div>
           <div class="md__dialog__content">
              <span class="md__dialog__content__text" ng-if="!self.showTerms">{{self.modalDialogText}}</span>
              <span class="md__dialog__content__text" ng-if="self.showTerms">
-                You are about to create an anoymous Account.
+                This action requires an account. If you want to proceed, we will create an anonymous account for you.
                 <br/>
-                This is only possible if you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'aboutSection': 'aboutTermsOfService'}) }}">Terms Of Service</a>.
-                <br/>
-                <br/>
-                Do you want to want to proceed and thus also accept the Terms of Service?
+                By clicking 'Yes', you accept the <a target="_blank" href="{{ self.absHRef(self.$state, 'about', {'aboutSection': 'aboutTermsOfService'}) }}">Terms Of Service(ToS)</a> and anonymous account will be created. Clicking 'No' will just cancel the action.
               </span>
           </div>
           <div class="md__dialog__footer">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/publish-button.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/publish-button.js
@@ -5,6 +5,8 @@ import {
   getOwnedPersonas,
   currentSkin,
 } from "../selectors/general-selectors.js";
+import * as accountUtils from "../account-utils.js";
+import { get } from "../utils.js";
 
 function genComponentConf($ngRedux) {
   return {
@@ -30,7 +32,9 @@ function genComponentConf($ngRedux) {
         elmApp.ports.publishIn.send({
           draftValid: scope.isValid ? true : false,
           showPersonas: scope.showPersonas ? true : false,
-          loggedIn: $ngRedux.getState().getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(
+            get($ngRedux.getState(), "account")
+          ),
         });
       };
 
@@ -48,7 +52,7 @@ function genComponentConf($ngRedux) {
       const disconnectOptions = $ngRedux.connect(state => {
         return {
           personas: getOwnedPersonas(state),
-          loggedIn: state.getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         };
       })(state => {
         sendNewValues();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -1,4 +1,5 @@
 import angular from "angular";
+import Immutable from "immutable";
 import "ng-redux";
 import postContentModule from "./post-content.js";
 import postMenuModule from "./post-menu.js";
@@ -134,35 +135,25 @@ function genComponentConf() {
           );
         }
       } else {
-        const payload = {
-          caption: "FIXME#2537: Attention!",
-          text:
-            "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-          buttons: [
-            {
-              caption: "Accept",
-              callback: () => {
-                this.view__hideModalDialog();
-                this.router__stateGoResetParams("connections");
+        this.view__showTermsDialog(
+          Immutable.fromJS({
+            acceptCallback: () => {
+              this.view__hideModalDialog();
+              this.router__stateGoResetParams("connections");
 
-                if (tempPostUriToConnectTo) {
-                  this.connections__connectAdHoc(
-                    tempPostUriToConnectTo,
-                    message,
-                    persona
-                  );
-                }
-              },
+              if (tempPostUriToConnectTo) {
+                this.connections__connectAdHoc(
+                  tempPostUriToConnectTo,
+                  message,
+                  persona
+                );
+              }
             },
-            {
-              caption: "Cancel",
-              callback: () => {
-                this.view__hideModalDialog();
-              },
+            cancelCallback: () => {
+              this.view__hideModalDialog();
             },
-          ],
-        };
-        this.view__showModalDialog(payload);
+          })
+        );
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/settings/settings-wrapper.js
@@ -6,7 +6,8 @@ import {
   getOwnedPersonas,
   currentSkin,
 } from "../../selectors/general-selectors.js";
-import { getIn } from "../../utils";
+import { get } from "../../utils";
+import * as accountUtils from "../../account-utils.js";
 
 function genComponentConf($ngRedux) {
   return {
@@ -35,8 +36,9 @@ function genComponentConf($ngRedux) {
       });
 
       elmApp.ports.getVerified.subscribe(() => {
-        const isVerified =
-          getIn($ngRedux.getState(), ["account", "emailVerified"]) || false;
+        const isVerified = accountUtils.isEmailVerified(
+          get($ngRedux.getState(), "account")
+        );
         elmApp.ports.isVerified.send(isVerified);
       });
 
@@ -48,7 +50,7 @@ function genComponentConf($ngRedux) {
       const disconnect = $ngRedux.connect(state => {
         return {
           personas: getOwnedPersonas(state),
-          isVerified: getIn(state, ["account", "emailVerified"]) || false,
+          isVerified: accountUtils.isEmailVerified(get(state, "account")),
         };
       })(state => {
         if (state.personas) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.html
@@ -49,7 +49,7 @@
             </div>
             <div>
                 <input id="acceptToS" ng-model="self.acceptToS" type="checkbox" required/>
-                <label for="acceptToS">I accept the <a href="{{ self.absHRef(self.$state, 'about', {'#': 'aboutTermsOfService'}) }}">Terms Of Service</a></label>
+                <label for="acceptToS">I accept the <a href="{{ self.absHRef(self.$state, 'about', {'aboutSection': 'aboutTermsOfService'}) }}">Terms Of Service</a></label>
             </div>
         </div>
         <button id="signup" class="won-button--filled red" ng-if="self.isAnonymous" ng-disabled="registerForm.$invalid" ng-click="::self.account__transfer({email: self.email, password: self.password, privateId: self.privateId, rememberMe: self.rememberMe})">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -32,7 +32,7 @@ class SignupController {
       const accountState = get(state, "account");
       return {
         loggedIn: accountUtils.isLoggedIn(accountState),
-        registerError: state.getIn(["account", "registerError"]),
+        registerError: accountUtils.getRegisterError(accountState),
         isAnonymous: accountUtils.isAnonymous(accountState),
         privateId: accountUtils.getPrivateId(accountState),
         showModalDialog: state.getIn(["view", "showModalDialog"]),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -3,13 +3,14 @@
  */
 import angular from "angular";
 import ngAnimate from "angular-animate";
-import { attach } from "../../utils.js";
+import { attach, get } from "../../utils.js";
 import { actionCreators } from "../../actions/actions.js";
 
 import signupTitleBarModule from "../signup-title-bar.js";
 import labelledHrModule from "../labelled-hr.js";
 
 import * as srefUtils from "../../sref-utils.js";
+import * as accountUtils from "../../account-utils.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
 
 import "style/_signup.scss";
@@ -29,7 +30,7 @@ class SignupController {
 
     const select = state => {
       return {
-        loggedIn: state.getIn(["account", "loggedIn"]),
+        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         registerError: state.getIn(["account", "registerError"]),
         isAnonymous: state.getIn(["account", "isAnonymous"]),
         privateId: state.getIn(["account", "privateId"]),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -29,10 +29,11 @@ class SignupController {
     Object.assign(this, srefUtils); // bind srefUtils to scope
 
     const select = state => {
+      const accountState = get(state, "account");
       return {
-        loggedIn: accountUtils.isLoggedIn(get(state, "account")),
+        loggedIn: accountUtils.isLoggedIn(accountState),
         registerError: state.getIn(["account", "registerError"]),
-        isAnonymous: state.getIn(["account", "isAnonymous"]),
+        isAnonymous: accountUtils.isAnonymous(accountState),
         privateId: state.getIn(["account", "privateId"]),
         showModalDialog: state.getIn(["view", "showModalDialog"]),
         showSlideIns:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/signup/signup.js
@@ -34,7 +34,7 @@ class SignupController {
         loggedIn: accountUtils.isLoggedIn(accountState),
         registerError: state.getIn(["account", "registerError"]),
         isAnonymous: accountUtils.isAnonymous(accountState),
-        privateId: state.getIn(["account", "privateId"]),
+        privateId: accountUtils.getPrivateId(accountState),
         showModalDialog: state.getIn(["view", "showModalDialog"]),
         showSlideIns:
           viewSelectors.hasSlideIns(state) && viewSelectors.showSlideIns(state),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -245,8 +245,9 @@ function genSlideInConf() {
         const path = "#!/connections" + `?privateId=${privateId}`;
         const anonymousLink = toAbsoluteURL(ownerBaseUrl).toString() + path;
 
-        const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
-        const isAnonymous = getIn(state, ["account", "isAnonymous"]);
+        const accountState = get(state, "account");
+        const isLoggedIn = accountUtils.isLoggedIn(accountState);
+        const isAnonymous = accountUtils.isAnonymous(accountState);
         const isEmailVerified = getIn(state, ["account", "emailVerified"]);
         const isTermsOfServiceAccepted = getIn(state, [
           "account",
@@ -288,7 +289,7 @@ function genSlideInConf() {
           ),
           isTermsOfServiceAccepted,
           isLoggedIn,
-          email: getIn(state, ["account", "email"]),
+          email: accountUtils.getEmail(accountState),
           isAnonymous,
           privateId,
           connectionHasBeenLost,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -249,6 +249,9 @@ function genSlideInConf() {
         const isLoggedIn = accountUtils.isLoggedIn(accountState);
         const isAnonymous = accountUtils.isAnonymous(accountState);
         const isEmailVerified = accountUtils.isEmailVerified(accountState);
+        const emailVerificationError = accountUtils.getEmailVerificationError(
+          accountState
+        );
         const isTermsOfServiceAccepted = getIn(state, [
           "account",
           "acceptedTermsOfService",
@@ -271,10 +274,10 @@ function genSlideInConf() {
         return {
           verificationToken,
           isEmailVerified,
-          emailVerificationError: getIn(state, [
-            "account",
-            "emailVerificationError",
-          ]),
+          emailVerificationError,
+          isAlreadyVerifiedError:
+            get(emailVerificationError, "code") ===
+            won.RESPONSECODE.TOKEN_RESEND_FAILED_ALREADY_VERIFIED,
           isProcessingVerifyEmailAddress: processSelectors.isProcessingVerifyEmailAddress(
             state
           ),
@@ -294,9 +297,6 @@ function genSlideInConf() {
           privateId,
           connectionHasBeenLost,
           reconnecting: getIn(state, ["messages", "reconnecting"]),
-          isAlreadyVerifiedError:
-            getIn(state, ["account", "emailVerificationError", "code"]) ==
-            won.RESPONSECODE.TOKEN_RESEND_FAILED_ALREADY_VERIFIED,
           isAnonymousSlideInExpanded,
           showAnonymousSlideInEmailInput,
           anonymousLinkSent,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -5,7 +5,7 @@ import won from "../won-es6.js";
 import angular from "angular";
 import ngAnimate from "angular-animate";
 import dropdownModule from "./covering-dropdown.js";
-import { attach, delay, getIn, toAbsoluteURL } from "../utils.js";
+import { attach, delay, get, getIn, toAbsoluteURL } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux, parseRestErrorMessage } from "../won-utils.js";
 import { ownerBaseUrl } from "config";
@@ -14,6 +14,7 @@ import * as viewSelectors from "../selectors/view-selectors.js";
 import * as processSelectors from "../selectors/process-selectors.js";
 
 import * as srefUtils from "../sref-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 import "style/_slidein.scss";
 
@@ -244,7 +245,7 @@ function genSlideInConf() {
         const path = "#!/connections" + `?privateId=${privateId}`;
         const anonymousLink = toAbsoluteURL(ownerBaseUrl).toString() + path;
 
-        const isLoggedIn = getIn(state, ["account", "loggedIn"]);
+        const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
         const isAnonymous = getIn(state, ["account", "isAnonymous"]);
         const isEmailVerified = getIn(state, ["account", "emailVerified"]);
         const isTermsOfServiceAccepted = getIn(state, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -240,12 +240,12 @@ function genSlideInConf() {
       const selectFromState = state => {
         const verificationToken = getVerificationTokenFromRoute(state);
 
-        const privateId = getIn(state, ["account", "privateId"]);
-
-        const path = "#!/connections" + `?privateId=${privateId}`;
-        const anonymousLink = toAbsoluteURL(ownerBaseUrl).toString() + path;
-
         const accountState = get(state, "account");
+
+        const privateId = accountUtils.getPrivateId(accountState);
+        const path = "#!/connections" + `?privateId=${privateId}`;
+
+        const anonymousLink = toAbsoluteURL(ownerBaseUrl).toString() + path;
         const isLoggedIn = accountUtils.isLoggedIn(accountState);
         const isAnonymous = accountUtils.isAnonymous(accountState);
         const isEmailVerified = accountUtils.isEmailVerified(accountState);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -248,7 +248,7 @@ function genSlideInConf() {
         const accountState = get(state, "account");
         const isLoggedIn = accountUtils.isLoggedIn(accountState);
         const isAnonymous = accountUtils.isAnonymous(accountState);
-        const isEmailVerified = getIn(state, ["account", "emailVerified"]);
+        const isEmailVerified = accountUtils.isEmailVerified(accountState);
         const isTermsOfServiceAccepted = getIn(state, [
           "account",
           "acceptedTermsOfService",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/slide-in.js
@@ -252,10 +252,9 @@ function genSlideInConf() {
         const emailVerificationError = accountUtils.getEmailVerificationError(
           accountState
         );
-        const isTermsOfServiceAccepted = getIn(state, [
-          "account",
-          "acceptedTermsOfService",
-        ]);
+        const isTermsOfServiceAccepted = accountUtils.isTermsOfServiceAccepted(
+          accountState
+        );
 
         const connectionHasBeenLost = getIn(state, [
           "messages",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/submit-button.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/submit-button.js
@@ -5,6 +5,8 @@ import {
   getOwnedPersonas,
   currentSkin,
 } from "../selectors/general-selectors.js";
+import { get } from "../utils.js";
+import * as accountUtils from "../account-utils.js";
 
 function genComponentConf($ngRedux) {
   return {
@@ -30,7 +32,9 @@ function genComponentConf($ngRedux) {
       scope.$watch("isValid", newValue => {
         elmApp.ports.publishIn.send({
           isValid: newValue ? true : false,
-          loggedIn: $ngRedux.getState().getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(
+            get($ngRedux.getState(), "account")
+          ),
           showPersonas: scope.showPersonas ? true : false,
           label: scope.label ? scope.label : "Submit",
         });
@@ -39,7 +43,9 @@ function genComponentConf($ngRedux) {
       scope.$watch("showPersonas", newValue => {
         elmApp.ports.publishIn.send({
           isValid: scope.isValid ? true : false,
-          loggedIn: $ngRedux.getState().getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(
+            get($ngRedux.getState(), "account")
+          ),
           showPersonas: newValue ? true : false,
           label: scope.label ? scope.label : "Submit",
         });
@@ -47,7 +53,7 @@ function genComponentConf($ngRedux) {
 
       elmApp.ports.publishIn.send({
         isValid: scope.isValid ? true : false,
-        loggedIn: $ngRedux.getState().getIn(["account", "loggedIn"]),
+        loggedIn: accountUtils.isLoggedIn(get($ngRedux.getState(), "account")),
         showPersonas: scope.showPersonas ? true : false,
         label: scope.label ? scope.label : "Submit",
       });
@@ -60,7 +66,7 @@ function genComponentConf($ngRedux) {
       const disconnectOptions = $ngRedux.connect(state => {
         return {
           personas: getOwnedPersonas(state),
-          loggedIn: state.getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
         };
       })(state => {
         elmApp.ports.publishIn.send({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -80,12 +80,13 @@ function genTopnavConf() {
 
       const selectFromState = state => {
         const currentRoute = getIn(state, ["router", "currentState", "name"]);
+        const accountState = get(state, "account");
 
         return {
           themeName: getIn(state, ["config", "theme", "name"]),
           appTitle: getIn(state, ["config", "theme", "title"]),
-          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
-          isAnonymous: state.getIn(["account", "isAnonymous"]),
+          loggedIn: accountUtils.isLoggedIn(accountState),
+          isAnonymous: accountUtils.isAnonymous(accountState),
           isSignUpView: currentRoute === "signup",
           showLoadingIndicator: isLoading(state),
           showSlideInIndicator:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.js
@@ -5,13 +5,14 @@ import angular from "angular";
 import ngAnimate from "angular-animate";
 import dropdownModule from "./covering-dropdown.js";
 import accountMenuModule from "./account-menu.js";
-import { attach, getIn } from "../utils.js";
+import { attach, get, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 import { isLoading } from "../selectors/process-selectors.js";
 import * as viewSelectors from "../selectors/view-selectors.js";
 
 import * as srefUtils from "../sref-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 import "style/_responsiveness-utils.scss";
 import "style/_topnav.scss";
@@ -83,7 +84,7 @@ function genTopnavConf() {
         return {
           themeName: getIn(state, ["config", "theme", "name"]),
           appTitle: getIn(state, ["config", "theme", "title"]),
-          loggedIn: state.getIn(["account", "loggedIn"]),
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
           isAnonymous: state.getIn(["account", "isAnonymous"]),
           isSignUpView: currentRoute === "signup",
           showLoadingIndicator: isLoading(state),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -2,6 +2,7 @@
  * Created by quasarchimaere on 03.07.2018.
  */
 import angular from "angular";
+import Immutable from "immutable";
 import ngAnimate from "angular-animate";
 import labelledHrModule from "./labelled-hr.js";
 
@@ -165,27 +166,17 @@ function genComponentConf() {
       if (this.loggedIn) {
         this.needs__whatsAround();
       } else {
-        const payload = {
-          caption: "FIXME#2537: Attention!",
-          text:
-            "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-          buttons: [
-            {
-              caption: "Accept",
-              callback: () => {
-                this.view__hideModalDialog();
-                this.needs__whatsAround();
-              },
+        this.view__showTermsDialog(
+          Immutable.fromJS({
+            acceptCallback: () => {
+              this.view__hideModalDialog();
+              this.needs__whatsAround();
             },
-            {
-              caption: "Cancel",
-              callback: () => {
-                this.view__hideModalDialog();
-              },
+            cancelCallback: () => {
+              this.view__hideModalDialog();
             },
-          ],
-        };
-        this.view__showModalDialog(payload);
+          })
+        );
       }
     }
 
@@ -198,27 +189,17 @@ function genComponentConf() {
       if (this.loggedIn) {
         this.needs__whatsNew();
       } else {
-        const payload = {
-          caption: "FIXME#2537: Attention!",
-          text:
-            "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
-          buttons: [
-            {
-              caption: "Accept",
-              callback: () => {
-                this.view__hideModalDialog();
-                this.needs__whatsNew();
-              },
+        this.view__showTermsDialog(
+          Immutable.fromJS({
+            acceptCallback: () => {
+              this.view__hideModalDialog();
+              this.needs__whatsNew();
             },
-            {
-              caption: "Cancel",
-              callback: () => {
-                this.view__hideModalDialog();
-              },
+            cancelCallback: () => {
+              this.view__hideModalDialog();
             },
-          ],
-        };
-        this.view__showModalDialog(payload);
+          })
+        );
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -6,7 +6,7 @@ import ngAnimate from "angular-animate";
 import labelledHrModule from "./labelled-hr.js";
 
 import "ng-redux";
-import { attach } from "../utils.js";
+import { attach, get } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect2Redux } from "../won-utils.js";
 import {
@@ -14,6 +14,7 @@ import {
   getUseCaseGroupFromRoute,
 } from "../selectors/general-selectors.js";
 import * as useCaseUtils from "../usecase-utils.js";
+import * as accountUtils from "../account-utils.js";
 
 import "style/_usecase-picker.scss";
 
@@ -137,6 +138,7 @@ function genComponentConf() {
         const showGroupsThreshold = 1; // only show groups with more than 1 use case(s) as groups
 
         return {
+          loggedIn: accountUtils.isLoggedIn(get(state, "account")),
           showAll: getUseCaseGroupFromRoute(state) === "all",
           processingPublish: state.getIn(["process", "processingPublish"]),
           connectionHasBeenLost: !selectIsConnected(state),
@@ -155,14 +157,68 @@ function genComponentConf() {
     // redirects start
 
     createWhatsAround() {
-      if (!this.processingPublish) {
+      if (this.processingPublish) {
+        console.debug("publish in process, do not take any action");
+        return;
+      }
+
+      if (this.loggedIn) {
         this.needs__whatsAround();
+      } else {
+        const payload = {
+          caption: "FIXME#2537: Attention!",
+          text:
+            "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+          buttons: [
+            {
+              caption: "Accept",
+              callback: () => {
+                this.view__hideModalDialog();
+                this.needs__whatsAround();
+              },
+            },
+            {
+              caption: "Cancel",
+              callback: () => {
+                this.view__hideModalDialog();
+              },
+            },
+          ],
+        };
+        this.view__showModalDialog(payload);
       }
     }
 
     createWhatsNew() {
-      if (!this.processingPublish) {
+      if (this.processingPublish) {
+        console.debug("publish in process, do not take any action");
+        return;
+      }
+
+      if (this.loggedIn) {
         this.needs__whatsNew();
+      } else {
+        const payload = {
+          caption: "FIXME#2537: Attention!",
+          text:
+            "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+          buttons: [
+            {
+              caption: "Accept",
+              callback: () => {
+                this.view__hideModalDialog();
+                this.needs__whatsNew();
+              },
+            },
+            {
+              caption: "Cancel",
+              callback: () => {
+                this.view__hideModalDialog();
+              },
+            },
+          ],
+        };
+        this.view__showModalDialog(payload);
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
@@ -27,6 +27,15 @@ export function isProcessingLogin(process) {
 }
 
 /**
+ * Return true if processingLoginForEmail is currently active
+ * @param process (full process from state)
+ * @returns {*}
+ */
+export function isProcessingLoginForEmail(process) {
+  return get(process, "processingLoginForEmail");
+}
+
+/**
  * Return true if processingLogout is currently active
  * @param process (full process from state)
  * @returns {*}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -101,15 +101,14 @@ export default function(viewState = initialState, action = {}) {
       const cancelCallback = get(payload, "cancelCallback");
 
       const termsDialog = Immutable.fromJS({
-        caption: "FIXME#2537: Attention!",
         showTerms: true,
         buttons: [
           {
-            caption: "Accept",
+            caption: "Yes",
             callback: acceptCallback,
           },
           {
-            caption: "Cancel",
+            caption: "No",
             callback: cancelCallback,
           },
         ],

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -3,7 +3,7 @@
  */
 import { actionTypes } from "../actions/actions.js";
 import Immutable from "immutable";
-import { getIn } from "../utils.js";
+import { get, getIn } from "../utils.js";
 
 const initialState = Immutable.fromJS({
   showRdf: false,
@@ -93,6 +93,32 @@ export default function(viewState = initialState, action = {}) {
 
     case actionTypes.view.removeAddMessageContent:
       return viewState.set("selectedAddMessageContent", undefined);
+
+    case actionTypes.view.showTermsDialog: {
+      const payload = Immutable.fromJS(action.payload);
+
+      const acceptCallback = get(payload, "acceptCallback");
+      const cancelCallback = get(payload, "cancelCallback");
+
+      const termsDialog = Immutable.fromJS({
+        caption: "FIXME#2537: Attention!",
+        text:
+          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+        buttons: [
+          {
+            caption: "Accept",
+            callback: acceptCallback,
+          },
+          {
+            caption: "Cancel",
+            callback: cancelCallback,
+          },
+        ],
+      });
+      return viewState
+        .set("showModalDialog", true)
+        .set("modalDialog", termsDialog);
+    }
 
     case actionTypes.view.showModalDialog: {
       const modalDialog = Immutable.fromJS(action.payload);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -102,8 +102,7 @@ export default function(viewState = initialState, action = {}) {
 
       const termsDialog = Immutable.fromJS({
         caption: "FIXME#2537: Attention!",
-        text:
-          "You are about to create an anonymous Account, if you proceed you accept the Terms of Service.",
+        showTerms: true,
         buttons: [
           {
             caption: "Accept",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/view-reducer.js
@@ -104,11 +104,11 @@ export default function(viewState = initialState, action = {}) {
         showTerms: true,
         buttons: [
           {
-            caption: "Yes",
+            caption: "Yes, I accept ToS",
             callback: acceptCallback,
           },
           {
-            caption: "No",
+            caption: "No, cancel",
             callback: cancelCallback,
           },
         ],

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -61,7 +61,9 @@ export function showSlideInAnonymous(state) {
 }
 
 export function showSlideInDisclaimer(state) {
-  const isDisclaimerAccepted = getIn(state, ["account", "acceptedDisclaimer"]);
+  const isDisclaimerAccepted = accountUtils.isDisclaimerAccepted(
+    get(state, "account")
+  );
 
   return !showSlideInConnectionLost(state) && !isDisclaimerAccepted;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -3,6 +3,7 @@
  */
 import { get, getIn } from "../utils.js";
 import * as viewUtils from "../view-utils.js";
+import * as accountUtils from "../account-utils.js";
 import { getVerificationTokenFromRoute } from "./general-selectors.js";
 
 /**
@@ -66,7 +67,7 @@ export function showSlideInDisclaimer(state) {
 }
 
 export function showSlideInTermsOfService(state) {
-  const isLoggedIn = getIn(state, ["account", "loggedIn"]);
+  const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
   const isTermsOfServiceAccepted = getIn(state, [
     "account",
     "acceptedTermsOfService",
@@ -79,7 +80,7 @@ export function showSlideInTermsOfService(state) {
 
 export function showSlideInEmailVerification(state) {
   const verificationToken = getVerificationTokenFromRoute(state);
-  const isLoggedIn = getIn(state, ["account", "loggedIn"]);
+  const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
   const isAnonymous = getIn(state, ["account", "isAnonymous"]);
   const isEmailVerified = getIn(state, ["account", "emailVerified"]);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -83,7 +83,7 @@ export function showSlideInEmailVerification(state) {
   const accountState = get(state, "account");
   const isLoggedIn = accountUtils.isLoggedIn(accountState);
   const isAnonymous = accountUtils.isAnonymous(accountState);
-  const isEmailVerified = getIn(state, ["account", "emailVerified"]);
+  const isEmailVerified = accountUtils.isEmailVerified(accountState);
 
   return (
     !showSlideInConnectionLost(state) &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -69,11 +69,11 @@ export function showSlideInDisclaimer(state) {
 }
 
 export function showSlideInTermsOfService(state) {
-  const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
-  const isTermsOfServiceAccepted = getIn(state, [
-    "account",
-    "acceptedTermsOfService",
-  ]);
+  const accountState = get(state, "account");
+  const isLoggedIn = accountUtils.isLoggedIn(accountState);
+  const isTermsOfServiceAccepted = accountUtils.isTermsOfServiceAccepted(
+    accountState
+  );
 
   return (
     isLoggedIn && !showSlideInConnectionLost(state) && !isTermsOfServiceAccepted

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/view-selectors.js
@@ -40,7 +40,7 @@ export function showAnonymousSlideInEmailInput(state) {
 }
 
 export function showSlideInAnonymousSuccess(state) {
-  const isAnonymous = getIn(state, ["account", "isAnonymous"]);
+  const isAnonymous = accountUtils.isAnonymous(get(state, "account"));
 
   return (
     !showSlideInConnectionLost(state) &&
@@ -50,7 +50,7 @@ export function showSlideInAnonymousSuccess(state) {
 }
 
 export function showSlideInAnonymous(state) {
-  const isAnonymous = getIn(state, ["account", "isAnonymous"]);
+  const isAnonymous = accountUtils.isAnonymous(get(state, "account"));
 
   return (
     !showSlideInConnectionLost(state) &&
@@ -80,8 +80,9 @@ export function showSlideInTermsOfService(state) {
 
 export function showSlideInEmailVerification(state) {
   const verificationToken = getVerificationTokenFromRoute(state);
-  const isLoggedIn = accountUtils.isLoggedIn(get(state, "account"));
-  const isAnonymous = getIn(state, ["account", "isAnonymous"]);
+  const accountState = get(state, "account");
+  const isLoggedIn = accountUtils.isLoggedIn(accountState);
+  const isAnonymous = accountUtils.isAnonymous(accountState);
   const isEmailVerified = getIn(state, ["account", "emailVerified"]);
 
   return (

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/tos.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/tos.html
@@ -1,1 +1,13 @@
-<p>TODO This is where your terms of service should go</p>
+<h2>Terms of Service</h2>
+
+<p>
+    This is a demonstrator service for the <a href="https://github.com/researchstudio-sat/webofneeds">Web of Needs technology</a>.
+</p>
+
+<p>
+    Use the service free of charge, don't post anything offensive or illegal. We do not give any guarantee as to the proper functioning of the service. We may remove any content permanently without prior warning.
+</p>
+
+<p>
+    To learn what happens to your data, please refer to our Privacy Policy.
+</p>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_modal-dialog.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_modal-dialog.scss
@@ -1,41 +1,102 @@
 @import "won-config";
 @import "animate";
 
-won-modal-dialog {
-  @include appearAnimation(0.5s);
-  display: flex;
-  width: 100%;
-  height: 100%;
-  z-index: 10000;
+@media (max-width: $responsivenessBreakPoint) {
+  won-modal-dialog {
+    @include appearAnimation(0.5s);
+    display: flex;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
 
-  align-items: center;
-  justify-content: center;
-  align-content: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  background: rgba(0, 0, 0, 0.5);
+    align-items: center;
+    justify-content: center;
+    align-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.5);
 
-  .md__dialog {
-    background: white;
-    display: grid;
-    grid-row-gap: 0.5rem;
-    padding: 0.5rem;
-
-    &__header {
-      &__caption {
-      }
-    }
-
-    &__content {
-      &__text {
-      }
-    }
-
-    &__footer {
+    .md__dialog {
+      max-height: 75vh;
+      box-sizing: border-box;
+      background: white;
       display: grid;
-      grid-auto-flow: column;
-      grid-column-gap: 0.5rem;
+      grid-row-gap: 0.5rem;
+      padding: 0.5rem;
+      grid-template-areas: "modal_header" "modal_content" "modal_footer";
+      grid-template-rows: min-content 1fr min-content;
+
+      &__header {
+        grid-area: modal_header;
+        &__caption {
+        }
+      }
+
+      &__content {
+        grid-area: modal_content;
+        overflow-y: auto;
+        &__text {
+        }
+      }
+
+      &__footer {
+        grid-area: modal_footer;
+        display: grid;
+        grid-auto-flow: column;
+        grid-column-gap: 0.5rem;
+      }
+    }
+  }
+}
+
+@media (min-width: $responsivenessBreakPoint) {
+  won-modal-dialog {
+    @include appearAnimation(0.5s);
+    display: flex;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
+
+    align-items: center;
+    justify-content: center;
+    align-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.5);
+
+    .md__dialog {
+      box-sizing: border-box;
+      max-width: $maxContentWidth/2;
+      min-width: $maxContentWidth/2;
+      max-height: 75vh;
+      background: white;
+      display: grid;
+      grid-row-gap: 0.5rem;
+      padding: 0.5rem;
+      grid-template-areas: "modal_header" "modal_content" "modal_footer";
+      grid-template-rows: min-content 1fr min-content;
+
+      &__header {
+        grid-area: modal_header;
+        &__caption {
+        }
+      }
+
+      &__content {
+        grid-area: modal_content;
+        overflow-y: auto;
+        &__text {
+        }
+      }
+
+      &__footer {
+        grid-area: modal_footer;
+        display: grid;
+        grid-auto-flow: column;
+        grid-column-gap: 0.5rem;
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a modal-dialog before executing the following actions in the following places (this is also how/where to test) when not logged in:
- publish in create-post
- publish in create-search
- createWhatsNew in usecase-picker
- createWhatsAround in usecase-picker
- createWhatsNew in about page
- createWhatsAround in about page
- Send (AdHoc)-Request from visitor view.

All these actions display a "Attention- if you proceed you accept the tos"-dialog now,
no just closes the dialog
yes continues with corresponding action

fixes #2537 

we could implement a login dialog as another option within this new dialog -> this is a different issue though (see #2833)

If there are issues with the wording of the dialog please change directly within this pr:
see `modal-dialog.js` component
