### PR TITLE
Fix editfail #2859

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -104,7 +104,7 @@ function genComponentConf() {
             <won-labelled-hr label="::'done?'" class="cp__footer__labelledhr"></won-labelled-hr>
             <won-publish-button on-publish="self.publish(persona)" is-valid="self.isValid()" show-personas="self.isHoldable" ng-if="self.showCreateInput && !self.isEditFromNeed"></won-publish-button>
             <div class="cp__footer__edit" ng-if="self.loggedIn && self.showCreateInput && self.isEditFromNeed && self.isFromNeedEditable">
-              <button class="cp__footer__edit__save won-button--filled red" ng-click="self.save()">
+              <button class="cp__footer__edit__save won-button--filled red" ng-click="self.save()" ng-disabled="!self.isValid()">
                   Save
               </button>
               <button class="cp__footer__edit__cancel won-button--outlined thin red" ng-click="self.router__back()">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -56,7 +56,7 @@ function genComponentConf() {
                         class="won-button--outlined thin red"
                         ng-if="self.isEditable"
                         ng-click="self.router__stateGoAbs('connections', {fromNeedUri: self.needUri, mode: 'EDIT'})">
-                        Edit Post
+                        Edit
                     </button>
                     <a class="won-button--outlined thin red"
                         ng-if="self.adminEmail"

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -457,13 +457,11 @@ export const eventObject = {
     } else if (is("Array", value)) {
       const eventObjects = value.map(item => {
         return {
-          "s:object": {
-            "@type": "s:Event",
-            "s:about": { "@id": item },
-          },
+          "@type": "s:Event",
+          "s:about": { "@id": item },
         };
       });
-      return eventObjects;
+      return { "s:object": eventObjects };
     } else {
       return {
         "s:object": {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -451,15 +451,27 @@ export const eventObject = {
   placeholder: "What? (Short title shown in lists)",
   parseToRDF: function({ value }) {
     const val = value ? value : undefined;
+
     if (!val) {
       return;
+    } else if (is("Array", value)) {
+      const eventObjects = value.map(item => {
+        return {
+          "s:object": {
+            "@type": "s:Event",
+            "s:about": { "@id": item },
+          },
+        };
+      });
+      return eventObjects;
+    } else {
+      return {
+        "s:object": {
+          "@type": "s:Event",
+          "s:about": { "@id": value },
+        },
+      };
     }
-    return {
-      "s:object": {
-        "@type": "s:Event",
-        "s:about": { "@id": value },
-      },
-    };
   },
   parseFromRDF: function(jsonLDImm) {
     const types = get(jsonLDImm, "@type");

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -450,9 +450,7 @@ export const eventObject = {
   icon: "#ico36_detail_title",
   placeholder: "What? (Short title shown in lists)",
   parseToRDF: function({ value }) {
-    const val = value ? value : undefined;
-
-    if (!val) {
+    if (!value) {
       return;
     } else if (is("Array", value)) {
       const eventObjects = value.map(item => {


### PR DESCRIPTION
- Fixes the parseToRDF of eventObject to work with strings and also lists of eventObjects
- Fixes findUseCaseByNeed to check for multiple eventObjects (if multiples are defined in the useCase/need)
- Fixes a problem that any useCase that has been edited (or used as a template) will display the edited content within the next empty useCase of that type (see comment in #2859)
- Disables the save button in the editNeed view if the edited need becomes invalid
- Removes the "post" from the "Edit post" label in the post-context-dropdown

fixes #2859
