### PR TITLE
Fixes parseFromRDF mishap in type detail

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -289,11 +289,12 @@ export const type = {
     const types = (rawTypes => {
       if (Immutable.List.isList(rawTypes)) {
         return Immutable.Set(rawTypes);
-      } else {
+      } else if (rawTypes) {
         return Immutable.Set([rawTypes]);
+      } else {
+        return undefined;
       }
     })(jsonLDImm.get("@type"));
-
     return types;
   },
   generateHumanReadable: function({ value, includeLabel }) {


### PR DESCRIPTION
Fixed parsing error of parseFromRDF of type, did not ONLY happen when editing "Need A Lift" usecases and error had nothing to do with routeparsing itself -> the problem was in every need where the useCase did not define any seeks: types at all -> these were parsed as a single item list within the need seeks state (one item with value of "null") -> this produced a parseToRDF of the type detail with @type: null, and that is not valid.

Fix was to ensure that type detail is only added to the seeks content (upon need parsing) if there are actual types in the seeks branch

fixes #2863 

