### PR TITLE
Feat  invite to group #2690

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -1,5 +1,6 @@
 import angular from "angular";
 import "ng-redux";
+import Immutable from "immutable";
 import { attach, sortBy, get, getIn, delay } from "../../../utils.js";
 import { DomCache } from "../../../cstm-ng-utils.js";
 import wonInput from "../../../directives/input.js";
@@ -8,7 +9,7 @@ import { actionCreators } from "../../../actions/actions.js";
 import postHeaderModule from "../../post-header.js";
 import labelledHrModule from "../../labelled-hr.js";
 import { getActiveNeeds } from "../../../selectors/general-selectors.js";
-import { isWhatsAroundNeed, isWhatsNewNeed } from "../../../need-utils.js";
+import * as needUtils from "../../../need-utils.js";
 
 import "style/_suggestpostpicker.scss";
 
@@ -26,7 +27,7 @@ function genComponentConf() {
         </div>
       </div>
       <div class="suggestpostp__noposts" ng-if="!self.suggestionsAvailable">
-        No Needs available to suggest
+        {{ self.noSuggestionsLabel }}
       </div>
       <won-labelled-hr label="::'Not happy with the options? Add a Need-URI below'" class="suggestpostp__labelledhr"></won-labelled-hr>
       <div class="suggestpostp__input">
@@ -60,6 +61,12 @@ function genComponentConf() {
       </div>
       <div class="suggestpostp__error" ng-if="self.uriToFetchIsWhatsAround && self.fetchNeedUriFieldHasText()">
           Suggestion invalid, you are trying to share a What's Around Need.
+      </div>
+      <div class="suggestpostp__error" ng-if="self.uriToFetchIsExcluded && self.fetchNeedUriFieldHasText()">
+          {{ self.excludedText }}
+      </div>
+      <div class="suggestpostp__error" ng-if="self.uriToFetchIsNotAllowed && self.fetchNeedUriFieldHasText()">
+          {{ self.notAllowedFacetText }}
       </div>
     `;
 
@@ -101,10 +108,16 @@ function genComponentConf() {
         ]);
         const uriToFetchLoading = !!get(uriToFetchProcess, "loading");
         const uriToFetchFailedToLoad = !!get(uriToFetchProcess, "failedToLoad");
-        const uriToFetchIsWhatsNew = isWhatsNewNeed(
+        const uriToFetchIsWhatsNew = needUtils.isWhatsNewNeed(
           get(allForbiddenNeeds, this.uriToFetch)
         );
-        const uriToFetchIsWhatsAround = isWhatsAroundNeed(
+        const uriToFetchIsWhatsAround = needUtils.isWhatsAroundNeed(
+          get(allForbiddenNeeds, this.uriToFetch)
+        );
+        const uriToFetchIsNotAllowed = !this.hasAtLeastOneAllowedFacet(
+          get(allForbiddenNeeds, this.uriToFetch)
+        );
+        const uriToFetchIsExcluded = this.isExcludedNeed(
           get(allForbiddenNeeds, this.uriToFetch)
         );
 
@@ -114,12 +127,16 @@ function genComponentConf() {
           uriToFetchFailedToLoad,
           uriToFetchIsWhatsNew,
           uriToFetchIsWhatsAround,
+          uriToFetchIsExcluded,
+          uriToFetchIsNotAllowed,
           allSuggestableNeeds,
           allForbiddenNeeds,
           suggestionsAvailable:
             allSuggestableNeeds && allSuggestableNeeds.size > 0,
           sortedActiveNeeds,
           suggestedNeed,
+          noSuggestionsLabel:
+            this.noSuggestionsText || "No Needs available to suggest",
           uriToFetchSuccess:
             this.uriToFetch &&
             !uriToFetchLoading &&
@@ -130,14 +147,25 @@ function genComponentConf() {
             !uriToFetchLoading &&
             (uriToFetchFailedToLoad ||
               uriToFetchIsWhatsAround ||
-              uriToFetchIsWhatsNew),
+              uriToFetchIsWhatsNew ||
+              uriToFetchIsExcluded ||
+              uriToFetchIsNotAllowed),
         };
       };
 
       connect2Redux(
         selectFromState,
         actionCreators,
-        ["self.initialValue", "self.detail", "self.uriToFetch"],
+        [
+          "self.initialValue",
+          "self.detail",
+          "self.uriToFetch",
+          "self.excludedUris",
+          "self.allowedFacets",
+          "self.notAllowedFacetText",
+          "self.excludedText",
+          "self.noSuggestionsText",
+        ],
         this
       );
 
@@ -153,8 +181,35 @@ function genComponentConf() {
       );
     }
 
+    hasAtLeastOneAllowedFacet(need) {
+      if (this.allowedFacets) {
+        const allowedFacetsImm = Immutable.fromJS(this.allowedFacets);
+        const needFacetsImm = need && need.getIn(["content", "facets"]);
+
+        return (
+          needFacetsImm &&
+          needFacetsImm.find(facet => allowedFacetsImm.contains(facet))
+        );
+      }
+      return true;
+    }
+
+    isExcludedNeed(need) {
+      if (this.excludedUris) {
+        const excludedUrisImm = Immutable.fromJS(this.excludedUris);
+
+        return excludedUrisImm.contains(get(need, "uri"));
+      }
+      return false;
+    }
+
     isSuggestable(need) {
-      return !isWhatsAroundNeed(need) && !isWhatsNewNeed(need);
+      return (
+        !needUtils.isWhatsAroundNeed(need) &&
+        !needUtils.isWhatsNewNeed(need) &&
+        !this.isExcludedNeed(need) &&
+        this.hasAtLeastOneAllowedFacet(need)
+      );
     }
 
     isSelected(need) {
@@ -248,6 +303,11 @@ function genComponentConf() {
       onUpdate: "&",
       initialValue: "=",
       detail: "=",
+      excludedUris: "=", //list of uris that should be excluded from the suggestions
+      allowedFacets: "=", //list of facets where at least one facet needs to be present in the need for it to be allowed as a suggestion
+      notAllowedFacetText: "=", //error message to display if need does not have any allowed facets
+      excludedText: "=", //error message to display when excluded need is added via the fetch input
+      noSuggestionsText: "=", //Text to display when no suggestions are available
     },
     template: template,
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -114,9 +114,11 @@ function genComponentConf() {
         const uriToFetchIsWhatsAround = needUtils.isWhatsAroundNeed(
           get(allForbiddenNeeds, this.uriToFetch)
         );
-        const uriToFetchIsNotAllowed = !this.hasAtLeastOneAllowedFacet(
-          get(allForbiddenNeeds, this.uriToFetch)
-        );
+        const uriToFetchIsNotAllowed =
+          !!get(allForbiddenNeeds, this.uriToFetch) &&
+          !this.hasAtLeastOneAllowedFacet(
+            get(allForbiddenNeeds, this.uriToFetch)
+          );
         const uriToFetchIsExcluded = this.isExcludedNeed(
           get(allForbiddenNeeds, this.uriToFetch)
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -198,13 +198,12 @@ function genComponentConf() {
       this.needs__connect(this.postUri, connUri, remoteNeedUri, message);
     }
 
-    inviteParticipant(needUri) {
+    inviteParticipant(needUri, message = "") {
       if (!this.isOwned || !this.hasGroupFacet) {
         console.warn("Trying to invite to a non-owned or non groupFacet need");
         return;
       }
-      console.debug("Trying to invite: ", needUri);
-      console.debug("TODO IMPL");
+      this.needs__connect(this.postUri, undefined, needUri, message);
     }
 
     markAsRead(conn) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -6,6 +6,7 @@ import angular from "angular";
 import inviewModule from "angular-inview";
 import labelledHrModule from "./labelled-hr.js";
 import postHeaderModule from "./post-header.js";
+import suggestPostPickerModule from "./details/picker/suggestpost-picker.js";
 import { attach, getIn, get } from "../utils.js";
 import won from "../won-es6.js";
 import { connect2Redux } from "../won-utils.js";
@@ -81,6 +82,16 @@ function genComponentConf() {
           ng-if="(!self.isOwned && !self.hasGroupMembers) || (self.isOwned && !self.hasGroupChatConnections)">
           No Groupmembers present.
       </div>
+      <won-labelled-hr label="::'Invite'" class="pc-participants__labelledhr" ng-if="self.isOwned"></won-labelled-hr>
+      <won-suggestpost-picker
+          ng-if="self.isOwned"
+          initial-value="undefined"
+          on-update="self.inviteParticipant(value)"
+          detail="::{placeholder: 'Insert NeedUri to invite'}"
+          allowed-facets="::[self.won.WON.ChatFacetCompacted, self.won.WON.GroupFacetCompacted]"
+          not-allowed-facet-text="::'Invitation does not work on needs without Group or Chat Facet'"
+          no-suggestions-text="::'No Participants available to invite'"
+      ></won-suggestpost-picker>
     `;
 
   class Controller {
@@ -176,6 +187,15 @@ function genComponentConf() {
       this.needs__connect(this.postUri, connUri, remoteNeedUri, message);
     }
 
+    inviteParticipant(needUri) {
+      if (!this.isOwned || !this.hasGroupFacet) {
+        console.warn("Trying to invite to a non-owned or non groupFacet need");
+        return;
+      }
+      console.debug("Trying to invite: ", needUri);
+      console.debug("TODO IMPL");
+    }
+
     markAsRead(conn) {
       if (conn && conn.get("unread")) {
         const payload = {
@@ -210,6 +230,7 @@ export default angular
     ngAnimate,
     labelledHrModule,
     postHeaderModule,
+    suggestPostPickerModule,
     inviewModule.name,
   ])
   .directive("wonPostContentParticipants", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -12,6 +12,7 @@ import won from "../won-es6.js";
 import { connect2Redux } from "../won-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as connectionSelectors from "../selectors/connection-selectors.js";
+import * as connectionUtils from "../connection-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import ngAnimate from "angular-animate";
 
@@ -120,9 +121,11 @@ function genComponentConf() {
         let excludedFromInviteUris = [this.postUri];
 
         if (groupChatConnections) {
-          groupChatConnections.map(conn =>
-            excludedFromInviteUris.push(get(conn, "remoteNeedUri"))
-          );
+          groupChatConnections
+            .filter(conn => !connectionUtils.isClosed(conn))
+            .map(conn =>
+              excludedFromInviteUris.push(get(conn, "remoteNeedUri"))
+            );
         }
 
         return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -1,0 +1,215 @@
+/**
+ * Created by quasarchimaere on 25.03.2019.
+ */
+
+import angular from "angular";
+import inviewModule from "angular-inview";
+import labelledHrModule from "./labelled-hr.js";
+import postHeaderModule from "./post-header.js";
+import { attach, getIn, get } from "../utils.js";
+import won from "../won-es6.js";
+import { connect2Redux } from "../won-utils.js";
+import * as needUtils from "../need-utils.js";
+import * as connectionSelectors from "../selectors/connection-selectors.js";
+import { actionCreators } from "../actions/actions.js";
+import ngAnimate from "angular-animate";
+
+import "style/_post-content-participants.scss";
+
+const CONNECTION_READ_TIMEOUT = 1500;
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <div
+          class="pc-participants__participant"
+          ng-if="!self.isOwned && self.hasGroupMembers"
+          ng-repeat="memberUri in self.groupMembersArray track by memberUri">
+          <div class="pc-participants__participant__indicator"></div>
+          <won-post-header
+            class="clickable"
+            ng-click="self.router__stateGoCurrent({viewNeedUri: memberUri, viewConnUri: undefined})"
+            need-uri="::memberUri">
+          </won-post-header>
+          <div class="pc-participants__participant__actions"></div>
+      </div>
+      <div class="pc-participants__participant"
+          ng-if="self.isOwned && self.hasGroupChatConnections && conn.get('state') !== self.won.WON.Closed"
+          ng-repeat="conn in self.groupChatConnectionsArray"
+          in-view="conn.get('unread') && $inview && self.markAsRead(conn)"
+          ng-class="{'won-unread': conn.get('unread')}">
+          <div class="pc-participants__participant__indicator"></div>
+          <won-post-header
+            class="clickable"
+            ng-click="self.router__stateGoCurrent({viewNeedUri: conn.get('remoteNeedUri'), viewConnUri: undefined})"
+            need-uri="::conn.get('remoteNeedUri')">
+          </won-post-header>
+          <div class="pc-participants__participant__actions">
+              <div
+                class="pc-participants__participant__actions__button red won-button--outlined thin"
+                ng-click="self.openRequest(conn)"
+                ng-if="conn.get('state') === self.won.WON.RequestReceived">
+                  Accept
+              </div>
+              <div
+                class="pc-participants__participant__actions__button red won-button--outlined thin"
+                ng-click="self.closeConnection(conn)"
+                ng-if="conn.get('state') === self.won.WON.RequestReceived">
+                  Reject
+              </div>
+              <div
+                class="pc-participants__participant__actions__button red won-button--outlined thin"
+                ng-click="self.sendRequest(conn)"
+                ng-if="conn.get('state') === self.won.WON.Suggested">
+                  Request
+              </div>
+              <div
+                class="pc-participants__participant__actions__button red won-button--outlined thin"
+                ng-disabled="true"
+                ng-if="conn.get('state') === self.won.WON.RequestSent">
+                  Waiting for Accept...
+              </div>
+              <div
+                class="pc-participants__participant__actions__button red won-button--outlined thin"
+                ng-click="self.closeConnection(conn)"
+                ng-if="conn.get('state') === self.won.WON.Suggested || conn.get('state') === self.won.WON.Connected">
+                  Remove
+              </div>
+          </div>
+      </div>
+      <div class="pc-participants__empty"
+          ng-if="(!self.isOwned && !self.hasGroupMembers) || (self.isOwned && !self.hasGroupChatConnections)">
+          No Groupmembers present.
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.won = won;
+      window.postcontentparticipants4dbg = this;
+
+      const selectFromState = state => {
+        const post = getIn(state, ["needs", this.postUri]);
+        const isOwned = needUtils.isOwned(post);
+
+        const hasGroupFacet = needUtils.hasGroupFacet(post);
+
+        const groupMembers = hasGroupFacet && get(post, "groupMembers");
+        const groupChatConnections =
+          isOwned &&
+          hasGroupFacet &&
+          connectionSelectors.getGroupChatConnectionsByNeedUri(
+            state,
+            this.postUri
+          );
+
+        return {
+          post,
+          isOwned,
+          hasGroupFacet,
+          hasGroupMembers: groupMembers && groupMembers.size > 0,
+          hasGroupChatConnections:
+            groupChatConnections && groupChatConnections.size > 0,
+          groupChatConnectionsArray:
+            groupChatConnections && groupChatConnections.toArray(),
+          groupMembersArray: groupMembers && groupMembers.toArray(),
+        };
+      };
+      connect2Redux(selectFromState, actionCreators, ["self.postUri"], this);
+    }
+
+    closeConnection(conn, rateBad = false) {
+      if (!conn) {
+        return;
+      }
+
+      const connUri = conn.get("uri");
+
+      if (rateBad) {
+        this.connections__rate(connUri, won.WON.binaryRatingBad);
+      }
+
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
+      this.connections__close(connUri);
+    }
+
+    openRequest(conn, message = "") {
+      if (!conn) {
+        return;
+      }
+
+      const connUri = get(conn, "uri");
+
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
+      this.connections__open(connUri, message);
+    }
+
+    sendRequest(conn, message = "") {
+      if (!conn) {
+        return;
+      }
+
+      const connUri = get(conn, "uri");
+      const remoteNeedUri = get(conn, "remoteNeedUri");
+
+      if (conn.get("unread")) {
+        this.connections__markAsRead({
+          connectionUri: connUri,
+          needUri: this.postUri,
+        });
+      }
+
+      this.connections__rate(connUri, won.WON.binaryRatingGood);
+      this.needs__connect(this.postUri, connUri, remoteNeedUri, message);
+    }
+
+    markAsRead(conn) {
+      if (conn && conn.get("unread")) {
+        const payload = {
+          connectionUri: conn.get("uri"),
+          needUri: this.postUri,
+        };
+
+        const tmp_connections__markAsRead = this.connections__markAsRead;
+
+        setTimeout(function() {
+          tmp_connections__markAsRead(payload);
+        }, CONNECTION_READ_TIMEOUT);
+      }
+    }
+  }
+
+  Controller.$inject = serviceDependencies;
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    template: template,
+    scope: {
+      postUri: "=",
+    },
+  };
+}
+
+export default angular
+  .module("won.owner.components.postContentParticipants", [
+    ngAnimate,
+    labelledHrModule,
+    postHeaderModule,
+    inviewModule.name,
+  ])
+  .directive("wonPostContentParticipants", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -88,7 +88,9 @@ function genComponentConf() {
           initial-value="undefined"
           on-update="self.inviteParticipant(value)"
           detail="::{placeholder: 'Insert NeedUri to invite'}"
+          excluded-uris="self.excludedFromInviteUris"
           allowed-facets="::[self.won.WON.ChatFacetCompacted, self.won.WON.GroupFacetCompacted]"
+          excluded-text="::'Invitation does not work for needs that are already part of the Group, or the group itself'"
           not-allowed-facet-text="::'Invitation does not work on needs without Group or Chat Facet'"
           no-suggestions-text="::'No Participants available to invite'"
       ></won-suggestpost-picker>
@@ -115,6 +117,14 @@ function genComponentConf() {
             this.postUri
           );
 
+        let excludedFromInviteUris = [this.postUri];
+
+        if (groupChatConnections) {
+          groupChatConnections.map(conn =>
+            excludedFromInviteUris.push(get(conn, "remoteNeedUri"))
+          );
+        }
+
         return {
           post,
           isOwned,
@@ -124,6 +134,7 @@ function genComponentConf() {
             groupChatConnections && groupChatConnections.size > 0,
           groupChatConnectionsArray:
             groupChatConnections && groupChatConnections.toArray(),
+          excludedFromInviteUris: [this.postUri],
           groupMembersArray: groupMembers && groupMembers.toArray(),
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -134,7 +134,7 @@ function genComponentConf() {
             groupChatConnections && groupChatConnections.size > 0,
           groupChatConnectionsArray:
             groupChatConnections && groupChatConnections.toArray(),
-          excludedFromInviteUris: [this.postUri],
+          excludedFromInviteUris,
           groupMembersArray: groupMembers && groupMembers.toArray(),
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -8,6 +8,7 @@ import postIsOrSeeksInfoModule from "./post-is-or-seeks-info.js";
 import labelledHrModule from "./labelled-hr.js";
 import postContentGeneral from "./post-content-general.js";
 import postContentPersona from "./post-content-persona.js";
+import postContentParticipants from "./post-content-participants.js";
 import postHeaderModule from "./post-header.js";
 import trigModule from "./trig.js";
 import { attach, getIn, get } from "../utils.js";
@@ -58,7 +59,7 @@ function genComponentConf() {
                 ng-click="self.tryReload()">
                 Try Reload
             </button>
-        </div>
+          </div>
         </div>
         <div class="post-content" ng-if="!self.postLoading && !self.postFailedToLoad">
           <!-- GENERAL INFORMATION -->
@@ -73,68 +74,7 @@ function genComponentConf() {
           <won-post-content-persona ng-if="self.isSelectedTab('HELDBY')" holds-uri="self.postUri"></won-post-content-persona>
           
           <!-- PARTICIPANT INFORMATION -->
-          <div class="post-content__members" ng-if="self.isSelectedTab('PARTICIPANTS')">
-            <div
-                class="post-content__members__member"
-                ng-if="!self.isOwned && self.hasGroupMembers"
-                ng-repeat="memberUri in self.groupMembersArray track by memberUri">
-                <div class="post-content__members__member__indicator"></div>
-                <won-post-header
-                  class="clickable"
-                  ng-click="self.router__stateGoCurrent({viewNeedUri: memberUri, viewConnUri: undefined})"
-                  need-uri="::memberUri">
-                </won-post-header>
-                <div class="post-content__members__member__actions"></div>
-            </div>
-            <div class="post-content__members__member"
-                ng-if="self.isOwned && self.hasGroupChatConnections && conn.get('state') !== self.won.WON.Closed"
-                ng-repeat="conn in self.groupChatConnectionsArray"
-                in-view="conn.get('unread') && $inview && self.markAsRead(conn)"
-                ng-class="{'won-unread': conn.get('unread')}">
-                <div class="post-content__members__member__indicator"></div>
-                <won-post-header
-                  class="clickable"
-                  ng-click="self.router__stateGoCurrent({viewNeedUri: conn.get('remoteNeedUri'), viewConnUri: undefined})"
-                  need-uri="::conn.get('remoteNeedUri')">
-                </won-post-header>
-                <div class="post-content__members__member__actions">
-                    <div
-                      class="post-content__members__member__actions__button red won-button--outlined thin"
-                      ng-click="self.openRequest(conn)"
-                      ng-if="conn.get('state') === self.won.WON.RequestReceived">
-                        Accept
-                    </div>
-                    <div
-                      class="post-content__members__member__actions__button red won-button--outlined thin"
-                      ng-click="self.closeConnection(conn)"
-                      ng-if="conn.get('state') === self.won.WON.RequestReceived">
-                        Reject
-                    </div>
-                    <div
-                      class="post-content__members__member__actions__button red won-button--outlined thin"
-                      ng-click="self.sendRequest(conn)"
-                      ng-if="conn.get('state') === self.won.WON.Suggested">
-                        Request
-                    </div>
-                    <div
-                      class="post-content__members__member__actions__button red won-button--outlined thin"
-                      ng-disabled="true"
-                      ng-if="conn.get('state') === self.won.WON.RequestSent">
-                        Waiting for Accept...
-                    </div>
-                    <div
-                      class="post-content__members__member__actions__button red won-button--outlined thin"
-                      ng-click="self.closeConnection(conn)"
-                      ng-if="conn.get('state') === self.won.WON.Suggested || conn.get('state') === self.won.WON.Connected">
-                        Remove
-                    </div>
-                </div>
-            </div>
-            <div class="post-content__members__empty"
-                ng-if="(!self.isOwned && !self.hasGroupMembers) || (self.isOwned && !self.hasGroupChatConnections)">
-                No Groupmembers present.
-            </div>
-          </div>
+          <won-post-content-participants ng-if="self.isSelectedTab('PARTICIPANTS')" post-uri="self.postUri"></won-post-content-participants>
 
           <!-- REVIEW INFORMATION -->
           <div class="post-content__reviews" ng-if="self.isSelectedTab('REVIEWS')">
@@ -241,17 +181,6 @@ function genComponentConf() {
         const hasContent = this.hasVisibleDetails(content);
         const hasSeeksBranch = this.hasVisibleDetails(seeks);
 
-        const hasGroupFacet = needUtils.hasGroupFacet(post);
-
-        const groupMembers = hasGroupFacet && get(post, "groupMembers");
-        const groupChatConnections =
-          isOwned &&
-          hasGroupFacet &&
-          connectionSelectors.getGroupChatConnectionsByNeedUri(
-            state,
-            this.postUri
-          );
-
         const heldPosts = isPersona && get(post, "holds");
 
         const suggestions = connectionSelectors.getSuggestedConnectionsByNeedUri(
@@ -275,14 +204,7 @@ function genComponentConf() {
           isOwned,
           hasHeldPosts: isPersona && heldPosts && heldPosts.size > 0,
           heldPostsArray: isPersona && heldPosts && heldPosts.toArray(),
-          hasGroupFacet,
           hasChatFacet: needUtils.hasChatFacet(post),
-          hasGroupMembers: groupMembers && groupMembers.size > 0,
-          hasGroupChatConnections:
-            groupChatConnections && groupChatConnections.size > 0,
-          groupChatConnectionsArray:
-            groupChatConnections && groupChatConnections.toArray(),
-          groupMembersArray: groupMembers && groupMembers.toArray(),
           hasSuggestions: isOwned && suggestions && suggestions.size > 0,
           suggestionsArray: isOwned && suggestions && suggestions.toArray(),
           postLoading:
@@ -328,23 +250,6 @@ function genComponentConf() {
       this.connections__close(connUri);
     }
 
-    openRequest(conn, message = "") {
-      if (!conn || this.isOwnedNeedWhatsX) {
-        return;
-      }
-
-      const connUri = get(conn, "uri");
-
-      if (conn.get("unread")) {
-        this.connections__markAsRead({
-          connectionUri: connUri,
-          needUri: this.postUri,
-        });
-      }
-
-      this.connections__open(connUri, message);
-    }
-
     sendRequest(conn, message = "") {
       if (!conn) {
         return;
@@ -379,10 +284,6 @@ function genComponentConf() {
 
     canAttachPersona() {
       return this.post.get("isOwned") && !this.post.get("heldBy");
-    }
-
-    toggleShowGeneral() {
-      this.needs__toggleGeneralInfo(this.postUri);
     }
 
     isSelectedTab(tabName) {
@@ -460,6 +361,7 @@ export default angular
     labelledHrModule,
     postContentGeneral,
     postContentPersona,
+    postContentParticipants,
     postHeaderModule,
     trigModule,
     inviewModule.name,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -115,37 +115,29 @@ export function isNeed(need) {
 }
 
 export function hasChatFacet(need) {
-  return (
-    getIn(need, ["content", "facets"]) &&
-    getIn(need, ["content", "facets"]).contains(won.WON.ChatFacetCompacted)
-  );
+  return hasFacet(need, won.WON.ChatFacetCompacted);
 }
 
 export function hasGroupFacet(need) {
-  return (
-    getIn(need, ["content", "facets"]) &&
-    getIn(need, ["content", "facets"]).contains(won.WON.GroupFacetCompacted)
-  );
+  return hasFacet(need, won.WON.GroupFacetCompacted);
 }
 
 export function hasHoldableFacet(need) {
-  return (
-    getIn(need, ["content", "facets"]) &&
-    getIn(need, ["content", "facets"]).contains(won.WON.HoldableFacetCompacted)
-  );
+  return hasFacet(need, won.WON.HoldableFacetCompacted);
 }
 
 export function hasHolderFacet(need) {
-  return (
-    getIn(need, ["content", "facets"]) &&
-    getIn(need, ["content", "facets"]).contains(won.WON.HolderFacetCompacted)
-  );
+  return hasFacet(need, won.WON.HolderFacetCompacted);
 }
 
 export function hasReviewFacet(need) {
+  return hasFacet(need, won.WON.ReviewFacetCompacted);
+}
+
+export function hasFacet(need, facet) {
   return (
     getIn(need, ["content", "facets"]) &&
-    getIn(need, ["content", "facets"]).contains(won.WON.ReviewFacetCompacted)
+    getIn(need, ["content", "facets"]).contains(facet)
   );
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -256,7 +256,7 @@ export default function(allNeedsInState = initialState, action = {}) {
         return addMessage(stateUpdated, optimisticEvent);
       } else {
         const tmpConnectionUri = "connectionFrom:" + eventUri;
-
+        //TODO: FIGURE OUT A WAY TO INCLUDE THE CORRECT FACET FOR ALL POSSIBLE CASES (e.g hasSenderFacet -> get Facet from need -> store said facet)
         let connSenderFacet = won.WON.ChatFacetCompacted; //Default add optimistic Connection as ChatConnection
         const ownedNeed = get(allNeedsInState, ownedNeedUri);
         if (

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-participants.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-participants.scss
@@ -1,0 +1,64 @@
+@import "won-config";
+@import "sizing-utils";
+@import "animate";
+
+won-post-content-participants {
+  & .pc-participants__empty {
+    color: $won-line-gray;
+    padding: 0.5rem;
+    text-align: center;
+  }
+
+  & .pc-participants__participant {
+    border: $thinGrayBorder;
+    border-left: 0;
+    background: $won-light-gray;
+    display: grid;
+    grid-template-areas: "participant_indicator participant_info participant_actions";
+    grid-template-columns: min-content 1fr min-content;
+    align-items: center;
+    margin-top: 0.5rem;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:hover {
+      background: white;
+    }
+
+    won-post-header {
+      padding: 0.5rem 0.25rem;
+      font-size: $normalFontSize;
+      grid-area: participant_info;
+    }
+
+    & > .pc-participants__participant__indicator {
+      grid-area: participant_indicator;
+      box-sizing: border-box;
+      width: 0.25rem;
+      height: 100%;
+    }
+
+    &.won-unread > .pc-participants__participant__indicator {
+      border-left: 0.25rem solid $won-unread-attention;
+    }
+
+    &:not(.won-unread) > .pc-participants__participant__indicator {
+      border-left: $thinGrayBorder;
+    }
+
+    &__actions {
+      padding-right: 0.5rem;
+      display: grid;
+      grid-auto-flow: column;
+      grid-gap: 0.25rem;
+      grid-area: participant_actions;
+
+      &__button.won-button--outlined.red.thin {
+        font-size: $smallFontSize;
+        padding: 0.5rem;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-participants.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content-participants.scss
@@ -9,6 +9,12 @@ won-post-content-participants {
     text-align: center;
   }
 
+  & won-suggestpost-picker {
+    background: var(--won-light-gray);
+    padding: 0.5rem;
+    border: 0.01rem solid var(--won-line-gray);
+  }
+
   & .pc-participants__participant {
     border: $thinGrayBorder;
     border-left: 0;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -24,67 +24,6 @@ won-post-content {
       padding: 0.5rem;
     }
 
-    .post-content__members {
-      &__empty {
-        color: $won-line-gray;
-        padding: 0.5rem;
-        text-align: center;
-      }
-
-      & .post-content__members__member {
-        border: $thinGrayBorder;
-        border-left: 0;
-        background: $won-light-gray;
-        display: grid;
-        grid-template-areas: "member_indicator member_info member_actions";
-        grid-template-columns: min-content 1fr min-content;
-        align-items: center;
-        margin-top: 0.5rem;
-
-        &:first-of-type {
-          margin-top: 0;
-        }
-
-        &:hover {
-          background: white;
-        }
-
-        won-post-header {
-          padding: 0.5rem 0.25rem;
-          font-size: $normalFontSize;
-          grid-area: member_info;
-        }
-
-        & > .post-content__members__member__indicator {
-          grid-area: member_indicator;
-          box-sizing: border-box;
-          width: 0.25rem;
-          height: 100%;
-        }
-
-        &.won-unread > .post-content__members__member__indicator {
-          border-left: 0.25rem solid $won-unread-attention;
-        }
-
-        &:not(.won-unread) > .post-content__members__member__indicator {
-          border-left: $thinGrayBorder;
-        }
-
-        &__actions {
-          padding-right: 0.5rem;
-          display: grid;
-          grid-auto-flow: column;
-          grid-gap: 0.25rem;
-          grid-area: member_actions;
-
-          &__button.won-button--outlined.red.thin {
-            font-size: $smallFontSize;
-            padding: 0.5rem;
-          }
-        }
-      }
-    }
-
     .post-content__reviews {
       &__empty {
         color: $won-line-gray;


### PR DESCRIPTION
fixes #2690 

Adds the ability to invite groupmembers (with the suggestpost-picker) in the Participants tab of owned GroupNeeds -> excludes/disallows any need that doesnt have the Group or ChatFacet, as well as any member need that is already present (including the pending ones, closed connections are allowed to be added again via suggestions)

How to test:
- open a groupchat-need
- go to the participants tab of that groupchat-need
- see the invite option underneath the participants list
- add any need you like (and see it pop up as a "Participant")

The following needs are inviteable:
- any need that is not yet a member or pending member of the groupchat
- any need that has the group or chatfacet
- any need that is not a whatsnew or whatsaround
- any need that isnt the groupchat itself