### PR TITLE
Feat store connection state and (own) facettype in redux-state onload #2823  (rebased)

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -131,6 +131,7 @@ const actionHierarchy = {
     updatePetriNetData: INJ_DEFAULT,
 
     storeActiveUrisInLoading: INJ_DEFAULT,
+    storeUrisToLoad: INJ_DEFAULT,
     storeActive: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -118,6 +118,7 @@ const actionHierarchy = {
     showLatestMessages: cnct.showLatestMessages,
     showMoreMessages: cnct.showMoreMessages,
     fetchMessagesStart: INJ_DEFAULT,
+    fetchMessagesEnd: INJ_DEFAULT,
     messageUrisInLoading: INJ_DEFAULT,
     fetchMessagesFailed: INJ_DEFAULT,
     fetchMessagesSuccess: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -723,40 +723,7 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
           []
         );
       })
-      .then(events => {
-        if (events) {
-          const eventsImm = Immutable.fromJS(events);
-
-          if (eventsImm.get("success").size > 0) {
-            dispatch({
-              type: actionTypes.connections.fetchMessagesSuccess,
-              payload: Immutable.fromJS({
-                connectionUri: connectionUri,
-                events: eventsImm.get("success"),
-              }),
-            });
-          }
-
-          if (eventsImm.get("failed").size > 0) {
-            dispatch({
-              type: actionTypes.connections.fetchMessagesFailed,
-              payload: Immutable.fromJS({
-                connectionUri: connectionUri,
-                events: eventsImm.get("failed"),
-              }),
-            });
-          }
-
-          if (
-            eventsImm.get("success").size == 0 &&
-            eventsImm.get("failed").size == 0
-          ) {
-            console.warn(
-              "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
-            );
-          }
-        }
-      });
+      .then(events => storeMessages(dispatch, events, connectionUri));
   };
 }
 
@@ -817,40 +784,7 @@ export function loadLatestMessagesOfConnection({
         []
       );
     })
-    .then(events => {
-      if (events) {
-        const eventsImm = Immutable.fromJS(events);
-
-        if (eventsImm.get("success").size > 0) {
-          dispatch({
-            type: actionTypes.connections.fetchMessagesSuccess,
-            payload: Immutable.fromJS({
-              connectionUri: connectionUri,
-              events: eventsImm.get("success"),
-            }),
-          });
-        }
-
-        if (eventsImm.get("failed").size > 0) {
-          dispatch({
-            type: actionTypes.connections.fetchMessagesFailed,
-            payload: Immutable.fromJS({
-              connectionUri: connectionUri,
-              events: eventsImm.get("failed"),
-            }),
-          });
-        }
-
-        if (
-          eventsImm.get("success").size == 0 &&
-          eventsImm.get("failed").size == 0
-        ) {
-          console.warn(
-            "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
-          );
-        }
-      }
-    });
+    .then(events => storeMessages(dispatch, events, connectionUri));
 }
 
 /**
@@ -929,41 +863,53 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
           []
         );
       })
-      .then(events => {
-        if (events) {
-          const eventsImm = Immutable.fromJS(events);
-
-          if (eventsImm.get("success").size > 0) {
-            dispatch({
-              type: actionTypes.connections.fetchMessagesSuccess,
-              payload: Immutable.fromJS({
-                connectionUri: connectionUri,
-                events: eventsImm.get("success"),
-              }),
-            });
-          }
-
-          if (eventsImm.get("failed").size > 0) {
-            dispatch({
-              type: actionTypes.connections.fetchMessagesFailed,
-              payload: Immutable.fromJS({
-                connectionUri: connectionUri,
-                events: eventsImm.get("failed"),
-              }),
-            });
-          }
-
-          if (
-            eventsImm.get("success").size == 0 &&
-            eventsImm.get("failed").size == 0
-          ) {
-            console.warn(
-              "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
-            );
-          }
-        }
-      });
+      .then(events => storeMessages(dispatch, events, connectionUri));
   };
+}
+
+/**
+ * Helper function that stores dispatches the success and failed actions for a given set of messages
+ * @param messages
+ * @param connectionUri
+ */
+function storeMessages(dispatch, messages, connectionUri) {
+  if (messages) {
+    const messagesImm = Immutable.fromJS(messages);
+
+    if (messagesImm.get("success").size > 0) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesSuccess,
+        payload: Immutable.fromJS({
+          connectionUri: connectionUri,
+          events: messagesImm.get("success"),
+        }),
+      });
+    }
+
+    if (messagesImm.get("failed").size > 0) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesFailed,
+        payload: Immutable.fromJS({
+          connectionUri: connectionUri,
+          events: messagesImm.get("failed"),
+        }),
+      });
+    }
+
+    /*If neither succes nor failed has any elements we simply say that fetching Ended, that way
+    we can ensure that there is not going to be a lock on the connection because loadingMessages was complete but never
+    reset its status
+    */
+    if (
+      messagesImm.get("success").size == 0 &&
+      messagesImm.get("failed").size == 0
+    ) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesEnd,
+        payload: Immutable.fromJS({ connectionUri: connectionUri }),
+      });
+    }
+  }
 }
 
 function numOfEvts2pageSize(numberOfEvents) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -746,6 +746,15 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
               }),
             });
           }
