### PR TITLE
Fix  need fetch rc #2862

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -285,7 +285,7 @@ $ngRedux.getState();
 As you can see in this State all "visible" Data is stored within the needs and the corresponding connections and messages are stored within this tree.
 Example: If you want to retrieve all present connections for a given need you will access it by `$ngRedux.getState().getIn(["needs", [needUri], "connections"])`.
 
-All The DataParsing happens within the `need-reducer.js` and should only be implemented here, in their respective Methods `parseNeed(jsonLdNeed, isOwned)`, `parseConnection(jsonLdConnection, unread)` and `parseMessage(jsonLdMessage, outgoingMessage, unread)`.
+All The DataParsing happens within the `need-reducer.js` and should only be implemented here, in their respective Methods `parseNeed(jsonLdNeed)`, `parseConnection(jsonLdConnection, unread)` and `parseMessage(jsonLdMessage, outgoingMessage, unread)`.
 It is very important to not parse needs/connections/messages in any other place or in any other way to make sure that the structure of the corresponding items is always the same, and so that the Views don't have to implement fail-safes when accessing elements, e.g. a Location is only present if the whole location data can be parsed/stored within the state, otherwise the location will stay empty.
 This is also true for every message connection and need, as soon as the data is in the state you can be certain that all the mandatory values are set correctly.
 

--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -192,7 +192,6 @@ $ngRedux.getState();
        creationDate: Date, //creationDate of this need
        lastUpdateDate: date, //date of lastUpdate of this need (last date of the message or connection that was added)
        nodeUri: string, //identifier of this need's server
-       isOwned: true|false, //whether this need is owned or not
        isBeingCreated: true|false, //whether or not the creation of this need was successfully completed yet
        state: "won:Active" | "won:Inactive", //state of the need
        groupMembers: Immutable.List() // needUris of participants of this needs (won:hasGroupMember) -> usually only set for groupChatNeeds

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/account-utils.js
@@ -2,7 +2,7 @@
  * Created by fsuda on 19.03.2019.
  */
 
