### PR TITLE
Feat  whats new rework

### DIFF
--- a/webofneeds/won-owner-webapp/README.md
+++ b/webofneeds/won-owner-webapp/README.md
@@ -202,8 +202,8 @@ $ngRedux.getState();
        matchedUseCase: { //saves a matchedUseCase within the need so we dont have to parse it multiple times
            identifier: undefined, //matched identifier that is set within the matched usecase
            icon: undefined, //matched icon that is set within the matched usecase
-           iconBackground: //generated background color based on a hash of the need-uri, (similar to identiconSvg),
        },
+       background: //generated background color based on a hash of the need-uri, (similar to identiconSvg),
        content : {...},
        seeks: {...}
    },

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestNeedController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestNeedController.java
@@ -40,6 +40,7 @@ import won.owner.model.User;
 import won.owner.model.UserNeed;
 import won.owner.pojo.CreateDraftPojo;
 import won.owner.repository.DraftRepository;
+import won.owner.repository.UserNeedRepository;
 import won.owner.repository.UserRepository;
 import won.owner.service.impl.URIService;
 import won.owner.service.impl.WONUserDetailService;
@@ -57,6 +58,8 @@ public class RestNeedController {
     private WONUserDetailService wonUserDetailService;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    UserNeedRepository userNeedRepository;
 
     /**
      * returns a List containing needs belonging to the user
@@ -112,6 +115,32 @@ public class RestNeedController {
             createDraftPojos.add(createDraftPojo);
         }
         return createDraftPojos;
+    }
+
+    /**
+     * returns a List containing needs belonging to the user
+     *
+     * @return JSON List of need objects
+     */
+    @ResponseBody
+    @RequestMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    public List<URI> getAllNeeds(@RequestParam(value = "state", required = false) NeedState state) {
+        List<UserNeed> allNeeds = userNeedRepository.findAllNeeds();
+        List<URI> needUris = new ArrayList(allNeeds.size());
+        if (state == null) {
+            logger.debug("Getting all needuris");
+            for (UserNeed userNeed : allNeeds) {
+                needUris.add(userNeed.getUri());
+            }
+        } else {
+            logger.debug("Getting all needuris filtered by state: " + state);
+            for (UserNeed userNeed : allNeeds) {
+                if (state.equals(userNeed.getState())) {
+                    needUris.add(userNeed.getUri());
+                }
+            }
+        }
+        return needUris;
     }
 
     /**

--- a/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
+++ b/webofneeds/won-owner-webapp/src/main/resources/spring/owner-security.xml
@@ -60,6 +60,7 @@
         <intercept-url pattern="/rest/users/settings" access="isAuthenticated()"/>
         <intercept-url pattern="/rest/users/acceptTermsOfService" access="isAuthenticated()"/>
         <intercept-url pattern="/rest/needs/drafts/*" access="hasRole('ROLE_ACCOUNT')"/>
+        <intercept-url pattern="/rest/needs/all" access="permitAll()"/>
         <intercept-url pattern="/rest/**" access="isAuthenticated()"/>
         <intercept-url pattern="/**"  requires-channel="https"/>
         <!--intercept-url pattern="/rest/**" access="isAuthenticated()" /-->

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -86,7 +86,10 @@ import * as cnct from "./connections-actions.js";
 import * as messages from "./messages-actions.js";
 import * as configActions from "./config-actions.js";
 
-import { pageLoadAction } from "./load-action.js";
+import {
+  pageLoadAction,
+  fetchAllActiveNeedUrisFromOwner,
+} from "./load-action.js";
 import { stateGo, stateReload } from "redux-ui-router";
 import {
   createPersona,
@@ -157,6 +160,8 @@ const actionHierarchy = {
     connect: needsConnect,
     fetchUnloadedNeeds: fetchUnloadedNeeds,
     fetchUnloadedNeed: fetchUnloadedNeed,
+
+    fetchAllActiveNeedUrisFromOwner: fetchAllActiveNeedUrisFromOwner,
 
     storeOwnedInactiveUris: INJ_DEFAULT,
     storeOwnedInactiveUrisInLoading: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -173,7 +173,7 @@ const actionHierarchy = {
     storeTheirs: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
-    storeUriDeleted: INJ_DEFAULT,
+    removeDeleted: INJ_DEFAULT,
     selectTab: INJ_DEFAULT,
   },
   personas: {
@@ -186,7 +186,7 @@ const actionHierarchy = {
     storeTheirUrisInLoading: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
-    storeUriDeleted: INJ_DEFAULT,
+    removeDeleted: INJ_DEFAULT,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -173,6 +173,7 @@ const actionHierarchy = {
     storeTheirs: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
+    storeUriDeleted: INJ_DEFAULT,
     selectTab: INJ_DEFAULT,
   },
   personas: {
@@ -185,6 +186,7 @@ const actionHierarchy = {
     storeTheirUrisInLoading: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
+    storeUriDeleted: INJ_DEFAULT,
   },
   router: {
     stateGo, // only overwrites parameters that are explicitly mentioned, unless called without queryParams object (which also resets "pervasive" parameters, that shouldn't be removed

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -88,7 +88,7 @@ import * as configActions from "./config-actions.js";
 
 import {
   pageLoadAction,
-  fetchAllActiveNeedUrisFromOwner,
+  loadAllActiveNeedUrisFromOwner,
 } from "./load-action.js";
 import { stateGo, stateReload } from "redux-ui-router";
 import {
@@ -161,7 +161,8 @@ const actionHierarchy = {
     fetchUnloadedNeeds: fetchUnloadedNeeds,
     fetchUnloadedNeed: fetchUnloadedNeed,
 
-    fetchAllActiveNeedUrisFromOwner: fetchAllActiveNeedUrisFromOwner,
+    loadAllActiveNeedUrisFromOwner: loadAllActiveNeedUrisFromOwner,
+    storeNeedUrisFromOwner: INJ_DEFAULT,
 
     storeOwnedInactiveUris: INJ_DEFAULT,
     storeOwnedInactiveUrisInLoading: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -42,7 +42,6 @@ import { hierarchy2Creators } from "./action-utils.js";
 import {
   needCreate,
   needEdit,
-  createWhatsNew,
   createWhatsAround,
 } from "./create-need-action.js";
 
@@ -149,7 +148,6 @@ const actionHierarchy = {
     edit: needEdit,
     editSuccessful: INJ_DEFAULT,
     editFailure: INJ_DEFAULT,
-    whatsNew: createWhatsNew,
     whatsAround: createWhatsAround,
     createSuccessful: INJ_DEFAULT,
     reopen: needsOpen,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -15,7 +15,7 @@ import {
   nominatim2draftLocation,
 } from "../utils.js";
 
-import { isWhatsAroundNeed, isWhatsNewNeed } from "../need-utils.js";
+import { isWhatsAroundNeed } from "../need-utils.js";
 import * as accountUtils from "../account-utils.js";
 
 export function needEdit(draft, oldNeed, nodeUri) {
@@ -128,30 +128,6 @@ export function needCreate(draft, persona, nodeUri) {
   };
 }
 
-export function createWhatsNew() {
-  return (dispatch, getState) => {
-    const state = getState();
-    const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
-
-    dispatch({ type: actionTypes.needs.whatsNew });
-
-    const whatsNewObject = {
-      content: {
-        flags: ["won:WhatsNew", "won:NoHintForCounterpart"],
-      },
-      seeks: {},
-    };
-
-    getIn(state, ["needs"])
-      .filter(need => isWhatsAroundNeed(need) || isWhatsNewNeed(need))
-      .map(need => {
-        dispatch(actionCreators.needs__delete(need.get("uri")));
-      });
-
-    dispatch(actionCreators.needs__create(whatsNewObject, null, nodeUri));
-  };
-}
-
 export function createWhatsAround() {
   return (dispatch, getState) => {
     const state = getState();
@@ -170,7 +146,7 @@ export function createWhatsAround() {
             const location = nominatim2draftLocation(searchResult);
 
             getIn(state, ["needs"])
-              .filter(need => isWhatsAroundNeed(need) || isWhatsNewNeed(need))
+              .filter(need => isWhatsAroundNeed(need))
               .map(need => {
                 dispatch(actionCreators.needs__delete(need.get("uri"))); //TODO action creators should not call other action creators, according to Moru
               });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-need-action.js
@@ -132,7 +132,6 @@ export function createWhatsNew() {
   return (dispatch, getState) => {
     const state = getState();
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
-    const defaultContext = getIn(state, ["config", "theme", "defaultContext"]);
 
     dispatch({ type: actionTypes.needs.whatsNew });
 
@@ -141,7 +140,6 @@ export function createWhatsNew() {
         flags: ["won:WhatsNew", "won:NoHintForCounterpart"],
       },
       seeks: {},
-      matchingContext: defaultContext,
     };
 
     getIn(state, ["needs"])
@@ -158,7 +156,6 @@ export function createWhatsAround() {
   return (dispatch, getState) => {
     const state = getState();
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
-    const defaultContext = getIn(state, ["config", "theme", "defaultContext"]);
 
     dispatch({ type: actionTypes.needs.whatsAround });
 
@@ -182,7 +179,6 @@ export function createWhatsAround() {
                 flags: ["won:WhatsAround", "won:NoHintForCounterpart"],
               },
               seeks: { location: location },
-              matchingContext: defaultContext,
             };
 
             dispatch(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -7,12 +7,12 @@ import { actionTypes, actionCreators } from "./actions.js";
 
 import { checkAccessToCurrentRoute } from "../configRouting.js";
 
-import { checkLoginStatus } from "../won-utils.js";
-
-import { fetchOwnedData } from "../won-message-utils.js";
+import * as wonUtils from "../won-utils.js";
+import * as wonMessageUtils from "../won-message-utils.js";
 
 export const pageLoadAction = () => (dispatch, getState) => {
-  checkLoginStatus()
+  wonUtils
+    .checkLoginStatus()
     /* handle data, dispatch actions */
     .then(data =>
       dispatch({
@@ -31,9 +31,15 @@ export const pageLoadAction = () => (dispatch, getState) => {
 function loadingWhileSignedIn(dispatch) {
   // reset websocket to make sure it's using the logged-in session
   dispatch(actionCreators.reconnect__start());
-  return fetchOwnedData(dispatch);
+  return wonMessageUtils.fetchOwnedData(dispatch);
 }
 
+export const loadAllActiveNeedUrisFromOwner = () => dispatch => {
+  dispatch({
+    type: actionTypes.needs.loadAllActiveNeedUrisFromOwner,
+  });
+  return wonMessageUtils.fetchAllActiveNeedUrisFromOwner(dispatch);
+};
 /*
  Simply prints a logline and resolves the promise so we can go on in the chain
 */

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -34,11 +34,11 @@ function loadingWhileSignedIn(dispatch) {
   return wonMessageUtils.fetchOwnedData(dispatch);
 }
 
-export const loadAllActiveNeedUrisFromOwner = () => dispatch => {
+export const loadAllActiveNeedUrisFromOwner = () => (dispatch, getState) => {
   dispatch({
     type: actionTypes.needs.loadAllActiveNeedUrisFromOwner,
   });
-  return wonMessageUtils.fetchAllActiveNeedUrisFromOwner(dispatch);
+  return wonMessageUtils.fetchAllActiveNeedUrisFromOwner(dispatch, getState);
 };
 /*
  Simply prints a logline and resolves the promise so we can go on in the chain

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/needs-actions.js
@@ -5,6 +5,7 @@
 import won from "../won-es6.js";
 
 import { actionTypes, actionCreators } from "./actions.js";
+import Immutable from "immutable";
 
 import {
   buildConnectMessage,
@@ -167,9 +168,9 @@ export function needsDelete(needUri) {
         // assume close went through successfully, update GUI
         dispatch({
           type: actionTypes.needs.delete,
-          payload: {
-            ownNeedUri: needUri,
-          },
+          payload: Immutable.fromJS({
+            uri: needUri,
+          }),
         })
       );
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app_jspm.js
@@ -39,6 +39,7 @@ import modalDialog from "./components/modal-dialog.js";
 import toasts from "./components/toasts.js";
 import slideIn from "./components/slide-in.js";
 import connectionsComponent from "./components/connections/connections.js";
+import overviewComponent from "./components/overview/overview.js";
 import postComponent from "./components/post/post.js";
 import aboutComponent from "./components/about/about.js";
 import signupComponent from "./components/signup/signup.js";
@@ -78,6 +79,7 @@ let app = angular.module("won.owner", [
 
   //views
   connectionsComponent,
+  overviewComponent,
   postComponent,
   aboutComponent,
   signupComponent,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.html
@@ -83,9 +83,7 @@
                 <span>What's in your Area?</span>
             </button>
             <button class="won-button--filled red about__howto__createx__button"
-                    ng-if="!self.processingPublish"
-                    ng-click="self.createWhatsNew()"
-                    ng-disabled="self.processingPublish">
+                    ng-click="self.router__stateGo('overview')">
                 <span>What's new?</span>
             </button>
             <won-labelled-hr label="::'Or'" class="about__howto__createx__labelledhr"></won-labelled-hr>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/about/about.js
@@ -269,29 +269,6 @@ class AboutController {
     }
   }
 
-  createWhatsNew() {
-    if (this.processingPublish) {
-      console.debug("publish in process, do not take any action");
-      return;
-    }
-
-    if (this.loggedIn) {
-      this.needs__whatsNew();
-    } else {
-      this.view__showTermsDialog(
-        Immutable.fromJS({
-          acceptCallback: () => {
-            this.view__hideModalDialog();
-            this.needs__whatsNew();
-          },
-          cancelCallback: () => {
-            this.view__hideModalDialog();
-          },
-        })
-      );
-    }
-  }
-
   toggleMoreInfo() {
     this.moreInfo = !this.moreInfo;
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggestpost-picker.js
@@ -56,9 +56,6 @@ function genComponentConf() {
       <div class="suggestpostp__error" ng-if="self.uriToFetchFailedToLoad && self.fetchNeedUriFieldHasText()">
           Failed to Load Suggestion, might not be a valid uri.
       </div>
-      <div class="suggestpostp__error" ng-if="self.uriToFetchIsWhatsNew && self.fetchNeedUriFieldHasText()">
-          Suggestion invalid, you are trying to share a What's New Need.
-      </div>
       <div class="suggestpostp__error" ng-if="self.uriToFetchIsWhatsAround && self.fetchNeedUriFieldHasText()">
           Suggestion invalid, you are trying to share a What's Around Need.
       </div>
@@ -108,9 +105,6 @@ function genComponentConf() {
         ]);
         const uriToFetchLoading = !!get(uriToFetchProcess, "loading");
         const uriToFetchFailedToLoad = !!get(uriToFetchProcess, "failedToLoad");
-        const uriToFetchIsWhatsNew = needUtils.isWhatsNewNeed(
-          get(allForbiddenNeeds, this.uriToFetch)
-        );
         const uriToFetchIsWhatsAround = needUtils.isWhatsAroundNeed(
           get(allForbiddenNeeds, this.uriToFetch)
         );
@@ -127,7 +121,6 @@ function genComponentConf() {
           suggestedNeedUri,
           uriToFetchLoading,
           uriToFetchFailedToLoad,
-          uriToFetchIsWhatsNew,
           uriToFetchIsWhatsAround,
           uriToFetchIsExcluded,
           uriToFetchIsNotAllowed,
@@ -149,7 +142,6 @@ function genComponentConf() {
             !uriToFetchLoading &&
             (uriToFetchFailedToLoad ||
               uriToFetchIsWhatsAround ||
-              uriToFetchIsWhatsNew ||
               uriToFetchIsExcluded ||
               uriToFetchIsNotAllowed),
         };
@@ -208,7 +200,6 @@ function genComponentConf() {
     isSuggestable(need) {
       return (
         !needUtils.isWhatsAroundNeed(need) &&
-        !needUtils.isWhatsNewNeed(need) &&
         !this.isExcludedNeed(need) &&
         this.hasAtLeastOneAllowedFacet(need)
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-post-messages.js
@@ -171,9 +171,7 @@ function genComponentConf() {
         const connectionUri = getConnectionUriFromRoute(state);
         const ownedNeed = getOwnedNeedByConnectionUri(state, connectionUri);
         const connection = getIn(ownedNeed, ["connections", connectionUri]);
-        const isOwnedNeedWhatsX =
-          needUtils.isWhatsAroundNeed(ownedNeed) ||
-          needUtils.isWhatsNewNeed(ownedNeed);
+        const isOwnedNeedWhatsX = needUtils.isWhatsAroundNeed(ownedNeed);
         const remoteNeedUri = get(connection, "remoteNeedUri");
         const remoteNeed = getIn(state, ["needs", remoteNeedUri]);
         const allChatMessages = get(connection, "messages");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -94,6 +94,14 @@ function genComponentConf() {
                 {{ self.friendlyTimestamp }}
             </div>
         </div>
+        <div class="card__main__location" ng-if="self.needLocation">
+          <svg class="card__main__location__icon">
+              <use xlink:href="#ico36_detail_location" href="#ico36_detail_location"></use>
+          </svg>
+          <span class="card__main__location__address">
+              {{ self.needLocation.get('address') }}
+          </span>
+        </div>
     </div>
     <div class="card__persona clickable" ng-if="self.needLoaded && self.persona" ng-click="self.router__stateGoCurrent({viewNeedUri: self.personaUri})">
           <img class="card__persona__icon"
@@ -166,7 +174,7 @@ function genComponentConf() {
           : undefined;
 
         const needImage = needUtils.getDefaultImage(need);
-        const needLocation = false; //needUtils.getLocation(need); //include the comment instead of the false, to display location in the need-card
+        const needLocation = needUtils.getLocation(need); //include the comment instead of the false, to display location in the need-card
 
         return {
           //General
@@ -202,7 +210,7 @@ function genComponentConf() {
           personaIdenticonSvg,
           needImage,
           needLocation,
-          showDefaultIcon: !needImage && !needLocation, //if no image and no locaiton are present we display the defaultIcon in the card__icon area, instead of next to the title
+          showDefaultIcon: !needImage /*&& !needLocation*/, //if no image and no location are present we display the defaultIcon in the card__icon area, instead of next to the title
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -21,22 +21,26 @@ function genComponentConf() {
   let template = `
     <div class="card__icon clickable"
         ng-if="self.needLoaded"
-        style="background-color: {{::self.iconBackground}}"
+        style="background-color: {{!self.hasImage && self.iconBackground}}"
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
         }"
         ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
-        <div class="image usecaseimage"
-            ng-if="::self.useCaseIcon">
+        <div class="identicon usecaseimage"
+            ng-if="!self.needImage && self.useCaseIcon">
             <svg class="si__usecaseicon">
                 <use xlink:href="{{ ::self.useCaseIcon }}" href="{{ ::self.useCaseIcon }}"></use>
             </svg>
         </div>
-        <img class="image"
-            ng-if="::self.identiconSvg"
+        <img class="identicon"
+            ng-if="!self.needImage && self.identiconSvg"
             alt="Auto-generated title image"
-            ng-src="data:image/svg+xml;base64,{{::self.identiconSvg}}">
+            ng-src="data:image/svg+xml;base64,{{::self.identiconSvg}}"/>
+        <img class="image"
+            ng-if="self.needImage"
+            alt="{{self.needImage.get('name')}}"
+            ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
@@ -76,7 +80,7 @@ function genComponentConf() {
           <img class="card__persona__icon"
               ng-if="::self.personaIdenticonSvg"
               alt="Auto-generated title image for persona that holds the need"
-              ng-src="data:image/svg+xml;base64,{{::self.personaIdenticonSvg}}">
+              ng-src="data:image/svg+xml;base64,{{::self.personaIdenticonSvg}}"/>
           <div class="card__persona__name"
               ng-if="self.personaName">
               <span class="card__persona__name__label">{{ self.personaName }}</span>
@@ -142,6 +146,8 @@ function genComponentConf() {
           ? needUtils.getIdenticonSvg(need)
           : undefined;
 
+        const needImage = needUtils.getDefaultImage(need);
+
         return {
           //General
           responseToNeed,
@@ -174,6 +180,7 @@ function genComponentConf() {
           useCaseIcon,
           identiconSvg,
           personaIdenticonSvg,
+          needImage,
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -112,8 +112,8 @@ function genComponentConf() {
         return {
           responseToNeed,
           need,
-          fullTypesLabel: need && needUtils.generateFullNeedTypesLabel(need),
-          shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
+          fullTypesLabel: need && needUtils.generateNeedTypeLabel(need),
+          shortTypesLabel: need && needUtils.generateNeedTypeLabel(need),
           personaName,
           needLoaded: processUtils.isNeedLoaded(process, this.needUri),
           needLoading: processUtils.isNeedLoading(process, this.needUri),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -19,11 +19,12 @@ import "style/_need-card.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
-    <div class="card__icon" ng-if="self.needLoaded"
+    <div class="card__icon clickable" ng-if="self.needLoaded"
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
-        }">
+        }"
+        ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
         <div class="image usecaseimage" style="background-color: {{::self.useCaseIconBackground}}"
             ng-if="::self.useCaseIcon">
             <svg class="si__usecaseicon">
@@ -38,7 +39,7 @@ function genComponentConf() {
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
     </div>
-    <div class="card__main" ng-if="self.needLoaded">
+    <div class="card__main clickable" ng-if="self.needLoaded" ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
         <div class="card__main__topline">
             <div class="card__main__topline__title" ng-if="self.hasTitle()">
                 {{ self.generateTitle() }}
@@ -69,7 +70,7 @@ function genComponentConf() {
             </div>
         </div>
     </div>
-    <div class="card__persona" ng-if="self.needLoaded && self.persona">
+    <div class="card__persona clickable" ng-if="self.needLoaded && self.persona" ng-click="self.router__stateGoCurrent({viewNeedUri: self.personaUri})">
           <img class="card__persona__icon"
               ng-if="::self.personaIdenticonSvg"
               alt="Auto-generated title image for persona that holds the need"
@@ -144,6 +145,7 @@ function genComponentConf() {
           responseToNeed,
           need,
           needTypeLabel: need && needUtils.generateNeedTypeLabel(need),
+          personaUri,
           persona,
           personaName,
           personaVerified,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -57,7 +57,7 @@ function genComponentConf() {
                     Group Chat enabled
                 </span>
                 <span ng-if="!self.shouldShowRdf">
-                    {{ self.shortTypesLabel }}{{ self.matchingContext }}
+                    {{ self.shortTypesLabel }}
                 </span>
                 <span ng-if="self.shouldShowRdf">
                     {{ self.fullTypesLabel }}
@@ -114,7 +114,6 @@ function genComponentConf() {
           need,
           fullTypesLabel: need && needUtils.generateFullNeedTypesLabel(need),
           shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
-          matchingContext: need && needUtils.generateNeedMatchingContext(need),
           personaName,
           needLoaded: processUtils.isNeedLoaded(process, this.needUri),
           needLoading: processUtils.isNeedLoading(process, this.needUri),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -114,11 +114,13 @@ function genComponentConf() {
           shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
           matchingContext: need && needUtils.generateNeedMatchingContext(need),
           personaName,
-          needLoading:
-            !need || processUtils.isNeedLoading(process, this.needUri),
-          needToLoad: !need || processUtils.isNeedToLoad(process, this.needUri),
-          needFailedToLoad:
-            need && processUtils.hasNeedFailedToLoad(process, this.needUri),
+          needLoaded: processUtils.isNeedLoaded(process, this.needUri),
+          needLoading: processUtils.isNeedLoading(process, this.needUri),
+          needToLoad: processUtils.isNeedToLoad(process, this.needUri),
+          needFailedToLoad: processUtils.hasNeedFailedToLoad(
+            process,
+            this.needUri
+          ),
           isDirectResponse: isDirectResponse,
           isGroupChatEnabled: needUtils.hasGroupFacet(need),
           isChatEnabled: needUtils.hasChatFacet(need),
@@ -141,7 +143,9 @@ function genComponentConf() {
     ensureNeedIsLoaded() {
       if (
         this.needUri &&
-        (!this.need || (this.needToLoad && !this.needLoading))
+        !this.needLoaded &&
+        !this.needLoading &&
+        this.needToLoad
       ) {
         this.needs__fetchUnloadedNeed(this.needUri);
       }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -5,6 +5,7 @@
 import angular from "angular";
 import inviewModule from "angular-inview";
 import "ng-redux";
+import needMapModule from "./need-map.js";
 import { actionCreators } from "../actions/actions.js";
 import { relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get } from "../utils.js";
@@ -41,10 +42,8 @@ function genComponentConf() {
             ng-if="self.needImage"
             alt="{{self.needImage.get('name')}}"
             ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
-        <div class="location"
-            ng-if="self.needImage && self.needLocation">
-            LOCATION
-        </div>
+        <won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation">
+        </won-need-map>
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
@@ -167,7 +166,7 @@ function genComponentConf() {
           : undefined;
 
         const needImage = needUtils.getDefaultImage(need);
-        const needLocation = false; //needUtils.getLocation(need); //TODO: Location implementation pending
+        const needLocation = false; //needUtils.getLocation(need); //include the comment instead of the false, to display location in the need-card
 
         return {
           //General
@@ -260,5 +259,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.needCard", [inviewModule.name])
+  .module("won.owner.components.needCard", [inviewModule.name, needMapModule])
   .directive("wonNeedCard", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -11,7 +11,6 @@ import { relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
-import * as viewSelectors from "../selectors/view-selectors.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as processUtils from "../process-utils.js";
@@ -56,11 +55,8 @@ function genComponentConf() {
                     ng-if="self.isGroupChatEnabled && self.isChatEnabled">
                     Group Chat enabled
                 </span>
-                <span ng-if="!self.shouldShowRdf">
-                    {{ self.shortTypesLabel }}
-                </span>
-                <span ng-if="self.shouldShowRdf">
-                    {{ self.fullTypesLabel }}
+                <span>
+                    {{ self.needTypeLabel }}
                 </span>
             </span>
             <div class="ph__right__subtitle__date">
@@ -112,8 +108,7 @@ function genComponentConf() {
         return {
           responseToNeed,
           need,
-          fullTypesLabel: need && needUtils.generateNeedTypeLabel(need),
-          shortTypesLabel: need && needUtils.generateNeedTypeLabel(need),
+          needTypeLabel: need && needUtils.generateNeedTypeLabel(need),
           personaName,
           needLoaded: processUtils.isNeedLoaded(process, this.needUri),
           needLoading: processUtils.isNeedLoading(process, this.needUri),
@@ -131,7 +126,6 @@ function genComponentConf() {
               selectLastUpdateTime(state),
               get(need, "lastUpdateDate")
             ),
-          shouldShowRdf: viewSelectors.showRdf(state),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -19,13 +19,15 @@ import "style/_need-card.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
-    <div class="card__icon clickable" ng-if="self.needLoaded"
+    <div class="card__icon clickable"
+        ng-if="self.needLoaded"
+        style="background-color: {{::self.useCaseIconBackground}}"
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
         }"
         ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
-        <div class="image usecaseimage" style="background-color: {{::self.useCaseIconBackground}}"
+        <div class="image usecaseimage"
             ng-if="::self.useCaseIcon">
             <svg class="si__usecaseicon">
                 <use xlink:href="{{ ::self.useCaseIcon }}" href="{{ ::self.useCaseIcon }}"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -42,8 +42,8 @@ function genComponentConf() {
             ng-if="self.needImage"
             alt="{{self.needImage.get('name')}}"
             ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
-        <won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation">
-        </won-need-map>
+        <!--won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation">
+        </won-need-map-->
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -1,0 +1,186 @@
+/**
+ * Component for rendering need-title
+ * Created by ksinger on 10.04.2017.
+ */
+import angular from "angular";
+import "ng-redux";
+import squareImageModule from "./square-image.js";
+import { actionCreators } from "../actions/actions.js";
+import { relativeTime } from "../won-label-utils.js";
+import { attach, getIn, get, delay } from "../utils.js";
+import { connect2Redux } from "../won-utils.js";
+import { selectLastUpdateTime } from "../selectors/general-selectors.js";
+import * as viewSelectors from "../selectors/view-selectors.js";
+import won from "../won-es6.js";
+import { classOnComponentRoot } from "../cstm-ng-utils.js";
+import * as needUtils from "../need-utils.js";
+import * as processUtils from "../process-utils.js";
+
+import "style/_need-card.scss";
+
+const serviceDependencies = ["$ngRedux", "$scope", "$element"];
+function genComponentConf() {
+  let template = `
+    <won-square-image
+        ng-if="!self.needLoading"
+        uri="::self.needUri">
+    </won-square-image>
+    <div class="ph__right" ng-if="!self.needLoading">
+      <div class="ph__right__topline" ng-if="!self.needFailedToLoad">
+        <div class="ph__right__topline__title" ng-if="self.hasTitle()">
+          {{ self.generateTitle() }}
+        </div>
+        <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && self.isDirectResponse">
+          RE: no title
+        </div>
+        <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && !self.isDirectResponse">
+          no title
+        </div>
+      </div>
+      <div class="ph__right__subtitle" ng-if="!self.needFailedToLoad">
+        <span class="ph__right__subtitle__type">
+          <span class="ph__right__subtitle__type__persona"
+            ng-if="self.personaName">
+            {{self.personaName}}
+          </span>
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && !self.isChatEnabled">
+            Group Chat
+          </span>
+          <span class="ph__right__subtitle__type__groupchat"
+            ng-if="self.isGroupChatEnabled && self.isChatEnabled">
+            Group Chat enabled
+          </span>
+          <span ng-if="!self.shouldShowRdf">
+            {{ self.shortTypesLabel }}{{ self.matchingContext }}
+          </span>
+          <span ng-if="self.shouldShowRdf">
+            {{ self.fullTypesLabel }}
+          </span>
+        </span>
+        <div class="ph__right__subtitle__date">
+          {{ self.friendlyTimestamp }}
+        </div>
+      </div>
+      <div class="ph__right__topline" ng-if="self.needFailedToLoad">
+        <div class="ph__right__topline__notitle">
+          Need Loading failed
+        </div>
+      </div>
+      <div class="ph__right__subtitle" ng-if="self.needFailedToLoad">
+        <span class="ph__right__subtitle__type">
+          Need might have been deleted.
+        </span>
+      </div>
+    </div>
+    
+    <div class="ph__icon__skeleton" ng-if="self.needLoading"></div>
+    <div class="ph__right" ng-if="self.needLoading">
+      <div class="ph__right__topline">
+        <div class="ph__right__topline__title"></div>
+      </div>
+      <div class="ph__right__subtitle">
+        <span class="ph__right__subtitle__type"></span>
+      </div>
+    </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      window.ph4dbg = this;
+
+      this.WON = won.WON;
+      const selectFromState = state => {
+        const need = getIn(state, ["needs", this.needUri]);
+        const isDirectResponse = needUtils.isDirectResponseNeed(need);
+        const responseToUri =
+          isDirectResponse && getIn(need, ["content", "responseToUri"]);
+        const responseToNeed =
+          responseToUri && getIn(state, ["needs", responseToUri]);
+
+        const personaUri = get(need, "heldBy");
+        const persona = personaUri && getIn(state, ["needs", personaUri]);
+        const personaName = get(persona, "humanReadable");
+
+        const process = get(state, "process");
+
+        return {
+          responseToNeed,
+          need,
+          fullTypesLabel: need && needUtils.generateFullNeedTypesLabel(need),
+          shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
+          matchingContext: need && needUtils.generateNeedMatchingContext(need),
+          personaName,
+          needLoading:
+            !need || processUtils.isNeedLoading(process, this.needUri),
+          needToLoad: !need || processUtils.isNeedToLoad(process, this.needUri),
+          needFailedToLoad:
+            need && processUtils.hasNeedFailedToLoad(process, this.needUri),
+          isDirectResponse: isDirectResponse,
+          isGroupChatEnabled: needUtils.hasGroupFacet(need),
+          isChatEnabled: needUtils.hasChatFacet(need),
+          friendlyTimestamp:
+            need &&
+            relativeTime(
+              selectLastUpdateTime(state),
+              get(need, "lastUpdateDate")
+            ),
+          shouldShowRdf: viewSelectors.showRdf(state),
+        };
+      };
+
+      connect2Redux(selectFromState, actionCreators, ["self.needUri"], this);
+
+      classOnComponentRoot("won-is-loading", () => this.needLoading, this);
+      classOnComponentRoot("won-is-toload", () => this.needToLoad, this);
+
+      this.$scope.$watch(
+        () =>
+          this.needUri &&
+          (!this.need || (this.needToLoad && !this.needLoading)),
+        () => delay(0).then(() => this.ensureNeedIsLoaded())
+      );
+    }
+
+    ensureNeedIsLoaded() {
+      if (
+        this.needUri &&
+        (!this.need || (this.needToLoad && !this.needLoading))
+      ) {
+        this.needs__fetchUnloadedNeed(this.needUri);
+      }
+    }
+
+    hasTitle() {
+      if (this.isDirectResponse && this.responseToNeed) {
+        return !!this.responseToNeed.get("humanReadable");
+      } else {
+        return !!this.need.get("humanReadable");
+      }
+    }
+
+    generateTitle() {
+      if (this.isDirectResponse && this.responseToNeed) {
+        return "Re: " + this.responseToNeed.get("humanReadable");
+      } else {
+        return this.need.get("humanReadable");
+      }
+    }
+  }
+  Controller.$inject = serviceDependencies;
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      needUri: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.needCard", [squareImageModule])
+  .directive("wonNeedCard", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -22,69 +22,71 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
     <won-square-image
-        ng-if="!self.needLoading && !self.needToLoad"
+        ng-if="self.needLoaded"
         uri="::self.needUri">
     </won-square-image>
     <div class="ph__icon__skeleton"
       ng-if="self.needToLoad"
       in-view="$inview && self.ensureNeedIsLoaded()">
     </div>
-    <div class="ph__icon__skeleton" ng-if="self.needLoading"></div>
-    <div class="ph__right" ng-if="!self.needLoading && !self.needToLoad">
-      <div class="ph__right__topline" ng-if="!self.needFailedToLoad">
-        <div class="ph__right__topline__title" ng-if="self.hasTitle()">
-          {{ self.generateTitle() }}
+    <div class="ph__icon__skeleton" ng-if="self.needLoading || self.needFailedToLoad"></div>
+    <div class="ph__right" ng-if="self.needLoaded">
+        <div class="ph__right__topline">
+            <div class="ph__right__topline__title" ng-if="self.hasTitle()">
+                {{ self.generateTitle() }}
+            </div>
+            <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && self.isDirectResponse">
+                RE: no title
+            </div>
+            <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && !self.isDirectResponse">
+                no title
+            </div>
         </div>
-        <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && self.isDirectResponse">
-          RE: no title
+        <div class="ph__right__subtitle">
+            <span class="ph__right__subtitle__type">
+                <span class="ph__right__subtitle__type__persona"
+                    ng-if="self.personaName">
+                    {{self.personaName}}
+                </span>
+                <span class="ph__right__subtitle__type__groupchat"
+                    ng-if="self.isGroupChatEnabled && !self.isChatEnabled">
+                    Group Chat
+                </span>
+                <span class="ph__right__subtitle__type__groupchat"
+                    ng-if="self.isGroupChatEnabled && self.isChatEnabled">
+                    Group Chat enabled
+                </span>
+                <span ng-if="!self.shouldShowRdf">
+                    {{ self.shortTypesLabel }}{{ self.matchingContext }}
+                </span>
+                <span ng-if="self.shouldShowRdf">
+                    {{ self.fullTypesLabel }}
+                </span>
+            </span>
+            <div class="ph__right__subtitle__date">
+                {{ self.friendlyTimestamp }}
+            </div>
         </div>
-        <div class="ph__right__topline__notitle" ng-if="!self.hasTitle() && !self.isDirectResponse">
-          no title
+    </div>
+    <div class="ph__right" ng-if="self.needFailedToLoad">
+        <div class="ph__right__topline">
+            <div class="ph__right__topline__notitle">
+                Need Loading failed
+            </div>
         </div>
-      </div>
-      <div class="ph__right__subtitle" ng-if="!self.needFailedToLoad">
-        <span class="ph__right__subtitle__type">
-          <span class="ph__right__subtitle__type__persona"
-            ng-if="self.personaName">
-            {{self.personaName}}
-          </span>
-          <span class="ph__right__subtitle__type__groupchat"
-            ng-if="self.isGroupChatEnabled && !self.isChatEnabled">
-            Group Chat
-          </span>
-          <span class="ph__right__subtitle__type__groupchat"
-            ng-if="self.isGroupChatEnabled && self.isChatEnabled">
-            Group Chat enabled
-          </span>
-          <span ng-if="!self.shouldShowRdf">
-            {{ self.shortTypesLabel }}{{ self.matchingContext }}
-          </span>
-          <span ng-if="self.shouldShowRdf">
-            {{ self.fullTypesLabel }}
-          </span>
-        </span>
-        <div class="ph__right__subtitle__date">
-          {{ self.friendlyTimestamp }}
+        <div class="ph__right__subtitle">
+            <span class="ph__right__subtitle__type">
+                Need might have been deleted.
+            </span>
         </div>
-      </div>
-      <div class="ph__right__topline" ng-if="self.needFailedToLoad">
-        <div class="ph__right__topline__notitle">
-          Need Loading failed
-        </div>
-      </div>
-      <div class="ph__right__subtitle" ng-if="self.needFailedToLoad">
-        <span class="ph__right__subtitle__type">
-          Need might have been deleted.
-        </span>
-      </div>
     </div>
     <div class="ph__right" ng-if="self.needLoading || self.needToLoad">
-      <div class="ph__right__topline">
-        <div class="ph__right__topline__title"></div>
-      </div>
-      <div class="ph__right__subtitle">
-        <span class="ph__right__subtitle__type"></span>
-      </div>
+        <div class="ph__right__topline">
+            <div class="ph__right__topline__title"></div>
+        </div>
+        <div class="ph__right__subtitle">
+            <span class="ph__right__subtitle__type"></span>
+        </div>
     </div>
     `;
 
@@ -138,6 +140,7 @@ function genComponentConf() {
 
       classOnComponentRoot("won-is-loading", () => this.needLoading, this);
       classOnComponentRoot("won-is-toload", () => this.needToLoad, this);
+      classOnComponentRoot("won-is-invisible", () => this.hideNeed(), this);
     }
 
     ensureNeedIsLoaded() {
@@ -149,6 +152,13 @@ function genComponentConf() {
       ) {
         this.needs__fetchUnloadedNeed(this.needUri);
       }
+    }
+
+    hideNeed() {
+      return (
+        this.needFailedToLoad ||
+        (this.needLoaded && needUtils.isInactive(this.need))
+      );
     }
 
     hasTitle() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -21,7 +21,7 @@ function genComponentConf() {
   let template = `
     <div class="card__icon clickable"
         ng-if="self.needLoaded"
-        style="background-color: {{::self.useCaseIconBackground}}"
+        style="background-color: {{::self.iconBackground}}"
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
@@ -135,8 +135,8 @@ function genComponentConf() {
         const useCaseIcon = !isPersona
           ? needUtils.getMatchedUseCaseIcon(need)
           : undefined;
-        const useCaseIconBackground = !isPersona
-          ? needUtils.getMatchedUseCaseIconBackground(need)
+        const iconBackground = !isPersona
+          ? needUtils.getBackground(need)
           : undefined;
         const identiconSvg = !useCaseIcon
           ? needUtils.getIdenticonSvg(need)
@@ -170,7 +170,7 @@ function genComponentConf() {
               get(need, "lastUpdateDate")
             ),
           //image specific
-          useCaseIconBackground,
+          iconBackground,
           useCaseIcon,
           identiconSvg,
           personaIdenticonSvg,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -12,7 +12,6 @@ import { attach, getIn, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
 import * as viewSelectors from "../selectors/view-selectors.js";
-import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import * as needUtils from "../need-utils.js";
 import * as processUtils from "../process-utils.js";
@@ -94,7 +93,6 @@ function genComponentConf() {
       attach(this, serviceDependencies, arguments);
       window.ph4dbg = this;
 
-      this.WON = won.WON;
       const selectFromState = state => {
         const need = getIn(state, ["needs", this.needUri]);
         const isDirectResponse = needUtils.isDirectResponseNeed(need);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -29,7 +29,7 @@ function genComponentConf() {
         ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
         <div class="identicon usecaseimage"
             ng-if="!self.needImage && self.useCaseIcon">
-            <svg class="si__usecaseicon">
+            <svg>
                 <use xlink:href="{{ ::self.useCaseIcon }}" href="{{ ::self.useCaseIcon }}"></use>
             </svg>
         </div>
@@ -45,7 +45,23 @@ function genComponentConf() {
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
     </div>
-    <div class="card__main clickable" ng-if="self.needLoaded" ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
+    <div class="card__main clickable"
+        ng-if="self.needLoaded" ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})"
+        ng-class="{
+          'card__main--showIcon': self.needImage,
+        }">
+        <div class="card__main__icon" ng-if="self.needImage"style=" background-color: {{!self.hasImage && self.iconBackground}}">
+            <div class="card__main__icon__usecaseimage"
+                ng-if="self.useCaseIcon">
+                <svg>
+                    <use xlink:href="{{ ::self.useCaseIcon }}" href="{{ ::self.useCaseIcon }}"></use>
+                </svg>
+            </div>
+            <img class="card__main__icon__identicon"
+                ng-if="self.identiconSvg"
+                alt="Auto-generated title image"
+                ng-src="data:image/svg+xml;base64,{{::self.identiconSvg}}"/>
+        </div>
         <div class="card__main__topline">
             <div class="card__main__topline__title" ng-if="self.hasTitle()">
                 {{ self.generateTitle() }}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -147,6 +147,7 @@ function genComponentConf() {
       }
     }
 
+    //FIXME: THIS and the corresponding css-class need to be removed, this is solely to prevent loaded/but inactive need to show up for now
     hideNeed() {
       return this.needLoaded && needUtils.isInactive(this.need);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -148,10 +148,7 @@ function genComponentConf() {
     }
 
     hideNeed() {
-      return (
-        this.needFailedToLoad ||
-        (this.needLoaded && needUtils.isInactive(this.need))
-      );
+      return this.needLoaded && needUtils.isInactive(this.need);
     }
 
     hasTitle() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -21,26 +21,30 @@ function genComponentConf() {
   let template = `
     <div class="card__icon clickable"
         ng-if="self.needLoaded"
-        style="background-color: {{!self.hasImage && self.iconBackground}}"
+        style="background-color: {{self.showDefaultIcon && self.iconBackground}}"
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
         }"
         ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
         <div class="identicon usecaseimage"
-            ng-if="!self.needImage && self.useCaseIcon">
+            ng-if="self.showDefaultIcon && self.useCaseIcon">
             <svg>
                 <use xlink:href="{{ ::self.useCaseIcon }}" href="{{ ::self.useCaseIcon }}"></use>
             </svg>
         </div>
         <img class="identicon"
-            ng-if="!self.needImage && self.identiconSvg"
+            ng-if="self.showDefaultIcon && self.identiconSvg"
             alt="Auto-generated title image"
             ng-src="data:image/svg+xml;base64,{{::self.identiconSvg}}"/>
         <img class="image"
             ng-if="self.needImage"
             alt="{{self.needImage.get('name')}}"
             ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
+        <div class="location"
+            ng-if="self.needImage && self.needLocation">
+            LOCATION
+        </div>
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
@@ -48,9 +52,9 @@ function genComponentConf() {
     <div class="card__main clickable"
         ng-if="self.needLoaded" ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})"
         ng-class="{
-          'card__main--showIcon': self.needImage,
+          'card__main--showIcon': !self.showDefaultIcon,
         }">
-        <div class="card__main__icon" ng-if="self.needImage"style=" background-color: {{!self.hasImage && self.iconBackground}}">
+        <div class="card__main__icon" ng-if="!self.showDefaultIcon" style=" background-color: {{!self.hasImage && self.iconBackground}}">
             <div class="card__main__icon__usecaseimage"
                 ng-if="self.useCaseIcon">
                 <svg>
@@ -163,6 +167,7 @@ function genComponentConf() {
           : undefined;
 
         const needImage = needUtils.getDefaultImage(need);
+        const needLocation = false; //needUtils.getLocation(need); //TODO: Location implementation pending
 
         return {
           //General
@@ -197,6 +202,8 @@ function genComponentConf() {
           identiconSvg,
           personaIdenticonSvg,
           needImage,
+          needLocation,
+          showDefaultIcon: !needImage && !needLocation, //if no image and no locaiton are present we display the defaultIcon in the card__icon area, instead of next to the title
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -3,11 +3,12 @@
  * Created by ksinger on 10.04.2017.
  */
 import angular from "angular";
+import inviewModule from "angular-inview";
 import "ng-redux";
 import squareImageModule from "./square-image.js";
 import { actionCreators } from "../actions/actions.js";
 import { relativeTime } from "../won-label-utils.js";
-import { attach, getIn, get, delay } from "../utils.js";
+import { attach, getIn, get } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
 import * as viewSelectors from "../selectors/view-selectors.js";
@@ -22,10 +23,15 @@ const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
     <won-square-image
-        ng-if="!self.needLoading"
+        ng-if="!self.needLoading && !self.needToLoad"
         uri="::self.needUri">
     </won-square-image>
-    <div class="ph__right" ng-if="!self.needLoading">
+    <div class="ph__icon__skeleton"
+      ng-if="self.needToLoad"
+      in-view="$inview && self.ensureNeedIsLoaded()">
+    </div>
+    <div class="ph__icon__skeleton" ng-if="self.needLoading"></div>
+    <div class="ph__right" ng-if="!self.needLoading && !self.needToLoad">
       <div class="ph__right__topline" ng-if="!self.needFailedToLoad">
         <div class="ph__right__topline__title" ng-if="self.hasTitle()">
           {{ self.generateTitle() }}
@@ -73,9 +79,7 @@ function genComponentConf() {
         </span>
       </div>
     </div>
-    
-    <div class="ph__icon__skeleton" ng-if="self.needLoading"></div>
-    <div class="ph__right" ng-if="self.needLoading">
+    <div class="ph__right" ng-if="self.needLoading || self.needToLoad">
       <div class="ph__right__topline">
         <div class="ph__right__topline__title"></div>
       </div>
@@ -134,13 +138,6 @@ function genComponentConf() {
 
       classOnComponentRoot("won-is-loading", () => this.needLoading, this);
       classOnComponentRoot("won-is-toload", () => this.needToLoad, this);
-
-      this.$scope.$watch(
-        () =>
-          this.needUri &&
-          (!this.need || (this.needToLoad && !this.needLoading)),
-        () => delay(0).then(() => this.ensureNeedIsLoaded())
-      );
     }
 
     ensureNeedIsLoaded() {
@@ -182,5 +179,8 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.needCard", [squareImageModule])
+  .module("won.owner.components.needCard", [
+    squareImageModule,
+    inviewModule.name,
+  ])
   .directive("wonNeedCard", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -1,0 +1,18 @@
+<won-modal-dialog ng-if="self.showModalDialog"></won-modal-dialog>
+<div class="won-modal-needview" ng-if="self.showNeedOverlay">
+    <won-post-info include-header="true" need-uri="self.viewNeedUri"></won-post-info>
+</div>
+<div class="won-modal-connectionview" ng-if="self.showConnectionOverlay">
+    <won-post-messages connection-uri="self.viewConnUri"></won-post-messages>
+</div>
+<header>
+    <won-topnav></won-topnav>
+</header>
+<won-toasts></won-toasts>
+<won-slide-in ng-if="self.showSlideIns"></won-slide-in>
+<main class="owneroverview" ng-class="{'owneroverview--won-loading': self.needLoading, 'owneroverview--won-failed': self.needFailedToLoad}">
+    <div class="owneroverview__need" ng-repeat="needUri in self.allActiveNeedUrisArray track by needUri" ng-click="self.router__stateGoCurrent({viewNeedUri: needUri})">
+        <won-post-info include-header="true" need-uri="needUri"></won-post-info>
+    </div>
+</main>
+<won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -13,7 +13,7 @@
 <main class="owneroverview">
     <div class="owneroverview__header">
         <div class="owneroverview__header__title">
-            Overview <span class="owneroverview__header__title__count" ng-if="!self.isOwnerNeedUrisLoading">({{ self.needUrisSize }})</span>
+            What's new? <span class="owneroverview__header__title__count" ng-if="!self.isOwnerNeedUrisLoading">({{ self.needUrisSize }})</span>
         </div>
         <div class="owneroverview__header__loading" ng-if="self.isOwnerNeedUrisLoading">
             Loading...

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -10,9 +10,27 @@
 </header>
 <won-toasts></won-toasts>
 <won-slide-in ng-if="self.showSlideIns"></won-slide-in>
-<main class="owneroverview" ng-class="{'owneroverview--won-loading': self.needLoading, 'owneroverview--won-failed': self.needFailedToLoad}">
-    <div class="owneroverview__need" ng-repeat="needUri in self.allActiveNeedUrisArray track by needUri" ng-click="self.router__stateGoCurrent({viewNeedUri: needUri})">
-        <won-post-info include-header="true" need-uri="needUri"></won-post-info>
+<main class="owneroverview">
+    <div class="owneroverview__header">
+        <div class="owneroverview__header__title">
+            Overview
+        </div>
+        <div class="owneroverview__header__loading" ng-if="self.isOwnerNeedUrisLoading">
+            Loading...
+        </div>
+        <div class="owneroverview__header__updated" ng-if="!self.isOwnerNeedUrisLoading">
+            <div class="owneroverview__header__updated__time">
+                Updated: {{ self.friendlyLastNeedUrisUpdateTimestamp }}
+            </div>
+            <div class="owneroverview__header__updated__reload won-button--filled red" ng-click="self.reload()">
+                Reload
+            </div>
+        </div>
+    </div>
+    <div class="owneroverview__content">
+        <div class="owneroverview__content__need" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGoCurrent({viewNeedUri: needUri})">
+            <won-post-info include-header="true" need-uri="needUri"></won-post-info>
+        </div>
     </div>
 </main>
 <won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -28,7 +28,7 @@
         </div>
     </div>
     <div class="owneroverview__content">
-        <won-need-card class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-need-card>
+        <won-need-card class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri"></won-need-card>
     </div>
 </main>
 <won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -13,7 +13,7 @@
 <main class="owneroverview">
     <div class="owneroverview__header">
         <div class="owneroverview__header__title">
-            Overview
+            Overview <span class="owneroverview__header__title__count" ng-if="!self.isOwnerNeedUrisLoading">({{ self.needUrisSize }})</span>
         </div>
         <div class="owneroverview__header__loading" ng-if="self.isOwnerNeedUrisLoading">
             Loading...
@@ -28,8 +28,7 @@
         </div>
     </div>
     <div class="owneroverview__content">
-        <!--won-need-card class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-need-card-->
-        <won-post-header class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-post-header>
+        <won-need-card class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-need-card>
     </div>
 </main>
 <won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.html
@@ -28,9 +28,8 @@
         </div>
     </div>
     <div class="owneroverview__content">
-        <div class="owneroverview__content__need" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGoCurrent({viewNeedUri: needUri})">
-            <won-post-info include-header="true" need-uri="needUri"></won-post-info>
-        </div>
+        <!--won-need-card class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-need-card-->
+        <won-post-header class="owneroverview__content__need" need-uri="needUri" ng-repeat="needUri in self.needUrisArray track by needUri" ng-click="self.router__stateGo('post', {postUri: needUri})"></won-post-header>
     </div>
 </main>
 <won-footer></won-footer>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -54,7 +54,7 @@ class Controller {
             generalSelectors.selectLastUpdateTime(state),
             lastNeedUrisUpdateDate
           ),
-        needUrisArray: needUris && needUris.toArray().splice(0, 1000), //FIXME: CURRENTLY LIMIT TO 1000 entries
+        needUrisArray: needUris && needUris.toArray().splice(0, 200), //FIXME: CURRENTLY LIMIT TO 200 entries
         needUrisSize: needUris ? needUris.size : 0,
         isOwnerNeedUrisLoading,
         isOwnerNeedUrisToLoad,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -1,0 +1,99 @@
+/**
+ * Created by quasarchimaere on 04.04.2019.
+ */
+import angular from "angular";
+import ngAnimate from "angular-animate";
+import { attach, getIn, get, delay } from "../../utils.js";
+import { connect2Redux } from "../../won-utils.js";
+import won from "../../won-es6.js";
+import { actionCreators } from "../../actions/actions.js";
+import sendRequestModule from "../send-request.js";
+import postMessagesModule from "../post-messages.js";
+import groupPostMessagesModule from "../group-post-messages.js";
+import visitorTitleBarModule from "../visitor-title-bar.js";
+import * as generalSelectors from "../../selectors/general-selectors.js";
+import * as viewSelectors from "../../selectors/view-selectors.js";
+import * as processUtils from "../../process-utils.js";
+import * as srefUtils from "../../sref-utils.js";
+
+import "style/_overview.scss";
+import "style/_need-overlay.scss";
+import "style/_connection-overlay.scss";
+
+const serviceDependencies = ["$ngRedux", "$scope"];
+class Controller {
+  constructor() {
+    attach(this, serviceDependencies, arguments);
+    this.selection = 0;
+    window.p4dbg = this;
+    this.WON = won.WON;
+    Object.assign(this, srefUtils); // bind srefUtils to scope
+
+    const selectFromState = state => {
+      const needUri = generalSelectors.getPostUriFromRoute(state);
+      const viewNeedUri = generalSelectors.getViewNeedUriFromRoute(state);
+      const viewConnUri = generalSelectors.getViewConnectionUriFromRoute(state);
+
+      const allActiveNeedUris = getIn(state, ["owner", "allActiveNeedUris"]);
+
+      const need = getIn(state, ["needs", needUri]);
+
+      const process = get(state, "process");
+
+      return {
+        allActiveNeedUrisArray:
+          allActiveNeedUris && allActiveNeedUris.toArray(),
+        needUri,
+        isOwnedNeed: generalSelectors.isNeedOwned(state, needUri),
+        need,
+        won: won.WON,
+        showSlideIns:
+          viewSelectors.hasSlideIns(state) && viewSelectors.showSlideIns(state),
+        showModalDialog: viewSelectors.showModalDialog(state),
+        showNeedOverlay: !!viewNeedUri,
+        showConnectionOverlay: !!viewConnUri,
+        viewNeedUri,
+        viewConnUri,
+        needLoading: !need || processUtils.isNeedLoading(process, needUri),
+        needToLoad: !need || processUtils.isNeedToLoad(process, needUri),
+        needFailedToLoad:
+          need && processUtils.hasNeedFailedToLoad(process, needUri),
+      };
+    };
+
+    connect2Redux(selectFromState, actionCreators, [], this);
+
+    this.$scope.$watch(
+      () =>
+        this.needUri && (!this.need || (this.needToLoad && !this.needLoading)),
+      () => delay(0).then(() => this.ensureNeedIsLoaded())
+    );
+  }
+
+  ensureNeedIsLoaded() {
+    if (
+      this.needUri &&
+      (!this.need || (this.needToLoad && !this.needLoading))
+    ) {
+      this.needs__fetchUnloadedNeed(this.needUri);
+    }
+  }
+
+  tryReload() {
+    if (this.needUri && this.needFailedToLoad) {
+      this.needs__fetchUnloadedNeed(this.needUri);
+    }
+  }
+}
+
+Controller.$inject = serviceDependencies;
+
+export default angular
+  .module("won.owner.components.overview", [
+    sendRequestModule,
+    ngAnimate,
+    visitorTitleBarModule,
+    postMessagesModule,
+    groupPostMessagesModule,
+  ])
+  .controller("OverviewController", Controller).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -54,7 +54,7 @@ class Controller {
             generalSelectors.selectLastUpdateTime(state),
             lastNeedUrisUpdateDate
           ),
-        needUrisArray: needUris && needUris.toArray(),
+        needUrisArray: needUris && needUris.toArray().splice(0, 1000), //FIXME: CURRENTLY LIMIT TO 1000 entries
         needUrisSize: needUris ? needUris.size : 0,
         isOwnerNeedUrisLoading,
         isOwnerNeedUrisToLoad,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -55,6 +55,7 @@ class Controller {
             lastNeedUrisUpdateDate
           ),
         needUrisArray: needUris && needUris.toArray(),
+        needUrisSize: needUris ? needUris.size : 0,
         isOwnerNeedUrisLoading,
         isOwnerNeedUrisToLoad,
         showSlideIns:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -8,6 +8,8 @@ import { connect2Redux } from "../../won-utils.js";
 import won from "../../won-es6.js";
 import { actionCreators } from "../../actions/actions.js";
 import postMessagesModule from "../post-messages.js";
+import needCardModule from "../need-card.js";
+import postHeaderModule from "../post-header.js";
 import * as generalSelectors from "../../selectors/general-selectors.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
 import * as processUtils from "../../process-utils.js";
@@ -89,5 +91,10 @@ class Controller {
 Controller.$inject = serviceDependencies;
 
 export default angular
-  .module("won.owner.components.overview", [ngAnimate, postMessagesModule])
+  .module("won.owner.components.overview", [
+    ngAnimate,
+    postMessagesModule,
+    needCardModule,
+    postHeaderModule,
+  ])
   .controller("OverviewController", Controller).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -41,29 +41,17 @@ function genComponentConf() {
               {{ self.friendlyModifiedDate }}
             </div>
           </div>
-          <!-- TYPES - IF SHOW RDF IS TRUE -->
-          <div class="pcg__columns__left__item" ng-if="self.shouldShowRdf">
+          <div class="pcg__columns__left__item">
             <div class="pcg__columns__left__item__label">
               Types
             </div>
             <div class="pcg__columns__left__item__value">
-              {{ self.fullTypesLabel }}
+              {{ self.needTypeLabel }}
             </div>
           </div>
         </div>
 
       <!-- RIGHT COLUMN -->
-        <!-- TYPES - IF SHOW RDF IS FALSE -->
-        <div class="pcg__columns__right" ng-if="!self.shouldShowRdf && self.shortTypesLabel.length > 0">
-          <div class="pcg__columns__left__item">
-            <div class="pcg__columns__left__item__label">
-              Type
-            </div>
-            <div class="pcg__columns__left__item__value">
-              {{ self.shortTypesLabel }}
-            </div>
-          </div>
-        </div>
         <!-- FLAGS -->
         <div class="pcg__columns__right" ng-if="self.shouldShowRdf || (self.shortFlags && self.shortFlags.length > 0)">
           <div class="pcg__columns__right__item">
@@ -120,8 +108,7 @@ function genComponentConf() {
 
         return {
           WON: won.WON,
-          fullTypesLabel: post && needUtils.generateNeedTypeLabel(post),
-          shortTypesLabel: post && needUtils.generateNeedTypeLabel(post),
+          needTypeLabel: post && needUtils.generateNeedTypeLabel(post),
           fullFlags: post && needUtils.generateFullNeedFlags(post),
           shortFlags: post && needUtils.generateShortNeedFlags(post),
           fullFacets: post && needUtils.generateFullNeedFacets(post),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -14,7 +14,6 @@ import {
   generateFullNeedFacets,
   generateShortNeedFlags,
   generateShortNeedFacets,
-  generateNeedMatchingContext,
 } from "../need-utils.js";
 import * as viewUtils from "../view-utils.js";
 import {
@@ -68,17 +67,7 @@ function genComponentConf() {
               Type
             </div>
             <div class="pcg__columns__left__item__value">
-              {{ self.shortTypesLabel }} {{self.matchingContext}}
-            </div>
-          </div>
-        </div>
-        <div class="pcg__columns__right" ng-if="!self.shouldShowRdf && self.shortTypesLabel.length === 0 && self.matchingContext.length > 0">
-          <div class="pcg__columns__left__item">
-            <div class="pcg__columns__left__item__label">
-              Context
-            </div>
-            <div class="pcg__columns__left__item__value">
-              {{self.matchingContext}}
+              {{ self.shortTypesLabel }}
             </div>
           </div>
         </div>
@@ -140,7 +129,6 @@ function genComponentConf() {
           WON: won.WON,
           fullTypesLabel: post && generateFullNeedTypesLabel(post),
           shortTypesLabel: post && generateShortNeedTypesLabel(post),
-          matchingContext: post && generateNeedMatchingContext(post),
           fullFlags: post && generateFullNeedFlags(post),
           shortFlags: post && generateShortNeedFlags(post),
           fullFacets: post && generateFullNeedFacets(post),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content-general.js
@@ -7,14 +7,7 @@ import { attach, get, getIn } from "../utils.js";
 import won from "../won-es6.js";
 import { relativeTime } from "../won-label-utils.js";
 import { connect2Redux } from "../won-utils.js";
-import {
-  generateFullNeedTypesLabel,
-  generateShortNeedTypesLabel,
-  generateFullNeedFlags,
-  generateFullNeedFacets,
-  generateShortNeedFlags,
-  generateShortNeedFacets,
-} from "../need-utils.js";
+import * as needUtils from "../need-utils.js";
 import * as viewUtils from "../view-utils.js";
 import {
   selectLastUpdateTime,
@@ -127,12 +120,12 @@ function genComponentConf() {
 
         return {
           WON: won.WON,
-          fullTypesLabel: post && generateFullNeedTypesLabel(post),
-          shortTypesLabel: post && generateShortNeedTypesLabel(post),
-          fullFlags: post && generateFullNeedFlags(post),
-          shortFlags: post && generateShortNeedFlags(post),
-          fullFacets: post && generateFullNeedFacets(post),
-          shortFacets: post && generateShortNeedFacets(post),
+          fullTypesLabel: post && needUtils.generateNeedTypeLabel(post),
+          shortTypesLabel: post && needUtils.generateNeedTypeLabel(post),
+          fullFlags: post && needUtils.generateFullNeedFlags(post),
+          shortFlags: post && needUtils.generateShortNeedFlags(post),
+          fullFacets: post && needUtils.generateFullNeedFacets(post),
+          shortFacets: post && needUtils.generateShortNeedFacets(post),
           friendlyCreationDate:
             creationDate &&
             relativeTime(selectLastUpdateTime(state), creationDate),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -196,9 +196,7 @@ function genComponentConf() {
           this.postUri
         );
 
-        const isOwnedNeedWhatsX =
-          isOwned &&
-          (needUtils.isWhatsAroundNeed(post) || needUtils.isWhatsNewNeed(post));
+        const isOwnedNeedWhatsX = isOwned && needUtils.isWhatsAroundNeed(post);
 
         const viewState = get(state, "view");
         const process = get(state, "process");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-content.js
@@ -128,6 +128,7 @@ function genComponentConf() {
               class="post-content__members__member"
               ng-if="self.hasHeldPosts"
               ng-repeat="heldPostUri in self.heldPostsArray track by heldPostUri">
+              <div class="post-content__members__member__indicator"></div>
               <won-post-header
                 class="clickable"
                 ng-click="self.router__stateGoCurrent({viewNeedUri: heldPostUri, viewConnUri: undefined})"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-context-dropdown.js
@@ -187,7 +187,7 @@ function genComponentConf() {
           text: "Deleting the Post is irreversible, do you want to proceed?",
           buttons: [
             {
-              caption: "YES",
+              caption: "Yes",
               callback: () => {
                 this.needs__delete(this.post.get("uri"));
                 this.router__stateGoCurrent({
@@ -198,7 +198,7 @@ function genComponentConf() {
               },
             },
             {
-              caption: "NO",
+              caption: "No",
               callback: () => {
                 this.view__hideModalDialog();
               },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -10,7 +10,6 @@ import { relativeTime } from "../won-label-utils.js";
 import { attach, getIn, get, delay } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { selectLastUpdateTime } from "../selectors/general-selectors.js";
-import * as viewSelectors from "../selectors/view-selectors.js";
 import won from "../won-es6.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
 import * as needUtils from "../need-utils.js";
@@ -52,11 +51,8 @@ function genComponentConf() {
             ng-if="self.isGroupChatEnabled && self.isChatEnabled">
             Group Chat enabled
           </span>
-          <span ng-if="!self.shouldShowRdf">
-            {{ self.shortTypesLabel }}
-          </span>
-          <span ng-if="self.shouldShowRdf">
-            {{ self.fullTypesLabel }}
+          <span>
+            {{ self.needTypeLabel }}
           </span>
         </span>
         <div class="ph__right__subtitle__date">
@@ -95,11 +91,8 @@ function genComponentConf() {
             ng-if="self.isGroupChatEnabled && self.isChatEnabled">
             Group Chat enabled
           </span>
-          <span class="ph__right__subtitle__type" ng-if="!self.shouldShowRdf">
-            {{ self.shortTypesLabel }}
-          </span>
-          <span class="ph__right__subtitle__type" ng-if="self.shouldShowRdf">
-            {{ self.fullTypesLabel }}
+          <span class="ph__right__subtitle__type"
+            {{ self.needTypeLabel }}
           </span>
       </div>
     </div>
@@ -137,8 +130,7 @@ function genComponentConf() {
         return {
           responseToNeed,
           need,
-          fullTypesLabel: need && needUtils.generateNeedTypeLabel(need),
-          shortTypesLabel: need && needUtils.generateNeedTypeLabel(need),
+          needTypeLabel: need && needUtils.generateNeedTypeLabel(need),
           personaName,
           needLoading:
             !need || processUtils.isNeedLoading(process, this.needUri),
@@ -154,7 +146,6 @@ function genComponentConf() {
               selectLastUpdateTime(state),
               get(need, "lastUpdateDate")
             ),
-          shouldShowRdf: viewSelectors.showRdf(state),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -53,7 +53,7 @@ function genComponentConf() {
             Group Chat enabled
           </span>
           <span ng-if="!self.shouldShowRdf">
-            {{ self.shortTypesLabel }}{{ self.matchingContext }}
+            {{ self.shortTypesLabel }}
           </span>
           <span ng-if="self.shouldShowRdf">
             {{ self.fullTypesLabel }}
@@ -96,7 +96,7 @@ function genComponentConf() {
             Group Chat enabled
           </span>
           <span class="ph__right__subtitle__type" ng-if="!self.shouldShowRdf">
-            {{ self.shortTypesLabel }}{{ self.matchingContext }}
+            {{ self.shortTypesLabel }}
           </span>
           <span class="ph__right__subtitle__type" ng-if="self.shouldShowRdf">
             {{ self.fullTypesLabel }}
@@ -139,7 +139,6 @@ function genComponentConf() {
           need,
           fullTypesLabel: need && needUtils.generateFullNeedTypesLabel(need),
           shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
-          matchingContext: need && needUtils.generateNeedMatchingContext(need),
           personaName,
           needLoading:
             !need || processUtils.isNeedLoading(process, this.needUri),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-header.js
@@ -137,8 +137,8 @@ function genComponentConf() {
         return {
           responseToNeed,
           need,
-          fullTypesLabel: need && needUtils.generateFullNeedTypesLabel(need),
-          shortTypesLabel: need && needUtils.generateShortNeedTypesLabel(need),
+          fullTypesLabel: need && needUtils.generateNeedTypeLabel(need),
+          shortTypesLabel: need && needUtils.generateNeedTypeLabel(need),
           personaName,
           needLoading:
             !need || processUtils.isNeedLoading(process, this.needUri),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -11,7 +11,6 @@ import shareDropdownModule from "./share-dropdown.js";
 import { attach, get, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import * as processUtils from "../process-utils.js";
-import * as needUtils from "../need-utils.js";
 import * as generalSelectors from "../selectors/general-selectors.js";
 import { actionCreators } from "../actions/actions.js";
 import { classOnComponentRoot } from "../cstm-ng-utils.js";
@@ -78,16 +77,6 @@ function genComponentConf() {
                     </svg>
                     <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
             </button>
-            <button class="won-button--filled red post-info__footer__button" style="margin: 0rem 0rem .3rem 0rem;"
-                ng-if="self.showCreateWhatsAround"
-                ng-click="self.createWhatsAround()"
-                ng-disabled="self.processingPublish">
-                <svg class="won-button-icon" style="--local-primary:white;">
-                    <use xlink:href="#ico36_location_current" href="#ico36_location_current"></use>
-                </svg>
-                <span ng-if="!self.processingPublish">What's in your Area?</span>
-                <span ng-if="self.processingPublish">Finding out what's going on&hellip;</span>
-            </button>
         </div>
     `;
 
@@ -112,8 +101,6 @@ function genComponentConf() {
         const postFailedToLoad =
           post && processUtils.hasNeedFailedToLoad(process, postUri);
         const isOwned = generalSelectors.isNeedOwned(state, postUri);
-        const showCreateWhatsAround =
-          post && isOwned && needUtils.isWhatsNewNeed(post);
 
         const reactionUseCases =
           post &&
@@ -126,7 +113,6 @@ function genComponentConf() {
           post && isOwned && getIn(post, ["matchedUseCase", "enabledUseCases"]);
         const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
         return {
-          processingPublish: state.getIn(["process", "processingPublish"]),
           postUri,
           post,
           postLoading,
@@ -137,13 +123,10 @@ function genComponentConf() {
           enabledUseCasesArray: enabledUseCases && enabledUseCases.toArray(),
           createdTimestamp: post && post.get("creationDate"),
           showOverlayNeed: !!this.needUri,
-          showCreateWhatsAround,
           showFooter:
             !postLoading &&
             !postFailedToLoad &&
-            (showCreateWhatsAround ||
-              hasReactionUseCases ||
-              hasEnabledUseCases),
+            (hasReactionUseCases || hasEnabledUseCases),
         };
       };
       connect2Redux(
@@ -154,12 +137,6 @@ function genComponentConf() {
       );
 
       classOnComponentRoot("won-is-loading", () => this.postLoading, this);
-    }
-
-    createWhatsAround() {
-      if (!this.processingPublish) {
-        this.needs__whatsAround();
-      }
     }
 
     getUseCaseIcon(ucIdentifier) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -313,9 +313,7 @@ function genComponentConf() {
         const connection =
           ownedNeed && ownedNeed.getIn(["connections", selectedConnectionUri]);
         const isOwnedNeedWhatsX =
-          ownedNeed &&
-          (needUtils.isWhatsAroundNeed(ownedNeed) ||
-            needUtils.isWhatsNewNeed(ownedNeed));
+          ownedNeed && needUtils.isWhatsAroundNeed(ownedNeed);
         const remoteNeedUri = connection && connection.get("remoteNeedUri");
         const remoteNeed =
           remoteNeedUri && state.getIn(["needs", remoteNeedUri]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/square-image.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/square-image.js
@@ -42,7 +42,7 @@ function genComponentConf() {
           ? needUtils.getMatchedUseCaseIcon(need)
           : undefined;
         const useCaseIconBackground = !isPersona
-          ? needUtils.getMatchedUseCaseIconBackground(need)
+          ? needUtils.getBackground(need)
           : undefined;
 
         const identiconSvg = !useCaseIcon

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -61,9 +61,7 @@ function genComponentConf() {
                 <span>What's in your Area?</span>
             </button>
             <button class="won-button--filled red ucp__createx__button"
-                    ng-if="!self.processingPublish"
-                    ng-click="self.createWhatsNew()"
-                    ng-disabled="self.processingPublish">
+                    ng-click="self.router__stateGo('overview')">
                 <span>What's new?</span>
             </button>
 
@@ -195,29 +193,6 @@ function genComponentConf() {
             acceptCallback: () => {
               this.view__hideModalDialog();
               this.needs__whatsAround();
-            },
-            cancelCallback: () => {
-              this.view__hideModalDialog();
-            },
-          })
-        );
-      }
-    }
-
-    createWhatsNew() {
-      if (this.processingPublish) {
-        console.debug("publish in process, do not take any action");
-        return;
-      }
-
-      if (this.loggedIn) {
-        this.needs__whatsNew();
-      } else {
-        this.view__showTermsDialog(
-          Immutable.fromJS({
-            acceptCallback: () => {
-              this.view__hideModalDialog();
-              this.needs__whatsNew();
             },
             cancelCallback: () => {
               this.view__hideModalDialog();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -8,7 +8,6 @@ import { getPostUriFromRoute } from "../selectors/general-selectors.js";
 import {
   generateFullNeedTypesLabel,
   generateShortNeedTypesLabel,
-  generateNeedMatchingContext,
 } from "../need-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import postContextDropDownModule from "../components/post-context-dropdown.js";
@@ -39,7 +38,7 @@ function genComponentConf() {
                           ng-if="self.isGroupChatEnabled && self.isChatEnabled">
                           Group Chat enabled
                         </span>
-                        <div class="vtb__titles__type" ng-if="!self.shouldShowRdf">{{ self.shortTypesLabel }}{{ self.matchingContext }}</div>
+                        <div class="vtb__titles__type" ng-if="!self.shouldShowRdf">{{ self.shortTypesLabel }}</div>
                         <div class="vtb__titles__type" ng-if="self.shouldShowRdf">{{ self.fullTypesLabel }}</div>
                     </hgroup>
                 </div>
@@ -77,7 +76,6 @@ function genComponentConf() {
           isChatEnabled: needUtils.hasChatFacet(post),
           fullTypesLabel: post && generateFullNeedTypesLabel(post),
           shortTypesLabel: post && generateShortNeedTypesLabel(post),
-          matchingContext: post && generateNeedMatchingContext(post),
           shouldShowRdf: state.getIn(["view", "showRdf"]),
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -34,8 +34,7 @@ function genComponentConf() {
                           ng-if="self.isGroupChatEnabled && self.isChatEnabled">
                           Group Chat enabled
                         </span>
-                        <div class="vtb__titles__type" ng-if="!self.shouldShowRdf">{{ self.shortTypesLabel }}</div>
-                        <div class="vtb__titles__type" ng-if="self.shouldShowRdf">{{ self.fullTypesLabel }}</div>
+                        <div class="vtb__titles__type">{{ self.needTypeLabel }}</div>
                     </hgroup>
                 </div>
             </div>
@@ -70,9 +69,7 @@ function genComponentConf() {
           responseToNeed,
           isGroupChatEnabled: needUtils.hasGroupFacet(post),
           isChatEnabled: needUtils.hasChatFacet(post),
-          fullTypesLabel: post && needUtils.generateNeedTypeLabel(post),
-          shortTypesLabel: post && needUtils.generateNeedTypeLabel(post),
-          shouldShowRdf: state.getIn(["view", "showRdf"]),
+          needTypeLabel: post && needUtils.generateNeedTypeLabel(post),
         };
       };
       connect2Redux(selectFromState, actionCreators, [], this);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/visitor-title-bar.js
@@ -5,10 +5,6 @@ import angular from "angular";
 import { attach, get, getIn } from "../utils.js";
 import { connect2Redux } from "../won-utils.js";
 import { getPostUriFromRoute } from "../selectors/general-selectors.js";
-import {
-  generateFullNeedTypesLabel,
-  generateShortNeedTypesLabel,
-} from "../need-utils.js";
 import { actionCreators } from "../actions/actions.js";
 import postContextDropDownModule from "../components/post-context-dropdown.js";
 import shareDropdownModule from "../components/share-dropdown.js";
@@ -74,8 +70,8 @@ function genComponentConf() {
           responseToNeed,
           isGroupChatEnabled: needUtils.hasGroupFacet(post),
           isChatEnabled: needUtils.hasChatFacet(post),
-          fullTypesLabel: post && generateFullNeedTypesLabel(post),
-          shortTypesLabel: post && generateShortNeedTypesLabel(post),
+          fullTypesLabel: post && needUtils.generateNeedTypeLabel(post),
+          shortTypesLabel: post && needUtils.generateNeedTypeLabel(post),
           shouldShowRdf: state.getIn(["view", "showRdf"]),
         };
       };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -66,6 +66,7 @@ export const configRouting = [
 
     [
       { path: "/about?aboutSection", component: "about" },
+      { path: "/overview?viewNeedUri?viewConnUri", component: "overview" },
       { path: "/signup", component: "signup" },
       { path: "/settings", component: "settings" },
       {
@@ -171,6 +172,7 @@ export function accessControl({
       }
       return;
 
+    case "overview":
     case "signup":
     case "about":
       return; // can always access these pages.

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -25,8 +25,8 @@ export function getMatchedUseCaseIcon(need) {
   return getIn(need, ["matchedUseCase", "icon"]);
 }
 
-export function getMatchedUseCaseIconBackground(need) {
-  return getIn(need, ["matchedUseCase", "iconBackground"]);
+export function getBackground(need) {
+  return get(need, "background");
 }
 
 export function getMatchedUseCaseIdentifier(need) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -74,7 +74,6 @@ export function getLocation(need) {
  */
 export function getDefaultImage(need) {
   if (hasImages(need)) {
-    console.debug("NEED HAS IMAGES");
     const contentImages = getIn(need, ["content", "images"]);
 
     if (contentImages) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -159,19 +159,7 @@ export function isWhatsNewNeed(need) {
 }
 
 /**
- * Generates a string that can be used to add matching contexts to a label.
- */
-export function generateNeedMatchingContext(needImm) {
-  const matchingContexts = needImm && needImm.get("matchingContexts");
-  if (matchingContexts && matchingContexts.size > 0) {
-    return " posted in " + matchingContexts.join(", ");
-  } else {
-    return "";
-  }
-}
-
-/**
- * Generates a string that can be used as a Types Label for any given need, includes the matchingContexts
+ * Generates a string that can be used as a Types Label for any given need
  * TODO: We Do not store a single type anymore but a list of types... adapt accordingly
  */
 export function generateFullNeedTypesLabel(needImm) {
@@ -185,7 +173,7 @@ export function generateFullNeedTypesLabel(needImm) {
     label = types.join(", ");
   }
 
-  return label + generateNeedMatchingContext(needImm);
+  return label;
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -51,6 +51,22 @@ export function hasImages(need) {
   );
 }
 
+export function hasLocation(need) {
+  return (
+    !!getIn(need, ["content", "location"]) ||
+    !!getIn(need, ["seeks", "location"])
+  );
+}
+
+export function getLocation(need) {
+  if (hasLocation(need)) {
+    return (
+      getIn(need, ["content", "location"]) || getIn(need, ["seeks", "location"])
+    );
+  }
+  return undefined;
+}
+
 /**
  * Returns the "Default" Image (currently the first one, branch content is checked before seeks) of a need
  * if the need does not have any images we return undefined

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -45,6 +45,35 @@ export function hasMatchedUseCase(need) {
   return !!getIn(need, ["matchedUseCase", "identifier"]);
 }
 
+export function hasImages(need) {
+  return (
+    !!getIn(need, ["content", "images"]) || !!getIn(need, ["seeks", "images"])
+  );
+}
+
+/**
+ * Returns the "Default" Image (currently the first one, branch content is checked before seeks) of a need
+ * if the need does not have any images we return undefined
+ * @param need
+ */
+export function getDefaultImage(need) {
+  if (hasImages(need)) {
+    console.debug("NEED HAS IMAGES");
+    const contentImages = getIn(need, ["content", "images"]);
+
+    if (contentImages) {
+      return contentImages.first();
+    }
+
+    const seeksImages = getIn(need, ["content", "images"]);
+
+    if (seeksImages) {
+      return seeksImages.first();
+    }
+  }
+  return undefined;
+}
+
 /**
  * Determines if a given need is a Inactive
  * @param need

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -6,6 +6,7 @@ import won from "./won-es6.js";
 import { get, getIn } from "./utils.js";
 import { labels } from "./won-label-utils.js";
 import * as connectionUtils from "./connection-utils.js";
+import * as useCaseUtils from "./usecase-utils.js";
 
 /**
  * Determines if a given need is a Active
@@ -159,24 +160,6 @@ export function isWhatsNewNeed(need) {
 }
 
 /**
- * Generates a string that can be used as a Types Label for any given need
- * TODO: We Do not store a single type anymore but a list of types... adapt accordingly
- */
-export function generateFullNeedTypesLabel(needImm) {
-  const types = getIn(needImm, ["content", "type"]);
-
-  //TODO: GENERATE CORRECT LABEL
-  //self.labels.type[self.need.getIn(['content','type'])]
-  let label = "";
-
-  if (types && types.size > 0) {
-    label = types.join(", ");
-  }
-
-  return label;
-}
-
-/**
  * Generates an array that contains all need flags, using a human readable label if available.
  */
 export function generateFullNeedFlags(needImm) {
@@ -207,49 +190,23 @@ export function generateFullNeedFacets(needImm) {
 }
 
 /**
- * Generates a string that can be used as a simplified Types Label for non-debug views. Hides information.
+ * Retrieves the Label of the used useCase as a needType, if no usecase is specified we check if need is a searchNeed or DirectResponseNeed
  * @param {*} needImm the need as saved in the state
  */
-export function generateShortNeedTypesLabel(needImm) {
-  const needTypes = needImm && needImm.getIn(["content", "type"]);
+export function generateNeedTypeLabel(needImm) {
+  const useCase = useCaseUtils.getUseCase(getMatchedUseCaseIdentifier(needImm));
 
-  const getNeedLabel = type => {
-    switch (type) {
-      //Insert specific overrides here
-      default: {
-        const match = /[^:/]+$/.exec(type);
-        if (match) {
-          return match[0];
-        } else {
-          return "Unknown";
-        }
-      }
+  if (useCase) {
+    return useCase.label;
+  } else {
+    if (isSearchNeed(needImm)) {
+      return "Search";
+    } else if (isDirectResponseNeed(needImm)) {
+      return "Direct Response";
     }
-  };
 
-  let label = "";
-
-  if (isWhatsAroundNeed(needImm) || isWhatsNewNeed(needImm)) {
-    label = "";
-  } else if (isSearchNeed(needImm)) {
-    label = "Search";
-  } else if (isDirectResponseNeed(needImm)) {
-    label = "Direct Response";
-    // TODO: groupchat label
-  } else if (needTypes && needTypes.size > 0) {
-    let types = new Array();
-    for (let type of Array.from(needTypes)) {
-      // hide won:Need
-      if (type === "won:Need") {
-        continue;
-        // cut off everything before the first :
-      } else {
-        types.push(getNeedLabel(type));
-      }
-    }
-    label += types.join(", ");
+    return "";
   }
-  return label;
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -148,18 +148,6 @@ export function isSearchNeed(need) {
 }
 
 /**
- * Determines if a given need is a WhatsNew-Need
- * @param need
- * @returns {*|boolean}
- */
-export function isWhatsNewNeed(need) {
-  return (
-    getIn(need, ["content", "flags"]) &&
-    getIn(need, ["content", "flags"]).contains("won:WhatsNew")
-  );
-}
-
-/**
  * Generates an array that contains all need flags, using a human readable label if available.
  */
 export function generateFullNeedFlags(needImm) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
@@ -119,6 +119,10 @@ export function isNeedLoading(process, needUri) {
   return needUri && getIn(process, ["needs", needUri, "loading"]);
 }
 
+export function isNeedLoaded(process, needUri) {
+  return needUri && getIn(process, ["needs", needUri, "loaded"]);
+}
+
 /**
  * Return true if given needUri is set toLoad
  * @param process (full process from state)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/process-utils.js
@@ -18,6 +18,15 @@ export function isProcessingInitialLoad(process) {
 }
 
 /**
+ * Return true if processingNeedUrisFromOwnerLoad is currently active
+ * @param process (full process from state)
+ * @returns {*}
+ */
+export function isProcessingNeedUrisFromOwnerLoad(process) {
+  return get(process, "processingNeedUrisFromOwnerLoad");
+}
+
+/**
  * Return true if processingLogin is currently active
  * @param process (full process from state)
  * @returns {*}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/account-reducer.js
@@ -44,6 +44,15 @@ export default function(userData = initialState, action = {}) {
       );
     }
 
+    case actionTypes.needs.removeDeleted:
+    case actionTypes.personas.removeDeleted:
+    case actionTypes.needs.delete: {
+      const needUri = action.payload.get("uri");
+
+      const ownedNeedUris = userData.get("ownedNeedUris");
+      return userData.set("ownedNeedUris", ownedNeedUris.remove(needUri));
+    }
+
     case actionTypes.needs.create: //for optimistic additions
     case actionTypes.personas.create: //for optimistic additions
     case actionTypes.needs.createSuccessful: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -73,6 +73,7 @@ export default function(allNeedsInState = initialState, action = {}) {
     }
 
     case actionTypes.personas.storeTheirUrisInLoading:
+    case actionTypes.needs.storeNeedUrisFromOwner:
     case actionTypes.needs.storeTheirUrisInLoading: {
       return addNeedStubs(allNeedsInState, action.payload.get("uris"));
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -5,7 +5,12 @@ import { actionTypes } from "../../actions/actions.js";
 import Immutable from "immutable";
 import won from "../../won-es6.js";
 import { msStringToDate, get, getIn } from "../../utils.js";
-import { addNeedStubs, addNeed, addNeedInCreation } from "./reduce-needs.js";
+import {
+  addNeedStubs,
+  addNeed,
+  addNeedInCreation,
+  deleteNeed,
+} from "./reduce-needs.js";
 import {
   addMessage,
   addExistingMessages,
@@ -129,25 +134,10 @@ export default function(allNeedsInState = initialState, action = {}) {
         won.WON.InactiveCompacted
       );
 
+    case actionTypes.needs.removeDeleted:
+    case actionTypes.personas.removeDeleted:
     case actionTypes.needs.delete:
-      return allNeedsInState.delete(action.payload.ownNeedUri).map(need => {
-        const removeHolder = need => {
-          if (need.get("heldBy") == action.payload.ownNeedUri) {
-            return need.delete("heldBy");
-          } else return need;
-        };
-        const removeHeld = need => {
-          return need.updateIn(
-            ["holds"],
-            heldItems =>
-              heldItems &&
-              heldItems.filter(
-                heldItem => heldItem != action.payload.ownNeedUri
-              )
-          );
-        };
-        return removeHeld(removeHolder(need));
-      });
+      return deleteNeed(allNeedsInState, action.payload.get("uri"));
 
     case actionTypes.personas.create: {
       //FIXME: Please let us use the addNeed method as a single entry point to add Needs(even Personas) to the State

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -2,7 +2,6 @@ import Immutable from "immutable";
 import won from "../../won-es6.js";
 import * as useCaseUtils from "../../usecase-utils.js";
 import {
-  isWhatsNewNeed,
   isWhatsAroundNeed,
   isSearchNeed,
   isPersona,
@@ -228,8 +227,6 @@ function getHumanReadableStringFromNeed(need, detailsToParse) {
 
     if (isPersona(need)) {
       return getIn(need, ["content", "personaName"]);
-    } else if (isWhatsNewNeed(immNeed)) {
-      return "What's New";
     } else if (isWhatsAroundNeed(immNeed)) {
       let location =
         (needContent && needContent["location"]) ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -38,10 +38,10 @@ export function parseNeed(jsonldNeed) {
       matchedUseCase: {
         identifier: undefined,
         icon: undefined,
-        iconBackground: undefined,
         enabledUseCases: undefined,
         reactionUseCases: undefined,
       },
+      background: generateBackground(jsonldNeedImm),
       unread: false,
       isBeingCreated: false,
       jsonld: jsonldNeed,
@@ -70,10 +70,6 @@ export function parseNeed(jsonldNeed) {
         parsedNeedImm = parsedNeedImm
           .setIn(["matchedUseCase", "identifier"], matchingUseCase.identifier)
           .setIn(["matchedUseCase", "icon"], matchingUseCase.icon)
-          .setIn(
-            ["matchedUseCase", "iconBackground"],
-            generateUseCaseIconBackground(jsonldNeedImm)
-          )
           .setIn(
             ["matchedUseCase", "enabledUseCases"],
             matchingUseCase.enabledUseCases
@@ -155,7 +151,7 @@ function generateIdenticon(needJsonLd) {
   return idc.toString();
 }
 
-function generateUseCaseIconBackground(needJsonLd) {
+function generateBackground(needJsonLd) {
   const needUri = needJsonLd.get("@id");
 
   if (!needUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/parse-need.js
@@ -22,7 +22,6 @@ export function parseNeed(jsonldNeed) {
       identiconSvg: generateIdenticon(jsonldNeedImm),
       nodeUri: jsonldNeedImm.getIn(["won:hasWonNode", "@id"]),
       state: extractState(jsonldNeedImm),
-      matchingContexts: extractMatchingContext(jsonldNeedImm),
       heldBy: won.parseFrom(jsonldNeedImm, ["won:heldBy"], "xsd:ID"),
       holds:
         won.parseListFrom(jsonldNeedImm, ["won:holds"], "xsd:ID") ||
@@ -135,15 +134,6 @@ function extractState(needJsonLd) {
     won.WON.ActiveCompacted
     ? won.WON.ActiveCompacted
     : won.WON.InactiveCompacted;
-}
-
-function extractMatchingContext(needJsonLd) {
-  const wonHasMatchingContexts = needJsonLd.get("won:hasMatchingContext");
-  return wonHasMatchingContexts
-    ? Immutable.List.isList(wonHasMatchingContexts)
-      ? wonHasMatchingContexts
-      : Immutable.List.of(wonHasMatchingContexts)
-    : undefined;
 }
 
 function generateIdenticon(needJsonLd) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -140,7 +140,6 @@ export default function(processState = initialState, action = {}) {
 
     case actionTypes.personas.create:
     case actionTypes.needs.create:
-    case actionTypes.needs.whatsNew:
     case actionTypes.needs.whatsAround:
       return processState.set("processingPublish", true);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -173,6 +173,7 @@ export default function(processState = initialState, action = {}) {
         toLoad: false,
         failedToLoad: false,
         loading: false,
+        loaded: true,
       });
       return processState.set("processingPublish", false);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -231,6 +231,7 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.personas.storeUriFailed: {
       return updateNeedProcess(processState, action.payload.get("uri"), {
         toLoad: false,
+        loaded: false,
         failedToLoad: true,
         loading: false,
       });
@@ -530,7 +531,11 @@ export default function(processState = initialState, action = {}) {
       return addOriginatorNeedToLoad(processState, action.payload);
 
     case actionTypes.needs.delete:
-      return processState.deleteIn(["needs", action.payload.ownNeedUri]);
+    case actionTypes.needs.removeDeleted:
+    case actionTypes.personas.removeDeleted: {
+      const needUri = action.payload.get("uri");
+      return processState.deleteIn(["needs", needUri]);
+    }
 
     default:
       return processState;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -17,6 +17,7 @@ const initialState = Immutable.fromJS({
   processingVerifyEmailAddress: false,
   processingResendVerificationEmail: false,
   processingSendAnonymousLinkEmail: false,
+  processingNeedUrisFromOwnerLoad: false,
   needs: Immutable.Map(),
   connections: Immutable.Map(),
 });
@@ -117,6 +118,20 @@ export default function(processState = initialState, action = {}) {
       }
 
       return processState;
+    }
+
+    case actionTypes.needs.loadAllActiveNeedUrisFromOwner:
+      return processState.set("processingNeedUrisFromOwnerLoad", true);
+
+    case actionTypes.needs.storeNeedUrisFromOwner: {
+      const needUris = action.payload.get("uris");
+      needUris &&
+        needUris.forEach(needUri => {
+          processState = updateNeedProcess(processState, needUri, {
+            toLoad: true,
+          });
+        });
+      return processState.set("processingNeedUrisFromOwnerLoad", false);
     }
 
     case actionTypes.personas.create:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -57,6 +57,31 @@ const reducers = {
         return config;
     }
   },
+  owner: (
+    owner = Immutable.fromJS({
+      needUris: Immutable.Set(),
+      lastNeedUrisUpdateTime: undefined,
+    }),
+    action = {}
+  ) => {
+    switch (action.type) {
+      case actionTypes.needs.storeNeedUrisFromOwner: {
+        const fetchedNeedUris = action.payload.get("uris");
+        let ownerNeedUris = owner.get("needUris");
+
+        fetchedNeedUris &&
+          fetchedNeedUris.forEach(
+            needUri => (ownerNeedUris = ownerNeedUris.add(needUri))
+          );
+
+        return owner
+          .set("needUris", ownerNeedUris)
+          .set("lastNeedUrisUpdateTime", Date.now());
+      }
+      default:
+        return owner;
+    }
+  },
 };
 
 export default reduceReducers(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -78,6 +78,16 @@ const reducers = {
           .set("needUris", ownerNeedUris)
           .set("lastNeedUrisUpdateTime", Date.now());
       }
+
+      case actionTypes.needs.removeDeleted:
+      case actionTypes.personas.removeDeleted:
+      case actionTypes.needs.delete: {
+        const needUri = action.payload.get("uri");
+        const needUris = owner.get("needUris");
+
+        return owner.set("needUris", needUris.remove(needUri));
+      }
+
       default:
         return owner;
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/selectors/process-selectors.js
@@ -14,6 +14,7 @@ export function isLoading(state) {
 
   return (
     processUtils.isProcessingInitialLoad(process) ||
+    processUtils.isProcessingNeedUrisFromOwnerLoad(process) ||
     processUtils.isProcessingLogin(process) ||
     processUtils.isProcessingLogout(process) ||
     processUtils.isProcessingPublish(process) ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -769,12 +769,16 @@ import won from "./won.js";
     })
       .then(response => {
         if (response.status === 200) return response;
-        else
-          throw new Error(
+        else {
+          let error = new Error(
             `${response.status} - ${
               response.statusText
             } for request ${uri}, ${JSON.stringify(params)}`
           );
+
+          error.response = response;
+          throw error;
+        }
       })
       .then(dataset => dataset.json())
       .then(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -8,10 +8,7 @@
 import won from "./won.js";
 import * as useCaseUtils from "../usecase-utils";
 import { is } from "../utils";
-import {
-  generateWhatsAroundQuery,
-  generateWhatsNewQuery,
-} from "../sparql-builder-utils.js";
+import { generateWhatsAroundQuery } from "../sparql-builder-utils.js";
 
 import { Generator } from "sparqljs";
 
@@ -134,10 +131,6 @@ import { Generator } from "sparqljs";
       flags &&
       ((is("Array", flags) && flags.indexOf("won:WhatsAround") != -1) ||
         flags === "won:WhatsAround");
-    const isWhatsNewDraft =
-      flags &&
-      ((is("Array", flags) && flags.indexOf("won:WhatsNew") != -1) ||
-        flags === "won:WhatsNew");
 
     let queryString = undefined;
     if (isWhatsAroundDraft) {
@@ -146,8 +139,6 @@ import { Generator } from "sparqljs";
       if (location && location.lat && location.lng) {
         queryString = generateWhatsAroundQuery(location.lat, location.lng);
       }
-    } else if (isWhatsNewDraft) {
-      queryString = generateWhatsNewQuery();
     } else if (useCase && useCase.generateQuery) {
       const queryMask = {
         type: "query",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/need-builder.js
@@ -122,8 +122,6 @@ import { Generator } from "sparqljs";
       return addContent(contentNode, seeksData);
     };
 
-    const matchingContext = args.matchingContext;
-
     let seeksContentUri = args.seeks && won.WON.contentNodeBlankUri.seeks;
 
     const useCase = useCaseUtils.getUseCase(args.useCase);
@@ -211,7 +209,6 @@ import { Generator } from "sparqljs";
       "won:doNotMatchAfter": doNotMatchAfter
         ? { "@value": doNotMatchAfter, "@type": "xsd:dateTime" }
         : undefined,
-      "won:hasMatchingContext": matchingContext ? matchingContext : undefined,
       "won:hasQuery": queryString,
     };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/won.js
@@ -135,7 +135,6 @@ won.WON.BasicNeedTypeCombinedCompacted = won.WON.baseUri + ":Combined";
 won.WON.BasicNeedTypeCritique = won.WON.baseUri + "Critique";
 won.WON.BasicNeedTypeCritiqueCompacted = won.WON.prefix + ":Critique";
 won.WON.BasicNeedTypeWhatsAroundCompacted = won.WON.prefix + ":WhatsAround";
-won.WON.BasicNeedTypeWhatsNewCompacted = won.WON.prefix + ":WhatsNew";
 won.WON.NoHintForCounterpartCompacted =
   won.WON.prefix + ":NoHintForCounterpart";
 won.WON.UsedForTestingCompacted = won.WON.prefix + ":UsedForTesting";

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/sparql-builder-utils.js
@@ -601,28 +601,6 @@ export function generateWhatsAroundQuery(latitude, longitude) {
         }
         FILTER(?location_geoDistance < ?radius)
         FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
-        FILTER NOT EXISTS { ?result won:hasFlag won:WhatsNew }
         FILTER NOT EXISTS { ?result won:hasFlag won:WhatsAround }
       }`;
-}
-
-export function generateWhatsNewQuery() {
-  return `PREFIX won: <http://purl.org/webofneeds/model#>
-        PREFIX s: <http://schema.org/>
-        PREFIX dct: <http://purl.org/dc/terms/>
-        SELECT DISTINCT ?result ((YEAR(?created) - 1970) * 40000000
-               + MONTH(?created) * 3000000
-               + DAY(?created) * 86400
-               + HOURS(?created) * 3600
-               + MINUTES(?created) * 60
-               + SECONDS(?created)
-                as ?score)
-                WHERE {
-          ?result <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Need.
-          ?result won:isInState won:Active .
-          ?result dct:created ?created.
-          FILTER NOT EXISTS { ?result won:hasFlag won:NoHintForCounterpart }
-          FILTER NOT EXISTS { ?result won:hasFlag won:WhatsNew }
-          FILTER NOT EXISTS { ?result won:hasFlag won:WhatsAround }
-        }`;
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -932,6 +932,8 @@ export function rethrow(e, prependedMsg = "") {
     // a class defined
     const g = new Error(prependedMsg + e.message);
     g.stack = e.stack;
+    g.response = e.response; //we add the response so we can look up why a request threw an error
+
     throw g;
   } else {
     throw new Error(prependedMsg + JSON.stringify(e));

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -10,7 +10,6 @@ export const labels = deepFreeze({
     [won.WON.BasicNeedTypeCombinedCompacted]: "Post + Search", //'I want to post and search',
     [won.WON.BasicNeedTypeCritiqueCompacted]: "Post", //'I want to change something',
     [won.WON.BasicNeedTypeWhatsAroundCompacted]: "What's Around",
-    [won.WON.BasicNeedTypeWhatsNewCompacted]: "What's New",
   },
   connectionState: {
     [won.WON.Suggested]: "Conversation suggested.",
@@ -29,7 +28,6 @@ export const labels = deepFreeze({
   },
   flags: {
     [won.WON.BasicNeedTypeWhatsAroundCompacted]: "What's Around",
-    [won.WON.BasicNeedTypeWhatsNewCompacted]: "What's New",
     [won.WON.NoHintForCounterpartCompacted]: "No Hint For Others",
     [won.WON.NoHintForMeCompacted]: "No Hint For Me",
     [won.WON.UsedForTestingCompacted]: "Used For Testing",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -594,6 +594,35 @@ export function fetchOwnedData(dispatch) {
     .then(needUris => fetchDataForOwnedNeeds(needUris, dispatch));
 }
 
+export function fetchAllActiveNeedUrisFromOwner(dispatch) {
+  return fetchAllNeedUrisFromOwner().then(needUris => {
+    dispatch({
+      type: actionTypes.needs.storeNeedUrisFromOwner,
+      payload: Immutable.fromJS({ uris: needUris }),
+    });
+    return needUris;
+  });
+}
+
+/**
+ * Calls the restendpoint of the owner webapp, to retrieve all needUris stored
+ * on this instance
+ * @param state ACTIVE or INACTIVE, default is ACTIVE
+ * @returns {*}
+ */
+function fetchAllNeedUrisFromOwner(state = "ACTIVE") {
+  return fetch(urljoin(ownerBaseUrl, "/rest/needs/all?state=" + state), {
+    method: "get",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  })
+    .then(checkHttpStatus)
+    .then(response => response.json());
+}
+
 function fetchOwnedInactiveNeedUris() {
   return fetch(urljoin(ownerBaseUrl, "/rest/needs?state=INACTIVE"), {
     method: "get",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -616,7 +616,7 @@ export function fetchAllActiveNeedUrisFromOwner(dispatch, getState) {
  * @param state ACTIVE or INACTIVE, default is ACTIVE
  * @returns {*}
  */ function fetchAllNeedUrisFromNode(getState) {
-  const nodeUri = getIn(getState(), ["config", "defaultNodeUri"]);
+  const nodeUri = getIn(getState(), ["config", "defaultNodeUri"]) + "/need/";
   //const nodeUri = "https://node.matchat.org/won/resource/need"; //for testing purposes
 
   return fetch("/owner/rest/linked-data/?uri=" + encodeURIComponent(nodeUri), {
@@ -651,7 +651,7 @@ export function fetchAllActiveNeedUrisFromOwner(dispatch, getState) {
           .get("@graph")
           .first()
           .get("rdfs:member")
-          .map(member => nodeUri + "/" + member.get("@id").split(":")[1])
+          .map(member => nodeUri + member.get("@id").split(":")[1])
           .toJS();
       } else {
         return [];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-message-utils.js
@@ -616,19 +616,32 @@ export function fetchAllActiveNeedUrisFromOwner(dispatch, getState) {
  * @param state ACTIVE or INACTIVE, default is ACTIVE
  * @returns {*}
  */ function fetchAllNeedUrisFromNode(getState) {
-  const nodeUri = getIn(getState(), ["config", "defaultNodeUri"]) + "/need/";
+  const nodeUri = getIn(getState(), ["config", "defaultNodeUri"]) + "/need";
   //const nodeUri = "https://node.matchat.org/won/resource/need"; //for testing purposes
 
-  return fetch("/owner/rest/linked-data/?uri=" + encodeURIComponent(nodeUri), {
-    method: "get",
-    //credentials: "same-origin",
-    headers: {
-      Accept: "application/ld+json",
-      "Content-Type": "application/ld+json",
-      //Prefer: `return=representation; max-member-count="2000"`,
-      Prefer: undefined,
-    },
-  })
+  const DAYS_BEFORE = 30;
+  const modifiedAfterDate = new Date(
+    Date.now() - DAYS_BEFORE * 24 * 60 * 60 * 1000
+  );
+
+  return fetch(
+    "/owner/rest/linked-data/?uri=" +
+      encodeURIComponent(
+        nodeUri +
+          "?state=Active&modifiedafter=" +
+          modifiedAfterDate.toISOString()
+      ),
+    {
+      method: "get",
+      //credentials: "same-origin",
+      headers: {
+        Accept: "application/ld+json",
+        "Content-Type": "application/ld+json",
+        //Prefer: `return=representation; max-member-count="2000"`,
+        Prefer: undefined,
+      },
+    }
+  )
     .then(response => {
       if (response.status === 200) return response;
       else
@@ -651,7 +664,7 @@ export function fetchAllActiveNeedUrisFromOwner(dispatch, getState) {
           .get("@graph")
           .first()
           .get("rdfs:member")
-          .map(member => nodeUri + member.get("@id").split(":")[1])
+          .map(member => nodeUri + "/" + member.get("@id").split(":")[1])
           .toJS();
       } else {
         return [];

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -21,7 +21,6 @@ const emptyDraftImm = Immutable.fromJS({
     defaultFacet: { "#chatFacet": "won:ChatFacet" },
   },
   seeks: {},
-  matchingContext: undefined,
 });
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -229,7 +229,6 @@ export const flags = {
   component: undefined, //this is so we do not display the component as a detail-picker, but are still able to use the parseToRDF, parseFromRDF functions
   multiSelect: true,
   options: [
-    { value: "won:WhatsNew", label: "WhatsNew" },
     { value: "won:WhatsAround", label: "WhatsAround" },
     { value: "won:NoHintForMe", label: "NoHintForMe" },
     { value: "won:NoHintForCounterpart", label: "NoHintForCounterpart" },

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/blue/config.json
@@ -4,6 +4,5 @@
   "imprintTemplate": "imprint.html",
   "tosTemplate": "tos.html",
   "privacyPolicyTemplate": "privacyPolicy.html",
-  "welcomeTemplate": "welcomeTemplate.html",
-  "defaultContext": []
+  "welcomeTemplate": "welcomeTemplate.html"
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/current/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/current/config.json
@@ -4,6 +4,5 @@
   "imprintTemplate": "imprint.html",
   "tosTemplate": "tos.html",
   "privacyPolicyTemplate": "privacyPolicy.html",
-  "welcomeTemplate": "welcomeTemplate.html",
-  "defaultContext": []
+  "welcomeTemplate": "welcomeTemplate.html"
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/green/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/green/config.json
@@ -4,6 +4,5 @@
   "imprintTemplate": "imprint.html",
   "tosTemplate": "tos.html",
   "privacyPolicyTemplate": "privacyPolicy.html",
-  "welcomeTemplate": "welcomeTemplate.html",
-  "defaultContext": []
+  "welcomeTemplate": "welcomeTemplate.html"
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/matchat/config.json
@@ -4,6 +4,5 @@
   "imprintTemplate": "imprint.html",
   "tosTemplate": "tos.html",
   "privacyPolicyTemplate": "privacyPolicy.html",
-  "welcomeTemplate": "welcomeTemplate.html",
-  "defaultContext": []
+  "welcomeTemplate": "welcomeTemplate.html"
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/config.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/skin/uki/config.json
@@ -3,7 +3,6 @@
   "adminEmail": "office.sat@researchstudio.at",
   "imprintTemplate": "imprint.html",
   "tosTemplate": "tos.html",
-  "defaultContext": ["cbi"],
   "privacyPolicyTemplate": "privacyPolicy.html",
   "welcomeTemplate": "welcomeTemplate.html"
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -11,13 +11,13 @@ won-need-card {
   padding: 0.5rem;
   color: black;
 
+  &.won-is-toload,
   &.won-is-loading {
     @include animateOpacityHeartBeat();
     pointer-events: none;
 
     .ph__icon__skeleton {
-      grid-area: icon;
-      @include fixed-square($postIconSize);
+      @include fixed-square(15rem);
       background-color: $won-skeleton-color;
     }
 
@@ -35,6 +35,7 @@ won-need-card {
   }
   @include square-image(15rem);
 
+  .ph__icon__skeleton,
   won-square-image {
     grid-area: icon;
   }
@@ -43,7 +44,8 @@ won-need-card {
     grid-area: main;
     display: grid;
     grid-template-areas: "topline" "subtitle";
-    min-width: 0;
+    width: 15rem;
+    max-width: 15rem;
 
     &__topline {
       grid-area: topline;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -11,10 +11,6 @@ won-need-card {
   padding: 0.5rem;
   color: black;
 
-  &.won-is-invisible {
-    display: none;
-  }
-
   &.won-is-toload,
   &.won-is-loading {
     @include animateOpacityHeartBeat();

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -152,13 +152,13 @@ won-need-card {
   .card__main {
     grid-area: card__main;
     display: grid;
-    grid-template-areas: "card__main__topline" "card__main__subtitle";
+    grid-template-areas: "card__main__topline" "card__main__subtitle" "card__main__location";
     grid-template-columns: 1fr;
     width: 15rem;
     max-width: 15rem;
 
     &--showIcon {
-      grid-template-areas: "card__main__icon card__main__topline" "card__main__icon card__main__subtitle";
+      grid-template-areas: "card__main__icon card__main__topline" "card__main__icon card__main__subtitle" "card__main__location card__main__location";
       grid-template-columns: min-content 1fr;
       grid-column-gap: 0.5rem;
     }
@@ -202,7 +202,6 @@ won-need-card {
       grid-template-columns: 1fr min-content;
       color: $won-subtitle-gray;
       font-size: $smallFontSize;
-      min-width: 0;
 
       &__type {
         text-overflow: ellipsis;
@@ -224,6 +223,25 @@ won-need-card {
         white-space: nowrap;
         padding-left: 0.5rem;
         min-width: 0;
+      }
+    }
+
+    &__location {
+      grid-area: card__main__location;
+      display: grid;
+      grid-template-columns: min-content 1fr;
+      margin-top: 0.5rem;
+      grid-column-gap: 0.25rem;
+
+      &__address {
+        font-size: $smallFontSize;
+        text-overflow: ellipsis;
+        color: $won-subtitle-gray;
+      }
+
+      &__icon {
+        @include fixed-square($normalFontSize);
+        --local-primary: #{$won-subtitle-gray};
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -84,6 +84,17 @@ won-need-card {
         height: 10rem;
       }
     }
+
+    & won-need-map.location {
+      display: block;
+      width: 15rem;
+      height: 10rem;
+
+      .need-map__mapmount {
+        width: 100%;
+        height: 10rem;
+      }
+    }
   }
 
   .card__persona {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -1,13 +1,11 @@
 @import "won-config";
 @import "sizing-utils";
-@import "square-image";
 @import "animate";
 
 won-need-card {
   display: grid;
-  grid-gap: 0.5rem;
-  grid-template-areas: "icon" "main";
-  grid-template-rows: max-content min-content;
+  grid-template-areas: "card__icon" "card__main" "card__persona";
+  grid-template-rows: max-content min-content min-content;
   padding: 0.5rem;
   color: black;
 
@@ -20,31 +18,117 @@ won-need-card {
     @include animateOpacityHeartBeat();
     pointer-events: none;
 
-    .ph__right__subtitle__type {
+    .card__main__subtitle__type {
       height: $smallFontSize;
       width: 5rem;
       background-color: $won-skeleton-color;
     }
 
-    .ph__right__topline__title {
+    .card__main__topline__title {
       height: $normalFontSize;
       width: 7rem;
       background-color: $won-skeleton-color;
     }
   }
-  @include square-image(15rem);
-
-  .ph__icon__skeleton {
+  .card__icon__skeleton {
     @include fixed-square(15rem);
     background-color: $won-skeleton-color;
+    margin-bottom: 0.5rem;
   }
 
-  won-square-image {
-    grid-area: icon;
+  .card__icon {
+    grid-area: card__icon;
+    margin-bottom: 0.5rem;
+
+    display: block;
+    user-select: none;
+    position: relative;
+    height: 15rem;
+
+    &.won-is-persona .image {
+      border-radius: 100%;
+    }
+
+    &.inactive {
+      -webkit-filter: grayscale(100%);
+      filter: grayscale(100%);
+    }
+
+    & .image {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      @include fixed-square(15rem);
+
+      &.usecaseimage {
+        box-sizing: border-box;
+        padding: 0.25rem;
+
+        > svg {
+          @include fixed-square(calc(#{15rem}-0.5rem));
+        }
+
+        & .si__usecaseicon {
+          --local-primary: #{$won-secondary-text-color};
+        }
+      }
+    }
   }
 
-  .ph__right {
-    grid-area: main;
+  .card__persona {
+    grid-area: card__persona;
+    margin-top: 0.5rem;
+
+    display: grid;
+    grid-template-areas:
+      "card__persona__icon card__persona__name card__persona__name"
+      "card__persona__icon card__persona__websitelabel card__persona__websitelink";
+    grid-template-columns: $postIconSize max-content 1fr;
+    grid-column-gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: $thinGrayBorder;
+
+    &__icon {
+      grid-area: card__persona__icon;
+
+      border-radius: 100%;
+      @include fixed-square($postIconSize);
+    }
+
+    &__name {
+      grid-area: card__persona__name;
+      display: flex;
+      align-items: center;
+
+      &__label {
+        font-size: $normalFontSize;
+      }
+
+      &__verification {
+        font-size: $smallFontSize;
+        margin-left: 0.25rem;
+
+        &--verified {
+          color: $won-line-gray;
+        }
+        &--unverified {
+          color: $won-unread-attention;
+        }
+      }
+    }
+
+    .card__persona__websitelabel {
+      font-size: $smallFontSize;
+      grid-area: card__persona__websitelabel;
+    }
+    .card__persona__websitelink {
+      font-size: $smallFontSize;
+      grid-area: card__persona__websitelink;
+    }
+  }
+
+  .card__main {
+    grid-area: card__main;
     display: grid;
     grid-template-areas: "topline" "subtitle";
     width: 15rem;
@@ -79,15 +163,6 @@ won-need-card {
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
-
-        &__persona {
-          border-radius: 0.19rem;
-          background: $won-secondary-color-lighter;
-          color: $won-secondary-text-color;
-          margin: 0.1rem;
-          padding: 0 0.25rem;
-          display: inline-block;
-        }
 
         &__groupchat {
           border-radius: 0.19rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -18,14 +18,18 @@ won-need-card {
     @include animateOpacityHeartBeat();
     pointer-events: none;
 
+    .card__main {
+      grid-row-gap: 0.15rem;
+    }
+
     .card__main__subtitle__type {
-      height: $smallFontSize;
+      height: calc(#{$smallFontSize} - 0.1rem);
       width: 5rem;
       background-color: $won-skeleton-color;
     }
 
     .card__main__topline__title {
-      height: $normalFontSize;
+      height: calc(#{$smallFontSize} - 0.05rem);
       width: 7rem;
       background-color: $won-skeleton-color;
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -31,19 +31,19 @@ won-need-card {
     }
   }
   .card__icon__skeleton {
-    @include fixed-square(15rem);
+    height: 10rem;
     background-color: $won-skeleton-color;
     margin-bottom: 0.5rem;
   }
 
   .card__icon {
     grid-area: card__icon;
+    display: grid;
+    justify-content: center;
+    align-items: center;
     margin-bottom: 0.5rem;
-
-    display: block;
     user-select: none;
-    position: relative;
-    height: 15rem;
+    height: 10rem;
 
     &.won-is-persona .image {
       border-radius: 100%;
@@ -58,14 +58,14 @@ won-need-card {
       display: flex;
       align-items: center;
       justify-content: center;
-      @include fixed-square(15rem);
+      @include fixed-square(5rem);
 
       &.usecaseimage {
         box-sizing: border-box;
         padding: 0.25rem;
 
         > svg {
-          @include fixed-square(calc(#{15rem}-0.5rem));
+          @include fixed-square(calc(#{5rem}-0.5rem));
         }
 
         & .si__usecaseicon {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -11,15 +11,14 @@ won-need-card {
   padding: 0.5rem;
   color: black;
 
+  &.won-is-invisible {
+    display: none;
+  }
+
   &.won-is-toload,
   &.won-is-loading {
     @include animateOpacityHeartBeat();
     pointer-events: none;
-
-    .ph__icon__skeleton {
-      @include fixed-square(15rem);
-      background-color: $won-skeleton-color;
-    }
 
     .ph__right__subtitle__type {
       height: $smallFontSize;
@@ -35,7 +34,11 @@ won-need-card {
   }
   @include square-image(15rem);
 
-  .ph__icon__skeleton,
+  .ph__icon__skeleton {
+    @include fixed-square(15rem);
+    background-color: $won-skeleton-color;
+  }
+
   won-square-image {
     grid-area: icon;
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -45,7 +45,7 @@ won-need-card {
     user-select: none;
     height: 10rem;
 
-    &.won-is-persona .image {
+    &.won-is-persona .identicon {
       border-radius: 100%;
     }
 
@@ -54,7 +54,7 @@ won-need-card {
       filter: grayscale(100%);
     }
 
-    & .image {
+    & .identicon {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -72,6 +72,12 @@ won-need-card {
           --local-primary: #{$won-secondary-text-color};
         }
       }
+    }
+
+    & .image {
+      object-fit: cover;
+      width: 15rem;
+      height: 10rem;
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -11,6 +11,10 @@ won-need-card {
   padding: 0.5rem;
   color: black;
 
+  &.won-is-invisible {
+    display: none;
+  }
+
   &.won-is-toload,
   &.won-is-loading {
     @include animateOpacityHeartBeat();

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -66,9 +66,6 @@ won-need-card {
 
         > svg {
           @include fixed-square(calc(#{5rem}-0.5rem));
-        }
-
-        & .si__usecaseicon {
           --local-primary: #{$won-secondary-text-color};
         }
       }
@@ -136,12 +133,32 @@ won-need-card {
   .card__main {
     grid-area: card__main;
     display: grid;
-    grid-template-areas: "topline" "subtitle";
+    grid-template-areas: "card__main__topline" "card__main__subtitle";
+    grid-template-columns: 1fr;
     width: 15rem;
     max-width: 15rem;
 
+    &--showIcon {
+      grid-template-areas: "card__main__icon card__main__topline" "card__main__icon card__main__subtitle";
+      grid-template-columns: min-content 1fr;
+      grid-column-gap: 0.5rem;
+    }
+
+    &__icon {
+      grid-area: card__main__icon;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      @include fixed-square($postIconSize);
+
+      &__usecaseimage > svg {
+        @include fixed-square(calc(#{$postIconSize}-0.5rem));
+        --local-primary: #{$won-secondary-text-color};
+      }
+    }
+
     &__topline {
-      grid-area: topline;
+      grid-area: card__main__topline;
       min-width: 0;
 
       &__notitle,
@@ -158,7 +175,7 @@ won-need-card {
     }
 
     &__subtitle {
-      grid-area: subtitle;
+      grid-area: card__main__subtitle;
       display: grid;
       grid-template-columns: 1fr min-content;
       color: $won-subtitle-gray;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -163,6 +163,9 @@ won-need-card {
         @include fixed-square(calc(#{$postIconSize}-0.5rem));
         --local-primary: #{$won-secondary-text-color};
       }
+      &__identicon {
+        @include fixed-square($postIconSize);
+      }
     }
 
     &__topline {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -73,8 +73,16 @@ won-need-card {
 
     & .image {
       object-fit: cover;
-      width: 15rem;
-      height: 10rem;
+
+      @media (max-width: $responsivenessBreakPoint) {
+        width: 100%;
+        height: 10rem;
+      }
+
+      @media (min-width: $responsivenessBreakPoint) {
+        width: 15rem;
+        height: 10rem;
+      }
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -1,0 +1,105 @@
+@import "won-config";
+@import "sizing-utils";
+@import "square-image";
+@import "animate";
+
+won-need-card {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-areas: "icon" "main";
+  grid-template-rows: max-content min-content;
+  padding: 0.5rem;
+  color: black;
+
+  &.won-is-loading {
+    @include animateOpacityHeartBeat();
+    pointer-events: none;
+
+    .ph__icon__skeleton {
+      grid-area: icon;
+      @include fixed-square($postIconSize);
+      background-color: $won-skeleton-color;
+    }
+
+    .ph__right__subtitle__type {
+      height: $smallFontSize;
+      width: 5rem;
+      background-color: $won-skeleton-color;
+    }
+
+    .ph__right__topline__title {
+      height: $normalFontSize;
+      width: 7rem;
+      background-color: $won-skeleton-color;
+    }
+  }
+  @include square-image(15rem);
+
+  won-square-image {
+    grid-area: icon;
+  }
+
+  .ph__right {
+    grid-area: main;
+    display: grid;
+    grid-template-areas: "topline" "subtitle";
+    min-width: 0;
+
+    &__topline {
+      grid-area: topline;
+      min-width: 0;
+
+      &__notitle,
+      &__title {
+        min-width: 0;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        font-weight: 400;
+      }
+      &__notitle {
+        color: $won-subtitle-gray;
+      }
+    }
+
+    &__subtitle {
+      grid-area: subtitle;
+      display: grid;
+      grid-template-columns: 1fr min-content;
+      color: $won-subtitle-gray;
+      font-size: $smallFontSize;
+      min-width: 0;
+
+      &__type {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+
+        &__persona {
+          border-radius: 0.19rem;
+          background: $won-secondary-color-lighter;
+          color: $won-secondary-text-color;
+          margin: 0.1rem;
+          padding: 0 0.25rem;
+          display: inline-block;
+        }
+
+        &__groupchat {
+          border-radius: 0.19rem;
+          background: $won-line-gray;
+          margin: 0.1rem;
+          padding: 0 0.25rem;
+          display: inline-block;
+        }
+      }
+
+      &__date {
+        font-size: $smallFontSize;
+        color: $won-subtitle-gray;
+        white-space: nowrap;
+        padding-left: 0.5rem;
+        min-width: 0;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -55,7 +55,6 @@ main.owneroverview {
     padding: 0.5rem;
 
     won-need-card.owneroverview__content__need {
-      cursor: pointer;
       border: $thinGrayBorder;
       background: $won-light-gray;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -50,25 +50,6 @@ main.owneroverview {
   }
 
   .owneroverview__content {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-gap: 0.5rem;
-    padding: 0.5rem;
-
-    @media (max-width: $responsivenessBreakPoint) {
-      grid-template-columns: 1fr;
-    }
-
-    won-post-header.owneroverview__content__need {
-      cursor: pointer;
-      border: $thinGrayBorder;
-      background: $won-light-gray;
-      padding: 0.5rem;
-    }
-  }
-  /*
-  //TODO: Once we figured out how we want to display need-cards we can use this instead
-  & .owneroverview__content {
     display: flex;
     flex-wrap: wrap;
     padding: 0.5rem;
@@ -89,5 +70,5 @@ main.owneroverview {
         margin-right: 0;
       }
     }
-  }*/
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -16,7 +16,6 @@ main.owneroverview {
     display: grid;
     grid-template-columns: 1fr min-content;
     grid-gap: 0.5rem;
-    margin-bottom: 0.5rem;
     border-bottom: $thinGrayBorder;
     padding: 0.5rem;
 
@@ -48,7 +47,7 @@ main.owneroverview {
     }
   }
 
-  & .owneroverview__content {
+  .owneroverview__content {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-gap: 0.5rem;
@@ -58,9 +57,35 @@ main.owneroverview {
       grid-template-columns: 1fr;
     }
 
-    &__need {
+    won-post-header.owneroverview__content__need {
+      cursor: pointer;
       border: $thinGrayBorder;
-      background: white;
+      background: $won-light-gray;
+      padding: 0.5rem;
     }
   }
+  /*
+  //TODO: Once we figured out how we want to display need-cards we can use this instead
+  & .owneroverview__content {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0.5rem;
+
+    won-need-card.owneroverview__content__need {
+      cursor: pointer;
+      border: $thinGrayBorder;
+      background: $won-light-gray;
+
+      margin-right: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    @media (max-width: $responsivenessBreakPoint) {
+      display: block;
+
+      won-need-card.owneroverview__content__need {
+        margin-right: 0;
+      }
+    }
+  }*/
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -18,6 +18,7 @@ main.owneroverview {
     grid-gap: 0.5rem;
     border-bottom: $thinGrayBorder;
     padding: 0.5rem;
+    align-items: center;
 
     &__title {
       font-size: $mediumFontSize;
@@ -42,6 +43,7 @@ main.owneroverview {
       }
 
       &__reload.won-button--filled.red {
+        font-size: 0.75rem;
         padding: 0.25rem;
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -1,0 +1,77 @@
+@import "won-config";
+@import "sizing-utils";
+@import "fonts";
+@import "flex-layout";
+
+main.owneroverview {
+  grid-column: 1 / -1;
+  padding: 0;
+  box-sizing: border-box;
+  align-items: stretch;
+  max-width: $maxContentWidth;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
+
+  & .owneroverview__need {
+    border: $thinGrayBorder;
+    background: white;
+  }
+
+  &:not(.owneroverview--won-failed):not(.owneroverview--won-loading) {
+    border-left: $thinGrayBorder;
+    border-right: $thinGrayBorder;
+    border-bottom: $thinGrayBorder;
+    background: white;
+  }
+  width: 100%;
+  margin: 0 auto;
+
+  @media (max-width: $responsivenessBreakPoint) {
+    border-left: none;
+    border-right: none;
+  }
+
+  & > .pc__loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 5rem 0;
+
+    > .pc__loading__spinner.hspinner {
+      @include fixed-square(5rem);
+    }
+    > .pc__loading__label {
+      color: $won-line-gray;
+      text-align: center;
+    }
+  }
+
+  & > .pc__failed {
+    display: grid;
+    grid-template-areas: "failed_icon failed_label" "failed_actions failed_actions";
+    align-items: center;
+    justify-content: center;
+    padding: 5rem 0.5rem;
+    grid-gap: 0.5rem;
+
+    > .pc__failed__icon {
+      grid-area: failed_icon;
+      @include fixed-square(5rem);
+      --local-primary: #{$won-primary-color};
+    }
+    > .pc__failed__label {
+      grid-area: failed_label;
+      text-align: center;
+    }
+    > .pc__failed__actions {
+      grid-area: failed_actions;
+      display: flex;
+      justify-content: center;
+
+      > .pc__failed__actions__button {
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -9,69 +9,58 @@ main.owneroverview {
   box-sizing: border-box;
   align-items: stretch;
   max-width: $maxContentWidth;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 1rem;
-
-  & .owneroverview__need {
-    border: $thinGrayBorder;
-    background: white;
-  }
-
-  &:not(.owneroverview--won-failed):not(.owneroverview--won-loading) {
-    border-left: $thinGrayBorder;
-    border-right: $thinGrayBorder;
-    border-bottom: $thinGrayBorder;
-    background: white;
-  }
   width: 100%;
   margin: 0 auto;
 
-  @media (max-width: $responsivenessBreakPoint) {
-    border-left: none;
-    border-right: none;
-  }
-
-  & > .pc__loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 5rem 0;
-
-    > .pc__loading__spinner.hspinner {
-      @include fixed-square(5rem);
-    }
-    > .pc__loading__label {
-      color: $won-line-gray;
-      text-align: center;
-    }
-  }
-
-  & > .pc__failed {
+  & .owneroverview__header {
     display: grid;
-    grid-template-areas: "failed_icon failed_label" "failed_actions failed_actions";
-    align-items: center;
-    justify-content: center;
-    padding: 5rem 0.5rem;
+    grid-template-columns: 1fr min-content;
     grid-gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    border-bottom: $thinGrayBorder;
+    padding: 0.5rem;
 
-    > .pc__failed__icon {
-      grid-area: failed_icon;
-      @include fixed-square(5rem);
-      --local-primary: #{$won-primary-color};
+    &__title {
+      font-size: $mediumFontSize;
     }
-    > .pc__failed__label {
-      grid-area: failed_label;
-      text-align: center;
-    }
-    > .pc__failed__actions {
-      grid-area: failed_actions;
-      display: flex;
-      justify-content: center;
 
-      > .pc__failed__actions__button {
+    &__loading {
+      font-size: $smallFontSize;
+      color: $won-line-gray;
+    }
+
+    &__updated {
+      display: grid;
+      grid-template-columns: min-content min-content;
+      grid-gap: 0.5rem;
+      align-items: center;
+
+      font-size: $smallFontSize;
+
+      &__time {
+        white-space: nowrap;
+        color: $won-line-gray;
       }
+
+      &__reload.won-button--filled.red {
+        padding: 0.25rem;
+      }
+    }
+  }
+
+  & .owneroverview__content {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: 0.5rem;
+    padding: 0.5rem;
+
+    @media (max-width: $responsivenessBreakPoint) {
+      grid-template-columns: 1fr;
+    }
+
+    &__need {
+      border: $thinGrayBorder;
+      background: white;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-content.scss
@@ -81,6 +81,7 @@ won-post-content {
       }
     }
 
+    .post-content__members,
     .post-content__suggestions {
       &__empty {
         color: $won-line-gray;
@@ -88,6 +89,7 @@ won-post-content {
         text-align: center;
       }
 
+      & .post-content__members__member,
       & .post-content__suggestions__suggestion {
         border: $thinGrayBorder;
         border-left: 0;
@@ -102,6 +104,7 @@ won-post-content {
           margin-top: 0;
         }
 
+        & > .post-content__members__member__indicator,
         & > .post-content__suggestions__suggestion__indicator {
           grid-area: member_indicator;
           box-sizing: border-box;
@@ -109,10 +112,12 @@ won-post-content {
           height: 100%;
         }
 
+        &.won-unread > .post-content__members__member__indicator,
         &.won-unread > .post-content__suggestions__suggestion__indicator {
           border-left: 0.25rem solid $won-unread-attention;
         }
 
+        &:not(.won-unread) > .post-content__members__member__indicator,
         &:not(.won-unread) > .post-content__suggestions__suggestion__indicator {
           border-left: $thinGrayBorder;
         }

--- a/webofneeds/won-owner/src/main/java/won/owner/repository/UserNeedRepository.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/repository/UserNeedRepository.java
@@ -11,6 +11,7 @@
 package won.owner.repository;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,4 +24,7 @@ import won.protocol.repository.WonRepository;
 public interface UserNeedRepository extends WonRepository<UserNeed> {
     @Query(value = "SELECT n from UserNeed n where n.uri = ?1")
     public UserNeed findByNeedUri(URI needUri);
+
+    @Query(value = "SELECT n from UserNeed n order by n.creationDate DESC")
+    public List<UserNeed> findAllNeeds();
 }


### PR DESCRIPTION
Implements an "overview" page -> show the needs of the defaultNode configured in the ownerWebapp which are:
 - active
 - modified in the last 30 days

Additionally:
- Removes the ability to create WhatsNew needs -> link to overview instead
- Removed all the WhatsNew handling within the ownerWebapp Frontend
- Changed need-fetching in a way that we remove needUris(and their respective connections) from the state if we find that the need has been deleted

Design/Styling in:
- overview.html
- need-card.js
is still going to be updated