+
+          if (
+            eventsImm.get("success").size == 0 &&
+            eventsImm.get("failed").size == 0
+          ) {
+            console.warn(
+              "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
+            );
+          }
         }
       });
   };
@@ -757,23 +766,22 @@ export function loadLatestMessagesOfConnection({
   state,
   dispatch,
 }) {
-  const connectionUri_ = connectionUri || getConnectionUriFromRoute(state);
   const need =
-    connectionUri_ && getOwnedNeedByConnectionUri(state, connectionUri_);
+    connectionUri && getOwnedNeedByConnectionUri(state, connectionUri);
   const needUri = need && need.get("uri");
   const connection =
-    connectionUri_ && getOwnedConnectionByUri(state, connectionUri_);
+    connectionUri && getOwnedConnectionByUri(state, connectionUri);
   if (
-    !connectionUri_ ||
+    !connectionUri ||
     !connection ||
-    getIn(state, ["process", "connections", connectionUri_, "loadingMessages"]) // only start loading once.
+    getIn(state, ["process", "connections", connectionUri, "loadingMessages"]) // only start loading once.
   ) {
     return Promise.resolve();
   }
 
   dispatch({
     type: actionTypes.connections.fetchMessagesStart,
-    payload: Immutable.fromJS({ connectionUri: connectionUri_ }),
+    payload: Immutable.fromJS({ connectionUri: connectionUri }),
   });
 
   const fetchParams = {
@@ -783,7 +791,7 @@ export function loadLatestMessagesOfConnection({
   };
 
   return won
-    .getConnectionWithEventUris(connectionUri_, fetchParams)
+    .getConnectionWithEventUris(connectionUri, fetchParams)
     .then(connection => {
       const messagesToFetch = limitNumberOfEventsToFetchInConnection(
         state,
@@ -795,7 +803,7 @@ export function loadLatestMessagesOfConnection({
       dispatch({
         type: actionTypes.connections.messageUrisInLoading,
         payload: Immutable.fromJS({
-          connectionUri: connectionUri_,
+          connectionUri: connectionUri,
           uris: messagesToFetch,
         }),
       });
@@ -817,7 +825,7 @@ export function loadLatestMessagesOfConnection({
           dispatch({
             type: actionTypes.connections.fetchMessagesSuccess,
             payload: Immutable.fromJS({
-              connectionUri: connectionUri_,
+              connectionUri: connectionUri,
               events: eventsImm.get("success"),
             }),
           });
@@ -827,10 +835,19 @@ export function loadLatestMessagesOfConnection({
           dispatch({
             type: actionTypes.connections.fetchMessagesFailed,
             payload: Immutable.fromJS({
-              connectionUri: connectionUri_,
+              connectionUri: connectionUri,
               events: eventsImm.get("failed"),
             }),
           });
+        }
+
+        if (
+          eventsImm.get("success").size == 0 &&
+          eventsImm.get("failed").size == 0
+        ) {
+          console.warn(
+            "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
+          );
         }
       }
     });
@@ -934,6 +951,15 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
                 events: eventsImm.get("failed"),
               }),
             });
+          }
+
+          if (
+            eventsImm.get("success").size == 0 &&
+            eventsImm.get("failed").size == 0
+          ) {
+            console.warn(
+              "NO MESSAGES RETRIEVED AT ALL, MIGHT BE SOME WEIRD COINCIDINK"
+            );
           }
         }
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -45,10 +45,10 @@ export function failedCloseNeed(event) {
         */
     won
       .invalidateCacheForNeed(needUri) // mark need and it's connection container dirty
-      .then(() => won.getConnectionUrisWithStateOfNeed(needUri))
-      .then(connectionsWithStateOfNeed =>
+      .then(() => won.getConnectionUrisWithStateByNeedUri(needUri))
+      .then(connectionsWithStateAndFacet =>
         Promise.all(
-          connectionsWithStateOfNeed.map(
+          connectionsWithStateAndFacet.map(
             conn => won.invalidateCacheForNewMessage(conn.connectionUri) // mark connections dirty
           )
         )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connections-overview.js
@@ -39,6 +39,7 @@ import {
 } from "../connection-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as viewUtils from "../view-utils.js";
+import * as processUtils from "../process-utils.js";
 
 const serviceDependencies = ["$ngRedux", "$scope"];
 function genComponentConf() {
@@ -376,7 +377,7 @@ function genComponentConf() {
     }
 
     isNeedLoading(needUri) {
-      return this.process.getIn(["needs", needUri, "loading"]);
+      return processUtils.isNeedLoading(this.process, needUri);
     }
 
     isOpenByConnection(ownedNeedUri) {
@@ -404,10 +405,7 @@ function genComponentConf() {
         !!need.get("connections").find(conn => {
           if (!isChatConnection(conn) && !isGroupChatConnection(conn))
             return false;
-          if (
-            process &&
-            process.getIn(["connections", conn.get("uri"), "loading"])
-          )
+          if (processUtils.isConnectionLoading(process, conn.get("uri")))
             return true; //if connection is currently loading we assume its a connection we want to show
 
           const remoteNeedUri = conn.get("remoteNeedUri");
@@ -439,10 +437,7 @@ function genComponentConf() {
         need.get("connections").filter(conn => {
           if (!isChatConnection(conn) && !isGroupChatConnection(conn))
             return false;
-          if (
-            process &&
-            process.getIn(["connections", conn.get("uri"), "loading"])
-          )
+          if (processUtils.isConnectionLoading(process, conn.get("uri")))
             return true; //if connection is currently loading we assume its a connection we want to show
 
           const remoteNeedUri = conn.get("remoteNeedUri");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -67,13 +67,13 @@ function genComponentConf() {
               connection-uri="self.connectionUri">
             </won-post-content-message>
             <div class="gpm__content__loadspinner"
-                ng-if="self.isProcessingLoadingMessages">
+                ng-if="self.isProcessingLoadingMessages || self.isConnectionLoading">
                 <svg class="hspinner">
                   <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
                 </svg>
             </div>
             <button class="gpm__content__loadbutton won-button--outlined thin red"
-                ng-if="!self.isSuggested && !self.isProcessingLoadingMessages && self.hasConnectionMessagesToLoad"
+                ng-if="!self.isSuggested && !self.isProcessingLoadingMessages && !self.isConnectionLoading && self.hasConnectionMessagesToLoad"
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
@@ -239,6 +239,10 @@ function genComponentConf() {
             processUtils.isNeedLoading(process, ownedNeed.get("uri")) ||
             processUtils.isNeedLoading(process, remoteNeedUri) ||
             processUtils.isConnectionLoading(process, connectionUri),
+          isConnectionLoading: processUtils.isConnectionLoading(
+            process,
+            connectionUri
+          ),
         };
       };
 
@@ -272,6 +276,7 @@ function genComponentConf() {
         const INITIAL_MESSAGECOUNT = 15;
         if (
           this.connection &&
+          !this.isConnectionLoading &&
           !this.isProcessingLoadingMessages &&
           this.connection.get("messages").size < INITIAL_MESSAGECOUNT &&
           this.hasConnectionMessagesToLoad
@@ -287,7 +292,11 @@ function genComponentConf() {
     loadPreviousMessages() {
       delay(0).then(() => {
         const MORE_MESSAGECOUNT = 5;
-        if (this.connection && !this.isProcessingLoadingMessages) {
+        if (
+          this.connection &&
+          !this.isProcessingLoadingMessages &&
+          !this.isConnectionLoading
+        ) {
           this.connections__showMoreMessages(
             this.connection.get("uri"),
             MORE_MESSAGECOUNT

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -385,14 +385,14 @@ function genComponentConf() {
         const reactionUseCases =
           remoteNeed &&
           !needUtils.isOwned(remoteNeed) &&
-          getIn(remoteNeed, ["matchedUseCase", "reactionUseCases"]);
+          needUtils.getReactionUseCases(remoteNeed);
         const hasReactionUseCases =
           reactionUseCases && reactionUseCases.size > 0;
 
         const enabledUseCases =
           remoteNeed &&
           needUtils.isOwned(remoteNeed) &&
-          getIn(remoteNeed, ["matchedUseCase", "enabledUseCases"]);
+          needUtils.getEnabledUseCases(remoteNeed);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
 
         return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -124,7 +124,7 @@ function genComponentConf() {
               connection-uri="self.selectedConnectionUri">
             </won-post-content-message>
             <div class="pm__content__loadspinner"
-                ng-if="self.isProcessingLoadingMessages || (self.showAgreementData && self.isProcessingLoadingAgreementData) || (self.showPetriNetData && self.isProcessingLoadingPetriNetData && !self.hasPetriNetData)">
+                ng-if="self.isConnectionLoading || self.isProcessingLoadingMessages || (self.showAgreementData && self.isProcessingLoadingAgreementData) || (self.showPetriNetData && self.isProcessingLoadingPetriNetData && !self.hasPetriNetData)">
                 <svg class="hspinner">
                   <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
                 </svg>
@@ -136,7 +136,7 @@ function genComponentConf() {
               Calculating PetriNet Status
             </div>
             <button class="pm__content__loadbutton won-button--outlined thin red"
-                ng-if="!self.isSuggested && self.showChatData && !self.isProcessingLoadingMessages && self.hasConnectionMessagesToLoad"
+                ng-if="!self.isSuggested && self.showChatData && !self.isConnectionLoading && !self.isProcessingLoadingMessages && self.hasConnectionMessagesToLoad"
                 ng-click="self.loadPreviousMessages()">
                 Load previous messages
             </button>
@@ -475,6 +475,10 @@ function genComponentConf() {
             processUtils.isNeedLoading(process, ownedNeed.get("uri")) ||
             processUtils.isNeedLoading(process, remoteNeedUri) ||
             processUtils.isConnectionLoading(process, selectedConnectionUri),
+          isConnectionLoading: processUtils.isConnectionLoading(
+            process,
+            selectedConnectionUri
+          ),
           showPostContentMessage:
             showChatData && !multiSelectType && remoteNeedUri,
           showOverlayConnection: !!this.connectionUri,
@@ -527,6 +531,7 @@ function genComponentConf() {
         const INITIAL_MESSAGECOUNT = 15;
         if (
           this.connection &&
+          !this.isConnectionLoading &&
           !this.isProcessingLoadingMessages &&
           this.connection.get("messages").size < INITIAL_MESSAGECOUNT &&
           this.hasConnectionMessagesToLoad
@@ -661,6 +666,7 @@ function genComponentConf() {
       delay(0).then(() => {
         if (
           this.isConnected &&
+          !this.isConnectionLoading &&
           !this.isProcessingLoadingAgreementData &&
           !this.isProcessingLoadingMessages &&
           this.agreementDataLoaded &&
@@ -760,7 +766,11 @@ function genComponentConf() {
     loadPreviousMessages() {
       delay(0).then(() => {
         const MORE_MESSAGECOUNT = 5;
-        if (this.connection && !this.isProcessingLoadingMessages) {
+        if (
+          this.connection &&
+          !this.isConnectionLoading &&
+          !this.isProcessingLoadingMessages
+        ) {
           this.connections__showMoreMessages(
             this.connection.get("uri"),
             MORE_MESSAGECOUNT

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -69,14 +69,12 @@ function genComponentConf() {
         const reactionUseCases =
           post &&
           !needUtils.isOwned(post) &&
-          getIn(post, ["matchedUseCase", "reactionUseCases"]);
+          needUtils.getReactionUseCases(post);
         const hasReactionUseCases =
           reactionUseCases && reactionUseCases.size > 0;
 
         const enabledUseCases =
-          post &&
-          needUtils.isOwned(post) &&
-          getIn(post, ["matchedUseCase", "enabledUseCases"]);
+          post && needUtils.isOwned(post) && needUtils.getEnabledUseCases(post);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
 
         return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -36,6 +36,14 @@ export function getMatchedUseCaseIdentifier(need) {
   return getIn(need, ["matchedUseCase", "identifier"]);
 }
 
+export function getReactionUseCases(need) {
+  return getIn(need, ["matchedUseCase", "reactionUseCases"]);
+}
+
+export function getEnabledUseCases(need) {
+  return getIn(need, ["matchedUseCase", "enabledUseCases"]);
+}
+
 /**
  * Determines if a given need is a Inactive
  * @param need

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
@@ -144,6 +144,16 @@ export function isConnectionLoading(process, connUri, includeSubData = false) {
 }
 
 /**
+ * Return true if given needUri has failedToLoad
+ * @param process (full process from state)
+ * @param needUri
+ * @returns {*}
+ */
+export function hasConnectionFailedToLoad(process, connUri) {
+  return connUri && getIn(process, ["connections", connUri, "failedToLoad"]);
+}
+
+/**
  * Return true if any connUri is currently loading, if includeSubData is true, we also check the petriNetData and agreementData
  * @param process
  * @param includeSubData (default=false, determines if the loading state should be checked for agreementData and petriNetData as well

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -31,7 +31,7 @@ import {
   markMessageExpandReferences,
 } from "./reduce-messages.js";
 import {
-  addActiveConnectionsToNeedInLoading,
+  addConnectionsToLoad,
   markConnectionAsRated,
   markConnectionAsRead,
   getOwnedNeedByConnectionUri,
@@ -100,11 +100,11 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.connections.storeActiveUrisInLoading: {
-      return addActiveConnectionsToNeedInLoading(
+    case actionTypes.connections.storeUrisToLoad: {
+      return addConnectionsToLoad(
         allNeedsInState,
         action.payload.get("needUri"),
-        action.payload.get("connUris")
+        action.payload.get("connections")
       );
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -28,6 +28,7 @@ export const emptyNeedProcess = Immutable.fromJS({
 });
 
 export const emptyConnectionProcess = Immutable.fromJS({
+  toLoad: false,
   loading: false,
   loadingMessages: false,
   failedToLoad: false,
@@ -318,12 +319,29 @@ export default function(processState = initialState, action = {}) {
       });
     }
 
+    case actionTypes.connections.storeUrisToLoad: {
+      const connections = action.payload.get("connections");
+
+      connections &&
+        connections.map(conn => {
+          processState = updateConnectionProcess(
+            processState,
+            conn.get("connectionUri"),
+            {
+              toLoad: true,
+            }
+          );
+        });
+      return processState;
+    }
+
     case actionTypes.connections.storeActiveUrisInLoading: {
       const connUris = action.payload.get("connUris");
 
       connUris &&
         connUris.forEach(connUri => {
           processState = updateConnectionProcess(processState, connUri, {
+            toLoad: false,
             loading: true,
           });
         });
@@ -349,6 +367,7 @@ export default function(processState = initialState, action = {}) {
       connections &&
         connections.map((conn, connUri) => {
           processState = updateConnectionProcess(processState, connUri, {
+            toLoad: false,
             loading: false,
           });
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -202,6 +202,15 @@ export default function(processState = initialState, action = {}) {
       });
     }
 
+    case actionTypes.connections.fetchMessagesEnd: {
+      const connUri = action.payload.get("connectionUri");
+
+      return updateConnectionProcess(processState, connUri, {
+        loadingMessages: false,
+        failedToLoad: false,
+      });
+    }
+
     case actionTypes.connections.messageUrisInLoading: {
       const connUri = action.payload.get("connectionUri");
       const messageUris = action.payload.get("uris");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/connection-selectors.js
@@ -11,7 +11,8 @@ import {
 } from "./general-selectors.js";
 import * as connectionUtils from "../connection-utils.js";
 import won from "../won-es6.js";
-import { getIn } from "../utils.js";
+import { get, getIn } from "../utils.js";
+import * as processUtils from "../process-utils.js";
 
 /**
  * Get the connection for a given connectionUri
@@ -94,21 +95,16 @@ export function getChatConnectionsToCrawl(state) {
           connectionUtils.isChatConnection(conn) ||
           connectionUtils.isGroupChatConnection(conn)
       )
-      .filter(
-        conn =>
-          !getIn(state, [
-            "process",
-            "connections",
-            conn.get("uri"),
-            "loadingMessages",
-          ]) &&
-          !getIn(state, [
-            "process",
-            "connections",
-            conn.get("uri"),
-            "failedToLoad",
-          ])
-      );
+      .filter(conn => {
+        const connUri = get(conn, "uri");
+        const process = get(state, "process");
+
+        return (
+          !processUtils.isConnectionLoading(process, connUri) &&
+          !processUtils.isConnectionLoadingMessages(process, connUri) &&
+          !processUtils.hasConnectionFailedToLoad(process, connUri)
+        );
+      });
 
   const connectionsInStateConnected =
     chatConnections &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -1153,7 +1153,7 @@ import won from "./won.js";
     return Promise.resolve(ret);
   };
 
-  won.getConnectionUrisWithStateOfNeed = (needUri, requesterWebId) => {
+  won.getConnectionUrisWithStateByNeedUri = (needUri, requesterWebId) => {
     return won
       .executeCrawlableQuery(
         won.queries["getAllConnectionUrisOfNeed"],
@@ -1165,6 +1165,7 @@ import won from "./won.js";
           return {
             connectionUri: x.connectionUri.value,
             connectionState: x.connectionState.value,
+            facetType: x.facetType.value,
           };
         })
       );
@@ -1679,12 +1680,14 @@ import won from "./won.js";
       query:
         "prefix won: <http://purl.org/webofneeds/model#> \n" +
         "prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> \n" +
-        "select ?connectionUri ?connectionState \n" +
+        "select ?connectionUri ?connectionState ?facetType \n" +
         " where { \n" +
         " <::baseUri::> a won:Need; \n" +
         "           won:hasConnections ?connections.\n" +
         "  ?connections rdfs:member ?connectionUri. \n" +
         "  ?connectionUri won:hasConnectionState ?connectionState. \n" +
+        "  ?connectionUri won:hasFacet ?facetUri. \n" +
+        "  ?facetUri a ?facetType. \n" +
         "} \n",
     },
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/view-utils.js
@@ -25,6 +25,10 @@ export function showRdf(viewState) {
   return get(viewState, "showRdf");
 }
 
+export function showClosedNeeds(viewState) {
+  return get(viewState, "showClosedNeeds");
+}
+
 export function isAnonymousLinkSent(viewState) {
   return getIn(viewState, ["anonymousSlideIn", "linkSent"]);
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -711,9 +711,17 @@ export async function fetchDataForOwnedNeeds(ownedNeedUris, dispatch) {
 
 function fetchConnectionsOfNeedAndDispatch(needUri, dispatch) {
   return won
-    .getConnectionUrisWithStateOfNeed(needUri, needUri, true)
-    .then(connectionsWithStateOfNeed => {
-      const activeConnectionUris = connectionsWithStateOfNeed
+    .getConnectionUrisWithStateByNeedUri(needUri, needUri)
+    .then(connectionsWithStateAndFacet => {
+      dispatch({
+        type: actionTypes.connections.storeUrisToLoad,
+        payload: Immutable.fromJS({
+          needUri: needUri,
+          connections: connectionsWithStateAndFacet,
+        }),
+      });
+
+      const activeConnectionUris = connectionsWithStateAndFacet
         .filter(conn => conn.connectionState !== won.WON.Closed)
         .map(conn => conn.connectionUri);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -89,6 +89,10 @@ won-usecase-picker {
 
     &__labelledhr {
       grid-column: 1 / -1;
+
+      & .wlh__label .wlh__label__text {
+        background: white;
+      }
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-markdown.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-markdown.scss
@@ -17,4 +17,8 @@
   ol {
     list-style-position: inside;
   }
+
+  img {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
~~blocked by #2840~~

related to #2828 (same changes just rebased with current master)

this pr stores the connection state and the (own) facet(type) of each connection directly after retrieving the connection container, this makes it easier to reload or prioritize loading by connectionstate and/or facet

fixes #2823
fixes #2840 