### PR TITLE
Fix find interests/plans  UseCases #2774

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -69,7 +69,7 @@ function genComponentConf() {
                 <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
             </button>
             <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasEnabledUseCases"></won-labelled-hr>
-            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;
+            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;"
                     ng-if="self.hasEnabledUseCases"
                     ng-repeat="ucIdentifier in self.enabledUseCasesArray"
                     ng-click="self.router__stateGoCurrent({useCase: ucIdentifier, useCaseGroup: undefined, postUri: undefined, fromNeedUri: self.postUri, mode: 'CONNECT'})">
@@ -78,7 +78,7 @@ function genComponentConf() {
                     </svg>
                     <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
             </button>
-            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;
+            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;"
                 ng-if="self.showCreateWhatsAround"
                 ng-click="self.createWhatsAround()"
                 ng-disabled="self.processingPublish">
@@ -142,7 +142,9 @@ function genComponentConf() {
           showFooter:
             !postLoading &&
             !postFailedToLoad &&
-            (showCreateWhatsAround || hasReactionUseCases),
+            (showCreateWhatsAround ||
+              hasReactionUseCases ||
+              hasEnabledUseCases),
         };
       };
       connect2Redux(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -265,7 +265,7 @@ function genComponentConf() {
             </button>
             <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasReactionUseCases"></won-labelled-hr>
             <!-- Reaction Use Cases -->
-            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;
+            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;"
                     ng-if="self.hasReactionUseCases"
                     ng-repeat="ucIdentifier in self.reactionUseCasesArray"
                     ng-click="self.selectUseCase(ucIdentifier)">
@@ -275,7 +275,7 @@ function genComponentConf() {
                     <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
             </button>
             <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasEnabledUseCases"></won-labelled-hr>
-            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;
+            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;"
                     ng-if="self.hasEnabledUseCases"
                     ng-repeat="ucIdentifier in self.enabledUseCasesArray"
                     ng-click="self.selectUseCase(ucIdentifier)">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -34,7 +34,7 @@ function genComponentConf() {
             </div>
             <!-- Reaction Use Cases -->
             <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasReactionUseCases"></won-labelled-hr>
-            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;
+            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;"
                     ng-if="self.hasReactionUseCases"
                     ng-repeat="ucIdentifier in self.reactionUseCasesArray"
                     ng-click="self.selectUseCase(ucIdentifier)">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
@@ -79,14 +79,30 @@ export function findUseCaseByNeed(needImm) {
         hasExactMatchingTypes(useCase, contentTypes, "content")
       );
 
-      if (matchingUseCases && matchingUseCases.size > 1) {
+      if (matchingUseCases.size > 1 && contentTypes.includes("s:PlanAction")) {
+        matchingUseCases = matchingUseCases.filter(useCase =>
+          getIn(needImm, ["content", "eventObject"]).includes(
+            getIn(useCase, ["draft", "content", "eventObject"])
+          )
+        );
+      }
+
+      if (matchingUseCases.size > 1) {
         //If there are multiple matched found based on the content type(s) alone we refine based on the seeks type as well
         matchingUseCases = matchingUseCases.filter(useCase =>
           hasExactMatchingTypes(useCase, seeksTypes, "seeks")
         );
       }
 
-      if (matchingUseCases && matchingUseCases.size > 1) {
+      if (matchingUseCases.size > 1 && seeksTypes.includes("s:PlanAction")) {
+        matchingUseCases = matchingUseCases.filter(useCase =>
+          getIn(needImm, ["seeks", "eventObject"]).includes(
+            getIn(useCase, ["draft", "seeks", "eventObject"])
+          )
+        );
+      }
+
+      if (matchingUseCases.size > 1) {
         console.warn(
           "Found multiple matching UseCases for: ",
           needImm,
@@ -95,7 +111,7 @@ export function findUseCaseByNeed(needImm) {
           " -> returning undefined"
         );
         return undefined;
-      } else if (matchingUseCases && matchingUseCases.size == 1) {
+      } else if (matchingUseCases.size == 1) {
         return matchingUseCases.first().toJS();
       } else {
         console.warn(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
@@ -79,7 +79,11 @@ export function findUseCaseByNeed(needImm) {
         hasExactMatchingTypes(useCase, contentTypes, "content")
       );
 
-      if (matchingUseCases.size > 1 && contentTypes.includes("s:PlanAction")) {
+      if (
+        matchingUseCases.size > 1 &&
+        contentTypes &&
+        contentTypes.includes("s:PlanAction")
+      ) {
         matchingUseCases = matchingUseCases.filter(useCase =>
           getIn(needImm, ["content", "eventObject"]).includes(
             getIn(useCase, ["draft", "content", "eventObject"])
@@ -94,7 +98,11 @@ export function findUseCaseByNeed(needImm) {
         );
       }
 
-      if (matchingUseCases.size > 1 && seeksTypes.includes("s:PlanAction")) {
+      if (
+        matchingUseCases.size > 1 &&
+        seeksTypes &&
+        seeksTypes.includes("s:PlanAction")
+      ) {
         matchingUseCases = matchingUseCases.filter(useCase =>
           getIn(needImm, ["seeks", "eventObject"]).includes(
             getIn(useCase, ["draft", "seeks", "eventObject"])

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -79,7 +79,7 @@ export const details = {
   responseToUri: basicDetails.responseToUri,
   website: basicDetails.website,
   flags: basicDetails.flags,
-  sPlanAction: basicDetails.sPlanAction,
+  eventObject: basicDetails.eventObject,
   facets: basicDetails.facets,
   defaultFacet: basicDetails.defaultFacet,
   type: basicDetails.type,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -1,5 +1,5 @@
 import won from "../../app/won-es6.js";
-import { is, get } from "../../app/utils.js";
+import { is, get, getIn } from "../../app/utils.js";
 import { select } from "../details/abstract.js";
 import Immutable from "immutable";
 
@@ -180,9 +180,7 @@ export const suggestPost = {
     }
   },
   parseFromRDF: function(jsonLDImm) {
-    const suggestUriJsonLDImm =
-      jsonLDImm && jsonLDImm.get("won:suggestPostUri");
-    return suggestUriJsonLDImm && suggestUriJsonLDImm.get("@id");
+    return getIn(jsonLDImm, ["won:suggestPostUri", "@id"]);
   },
   generateHumanReadable: function({ value, includeLabel }) {
     if (value) {
@@ -212,9 +210,7 @@ export const responseToUri = {
     }
   },
   parseFromRDF: function(jsonLDImm) {
-    const responseToUriJsonLDImm =
-      jsonLDImm && jsonLDImm.get("won:responseToUri");
-    return responseToUriJsonLDImm && responseToUriJsonLDImm.get("@id");
+    return getIn(jsonLDImm, ["won:responseToUri", "@id"]);
   },
   generateHumanReadable: function({ value, includeLabel }) {
     if (value) {
@@ -428,9 +424,12 @@ export const defaultFacet = {
   },
 };
 
-export const sPlanAction = {
-  identifier: "sPlanAction",
-  label: "Plan",
+/*
+  Use this detail with the s:PlanAction type -> if you use this detail make sure you add the s:PlanAction type to the corresponding branch (content or seeks)
+*/
+export const eventObject = {
+  identifier: "eventObject",
+  label: "Event",
   icon: "#ico36_detail_title",
   placeholder: "What? (Short title shown in lists)",
   parseToRDF: function({ value }) {
@@ -439,20 +438,19 @@ export const sPlanAction = {
       return;
     }
     return {
-      "@type": "s:PlanAction",
       "s:object": {
         "@type": "s:Event",
-        "s:about": value,
+        "s:about": { "@id": value },
       },
     };
   },
   parseFromRDF: function(jsonLDImm) {
-    const types = jsonLDImm.getIn(["@type"]);
+    const types = get(jsonLDImm, "@type");
     if (
       (Immutable.List.isList(types) && types.includes("s:PlanAction")) ||
       types === "s:PlanAction"
     ) {
-      const planObjs = jsonLDImm.getIn(jsonLDImm, ["s:object"]);
+      const planObjs = get(jsonLDImm, "s:object");
       let plns = [];
 
       if (Immutable.List.isList(planObjs)) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling-interest.js
@@ -20,7 +20,8 @@ export const cyclingInterest = {
         title: "I am interested in cycling!",
       },
       seeks: {
-        sPlanAction: { "@id": "http://dbpedia.org/resource/Cycling" },
+        type: ["s:PlanAction"],
+        eventObject: "http://dbpedia.org/resource/Cycling",
       },
     }),
   },
@@ -34,9 +35,7 @@ export const cyclingInterest = {
       mandatory: true,
     },
   },
-  seeksDetails: {
-    sPlanAction: { ...details.sPlanAction },
-  },
+  seeksDetails: {},
 
   generateQuery: (draft, resultName) => {
     const vicinityScoreSQ = vicinityScoreSubQuery({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling-plan.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling-plan.js
@@ -18,9 +18,9 @@ export const cyclingPlan = {
   draft: {
     ...mergeInEmptyDraft({
       content: {
-        type: ["won:CyclingPlan"],
+        type: ["s:PlanAction"],
         title: "Let's go for a bike ride!",
-        sPlanAction: { "@id": "http://dbpedia.org/resource/Cycling" },
+        eventObject: "http://dbpedia.org/resource/Cycling",
         facets: {
           "#groupFacet": won.WON.GroupFacetCompacted,
           "#holdableFacet": won.WON.HoldableFacetCompacted,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch-interest.js
@@ -12,7 +12,7 @@ window.SparqlGenerator4dbg = Generator;
 export const lunchInterest = {
   identifier: "lunchInterest",
   label: "Add Lunch Interest",
-  icon: undefined,
+  icon: "#ico36_uc_meal-half",
   draft: {
     ...mergeInEmptyDraft({
       content: {
@@ -20,7 +20,8 @@ export const lunchInterest = {
         title: "I am interested in meeting up for lunch!",
       },
       seeks: {
-        sPlanAction: { "@id": "http://dbpedia.org/resource/Lunch" },
+        type: ["s:PlanAction"],
+        eventObject: "http://dbpedia.org/resource/Lunch",
       },
     }),
   },
@@ -32,9 +33,7 @@ export const lunchInterest = {
       mandatory: true,
     },
   },
-  seeksDetails: {
-    sPlanAction: { ...details.sPlanAction },
-  },
+  seeksDetails: {},
 
   generateQuery: (draft, resultName) => {
     const vicinityScoreSQ = vicinityScoreSubQuery({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch-plan.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch-plan.js
@@ -18,9 +18,9 @@ export const lunchPlan = {
   draft: {
     ...mergeInEmptyDraft({
       content: {
-        type: ["won:LunchPlan"],
+        type: ["s:PlanAction"],
         title: "Let's go get lunch!",
-        sPlanAction: { "@id": "http://dbpedia.org/resource/Lunch" },
+        eventObject: "http://dbpedia.org/resource/Lunch",
         facets: {
           "#groupFacet": won.WON.GroupFacetCompacted,
           "#holdableFacet": won.WON.HoldableFacetCompacted,


### PR DESCRIPTION
Refactored the cycling/lunch interest and plan usecases:
- add type s:PlanAction in draft
- refactor sPlanAction detail to eventObject and remove the parsing of the type directly within the detail
- fixed a parseFromRDF bug that prevented us from storing the eventObject within the state

Refactored findUseCaseByNeed to include a check for eventObjects if the need type is also a s:PlanAction -> needs have corresponding useCases now

fixes #2774 

HOW TO TEST:
- Create each of the Lunch/Cycling Plan/Interest  UseCases
- Check the redux state for the corresponding needs in the console and look at the ["matchedUseCase", "identifier"] -> this should include the correct useCase for each of the needs