-import { get } from "./utils.js";
+import { get, getIn } from "./utils.js";
 
 /**
  * Determines if a there is currently a user logged in or not
@@ -97,4 +97,17 @@ export function isDisclaimerAccepted(accountState) {
  */
 export function isTermsOfServiceAccepted(accountState) {
   return !!get(accountState, "acceptedTermsOfService");
+}
+
+/**
+ * Returns true if the given needUri is owned by the loggedIn account
+ * @param accountState
+ * @param needUri
+ * @returns {*|boolean|boolean}
+ */
+export function isNeedOwned(accountState, needUri) {
+  return (
+    isLoggedIn(accountState) &&
+    !!getIn(accountState, ["ownedNeedUris", needUri])
+  );
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -228,8 +228,14 @@ function genComponentConf() {
           isEditFromNeed,
           isFromNeedLoading,
           isFromNeedToLoad,
-          isFromNeedEditable: needUtils.isEditable(fromNeed),
-          isFromNeedUsableAsTemplate: needUtils.isUsableAsTemplate(fromNeed),
+          isFromNeedEditable: generalSelectors.isNeedEditable(
+            state,
+            fromNeedUri
+          ),
+          isFromNeedUsableAsTemplate: generalSelectors.isNeedUsableAsTemplate(
+            state,
+            fromNeedUri
+          ),
           isHoldable: useCaseUtils.isHoldable(useCase),
           hasFromNeedFailedToLoad,
           showCreateInput:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -223,6 +223,7 @@ function genComponentConf() {
           useCase,
           fromNeed,
           fromNeedUri,
+          isFromNeedOwned: generalSelectors.isNeedOwned(state, fromNeedUri),
           isCreateFromNeed,
           isEditFromNeed,
           isFromNeedLoading,
@@ -329,7 +330,7 @@ function genComponentConf() {
     }
 
     save() {
-      if (this.loggedIn && needUtils.isOwned(this.fromNeed)) {
+      if (this.loggedIn && this.isFromNeedOwned) {
         this.draftObject.useCase = get(this.useCase, "identifier");
 
         if (!isBranchContentPresent(this.draftObject.content, true)) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-participants.js
@@ -13,6 +13,7 @@ import { connect2Redux } from "../won-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as connectionSelectors from "../selectors/connection-selectors.js";
 import * as connectionUtils from "../connection-utils.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import ngAnimate from "angular-animate";
 
@@ -105,7 +106,7 @@ function genComponentConf() {
 
       const selectFromState = state => {
         const post = getIn(state, ["needs", this.postUri]);
-        const isOwned = needUtils.isOwned(post);
+        const isOwned = generalSelectors.isNeedOwned(state, this.postUri);
 
         const hasGroupFacet = needUtils.hasGroupFacet(post);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-persona.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-persona.js
@@ -6,10 +6,7 @@ import angular from "angular";
 import Immutable from "immutable";
 import { attach, get, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
-import {
-  getConnectionUriFromRoute,
-  getOwnedNeedByConnectionUri,
-} from "../selectors/general-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import * as needUtils from "../need-utils.js";
 import * as processUtils from "../process-utils.js";
 import { actionCreators } from "../actions/actions.js";
@@ -64,9 +61,12 @@ function genComponentConf() {
       this.editNeedModule = Elm.EditNeed;
 
       const selectFromState = state => {
-        const connectionUri = getConnectionUriFromRoute(state);
+        const connectionUri = generalSelectors.getConnectionUriFromRoute(state);
         const connection = getOwnedConnectionByUri(state, connectionUri);
-        const ownNeed = getOwnedNeedByConnectionUri(state, connectionUri);
+        const ownNeed = generalSelectors.getOwnedNeedByConnectionUri(
+          state,
+          connectionUri
+        );
 
         const ratingConnectionUri =
           get(connection, "remoteNeedUri") == this.holdsUri &&
@@ -93,7 +93,7 @@ function genComponentConf() {
         return {
           post,
           personaUri,
-          postIsOwned: needUtils.isOwned(post),
+          postIsOwned: generalSelectors.isNeedOwned(state, this.holdsUri),
           postHasHoldableFacet: needUtils.hasHoldableFacet(post),
           personaLoading:
             !persona || processUtils.isNeedLoading(process, personaUri),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -18,7 +18,7 @@ import * as needUtils from "../need-utils.js";
 import * as viewUtils from "../view-utils.js";
 import * as processUtils from "../process-utils.js";
 import * as connectionSelectors from "../selectors/connection-selectors.js";
-import { getConnectionUriFromRoute } from "../selectors/general-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import ngAnimate from "angular-animate";
@@ -175,10 +175,12 @@ function genComponentConf() {
       this.editNeedModule = Elm.EditNeed;
 
       const selectFromState = state => {
-        const openConnectionUri = getConnectionUriFromRoute(state);
+        const openConnectionUri = generalSelectors.getConnectionUriFromRoute(
+          state
+        );
         const post = getIn(state, ["needs", this.postUri]);
         const isPersona = needUtils.isPersona(post);
-        const isOwned = needUtils.isOwned(post);
+        const isOwned = generalSelectors.isNeedOwned(state, this.postUri);
         const content = get(post, "content");
 
         //TODO it will be possible to have more than one seeks
@@ -289,10 +291,6 @@ function genComponentConf() {
 
     addPersona(persona) {
       this.personas__connect(this.postUri, persona);
-    }
-
-    canAttachPersona() {
-      return this.post.get("isOwned") && !this.post.get("heldBy");
     }
 
     isSelectedTab(tabName) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -12,6 +12,7 @@ import {
 } from "../won-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as processUtils from "../process-utils.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
 
@@ -100,7 +101,7 @@ function genComponentConf() {
 
         return {
           adminEmail: getIn(state, ["config", "theme", "adminEmail"]),
-          isOwnPost: needUtils.isOwned(post),
+          isOwnPost: generalSelectors.isNeedOwned(state, this.needUri),
           isActive: needUtils.isActive(post),
           isInactive: needUtils.isInactive(post),
           isUsableAsTemplate: needUtils.isUsableAsTemplate(post),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -104,8 +104,11 @@ function genComponentConf() {
           isOwnPost: generalSelectors.isNeedOwned(state, this.needUri),
           isActive: needUtils.isActive(post),
           isInactive: needUtils.isInactive(post),
-          isUsableAsTemplate: needUtils.isUsableAsTemplate(post),
-          isEditable: needUtils.isEditable(post),
+          isUsableAsTemplate: generalSelectors.isNeedUsableAsTemplate(
+            state,
+            this.needUri
+          ),
+          isEditable: generalSelectors.isNeedEditable(state, this.needUri),
           post,
           postLoading:
             !post || processUtils.isNeedLoading(process, post.get("uri")),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -12,7 +12,7 @@ import { attach, get, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import * as processUtils from "../process-utils.js";
 import * as needUtils from "../need-utils.js";
-import { getPostUriFromRoute } from "../selectors/general-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 
@@ -103,7 +103,7 @@ function genComponentConf() {
         */
         const postUri = this.needUri
           ? this.needUri
-          : getPostUriFromRoute(state);
+          : generalSelectors.getPostUriFromRoute(state);
         const post = state.getIn(["needs", postUri]);
         const process = get(state, "process");
 
@@ -111,20 +111,19 @@ function genComponentConf() {
           !post || processUtils.isNeedLoading(process, postUri);
         const postFailedToLoad =
           post && processUtils.hasNeedFailedToLoad(process, postUri);
+        const isOwned = generalSelectors.isNeedOwned(state, postUri);
         const showCreateWhatsAround =
-          post && needUtils.isOwned(post) && needUtils.isWhatsNewNeed(post);
+          post && isOwned && needUtils.isWhatsNewNeed(post);
 
         const reactionUseCases =
           post &&
-          !needUtils.isOwned(post) &&
+          !isOwned &&
           getIn(post, ["matchedUseCase", "reactionUseCases"]);
         const hasReactionUseCases =
           reactionUseCases && reactionUseCases.size > 0;
 
         const enabledUseCases =
-          post &&
-          needUtils.isOwned(post) &&
-          getIn(post, ["matchedUseCase", "enabledUseCases"]);
+          post && isOwned && getIn(post, ["matchedUseCase", "enabledUseCases"]);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
         return {
           processingPublish: state.getIn(["process", "processingPublish"]),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-menu.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-menu.js
@@ -11,6 +11,7 @@ import * as needUtils from "../need-utils.js";
 import * as viewUtils from "../view-utils.js";
 import * as processUtils from "../process-utils.js";
 import * as connectionSelectors from "../selectors/connection-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import * as connectionUtils from "../connection-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -109,7 +110,7 @@ function genComponentConf() {
       const selectFromState = state => {
         const post = getIn(state, ["needs", this.postUri]);
         const isPersona = needUtils.isPersona(post);
-        const isOwned = needUtils.isOwned(post);
+        const isOwned = generalSelectors.isNeedOwned(state, this.postUri);
 
         const hasHolderFacet = needUtils.hasHolderFacet(post);
         const hasGroupFacet = needUtils.hasGroupFacet(post);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -22,10 +22,7 @@ import {
   fetchMessage,
 } from "../won-message-utils.js";
 import { actionCreators } from "../actions/actions.js";
-import {
-  getConnectionUriFromRoute,
-  getOwnedNeedByConnectionUri,
-} from "../selectors/general-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import { hasMessagesToLoad } from "../selectors/connection-selectors.js";
 import {
   getAgreementMessagesByConnectionUri,
@@ -308,8 +305,8 @@ function genComponentConf() {
       const selectFromState = state => {
         const selectedConnectionUri = this.connectionUri
           ? this.connectionUri
-          : getConnectionUriFromRoute(state);
-        const ownedNeed = getOwnedNeedByConnectionUri(
+          : generalSelectors.getConnectionUriFromRoute(state);
+        const ownedNeed = generalSelectors.getOwnedNeedByConnectionUri(
           state,
           selectedConnectionUri
         );
@@ -382,16 +379,20 @@ function genComponentConf() {
 
         const process = get(state, "process");
 
+        const isRemoteNeedOwned = generalSelectors.isNeedOwned(
+          state,
+          remoteNeedUri
+        );
         const reactionUseCases =
           remoteNeed &&
-          !needUtils.isOwned(remoteNeed) &&
+          !isRemoteNeedOwned &&
           needUtils.getReactionUseCases(remoteNeed);
         const hasReactionUseCases =
           reactionUseCases && reactionUseCases.size > 0;
 
         const enabledUseCases =
           remoteNeed &&
-          needUtils.isOwned(remoteNeed) &&
+          isRemoteNeedOwned &&
           needUtils.getEnabledUseCases(remoteNeed);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-share-link.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-share-link.js
@@ -6,13 +6,15 @@ import { attach, toAbsoluteURL } from "../utils.js";
 import { connect2Redux, generateSvgQrCode } from "../won-utils.js";
 import { ownerBaseUrl } from "config";
 
+import * as generalSelectors from "../selectors/general-selectors.js";
+
 import "style/_post-share-link.scss";
 
 const serviceDependencies = ["$scope", "$ngRedux", "$element"];
 function genComponentConf() {
   let template = `
         <div class="psl__content">
-            <p class="psl__text" ng-if="(self.post.get('connections').size != 0 && self.post.get('isOwned')) || !self.post.get('isOwned')">
+            <p class="psl__text" ng-if="(self.post.get('connections').size != 0 && self.isOwned) || !self.isOwned">
                 Know someone who might also be interested in this posting? Consider sharing the link below in social media.
             </p>
             <div class="psl__tabs">
@@ -49,7 +51,7 @@ function genComponentConf() {
 
         let linkToPost;
         if (ownerBaseUrl && post) {
-          const path = "#!post/" + `?postUri=${encodeURI(post.get("uri"))}`;
+          const path = "#!post/" + `?postUri=${encodeURI(this.postUri)}`;
 
           linkToPost = toAbsoluteURL(ownerBaseUrl).toString() + path;
         }
@@ -57,6 +59,7 @@ function genComponentConf() {
 
         return {
           post,
+          isOwned: generalSelectors.isNeedOwned(state, this.postUri),
           linkToPost,
           svgQrCodeToPost,
         };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post/post.js
@@ -13,7 +13,6 @@ import groupPostMessagesModule from "../group-post-messages.js";
 import visitorTitleBarModule from "../visitor-title-bar.js";
 import * as generalSelectors from "../../selectors/general-selectors.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
-import * as needUtils from "../../need-utils.js";
 import * as processUtils from "../../process-utils.js";
 import * as srefUtils from "../../sref-utils.js";
 
@@ -40,7 +39,7 @@ class Controller {
 
       return {
         needUri,
-        isOwnedNeed: needUtils.isOwned(need),
+        isOwnedNeed: generalSelectors.isNeedOwned(state, needUri),
         need,
         won: won.WON,
         showSlideIns:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -5,7 +5,7 @@ import postContentModule from "./post-content.js";
 import postMenuModule from "./post-menu.js";
 import chatTextFieldModule from "./chat-textfield.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
-import { getPostUriFromRoute } from "../selectors/general-selectors.js";
+import * as generalSelectors from "../selectors/general-selectors.js";
 import { connect2Redux } from "../won-utils.js";
 import { attach, get, getIn } from "../utils.js";
 import * as needUtils from "../need-utils.js";
@@ -64,19 +64,19 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
 
       const selectFromState = state => {
-        const postUriToConnectTo = getPostUriFromRoute(state);
+        const postUriToConnectTo = generalSelectors.getPostUriFromRoute(state);
         const displayedPost = state.getIn(["needs", postUriToConnectTo]);
 
         const post = state.getIn(["needs", postUriToConnectTo]);
+        const isOwned = generalSelectors.isNeedOwned(state, postUriToConnectTo);
+
         const reactionUseCases =
-          post &&
-          !needUtils.isOwned(post) &&
-          needUtils.getReactionUseCases(post);
+          post && !isOwned && needUtils.getReactionUseCases(post);
         const hasReactionUseCases =
           reactionUseCases && reactionUseCases.size > 0;
 
         const enabledUseCases =
-          post && needUtils.isOwned(post) && needUtils.getEnabledUseCases(post);
+          post && isOwned && needUtils.getEnabledUseCases(post);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
 
         return {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -16,10 +16,6 @@ export function isActive(need) {
   return get(need, "state") && get(need, "state") === won.WON.ActiveCompacted;
 }
 
-export function isOwned(need) {
-  return get(need, "isOwned");
-}
-
 export function getIdenticonSvg(need) {
   return get(need, "identiconSvg");
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -70,26 +70,6 @@ export function isWhatsAroundNeed(need) {
 }
 
 /**
- * This checks if the need is allowed to be used as a template,
- * it is only allowed if the need exists, and if it has a matchedUseCase
- * @param need
- * @returns {*|boolean}
- */
-export function isUsableAsTemplate(need) {
-  return need && !isOwned(need) && hasMatchedUseCase(need);
-}
-
-/**
- * This checks if the need is allowed to be edited,
- * it is only allowed if the need exists, and if it is OWNED and has a matchedUseCase
- * @param need
- * @returns {*|boolean}
- */
-export function isEditable(need) {
-  return need && isOwned(need) && hasMatchedUseCase(need);
-}
-
-/**
  * Determines if a given need is a DirectResponse-Need
  * @param need
  * @returns {*|boolean}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
@@ -44,6 +44,8 @@ export default function(userData = initialState, action = {}) {
       );
     }
 
+    case actionTypes.needs.create: //for optimistic additions
+    case actionTypes.personas.create: //for optimistic additions
     case actionTypes.needs.createSuccessful: {
       const ownedNeedUris = userData.get("ownedNeedUris");
       return userData.set(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -5,14 +5,7 @@ import { actionTypes } from "../../actions/actions.js";
 import Immutable from "immutable";
 import won from "../../won-es6.js";
 import { msStringToDate, get, getIn } from "../../utils.js";
-import {
-  addOwnActiveNeedsInLoading,
-  addOwnInactiveNeedsInLoading,
-  addOwnInactiveNeedsToLoad,
-  addTheirNeedsInLoading,
-  addNeed,
-  addNeedInCreation,
-} from "./reduce-needs.js";
+import { addNeedStubs, addNeed, addNeedInCreation } from "./reduce-needs.js";
 import {
   addMessage,
   addExistingMessages,
@@ -63,35 +56,30 @@ export default function(allNeedsInState = initialState, action = {}) {
       );
 
     case actionTypes.needs.storeOwnedActiveUris: {
-      return addOwnActiveNeedsInLoading(
+      return addNeedStubs(
         allNeedsInState,
-        action.payload.get("uris")
+        action.payload.get("uris"),
+        won.WON.ActiveCompacted
       );
     }
 
+    case actionTypes.needs.storeOwnedInactiveUrisInLoading:
     case actionTypes.needs.storeOwnedInactiveUris: {
-      return addOwnInactiveNeedsToLoad(
+      return addNeedStubs(
         allNeedsInState,
-        action.payload.get("uris")
-      );
-    }
-
-    case actionTypes.needs.storeOwnedInactiveUrisInLoading: {
-      return addOwnInactiveNeedsInLoading(
-        allNeedsInState,
-        action.payload.get("uris")
+        action.payload.get("uris"),
+        won.WON.InactiveCompacted
       );
     }
 
     case actionTypes.personas.storeTheirUrisInLoading:
     case actionTypes.needs.storeTheirUrisInLoading: {
-      return addTheirNeedsInLoading(
-        allNeedsInState,
-        action.payload.get("uris")
-      );
+      return addNeedStubs(allNeedsInState, action.payload.get("uris"));
     }
 
-    case actionTypes.needs.storeOwned: {
+    case actionTypes.needs.storeOwned:
+    case actionTypes.needs.storeTheirs:
+    case actionTypes.personas.storeTheirs: {
       let needs = action.payload.get("needs");
       needs = needs ? needs : Immutable.Set();
 
@@ -113,17 +101,6 @@ export default function(allNeedsInState = initialState, action = {}) {
       return storeConnectionsData(
         allNeedsInState,
         action.payload.get("connections")
-      );
-    }
-
-    case actionTypes.needs.storeTheirs:
-    case actionTypes.personas.storeTheirs: {
-      let needs = action.payload.get("needs");
-      needs = needs ? needs : Immutable.Set();
-
-      return needs.reduce(
-        (updatedState, need) => addNeed(updatedState, need),
-        allNeedsInState
       );
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -56,10 +56,10 @@ export default function(allNeedsInState = initialState, action = {}) {
 
     case actionTypes.account.loginStarted:
       // starting a new login process. this could mean switching
-      // to a different session. we need to mark any needs
-      // that are already loaded as non-owned.
+      // to a different session. we need to remove all connections
+      // that are already of loaded needs loaded.
       return allNeedsInState.map(need =>
-        need.set("isOwned", false).set("connections", Immutable.Map())
+        need.set("connections", Immutable.Map())
       );
 
     case actionTypes.needs.storeOwnedActiveUris: {
@@ -96,7 +96,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       needs = needs ? needs : Immutable.Set();
 
       return needs.reduce(
-        (updatedState, need) => addNeed(updatedState, need, true),
+        (updatedState, need) => addNeed(updatedState, need),
         allNeedsInState
       );
     }
@@ -122,7 +122,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       needs = needs ? needs : Immutable.Set();
 
       return needs.reduce(
-        (updatedState, need) => addNeed(updatedState, need, false),
+        (updatedState, need) => addNeed(updatedState, need),
         allNeedsInState
       );
     }
@@ -229,7 +229,7 @@ export default function(allNeedsInState = initialState, action = {}) {
     }
 
     case actionTypes.needs.createSuccessful:
-      return addNeed(allNeedsInState, action.payload.need, true);
+      return addNeed(allNeedsInState, action.payload.need);
 
     case actionTypes.messages.openMessageReceived:
     case actionTypes.messages.connectMessageReceived: {
@@ -481,9 +481,6 @@ export default function(allNeedsInState = initialState, action = {}) {
         // connection uri. now that we have the uri, we can store it
         // (see connectAdHoc)
         const needUri = tmpNeed.get("uri");
-        if (!tmpNeed.get("isOwned")) {
-          throw new Error("Need not owned, can't alter connection.");
-        }
 
         const properConnection = tmpConnection
           .delete("usingTemporaryUri")

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -34,7 +34,7 @@ import {
   addConnectionsToLoad,
   markConnectionAsRated,
   markConnectionAsRead,
-  getOwnedNeedByConnectionUri,
+  getNeedByConnectionUri,
   changeConnectionState,
   changeConnectionStateByFun,
   storeConnectionsData,
@@ -177,7 +177,6 @@ export default function(allNeedsInState = initialState, action = {}) {
         action.payload.needUri,
         Immutable.fromJS({
           jsonld: action.payload.persona,
-          isOwned: true,
           isBeingCreated: true,
           uri: action.payload.needUri,
           creationDate: new Date(),
@@ -474,7 +473,7 @@ export default function(allNeedsInState = initialState, action = {}) {
       const connUri = wonMessage.getReceiver();
 
       const tmpConnUri = "connectionFrom:" + wonMessage.getIsResponseTo();
-      const tmpNeed = getOwnedNeedByConnectionUri(allNeedsInState, tmpConnUri);
+      const tmpNeed = getNeedByConnectionUri(allNeedsInState, tmpConnUri);
       const tmpConnection = getIn(tmpNeed, ["connections", tmpConnUri]);
 
       if (tmpConnection) {
@@ -509,7 +508,7 @@ export default function(allNeedsInState = initialState, action = {}) {
         }
         return allNeedsInState;
       } else {
-        const needByConnectionUri = getOwnedNeedByConnectionUri(
+        const needByConnectionUri = getNeedByConnectionUri(
           allNeedsInState,
           connUri
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -11,7 +11,7 @@ import { generateHexColor, generateRgbColorArray, getIn } from "../../utils.js";
 import shajs from "sha.js";
 import Identicon from "identicon.js";
 
-export function parseNeed(jsonldNeed, isOwned) {
+export function parseNeed(jsonldNeed) {
   const jsonldNeedImm = Immutable.fromJS(jsonldNeed);
 
   if (jsonldNeedImm && jsonldNeedImm.get("@id")) {
@@ -45,7 +45,6 @@ export function parseNeed(jsonldNeed, isOwned) {
         reactionUseCases: undefined,
       },
       unread: false,
-      isOwned: !!isOwned,
       isBeingCreated: false,
       jsonld: jsonldNeed,
       connections: Immutable.Map(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-connections.js
@@ -144,7 +144,7 @@ export function markConnectionAsRead(state, connectionUri, needUri) {
 }
 
 export function markConnectionAsRated(state, connectionUri) {
-  let need = connectionUri && getOwnedNeedByConnectionUri(state, connectionUri);
+  let need = connectionUri && getNeedByConnectionUri(state, connectionUri);
   let connection = need && need.getIn(["connections", connectionUri]);
 
   if (!connection) {
@@ -172,14 +172,14 @@ export function markConnectionAsRated(state, connectionUri) {
  * @param connectionUri
  *            to find corresponding need for
  */
-export function getOwnedNeedByConnectionUri(allNeedsInState, connectionUri) {
+export function getNeedByConnectionUri(allNeedsInState, connectionUri) {
   return allNeedsInState.find(need =>
     need.getIn(["connections", connectionUri])
   );
 }
 
 export function changeConnectionState(state, connectionUri, newState) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need) {
     console.warn(
@@ -215,7 +215,7 @@ export function changeConnectionState(state, connectionUri, newState) {
 }
 
 export function changeConnectionStateByFun(state, connectionUri, fun) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need) {
     console.warn(
@@ -238,7 +238,7 @@ export function changeConnectionStateByFun(state, connectionUri, fun) {
 }
 
 export function updatePetriNetStateData(state, connectionUri, petriNetData) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need || !petriNetData) {
     console.warn(
@@ -258,7 +258,7 @@ export function updatePetriNetStateData(state, connectionUri, petriNetData) {
 }
 
 export function updateAgreementStateData(state, connectionUri, agreementData) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need || !agreementData) {
     console.warn(
@@ -278,7 +278,7 @@ export function updateAgreementStateData(state, connectionUri, agreementData) {
 }
 
 export function setShowAgreementData(state, connectionUri, showAgreementData) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need) {
     console.warn(
@@ -298,7 +298,7 @@ export function setShowAgreementData(state, connectionUri, showAgreementData) {
 }
 
 export function setShowPetriNetData(state, connectionUri, showPetriNetData) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need) {
     console.warn(
@@ -322,7 +322,7 @@ export function setMultiSelectType(
   connectionUri,
   multiSelectType = undefined
 ) {
-  const need = getOwnedNeedByConnectionUri(state, connectionUri);
+  const need = getNeedByConnectionUri(state, connectionUri);
 
   if (!need) {
     console.warn(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-messages.js
@@ -1,7 +1,7 @@
 import { parseMessage } from "./parse-message.js";
 import { markUriAsRead } from "../../won-localstorage.js";
 import { markConnectionAsRead } from "./reduce-connections.js";
-import { addTheirNeedToLoad } from "./reduce-needs.js";
+import { addNeedStub } from "./reduce-needs.js";
 import { getOwnMessageUri } from "../../message-utils.js";
 import { isChatToGroup } from "../../connection-utils.js";
 
@@ -102,7 +102,7 @@ export function addMessage(
           console.debug(
             "Originator Need is not in the state yet, we need to add it"
           );
-          state = addTheirNeedToLoad(state, originatorUri);
+          state = addNeedStub(state, originatorUri);
         }
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -4,7 +4,7 @@ import won from "../../won-es6.js";
 
 export function addNeed(needs, jsonldNeed, isOwned) {
   let newState;
-  let parsedNeed = parseNeed(jsonldNeed, isOwned);
+  let parsedNeed = parseNeed(jsonldNeed);
 
   if (parsedNeed && parsedNeed.get("uri")) {
     let existingNeed = needs.get(parsedNeed.get("uri"));
@@ -49,14 +49,13 @@ export function addNeed(needs, jsonldNeed, isOwned) {
   return newState;
 }
 
-function addNeedInLoading(needs, needUri, state, isOwned) {
+function addNeedInLoading(needs, needUri, state) {
   const oldNeed = needs.get(needUri);
   if (oldNeed) {
     return needs;
   } else {
     let need = Immutable.fromJS({
       uri: needUri,
-      isOwned: isOwned,
       state: state,
       connections: Immutable.Map(),
     });
@@ -71,7 +70,6 @@ function addTheirNeedInLoading(needs, needUri) {
   } else {
     let need = Immutable.fromJS({
       uri: needUri,
-      isOwned: false,
       connections: Immutable.Map(),
     });
     return needs.setIn([needUri], need);
@@ -85,7 +83,6 @@ export function addTheirNeedToLoad(needs, needUri) {
   } else {
     let need = Immutable.fromJS({
       uri: needUri,
-      isOwned: false,
       connections: Immutable.Map(),
     });
     return needs.setIn([needUri], need);
@@ -143,13 +140,12 @@ export function addOwnInactiveNeedsToLoad(needs, needUris) {
   return newState;
 }
 
-function addNeedToLoad(needs, needUri, state, isOwned) {
+function addNeedToLoad(needs, needUri, state) {
   if (needs.get(needUri)) {
     return needs;
   } else {
     let need = Immutable.fromJS({
       uri: needUri,
-      isOwned: isOwned,
       state: state,
       connections: Immutable.Map(),
     });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -85,16 +85,24 @@ export function addTheirNeedToLoad(needs, needUri) {
   }
 }
 
+function addNeedToLoad(needs, needUri, state) {
+  if (needs.get(needUri)) {
+    return needs;
+  } else {
+    let need = Immutable.fromJS({
+      uri: needUri,
+      state: state,
+      connections: Immutable.Map(),
+    });
+    return needs.setIn([needUri], need);
+  }
+}
+
 export function addOwnActiveNeedsInLoading(needs, needUris) {
   let newState = needs;
   needUris &&
     needUris.forEach(needUri => {
-      newState = addNeedInLoading(
-        newState,
-        needUri,
-        won.WON.ActiveCompacted,
-        true
-      );
+      newState = addNeedInLoading(newState, needUri, won.WON.ActiveCompacted);
     });
   return newState;
 }
@@ -103,12 +111,7 @@ export function addOwnInactiveNeedsInLoading(needs, needUris) {
   let newState = needs;
   needUris &&
     needUris.forEach(needUri => {
-      newState = addNeedInLoading(
-        newState,
-        needUri,
-        won.WON.InactiveCompacted,
-        true
-      );
+      newState = addNeedInLoading(newState, needUri, won.WON.InactiveCompacted);
     });
   return newState;
 }
@@ -126,27 +129,9 @@ export function addOwnInactiveNeedsToLoad(needs, needUris) {
   let newState = needs;
   needUris &&
     needUris.forEach(needUri => {
-      newState = addNeedToLoad(
-        newState,
-        needUri,
-        won.WON.InactiveCompacted,
-        true
-      );
+      newState = addNeedToLoad(newState, needUri, won.WON.InactiveCompacted);
     });
   return newState;
-}
-
-function addNeedToLoad(needs, needUri, state) {
-  if (needs.get(needUri)) {
-    return needs;
-  } else {
-    let need = Immutable.fromJS({
-      uri: needUri,
-      state: state,
-      connections: Immutable.Map(),
-    });
-    return needs.setIn([needUri], need);
-  }
 }
 
 export function addNeedInCreation(needs, needInCreation, needUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/reduce-needs.js
@@ -1,6 +1,5 @@
 import { parseNeed } from "./parse-need.js";
 import Immutable from "immutable";
-import won from "../../won-es6.js";
 import { get } from "../../utils.js";
 
 export function addNeed(needs, jsonldNeed) {
@@ -21,7 +20,7 @@ export function addNeed(needs, jsonldNeed) {
       if (heldNeedUris.size > 0) {
         heldNeedUris.map(needUri => {
           if (!get(needs, needUri)) {
-            needs = addTheirNeedToLoad(needs, needUri);
+            needs = addNeedStub(needs, needUri);
           }
         });
       }
@@ -30,7 +29,7 @@ export function addNeed(needs, jsonldNeed) {
       if (groupMemberUris.size > 0) {
         groupMemberUris.map(needUri => {
           if (!get(needs, needUri)) {
-            needs = addTheirNeedToLoad(needs, needUri);
+            needs = addNeedStub(needs, needUri);
           }
         });
       }
@@ -45,91 +44,42 @@ export function addNeed(needs, jsonldNeed) {
   return newState;
 }
 
-function addNeedInLoading(needs, needUri, state) {
-  const oldNeed = needs.get(needUri);
-  if (oldNeed) {
+/**
+ * Adds a need-stub into the need-redux-state, needed to get Posts that are not loaded/loading to show up as skeletons
+ * Checks if stub/need already exists, if so do nothing
+ * @param needs redux need state
+ * @param needUri stub accessible under uri
+ * @param state not mandatory will be set undefined if not set, otherwise the needState is stored (e.g. Active/Inactive)
+ * @returns {*}
+ */
+export function addNeedStub(needs, needUri, state) {
+  if (get(needs, needUri)) {
     return needs;
   } else {
-    let need = Immutable.fromJS({
-      uri: needUri,
-      state: state,
-      connections: Immutable.Map(),
-    });
-    return needs.setIn([needUri], need);
+    return needs.setIn(
+      [needUri],
+      Immutable.fromJS({
+        uri: needUri,
+        state: state,
+        connections: Immutable.Map(),
+      })
+    );
   }
 }
 
-function addTheirNeedInLoading(needs, needUri) {
-  const oldNeed = needs.get(needUri);
-  if (oldNeed) {
-    return needs;
-  } else {
-    let need = Immutable.fromJS({
-      uri: needUri,
-      connections: Immutable.Map(),
-    });
-    return needs.setIn([needUri], need);
-  }
-}
-
-export function addTheirNeedToLoad(needs, needUri) {
-  const oldNeed = needs.get(needUri);
-  if (oldNeed) {
-    return needs;
-  } else {
-    let need = Immutable.fromJS({
-      uri: needUri,
-      connections: Immutable.Map(),
-    });
-    return needs.setIn([needUri], need);
-  }
-}
-
-function addNeedToLoad(needs, needUri, state) {
-  if (needs.get(needUri)) {
-    return needs;
-  } else {
-    let need = Immutable.fromJS({
-      uri: needUri,
-      state: state,
-      connections: Immutable.Map(),
-    });
-    return needs.setIn([needUri], need);
-  }
-}
-
-export function addOwnActiveNeedsInLoading(needs, needUris) {
+/**
+ * Adds need-stubs into the need-redux-state, needed to get Posts that are not loaded/loading to show up as skeletons
+ * Checks if stub/need already exists, if so do nothing
+ * @param needs redux need state
+ * @param needUris stub accessible under uris
+ * @param state not mandatory will be set undefined if not set, otherwise the needState is stored (e.g. Active/Inactive)
+ * @returns {*}
+ */
+export function addNeedStubs(needs, needUris, state) {
   let newState = needs;
   needUris &&
     needUris.forEach(needUri => {
-      newState = addNeedInLoading(newState, needUri, won.WON.ActiveCompacted);
-    });
-  return newState;
-}
-
-export function addOwnInactiveNeedsInLoading(needs, needUris) {
-  let newState = needs;
-  needUris &&
-    needUris.forEach(needUri => {
-      newState = addNeedInLoading(newState, needUri, won.WON.InactiveCompacted);
-    });
-  return newState;
-}
-
-export function addTheirNeedsInLoading(needs, needUris) {
-  let newState = needs;
-  needUris &&
-    needUris.forEach(needUri => {
-      newState = addTheirNeedInLoading(newState, needUri);
-    });
-  return newState;
-}
-
-export function addOwnInactiveNeedsToLoad(needs, needUris) {
-  let newState = needs;
-  needUris &&
-    needUris.forEach(needUri => {
-      newState = addNeedToLoad(newState, needUri, won.WON.InactiveCompacted);
+      newState = addNeedStub(newState, needUri, state);
     });
   return newState;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -3,7 +3,7 @@
  */
 import { actionTypes } from "../actions/actions.js";
 import Immutable from "immutable";
-import { getIn, get } from "../utils.js";
+import { getIn } from "../utils.js";
 import { parseNeed } from "./need-reducer/parse-need.js";
 import { parseMessage } from "./need-reducer/parse-message.js";
 
@@ -150,10 +150,7 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.needs.createSuccessful: {
-      const needUri =
-        action.payload.need && get(parseNeed(action.payload.need), "uri");
-
-      processState = updateNeedProcess(processState, needUri, {
+      processState = updateNeedProcess(processState, action.payload.needUri, {
         toLoad: false,
         failedToLoad: false,
         loading: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -130,11 +130,7 @@ function deleteChatConnectionsBetweenOwnedNeeds(state) {
           //Any connection that is not of type chatFacet will be exempt from deletion
           if (isChatConnection(conn)) {
             //Any other connection will be checked if it would be connected to the ownedNeed, if so we remove it.
-            return !state.getIn([
-              "needs",
-              conn.get("remoteNeedUri"),
-              "isOwned",
-            ]);
+            return !generalSelectors.isNeedOwned(state, conn.get("remoteNeedUri"));
           }
           return true;
         });*/

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -6,6 +6,7 @@ import { createSelector } from "reselect";
 
 import { decodeUriComponentProperly, getIn, get } from "../utils.js";
 import { isPersona, isNeed, isActive, isInactive } from "../need-utils.js";
+import * as accountUtils from "../account-utils.js";
 import Color from "color";
 
 export const selectLastUpdateTime = state => state.get("lastUpdateTime");
@@ -220,4 +221,16 @@ export function currentSkin() {
     lineGray: getColor("--won-line-gray"),
     subtitleGray: getColor("--won-subtitle-gray"),
   };
+}
+/**
+ * Returns true if the need is owned by the user who is currently logged in
+ * @param state FULL redux state, no substates allowed
+ * @param needUri needUri to check isOwned state
+ */
+export function isNeedOwned(state, needUri) {
+  if (needUri) {
+    const accountState = get(state, "account");
+    return accountUtils.isNeedOwned(accountState, needUri);
+  }
+  return false;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -14,10 +14,18 @@ export const getRouterParams = state =>
   getIn(state, ["router", "currentParams"]);
 
 export const getNeeds = state => state.get("needs");
-export const getOwnedNeeds = state =>
-  getNeeds(state).filter(need => need.get("isOwned"));
-export const getNonOwnedNeeds = state =>
-  getNeeds(state).filter(need => !need.get("isOwned"));
+export const getOwnedNeeds = state => {
+  const accountState = get(state, "account");
+  return getNeeds(state).filter(need =>
+    accountUtils.isNeedOwned(accountState, get(need, "uri"))
+  );
+};
+export const getNonOwnedNeeds = state => {
+  const accountState = get(state, "account");
+  return getNeeds(state).filter(
+    need => !accountUtils.isNeedOwned(accountState, get(need, "uri"))
+  );
+};
 
 export function getPosts(state) {
   const needs = getNeeds(state);
@@ -28,8 +36,12 @@ export function getPosts(state) {
   });
 }
 
-export const getOwnedPosts = state =>
-  getPosts(state).filter(need => need.get("isOwned"));
+export const getOwnedPosts = state => {
+  const accountState = get(state, "account");
+  return getPosts(state).filter(need =>
+    accountUtils.isNeedOwned(accountState, get(need, "uri"))
+  );
+};
 
 export function getOwnedOpenPosts(state) {
   const allOwnedNeeds = getOwnedPosts(state);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/general-selectors.js
@@ -241,7 +241,7 @@ export function currentSkin() {
 /**
  * Returns true if the need is owned by the user who is currently logged in
  * @param state FULL redux state, no substates allowed
- * @param needUri needUri to check isOwned state
+ * @param needUri
  */
 export function isNeedOwned(state, needUri) {
   if (needUri) {


### PR DESCRIPTION
See description in issue #2862 

What has been done?
- removed the isOwned bool parameter from the needState completely
- added ownedNeedUris to the account-redux-state in our app
- all usages of needUtils.isOwned have changed to generealSelectors.isNeedOwned function
- This removes the race condition and also gives us the ability to handle our pageLoad or accountLogin completely different -> refactoring opportunities arise

caveat:
- i removed all isOwned occurences from the codebase, however the ELM state still uses some of the isOwned and does not have any knowledge about the account state yet (afaik) -> however testing persona creation and subsequent viewing of the personas in the elm components still work so i guess this can be handled after this pr (if need be)

fixes #2862 