### PR TITLE
Feat  edit need frontend #2825

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -41,6 +41,7 @@ import { hierarchy2Creators } from "./action-utils.js";
 
 import {
   needCreate,
+  needEdit,
   createWhatsNew,
   createWhatsAround,
 } from "./create-need-action.js";
@@ -142,6 +143,9 @@ const actionHierarchy = {
     connectionsReceived: INJ_DEFAULT,
     clean: INJ_DEFAULT,
     create: needCreate,
+    edit: needEdit,
+    editSuccessful: INJ_DEFAULT,
+    editFailure: INJ_DEFAULT,
     whatsNew: createWhatsNew,
     whatsAround: createWhatsAround,
     createSuccessful: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -263,6 +263,7 @@ const actionHierarchy = {
     },
     updateMessageStatus: messages.updateMessageStatus,
     processConnectionMessage: messages.processConnectionMessage,
+    processChangeNotificationMessage: messages.processChangeNotificationMessage,
     processAgreementMessage: messages.processAgreementMessage,
     needMessageReceived: messages.needMessageReceived,
     processConnectMessage: messages.processConnectMessage,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -210,6 +210,10 @@ const actionHierarchy = {
       success: messages.successfulCreate,
       //TODO failure: messages.failedCreate
     },
+    edit: {
+      success: messages.successfulEdit,
+      //TODO failure: messages.failedEdit
+    },
     open: {
       successRemote: INJ_DEFAULT, //2nd successResponse
       successOwn: INJ_DEFAULT, //1st successResponse

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -41,30 +41,20 @@ export function needEdit(draft, oldNeed, nodeUri) {
       delete prevParams.privateId;
     }
 
-    return ensureLoggedIn(dispatch, getState)
-      .then(() => {
-        return dispatch(actionCreators.router__stateGoDefault()); //TODO: MIGHT NOT BE NECESSARY/FIND CORRECT REDIRECT ROUTE (maybe router__back would work) or dispatch edit in progress...
-      })
-      .then(async () => {
-        const { message, eventUri, needUri } = await buildEditMessage(
-          draft,
-          oldNeed,
-          nodeUri
-        );
+    return ensureLoggedIn(dispatch, getState).then(async () => {
+      const { message, eventUri, needUri } = await buildEditMessage(
+        draft,
+        oldNeed,
+        nodeUri
+      );
 
-        dispatch({
-          type: actionTypes.needs.create, //CHANGE TYPE
-          payload: { eventUri, message, needUri, need: draft, oldNeed },
-        });
-
-        dispatch(
-          //TODO SET UP CORRECT REDIRECT (maybe router__back)
-          actionCreators.router__stateGoAbs("connections", {
-            postUri: undefined,
-            connectionUri: undefined,
-          })
-        );
+      dispatch({
+        type: actionTypes.needs.edit,
+        payload: { eventUri, message, needUri, need: draft, oldNeed },
       });
+
+      dispatch(actionCreators.router__back());
+    });
   };
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -133,7 +133,26 @@ export function successfulCreate(event) {
     won.getNeed(needURI).then(need => {
       dispatch(
         actionCreators.needs__createSuccessful({
-          publishEventUri: event.getIsResponseTo(),
+          eventUri: event.getIsResponseTo(),
+          needUri: event.getSenderNeed(),
+          need: need,
+        })
+      );
+    });
+  };
+}
+
+export function successfulEdit(event) {
+  return dispatch => {
+    console.debug("Received success replace message:", event);
+    //const state = getState();
+    //load the edited data into the local rdf store and publish NeedEditEvent when done
+    const needURI = event.getReceiverNeed();
+    //TODO: invalidate cache for need
+    won.getNeed(needURI).then(need => {
+      dispatch(
+        actionCreators.needs__editSuccessful({
+          eventUri: event.getIsResponseTo(),
           needUri: event.getSenderNeed(),
           need: need,
         })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -47,8 +47,9 @@ function genComponentConf() {
                 style="--local-primary:var(--won-primary-color);">
                     <use xlink:href="{{self.useCase['icon']}}" href="{{self.useCase['icon']}}"></use>
             </svg>
-            <span class="cp__header__title" ng-if="!self.isCreateFromNeed">{{self.useCase.label}}</span>
+            <span class="cp__header__title" ng-if="!self.isCreateFromNeed && !self.isEditFromNeed">{{self.useCase.label}}</span>
             <span class="cp__header__title" ng-if="self.isCreateFromNeed">Duplicate from '{{self.useCase.label}}'</span>
+            <span class="cp__header__title" ng-if="self.isEditFromNeed">Edit Need</span>
         </div>
         <div class="cp__content">
             <div class="cp__content__loading" ng-if="!self.showCreateInput && self.isFromNeedLoading">
@@ -330,11 +331,7 @@ function genComponentConf() {
           delete this.draftObject.seeks;
         }
 
-        /*const tempDefaultNodeUri = this.$ngRedux
-          .getState()
-          .getIn(["config", "defaultNodeUri"]);*/
-
-        //TODO: Impl this method this.needs__edit(tempDraft, this.fromNeedUri, tempDefaultNodeUri);
+        //TODO: Impl this method this.needs__edit(tempDraft, this.fromNeedUri);
         console.debug(
           "Called edit for: ",
           this.fromNeed,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -101,7 +101,15 @@ function genComponentConf() {
         </div>
         <div class="cp__footer" >
             <won-labelled-hr label="::'done?'" class="cp__footer__labelledhr"></won-labelled-hr>
-            <won-publish-button on-publish="self.publish(persona)" is-valid="self.isValid()" show-personas="self.isHoldable" ng-if="self.showCreateInput"></won-publish-button>
+            <won-publish-button on-publish="self.publish(persona)" is-valid="self.isValid()" show-personas="self.isHoldable" ng-if="self.showCreateInput && !self.isEditFromNeed"></won-publish-button>
+            <div class="cp__footer__edit" ng-if="self.loggedIn && self.showCreateInput && self.isEditFromNeed">
+              <button class="cp__footer__edit__save won-button--filled red" ng-click="self.save()">
+                  Save
+              </button>
+              <button class="cp__footer__edit__cancel won-button--outlined thin red" ng-click="self.router__back()">
+                  Cancel
+              </button>
+            </div>
         </div>
     `;
 
@@ -128,6 +136,7 @@ function genComponentConf() {
         let useCase;
 
         const isCreateFromNeed = !!(fromNeedUri && mode === "DUPLICATE");
+        const isEditFromNeed = !!(fromNeedUri && mode === "EDIT");
 
         let isFromNeedLoading = false;
         let isFromNeedToLoad = false;
@@ -135,7 +144,7 @@ function genComponentConf() {
 
         const connectToNeedUri = mode === "CONNECT" && fromNeedUri;
 
-        if (isCreateFromNeed) {
+        if (isCreateFromNeed || isEditFromNeed) {
           isFromNeedLoading = processSelectors.isNeedLoading(
             state,
             fromNeedUri
@@ -208,6 +217,7 @@ function genComponentConf() {
           fromNeed,
           fromNeedUri,
           isCreateFromNeed,
+          isEditFromNeed,
           isFromNeedLoading,
           isFromNeedToLoad,
           isHoldable: useCaseUtils.isHoldable(useCase),
@@ -216,6 +226,7 @@ function genComponentConf() {
             useCase &&
             !(
               isCreateFromNeed &&
+              isEditFromNeed &&
               (isFromNeedLoading || hasFromNeedFailedToLoad || isFromNeedToLoad)
             ),
         };
@@ -306,6 +317,31 @@ function genComponentConf() {
       }
 
       this.draftObject[branch] = updatedDraft;
+    }
+
+    save() {
+      if (this.loggedIn && needUtils.isOwned(this.fromNeed)) {
+        this.draftObject.useCase = get(this.useCase, "identifier");
+
+        if (!isBranchContentPresent(this.draftObject.content, true)) {
+          delete this.draftObject.content;
+        }
+        if (!isBranchContentPresent(this.draftObject.seeks, true)) {
+          delete this.draftObject.seeks;
+        }
+
+        /*const tempDefaultNodeUri = this.$ngRedux
+          .getState()
+          .getIn(["config", "defaultNodeUri"]);*/
+
+        //TODO: Impl this method this.needs__edit(tempDraft, this.fromNeedUri, tempDefaultNodeUri);
+        console.debug(
+          "Called edit for: ",
+          this.fromNeed,
+          "with new draft: ",
+          this.draftObject
+        );
+      }
     }
 
     publish(persona) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -331,13 +331,7 @@ function genComponentConf() {
           delete this.draftObject.seeks;
         }
 
-        //TODO: Impl this method this.needs__edit(tempDraft, this.fromNeedUri);
-        console.debug(
-          "Called edit for: ",
-          this.fromNeed,
-          "with new draft: ",
-          this.draftObject
-        );
+        this.needs__edit(this.draftObject, this.fromNeed);
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -102,14 +102,20 @@ function genComponentConf() {
         </div>
         <div class="cp__footer" >
             <won-labelled-hr label="::'done?'" class="cp__footer__labelledhr"></won-labelled-hr>
-            <won-publish-button on-publish="self.publish(persona)" is-valid="self.isValid()" show-personas="self.isHoldable" ng-if="self.showCreateInput && !self.isEditFromNeed"></won-publish-button>
-            <div class="cp__footer__edit" ng-if="self.loggedIn && self.showCreateInput && self.isEditFromNeed">
+            <won-publish-button on-publish="self.publish(persona)" is-valid="self.isValid()" show-personas="self.isHoldable" ng-if="self.showCreateInput && !self.isEditFromNeed && self.isFromNeedUsableAsTemplate"></won-publish-button>
+            <div class="cp__footer__edit" ng-if="self.loggedIn && self.showCreateInput && self.isEditFromNeed && self.isFromNeedEditable">
               <button class="cp__footer__edit__save won-button--filled red" ng-click="self.save()">
                   Save
               </button>
               <button class="cp__footer__edit__cancel won-button--outlined thin red" ng-click="self.router__back()">
                   Cancel
               </button>
+            </div>
+            <div class="cp__footer__error" ng-if="self.showCreateInput && self.isEditFromNeed && !self.isFromNeedEditable">
+              Can't edit this need (need not owned or doesn't have a matching usecase)
+            </div>
+            <div class="cp__footer__error" ng-if="self.showCreateInput && self.isCreateFromNeed && !self.isFromNeedUsableAsTemplate">
+              Can't use this need as a template (need is owned or doesn't have a matching usecase)
             </div>
         </div>
     `;
@@ -221,6 +227,8 @@ function genComponentConf() {
           isEditFromNeed,
           isFromNeedLoading,
           isFromNeedToLoad,
+          isFromNeedEditable: needUtils.isEditable(fromNeed),
+          isFromNeedUsableAsTemplate: needUtils.isUsableAsTemplate(fromNeed),
           isHoldable: useCaseUtils.isHoldable(useCase),
           hasFromNeedFailedToLoad,
           showCreateInput:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.js
@@ -9,30 +9,13 @@ import connectionMessageActionsModule from "./connection-message-actions.js";
 import messageContentModule from "./message-content.js"; // due to our need of recursivley integrating the combinedMessageContentModule within referencedMessageModule, we need to import the components here otherwise we will not be able to generate the component
 import referencedMessageContentModule from "./referenced-message-content.js";
 import combinedMessageContentModule from "./combined-message-content.js";
+import labelledHrModule from "../labelled-hr.js";
 
 import { connect2Redux } from "../../won-utils.js";
 import { attach, getIn, get } from "../../utils.js";
 import { actionCreators } from "../../actions/actions.js";
 import { getOwnedNeedByConnectionUri } from "../../selectors/general-selectors.js";
-import {
-  isMessageProposable,
-  isMessageClaimable,
-  isMessageCancelable,
-  isMessageRetractable,
-  isMessageAcceptable,
-  isMessageRejectable,
-  hasProposesReferences,
-  hasClaimsReferences,
-  hasProposesToCancelReferences,
-  isMessageProposed,
-  isMessageClaimed,
-  isMessageRejected,
-  isMessageAccepted,
-  isMessageRetracted,
-  isMessageCancelled,
-  isMessageCancellationPending,
-  isMessageUnread,
-} from "../../message-utils.js";
+import * as messageUtils from "../../message-utils.js";
 import { classOnComponentRoot } from "../../cstm-ng-utils.js";
 
 import { ownerBaseUrl } from "config";
@@ -51,17 +34,17 @@ function genComponentConf() {
             class="clickable"
             uri="::self.theirNeed.get('uri')"
             ng-click="!self.multiSelectType && self.router__stateGoCurrent({viewNeedUri: self.theirNeed.get('uri'), viewConnUri: undefined})"
-            ng-if="!self.isSent && !(self.isGroupChatMessage && self.originatorUri)">
+            ng-if="!self.isChangeNotificationMessage && !self.isSent && !(self.isGroupChatMessage && self.originatorUri)">
         </won-square-image>
         <won-square-image
             class="clickable"
             uri="::self.originatorUri"
             ng-click="!self.multiSelectType && self.router__stateGoCurrent({viewNeedUri: self.originatorUri, viewConnUri: undefined})"
-            ng-if="self.isReceived && self.isGroupChatMessage && self.originatorUri">
+            ng-if="!self.isChangeNotificationMessage && self.isReceived && self.isGroupChatMessage && self.originatorUri">
         </won-square-image>
         <won-square-image
             uri="::self.messageSenderUri"
-            ng-if="self.isFromSystem">
+            ng-if="!self.isChangeNotificationMessage && self.isFromSystem">
         </won-square-image>
         <div class="won-cm__center"
                 ng-class="{
@@ -69,7 +52,8 @@ function genComponentConf() {
                   'won-cm__center--system': self.isFromSystem,
                   'won-cm__center--inject-into': self.isInjectIntoMessage
                 }"
-                in-view="self.isUnread && $inview && self.markAsRead()">
+                in-view="self.isUnread && $inview && self.markAsRead()"
+                ng-if="!self.isChangeNotificationMessage">
             <div class="won-cm__center__bubble"
                 ng-class="{
     			        'references' : 	self.hasReferences,
@@ -109,6 +93,11 @@ function genComponentConf() {
                 </svg>
             </a>
         </div>
+        <won-labelled-hr
+            ng-if="self.isChangeNotificationMessage"
+            in-view="self.isUnread && $inview && self.markAsRead()"
+            label="::'Need has been modified'" class="won-cm__modified">
+        </won-labelled-hr>
     `;
 
   class Controller {
@@ -171,33 +160,37 @@ function genComponentConf() {
           messageSenderUri: get(message, "senderUri"),
           isGroupChatMessage: this.groupChatMessage,
           originatorUri: get(message, "originatorUri"),
-          isConnectionMessage:
-            get(message, "messageType") === won.WONMSG.connectionMessage,
+          isConnectionMessage: messageUtils.isConnectionMessage(message),
+          isChangeNotificationMessage: messageUtils.isChangeNotificationMessage(
+            message
+          ),
           isSelected: getIn(message, ["viewState", "isSelected"]),
           isCollapsed: getIn(message, ["viewState", "isCollapsed"]),
           showActions: getIn(message, ["viewState", "showActions"]),
           multiSelectType: get(connection, "multiSelectType"),
           shouldShowRdf,
           rdfLinkURL,
-          isParsable: get(message, "isParsable"),
-          isClaimed: isMessageClaimed(message),
-          isProposed: isMessageProposed(message),
-          isAccepted: isMessageAccepted(message),
-          isRejected: isMessageRejected(message),
-          isRetracted: isMessageRetracted(message),
-          isCancellationPending: isMessageCancellationPending(message),
-          isCancelled: isMessageCancelled(message),
+          isParsable: messageUtils.isParsable(message),
+          isClaimed: messageUtils.isMessageClaimed(message),
+          isProposed: messageUtils.isMessageProposed(message),
+          isAccepted: messageUtils.isMessageAccepted(message),
+          isRejected: messageUtils.isMessageRejected(message),
+          isRetracted: messageUtils.isMessageRetracted(message),
+          isCancellationPending: messageUtils.isMessageCancellationPending(
+            message
+          ),
+          isCancelled: messageUtils.isMessageCancelled(message),
           isProposable:
             get(connection, "state") === won.WON.Connected &&
-            isMessageProposable(message),
+            messageUtils.isMessageProposable(message),
           isClaimable:
             get(connection, "state") === won.WON.Connected &&
-            isMessageClaimable(message),
-          isCancelable: isMessageCancelable(message),
-          isRetractable: isMessageRetractable(message),
-          isRejectable: isMessageRejectable(message),
-          isAcceptable: isMessageAcceptable(message),
-          isUnread: isMessageUnread(message),
+            messageUtils.isMessageClaimable(message),
+          isCancelable: messageUtils.isMessageCancelable(message),
+          isRetractable: messageUtils.isMessageRetractable(message),
+          isRejectable: messageUtils.isMessageRejectable(message),
+          isAcceptable: messageUtils.isMessageAcceptable(message),
+          isUnread: messageUtils.isMessageUnread(message),
           isInjectIntoMessage: injectInto && injectInto.size > 0,
           injectInto: injectInto,
           isReceived,
@@ -237,6 +230,11 @@ function genComponentConf() {
       classOnComponentRoot("won-is-accepted", () => this.isAccepted, this);
       classOnComponentRoot("won-is-cancelled", () => this.isCancelled, this);
       classOnComponentRoot("won-is-collapsed", () => this.isCollapsed, this);
+      classOnComponentRoot(
+        "won-change-notification",
+        () => this.isChangeNotificationMessage,
+        this
+      );
 
       classOnComponentRoot(
         "won-is-cancellationPending",
@@ -308,9 +306,9 @@ function genComponentConf() {
       return (
         !this.isGroupChatMessage &&
         (this.showActions ||
-          hasProposesReferences(this.message) ||
-          hasClaimsReferences(this.message) ||
-          hasProposesToCancelReferences(this.message))
+          messageUtils.hasProposesReferences(this.message) ||
+          messageUtils.hasClaimsReferences(this.message) ||
+          messageUtils.hasProposesToCancelReferences(this.message))
       );
     }
 
@@ -358,6 +356,7 @@ export default angular
     messageContentModule,
     referencedMessageContentModule,
     combinedMessageContentModule,
+    labelledHrModule,
     inviewModule.name,
   ])
   .directive("wonConnectionMessage", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.js
@@ -37,7 +37,7 @@ function genComponentConf() {
         "«This message couldn't be displayed as it didn't contain," +
         "any parsable content! " +
         'Click on the "Show raw RDF data"-button in ' +
-        'the main-menu on the right side of the navigationbar to see the "raw" message-data.»';
+        'the footer of the page to see the "raw" message-data.»';
 
       this.allDetails = useCaseUtils.getAllDetails();
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -33,12 +33,20 @@ function genComponentConf() {
       <div class="pcg__columns">
       <!-- LEFT COLUMN -->
         <div class="pcg__columns__left">
-          <div class="pcg__columns__left__item" ng-if="self.friendlyTimestamp">
+          <div class="pcg__columns__left__item" ng-if="self.friendlyCreationDate">
             <div class="pcg__columns__left__item__label">
               Created
             </div>
             <div class="pcg__columns__left__item__value">
-              {{ self.friendlyTimestamp }}
+              {{ self.friendlyCreationDate }}
+            </div>
+          </div>
+          <div class="pcg__columns__left__item" ng-if="self.friendlyModifiedDate">
+            <div class="pcg__columns__left__item__label">
+              Modified
+            </div>
+            <div class="pcg__columns__left__item__value">
+              {{ self.friendlyModifiedDate }}
             </div>
           </div>
           <!-- TYPES - IF SHOW RDF IS TRUE -->
@@ -125,6 +133,9 @@ function genComponentConf() {
         const post = this.postUri && getIn(state, ["needs", this.postUri]);
         const viewState = get(state, "view");
 
+        const creationDate = get(post, "creationDate");
+        const modifiedDate = get(post, "modifiedDate");
+
         return {
           WON: won.WON,
           fullTypesLabel: post && generateFullNeedTypesLabel(post),
@@ -134,12 +145,13 @@ function genComponentConf() {
           shortFlags: post && generateShortNeedFlags(post),
           fullFacets: post && generateFullNeedFacets(post),
           shortFacets: post && generateShortNeedFacets(post),
-          friendlyTimestamp:
-            post &&
-            relativeTime(
-              selectLastUpdateTime(state),
-              get(post, "creationDate")
-            ),
+          friendlyCreationDate:
+            creationDate &&
+            relativeTime(selectLastUpdateTime(state), creationDate),
+          friendlyModifiedDate:
+            modifiedDate &&
+            modifiedDate != creationDate &&
+            relativeTime(selectLastUpdateTime(state), modifiedDate),
           ratingConnectionUri: ratingConnectionUri,
           shouldShowRdf: viewUtils.showRdf(viewState),
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -62,6 +62,12 @@ function genComponentConf() {
           </div>
         </div>
         <div class="post-content" ng-if="!self.postLoading && !self.postFailedToLoad">
+          <div class="post-content__updateindicator" ng-if="self.postProcessingUpdate">
+            <svg class="hspinner post-content__updateindicator__spinner">
+              <use xlink:href="#ico_loading_anim" href="#ico_loading_anim"></use>
+            </svg>
+            <span class="post-content__updateindicator__label">Processing changes...</span>
+          </div>
           <!-- GENERAL INFORMATION -->
           <won-post-content-general ng-if="self.isSelectedTab('DETAIL')" post-uri="self.postUri"></won-post-content-general>
           <!-- DETAIL INFORMATION -->
@@ -212,6 +218,8 @@ function genComponentConf() {
             !post || processUtils.isNeedLoading(process, this.postUri),
           postFailedToLoad:
             post && processUtils.hasNeedFailedToLoad(process, this.postUri),
+          postProcessingUpdate:
+            post && processUtils.isNeedProcessingUpdate(process, this.postUri),
           createdTimestamp: post && post.get("creationDate"),
           shouldShowRdf: viewUtils.showRdf(viewState),
           fromConnection: !!openConnectionUri,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -52,6 +52,12 @@ function genComponentConf() {
                         ng-click="self.router__stateGoAbs('connections', {fromNeedUri: self.needUri, mode: 'DUPLICATE'})">
                         Post this too!
                     </button>
+                    <button
+                        class="won-button--outlined thin red"
+                        ng-if="self.isEditable"
+                        ng-click="self.router__stateGoAbs('connections', {fromNeedUri: self.needUri, mode: 'EDIT'})">
+                        Edit Need
+                    </button>
                     <a class="won-button--outlined thin red"
                         ng-if="self.adminEmail"
                         href="mailto:{{ self.adminEmail }}?{{ self.generateReportPostMailParams()}}">
@@ -98,6 +104,7 @@ function genComponentConf() {
           isActive: needUtils.isActive(post),
           isInactive: needUtils.isInactive(post),
           isUsableAsTemplate: needUtils.isUsableAsTemplate(post),
+          isEditable: needUtils.isEditable(post),
           post,
           postLoading:
             !post || processUtils.isNeedLoading(process, post.get("uri")),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/message-utils.js
@@ -16,6 +16,7 @@ export function isMessageProposable(msg) {
     msg &&
     msg.get("hasContent") &&
     msg.get("messageType") !== won.WONMSG.connectMessage &&
+    msg.get("messageType") !== won.WONMSG.changeNotificationMessage &&
     !msg.get("hasReferences")
   );
 }
@@ -31,6 +32,7 @@ export function isMessageClaimable(msg) {
     msg &&
     msg.get("hasContent") &&
     msg.get("messageType") !== won.WONMSG.connectMessage &&
+    msg.get("messageType") !== won.WONMSG.changeNotificationMessage &&
     !msg.get("hasReferences")
   );
 }
@@ -284,6 +286,18 @@ export function isMessageAgreement(msg) {
 
 export function isHintMessage(msg) {
   return get(msg, "messageType") === won.WONMSG.hintMessage;
+}
+
+export function isConnectionMessage(msg) {
+  return get(msg, "messageType") === won.WONMSG.connectionMessage;
+}
+
+export function isChangeNotificationMessage(msg) {
+  return get(msg, "messageType") === won.WONMSG.changeNotificationMessage;
+}
+
+export function isParsable(msg) {
+  return get(msg, "isParsable");
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -84,6 +84,17 @@ export function runMessagingAgent(redux) {
       return false;
     },
     function(message) {
+      if (
+        message.isFromSystem() &&
+        message.isSuccessResponse() &&
+        message.isResponseToReplaceMessage()
+      ) {
+        redux.dispatch(actionCreators.messages__edit__success(message));
+        return true;
+      }
+      return false;
+    },
+    function(message) {
       if (message.isResponseToConnectMessage()) {
         if (message.isSuccessResponse()) {
           if (message.isFromExternal()) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/messaging-agent.js
@@ -66,6 +66,15 @@ export function runMessagingAgent(redux) {
       return false;
     },
     function(message) {
+      if (message.isChangeNotificationMessage()) {
+        redux.dispatch(
+          actionCreators.messages__processChangeNotificationMessage(message)
+        );
+        return true;
+      }
+      return false;
+    },
+    function(message) {
       if (message.isFromExternal() && message.isCloseMessage()) {
         redux.dispatch(actionCreators.messages__close__success(message));
         return true;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -89,6 +89,29 @@ export function isUsableAsTemplate(need) {
 }
 
 /**
+ * This checks if the need is allowed to be edited,
+ * it is only allowed if the need exists, and if it is OWNED and not one of the following:
+ * - DirectResponseNeed
+ * - WhatsAroundNeed
+ * - WhatsNewNeed
+ * - SearchNeed
+ * @param need
+ * @returns {*|boolean}
+ */
+export function isEditable(need) {
+  return (
+    need &&
+    isOwned(need) &&
+    !(
+      isDirectResponseNeed(need) ||
+      isWhatsAroundNeed(need) ||
+      isWhatsNewNeed(need) ||
+      isSearchNeed(need)
+    )
+  );
+}
+
+/**
  * Determines if a given need is a DirectResponse-Need
  * @param need
  * @returns {*|boolean}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -44,6 +44,10 @@ export function getEnabledUseCases(need) {
   return getIn(need, ["matchedUseCase", "enabledUseCases"]);
 }
 
+export function hasMatchedUseCase(need) {
+  return !!getIn(need, ["matchedUseCase", "identifier"]);
+}
+
 /**
  * Determines if a given need is a Inactive
  * @param need
@@ -67,48 +71,22 @@ export function isWhatsAroundNeed(need) {
 
 /**
  * This checks if the need is allowed to be used as a template,
- * it is only allowed if the need exists, and if it is not one of the following:
- * - DirectResponseNeed
- * - WhatsAroundNeed
- * - WhatsNewNeed
- * - SearchNeed
+ * it is only allowed if the need exists, and if it has a matchedUseCase
  * @param need
  * @returns {*|boolean}
  */
 export function isUsableAsTemplate(need) {
-  return (
-    need &&
-    !(
-      isOwned(need) ||
-      isDirectResponseNeed(need) ||
-      isWhatsAroundNeed(need) ||
-      isWhatsNewNeed(need) ||
-      isSearchNeed(need)
-    )
-  );
+  return need && !isOwned(need) && hasMatchedUseCase(need);
 }
 
 /**
  * This checks if the need is allowed to be edited,
- * it is only allowed if the need exists, and if it is OWNED and not one of the following:
- * - DirectResponseNeed
- * - WhatsAroundNeed
- * - WhatsNewNeed
- * - SearchNeed
+ * it is only allowed if the need exists, and if it is OWNED and has a matchedUseCase
  * @param need
  * @returns {*|boolean}
  */
 export function isEditable(need) {
-  return (
-    need &&
-    isOwned(need) &&
-    !(
-      isDirectResponseNeed(need) ||
-      isWhatsAroundNeed(need) ||
-      isWhatsNewNeed(need) ||
-      isSearchNeed(need)
-    )
-  );
+  return need && isOwned(need) && hasMatchedUseCase(need);
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
@@ -90,6 +90,17 @@ export function isProcessingSendAnonymousLinkEmail(process) {
 }
 
 /**
+ * Return true if given needUri is currently processing an update
+ * @param process (full process from state)
+ * @param needUri
+ * @returns {*}
+ */
+
+export function isNeedProcessingUpdate(process, needUri) {
+  return needUri && getIn(process, ["needs", needUri, "processUpdate"]);
+}
+
+/**
  * Return true if given needUri is currently loading
  * @param process (full process from state)
  * @param needUri

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -15,6 +15,10 @@ const initialState = Immutable.fromJS({
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
+    case actionTypes.needs.edit:
+      //TODO: IMPL
+      return messages;
+
     case actionTypes.needs.connect:
     case actionTypes.personas.create:
     case actionTypes.needs.create:
@@ -22,6 +26,14 @@ export function messagesReducer(messages = initialState, action = {}) {
         ["enqueued", action.payload.eventUri],
         action.payload.message
       );
+
+    case actionTypes.needs.editFailure:
+      //TODO: IMPL
+      return messages;
+
+    case actionTypes.needs.editSuccessful:
+      //TODO: IMPL
+      return messages;
 
     case actionTypes.needs.createSuccessful:
       return messages.removeIn([

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -15,9 +15,17 @@ const initialState = Immutable.fromJS({
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
-    case actionTypes.needs.edit:
+    case actionTypes.needs.edit: {
+      console.debug(
+        "payload = {eventUri, message, needUri, need: draft, oldNeed}"
+      );
+      console.debug(
+        "message-reducer actionTypes.needs.edit todo: impl / payload-> ",
+        action.payload
+      );
       //TODO: IMPL
       return messages;
+    }
 
     case actionTypes.needs.connect:
     case actionTypes.personas.create:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -15,18 +15,12 @@ const initialState = Immutable.fromJS({
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
-    case actionTypes.needs.edit: {
-      console.debug(
-        "payload = {eventUri, message, needUri, need: draft, oldNeed}"
-      );
-      console.debug(
-        "message-reducer actionTypes.needs.edit todo: impl / payload-> ",
-        action.payload
-      );
-      //TODO: IMPL
-      return messages;
-    }
-
+    case actionTypes.connections.open:
+    case actionTypes.connections.sendChatMessage:
+    case actionTypes.connections.rate:
+    case actionTypes.connections.close:
+    case actionTypes.messages.send:
+    case actionTypes.needs.edit:
     case actionTypes.needs.connect:
     case actionTypes.personas.create:
     case actionTypes.needs.create:
@@ -60,16 +54,6 @@ export function messagesReducer(messages = initialState, action = {}) {
         .removeIn(["enqueued", pendingEventUri])
         .setIn(["waitingForAnswer", pendingEventUri], msg);
     }
-
-    case actionTypes.connections.open:
-    case actionTypes.connections.sendChatMessage:
-    case actionTypes.connections.rate:
-    case actionTypes.connections.close:
-    case actionTypes.messages.send:
-      return messages.setIn(
-        ["enqueued", action.payload.eventUri],
-        action.payload.message
-      );
 
     case actionTypes.connections.sendChatMessageRefreshDataOnSuccess:
       return messages

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -29,20 +29,17 @@ export function messagesReducer(messages = initialState, action = {}) {
         action.payload.message
       );
 
-    case actionTypes.needs.editFailure:
+    case actionTypes.needs.editFailure: {
       //TODO: IMPL
+      console.debug(
+        "message-reducer actionTypes.needs.editFailure todo: impl / payload-> ",
+        action.payload
+      );
       return messages;
+    }
 
     case actionTypes.needs.editSuccessful:
-      //TODO: IMPL
-      return messages;
-
     case actionTypes.needs.createSuccessful:
-      return messages.removeIn([
-        "waitingForAnswer",
-        action.payload.publishEventUri,
-      ]);
-
     case actionTypes.messages.chatMessage.failure:
     case actionTypes.messages.chatMessage.success:
       return messages.removeIn(["waitingForAnswer", action.payload.eventUri]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -211,13 +211,23 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.needUri
       );
 
-    case actionTypes.needs.editFailure:
+    case actionTypes.needs.editFailure: {
+      console.debug(
+        "need-reducer-main actionTypes.needs.editFailure todo: impl / payload-> ",
+        action.payload
+      );
       //TODO: IMPL change
       return allNeedsInState;
+    }
 
-    case actionTypes.needs.editSuccessful:
+    case actionTypes.needs.editSuccessful: {
+      console.debug(
+        "need-reducer-main actionTypes.needs.editSuccessful todo: impl / payload-> ",
+        action.payload
+      );
       //TODO: IMPL change
       return allNeedsInState;
+    }
 
     case actionTypes.needs.createSuccessful:
       return addNeed(allNeedsInState, action.payload.need, true);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -192,12 +192,24 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
+    case actionTypes.needs.edit:
+      //TODO: IMPL Optimistic change
+      return allNeedsInState;
+
     case actionTypes.needs.create: // optimistic need adding
       return addNeedInCreation(
         allNeedsInState,
         action.payload.need,
         action.payload.needUri
       );
+
+    case actionTypes.needs.editFailure:
+      //TODO: IMPL change
+      return allNeedsInState;
+
+    case actionTypes.needs.editSuccessful:
+      //TODO: IMPL change
+      return allNeedsInState;
 
     case actionTypes.needs.createSuccessful:
       return addNeed(allNeedsInState, action.payload.need, true);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -192,9 +192,17 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
     }
 
-    case actionTypes.needs.edit:
+    case actionTypes.needs.edit: {
+      console.debug(
+        "payload = {eventUri, message, needUri, need: draft, oldNeed}"
+      );
+      console.debug(
+        "need-reducer-main actionTypes.needs.edit todo: impl / payload-> ",
+        action.payload
+      );
       //TODO: IMPL Optimistic change
       return allNeedsInState;
+    }
 
     case actionTypes.needs.create: // optimistic need adding
       return addNeedInCreation(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -725,6 +725,8 @@ export default function(allNeedsInState = initialState, action = {}) {
       //add a message that has been already processed (so sent status is ommitted)
       return addMessage(allNeedsInState, action.payload, true);
     // NEW MESSAGE STATE UPDATES
+
+    case actionTypes.messages.processChangeNotificationMessage:
     case actionTypes.messages.processConnectionMessage:
       // ADD RECEIVED CHAT MESSAGES
       // payload; { events }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -34,7 +34,8 @@ export function parseNeed(jsonldNeed, isOwned) {
       content: generateContent(jsonldNeedImm, detailsToParse),
       seeks: generateContent(jsonldNeedImm.get("won:seeks"), detailsToParse),
       creationDate: extractCreationDate(jsonldNeedImm),
-      lastUpdateDate: extractCreationDate(jsonldNeedImm),
+      lastUpdateDate: extractCreationDate(jsonldNeedImm), //Used for sorting/updates (e.g. if connection comes in etc...)
+      modifiedDate: extractLastModifiedDate(jsonldNeedImm), //Used as a flag if the need itself has changed (e.g. need edit)
       humanReadable: undefined, //can only be determined after we generated The Content
       matchedUseCase: {
         identifier: undefined,
@@ -183,6 +184,16 @@ function extractCreationDate(needJsonLd) {
     needJsonLd.get("http://purl.org/dc/terms/created");
   if (creationDate) {
     return new Date(creationDate);
+  }
+  return undefined;
+}
+
+function extractLastModifiedDate(needJsonLd) {
+  const lastModifiedDate =
+    needJsonLd.get("dct:modified") ||
+    needJsonLd.get("http://purl.org/dc/terms/modified");
+  if (lastModifiedDate) {
+    return new Date(lastModifiedDate);
   }
   return undefined;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -128,13 +128,26 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.failedToGetLocation:
       return processState.set("processingPublish", false);
 
-    case actionTypes.needs.editFailure:
+    case actionTypes.needs.editFailure: {
+      console.debug(
+        "process-reducer actionTypes.needs.editFailure todo: impl / payload-> ",
+        action.payload
+      );
       //TODO: IMPL
       return processState;
+    }
 
-    case actionTypes.needs.editSuccessful:
-      //TODO: IMPL
+    case actionTypes.needs.editSuccessful: {
+      const needUri = action.payload.needUri;
+
+      if (needUri) {
+        processState = updateNeedProcess(processState, needUri, {
+          processUpdate: false,
+        });
+      }
+
       return processState;
+    }
 
     case actionTypes.needs.createSuccessful: {
       const needUri =

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -25,6 +25,7 @@ export const emptyNeedProcess = Immutable.fromJS({
   loading: false,
   toLoad: false,
   failedToLoad: false,
+  processUpdate: false,
 });
 
 export const emptyConnectionProcess = Immutable.fromJS({
@@ -106,9 +107,17 @@ function updateMessageProcess(processState, connUri, messageUri, payload) {
 
 export default function(processState = initialState, action = {}) {
   switch (action.type) {
-    case actionTypes.needs.edit:
-      //TODO: IMPL
+    case actionTypes.needs.edit: {
+      const needUri = action.payload.needUri;
+
+      if (needUri) {
+        processState = updateNeedProcess(processState, needUri, {
+          processUpdate: true,
+        });
+      }
+
       return processState;
+    }
 
     case actionTypes.personas.create:
     case actionTypes.needs.create:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -106,6 +106,10 @@ function updateMessageProcess(processState, connUri, messageUri, payload) {
 
 export default function(processState = initialState, action = {}) {
   switch (action.type) {
+    case actionTypes.needs.edit:
+      //TODO: IMPL
+      return processState;
+
     case actionTypes.personas.create:
     case actionTypes.needs.create:
     case actionTypes.needs.whatsNew:
@@ -114,6 +118,14 @@ export default function(processState = initialState, action = {}) {
 
     case actionTypes.failedToGetLocation:
       return processState.set("processingPublish", false);
+
+    case actionTypes.needs.editFailure:
+      //TODO: IMPL
+      return processState;
+
+    case actionTypes.needs.editSuccessful:
+      //TODO: IMPL
+      return processState;
 
     case actionTypes.needs.createSuccessful: {
       const needUri =

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -120,6 +120,11 @@ import won from "./won.js";
     privateData.cacheStatus = {}; //uri -> {timestamp, cacheItemState}
     privateData.documentToGraph = {}; // document-uri -> Set<uris of contained graphs>
   };
+
+  won.clearStoreWithPromise = async function() {
+    won.clearStore();
+  };
+
   /**
    * OK: fully fetched
    * DIRTY: has changed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -1593,7 +1593,12 @@ WonMessage.prototype = {
       "http://purl.org/webofneeds/message#FailureResponse"
     );
   },
-
+  isResponseToReplaceMessage: function() {
+    return (
+      this.getIsResponseToMessageType() ===
+      "http://purl.org/webofneeds/message#ReplaceMessage"
+    );
+  },
   isResponseToHintMessage: function() {
     return (
       this.getIsResponseToMessageType() ===

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -243,6 +243,8 @@ won.WONMSG.FromSystem = won.WONMSG.baseUri + "FromSystem";
 //message types
 won.WONMSG.createMessage = won.WONMSG.baseUri + "CreateMessage";
 won.WONMSG.createMessageCompacted = won.WONMSG.prefix + ":CreateMessage";
+won.WONMSG.replaceMessage = won.WONMSG.baseUri + "ReplaceMessage";
+won.WONMSG.replaceMessageCompacted = won.WONMSG.prefix + ":ReplaceMessage";
 won.WONMSG.activateNeedMessage = won.WONMSG.baseUri + "ActivateMessage";
 won.WONMSG.activateNeedMessageCompacted =
   won.WONMSG.prefix + ":ActivateMessage";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -277,6 +277,10 @@ won.WONMSG.feedbackMessage = won.WONMSG.baseUri + "HintFeedbackMessage";
 won.WONMSG.openMessageCompacted = won.WONMSG.prefix + ":OpenMessage";
 won.WONMSG.openSentMessage = won.WONMSG.baseUri + "OpenSentMessage";
 won.WONMSG.openSentMessageCompacted = won.WONMSG.prefix + ":OpenSentMessage";
+won.WONMSG.changeNotificationMessage =
+  won.WONMSG.baseUri + "ChangeNotificationMessage";
+won.WONMSG.changeNotificationMessageCompacted =
+  won.WONMSG.prefix + ":ChangeNotificationMessage";
 won.WONMSG.connectionMessage = won.WONMSG.baseUri + "ConnectionMessage";
 won.WONMSG.connectionMessageCompacted =
   won.WONMSG.prefix + ":ConnectionMessage";
@@ -1340,9 +1344,18 @@ WonMessage.prototype = {
     return this.compactRawMessage;
   },
   getMessageType: function() {
-    return this.getProperty(
-      "http://purl.org/webofneeds/message#hasMessageType"
-    );
+    if (
+      this.getProperty("http://purl.org/webofneeds/message#hasMessageType") ===
+        "http://purl.org/webofneeds/message#ConnectionMessage" &&
+      this.getTextMessage() === "Note: need content was changed."
+    ) {
+      //TODO: REMOVE THIS HANDLER ONCE THE CHANGENOTIFICATIONMESSAGE TYPE HAS BEEN IMPLEMENTED IN THE BACKEND
+      return "http://purl.org/webofneeds/message#ChangeNotificationMessage";
+    } else {
+      return this.getProperty(
+        "http://purl.org/webofneeds/message#hasMessageType"
+      );
+    }
   },
   getInjectIntoConnectionUris: function() {
     return createArray(
@@ -1657,6 +1670,12 @@ WonMessage.prototype = {
     return (
       this.getIsResponseToMessageType() ===
       "http://purl.org/webofneeds/message#DeleteMessage"
+    );
+  },
+  isChangeNotificationMessage: function() {
+    return (
+      this.getMessageType() ===
+      "http://purl.org/webofneeds/message#ChangeNotificationMessage"
     );
   },
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -440,6 +440,25 @@ export function buildOpenMessage(
   return messageP;
 }
 
+export async function buildEditMessage(editedNeedData, oldNeed, wonNodeUri) {
+  console.debug(
+    "TODO: IMPL buildEditMessage: ",
+    editedNeedData,
+    oldNeed,
+    wonNodeUri
+  );
+  const needUriToEdit = oldNeed && oldNeed.get("uri");
+
+  const msgJson = undefined;
+  const msgUri = undefined;
+  //TODO FIX ME ACCORDING TO THE spec:
+  return {
+    message: msgJson,
+    eventUri: msgUri,
+    needUri: needUriToEdit,
+  };
+}
+
 /**
  *
  * @param needData

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -486,17 +486,6 @@ export async function buildCreateMessage(needData, wonNodeUri) {
 
   const publishedContentUri = wonNodeUri + "/need/" + getRandomWonId();
 
-  const imgs = needData.images;
-  let attachmentUris = [];
-  if (imgs) {
-    imgs.forEach(function(img) {
-      img.uri = wonNodeUri + "/attachment/" + getRandomWonId();
-    });
-    attachmentUris = imgs.map(function(img) {
-      return img.uri;
-    });
-  }
-
   //if type  create -> use needBuilder as well
   const prepareContentNodeData = async needData => ({
     // Adds all fields from needDataIsOrSeeks:
@@ -504,8 +493,6 @@ export async function buildCreateMessage(needData, wonNodeUri) {
     ...needData,
 
     publishedContentUri: publishedContentUri, //mandatory
-    //TODO attach to either is or seeks?
-    attachmentUris: attachmentUris, //optional, should be same as in `attachments` below
     arbitraryJsonLd: needData.ttl ? await won.ttlToJsonLd(needData.ttl) : [],
   });
 
@@ -531,7 +518,6 @@ export async function buildCreateMessage(needData, wonNodeUri) {
     msgType: won.WONMSG.createMessage, //mandatory
     publishedContentUri: publishedContentUri, //mandatory
     msgUri: msgUri,
-    attachments: imgs, //optional, should be same as in `attachmentUris` above
   });
   //add the @base definition to the @context so we can use #fragments in the need structure
   msgJson["@context"]["@base"] = publishedContentUri;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -410,9 +410,26 @@ export const defaultFacet = {
   },
   parseFromRDF: function(jsonLDImm) {
     const wonHasDefaultFacet = get(jsonLDImm, "won:hasDefaultFacet");
+    let defaultFacet = Immutable.Map();
 
     if (wonHasDefaultFacet && !Immutable.List.isList(wonHasDefaultFacet)) {
-      return wonHasDefaultFacet;
+      const defaultFacetId = get(wonHasDefaultFacet, "@id");
+
+      const wonHasFacets = get(jsonLDImm, "won:hasFacet");
+
+      if (wonHasFacets) {
+        if (Immutable.List.isList(wonHasFacets)) {
+          const foundDefaultFacet = wonHasFacets.find(
+            facet => get(facet, "@id") === defaultFacetId
+          );
+          return defaultFacet.set(
+            defaultFacetId,
+            get(foundDefaultFacet, "@type")
+          );
+        } else if (get(wonHasFacets, "@id") === defaultFacetId) {
+          return defaultFacet.set(defaultFacetId, get(wonHasFacets, "@type"));
+        }
+      }
     }
     return undefined;
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -11,6 +11,19 @@ won-connection-message {
   display: grid;
   grid-template-areas: "icon content";
 
+  &.won-change-notification {
+    grid-template-columns: 1fr;
+    grid-template-areas: "labelledhr";
+
+    won-labelled-hr.won-cm__modified {
+      grid-area: labelledhr;
+
+      .wlh__label__text {
+        background: white;
+      }
+    }
+  }
+
   &.won-is-multiSelect {
     padding-left: 3rem;
     cursor: pointer;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-message.scss
@@ -24,7 +24,7 @@ won-connection-message {
     }
   }
 
-  &.won-is-multiSelect {
+  &.won-is-multiSelect:not(.won-change-notification) {
     padding-left: 3rem;
     cursor: pointer;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
@@ -147,6 +147,12 @@ won-create-search {
       width: 100%;
       margin-top: 1rem;
     }
+
+    .cp__footer__edit {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-gap: 0.5rem;
+    }
   }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -24,6 +24,22 @@ won-post-content {
       padding: 0.5rem;
     }
 
+    .post-content__updateindicator {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+
+      padding: 0.25rem;
+      background: $won-secondary-color-light;
+      color: $won-secondary-text-color;
+
+      &__label {
+        margin-left: 0.5rem;
+        white-space: nowrap;
+      }
+    }
+
     .post-content__reviews {
       &__empty {
         color: $won-line-gray;


### PR DESCRIPTION
This PR implements the frontend for editing needs, this includes:
- react to changes (non optimistic) of owned and edited needs and their respective connections without reload
- react to changes of ws-messages that indicate that the remote need has changed
- Edit Component can be accessed within the post-context-dropdown of an owned need that has a matched UseCase

Any owned Need that has a matchedUseCase is editable, anything else is not allowed to be edited

Caveats:
- Reload while having the edit view open might result in a owned need to disappear -> this will be handled separately since we also have this issue when looking at a visitor view of an owned need while being logged in
- ChangeNotificationMessage is currently not implemented in the backend (we assume that the message will be of that type if the getTextMessage of a connectionMessage is a certain string (something with Note: yada yada content has changed)
- Not sure how groupchats will update the groupmembers needs yet
- Processing Edit Indicator seems to be misplaced or too ugly for production usage
- failure response of an edit is not handled yet -> but that it is also not yet implemented for need creation itself

fixes #2854 
fixes #2825 
