### PR TITLE
Feat  image viewer rework

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/image-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/image-picker.js
@@ -1,0 +1,140 @@
+import angular from "angular";
+import { attach, delay } from "../../../utils.js";
+import { DomCache } from "../../../cstm-ng-utils.js";
+import dropzoneModule from "../../file-dropzone.js";
+
+import "style/_imagepicker.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <won-file-dropzone on-image-picked="::self.updateImages(image)" accepts="::self.detail.accepts" multi-select="::self.detail.multiSelect" ng-if="self.detail.multiSelect || !self.addedImages || self.addedImages.length == 0">
+      </won-file-dropzone>
+      <div class="imagep__header" ng-if="self.addedImages && self.addedImages.length > 0">
+        {{ self.getUploadedHeader() }}
+      </div>
+      <div class="imagep__preview" ng-if="self.addedImages && self.addedImages.length > 0">
+        <div class="imagep__preview__item"
+          ng-repeat="image in self.addedImages"
+          ng-if="self.isImage(image)"
+          ng-class="{
+            'imagep__preview__item--default': image.default,
+          }">
+          <div class="imagep__preview__item__label" ng-click="self.setImageAsDefault(image)">
+            {{ image.name }}
+          </div>
+          <svg
+            class="imagep__preview__item__remove"
+            ng-click="self.removeImage(image)">
+            <use xlink:href="#ico36_close" href="#ico36_close"></use>
+          </svg>
+          <img class="imagep__preview__item__image"
+            ng-click="self.setImageAsDefault(image)"
+            alt="{{image.name}}"
+            ng-src="data:{{image.type}};base64,{{image.data}}"/>
+          <div class="imagep__preview__item__default" ng-click="self.setImageAsDefault(image)">
+            <span ng-if="image.default">Default Image</span>
+            <span class="imagep__preview__item__default__set" ng-if="!image.default">Click to set Image as Default</span>
+          </div>
+        </div>
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.domCache = new DomCache(this.$element);
+
+      window.imagep4dbg = this;
+
+      this.addedImages = this.initialValue;
+
+      delay(0).then(() => this.showInitialImages());
+    }
+
+    /**
+     * Checks validity and uses callback method
+     */
+    update(data) {
+      if (data && data.length > 0) {
+        this.onUpdate({ value: data });
+      } else {
+        this.onUpdate({ value: undefined });
+      }
+    }
+
+    showInitialImages() {
+      this.addedImages = this.initialValue;
+      this.$scope.$apply();
+    }
+
+    updateImages(image) {
+      if (!this.addedImages) {
+        this.addedImages = [];
+      }
+      if (this.isImage(image)) {
+        if (this.addedImages.length == 0) {
+          image.default = true;
+        }
+        this.addedImages.push(image);
+        this.update(this.addedImages);
+      }
+      this.$scope.$apply();
+    }
+
+    setImageAsDefault(imageToSetAsDefault) {
+      if (imageToSetAsDefault) {
+        this.addedImages = this.addedImages.map(image => {
+          image.default = image === imageToSetAsDefault;
+          return image;
+        });
+        this.update(this.addedImages);
+      }
+    }
+
+    removeImage(imageToRemove) {
+      if (!this.addedImages) {
+        this.addedImages = [];
+      }
+      this.addedImages = this.addedImages.filter(
+        image => imageToRemove !== image
+      );
+
+      const hasDefaultImage = !!this.addedImages.find(image => image.default);
+
+      if (!hasDefaultImage && this.addedImages.length > 0) {
+        this.addedImages[0].default = true;
+      }
+
+      this.update(this.addedImages);
+    }
+
+    isImage(image) {
+      return image && /^image\//.test(image.type);
+    }
+
+    getUploadedHeader() {
+      return this.addedImages && this.addedImages.length > 1
+        ? "Chosen Images:"
+        : "Chosen Image:";
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      onUpdate: "&",
+      initialValue: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.imagePicker", [dropzoneModule])
+  .directive("wonImagePicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
@@ -13,6 +13,7 @@ import selectPickerModule from "./select-picker.js";
 import rangePickerModule from "./range-picker.js";
 import priceRangePickerModule from "./price-range-picker.js";
 import filePickerModule from "./file-picker.js";
+import imagePickerModule from "./image-picker.js";
 import workflowPickerModule from "./workflow-picker.js";
 import petrinetPickerModule from "./petrinet-picker.js";
 import petrinettransitionPickerModule from "./petrinettransition-picker.js";
@@ -39,6 +40,7 @@ export default [
   rangePickerModule,
   priceRangePickerModule,
   filePickerModule,
+  imagePickerModule,
   workflowPickerModule,
   petrinetPickerModule,
   petrinettransitionPickerModule,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.js
@@ -1,0 +1,98 @@
+import angular from "angular";
+import { attach } from "../../../utils.js";
+
+import "style/_image-viewer.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+        <div class="imagev__header">
+          <svg class="imagev__header__icon" ng-if="self.detail.icon">
+              <use xlink:href={{self.detail.icon}} href={{self.detail.icon}}></use>
+          </svg>
+          <span class="imagev__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
+        </div>
+        <div class="imagev__content" ng-if="self.content && self.content.size > 0">
+          <div class="imagev__content__selected">
+            <img class="imagev__content__selected__image"
+              ng-click="self.openImageInNewTab(self.getSelectedImage())"
+              alt="{{self.getSelectedImage().get('name')}}"
+              ng-src="data:{{self.getSelectedImage().get('type')}};base64,{{self.getSelectedImage().get('data')}}"/>
+          </div>
+          <div class="imagev__content__thumbnails" ng-if="self.content.size > 1">
+            <div class="imagev__content__thumbnails__thumbnail"
+              ng-repeat="file in self.content.toArray()"
+              ng-if="self.isImage(file)">
+              <img class="imagev__content__thumbnails__thumbnail__image" ng-click="self.changeSelectedIndex($index)"
+                alt="{{file.get('name')}}"
+                ng-src="data:{{file.get('type')}};base64,{{file.get('data')}}"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      window.imagev4dbg = this;
+      this.selectedIndex = 0;
+      this.$scope.$watch("self.content", (newContent, prevContent) =>
+        this.updatedContent(newContent, prevContent)
+      );
+      this.$scope.$watch("self.details", (newDetails, prevDetails) =>
+        this.updatedDetails(newDetails, prevDetails)
+      );
+    }
+
+    updatedDetails(newDetails, prevDetails) {
+      if (newDetails && newDetails != prevDetails) {
+        this.details = newDetails;
+      }
+    }
+    updatedContent(newContent, prevContent) {
+      if (newContent && newContent != prevContent) {
+        this.content = newContent;
+      }
+    }
+
+    isImage(file) {
+      return file && /^image\//.test(file.get("type"));
+    }
+
+    openImageInNewTab(file) {
+      if (file) {
+        let image = new Image();
+        image.src = "data:" + file.get("type") + ";base64," + file.get("data");
+
+        let w = window.open("");
+        w.document.write(image.outerHTML);
+      }
+    }
+
+    changeSelectedIndex(index) {
+      this.selectedIndex = index;
+    }
+
+    getSelectedImage() {
+      return this.content && this.content.toArray()[this.selectedIndex];
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      content: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.imageViewer", [])
+  .directive("wonImageViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.js
@@ -22,7 +22,10 @@ function genComponentConf() {
           <div class="imagev__content__thumbnails" ng-if="self.content.size > 1">
             <div class="imagev__content__thumbnails__thumbnail"
               ng-repeat="file in self.content.toArray()"
-              ng-if="self.isImage(file)">
+              ng-if="self.isImage(file)"
+              ng-class="{
+                'imagev__content__thumbnails__thumbnail--selected': self.selectedIndex == $index,
+              }">
               <img class="imagev__content__thumbnails__thumbnail__image" ng-click="self.changeSelectedIndex($index)"
                 alt="{{file.get('name')}}"
                 ng-src="data:{{file.get('type')}};base64,{{file.get('data')}}"/>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
@@ -11,6 +11,7 @@ import dropdownViewerModule from "./dropdown-viewer.js";
 import selectViewerModule from "./select-viewer.js";
 import rangeViewerModule from "./range-viewer.js";
 import fileViewerModule from "./file-viewer.js";
+import imageViewerModule from "./image-viewer.js";
 import workflowViewerModule from "./workflow-viewer.js";
 import petrinetViewerModule from "./petrinet-viewer.js";
 import petrinettransitionViewerModule from "./petrinettransition-viewer.js";
@@ -35,6 +36,7 @@ export default [
   selectViewerModule,
   rangeViewerModule,
   fileViewerModule,
+  imageViewerModule,
   workflowViewerModule,
   petrinetViewerModule,
   petrinettransitionViewerModule,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
@@ -92,7 +92,7 @@ export const images = {
   accepts: "image/*",
   multiSelect: true,
   component: "won-file-picker",
-  viewerComponent: "won-file-viewer",
+  viewerComponent: "won-image-viewer",
   messageEnabled: true,
   parseToRDF: function({ value, identifier, contentUri }) {
     if (!value) {
@@ -100,8 +100,12 @@ export const images = {
     }
     let payload = [];
     value.forEach(image => {
-      //TODO: SAVE CORRECT RDF THIS METHOD
-      if (image.name && image.type && image.data) {
+      if (
+        image.name &&
+        image.type &&
+        image.data &&
+        /^image\//.test(image.type)
+      ) {
         let img = {
           "@id":
             contentUri && identifier
@@ -128,13 +132,12 @@ export const images = {
     if (Immutable.List.isList(images)) {
       images &&
         images.forEach(image => {
-          //TODO: RETRIEVE FROM CORRECT RDF THIS METHOD
           let img = {
             name: get(image, "s:name"),
             type: get(image, "s:type"),
             data: get(image, "s:data"),
           };
-          if (img.name && img.type && img.data) {
+          if (img.name && img.type && img.data && /^image\//.test(img.type)) {
             imgs.push(img);
           }
         });
@@ -144,7 +147,7 @@ export const images = {
         type: get(images, "s:type"),
         data: get(images, "s:data"),
       };
-      if (img.name && img.type && img.data) {
+      if (img.name && img.type && img.data && /^image\//.test(img.type)) {
         return Immutable.fromJS([img]);
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
@@ -17,7 +17,6 @@ export const files = {
     }
     let payload = [];
     value.forEach(file => {
-      //TODO: SAVE CORRECT RDF THIS METHOD
       if (file.name && file.type && file.data) {
         let f = {
           "@id":
@@ -45,7 +44,6 @@ export const files = {
     if (Immutable.List.isList(files)) {
       files &&
         files.forEach(file => {
-          //TODO: RETRIEVE FROM CORRECT RDF THIS METHOD
           let f = {
             name: get(file, "s:name"),
             type: get(file, "s:type"),
@@ -91,7 +89,7 @@ export const images = {
   placeholder: "",
   accepts: "image/*",
   multiSelect: true,
-  component: "won-file-picker",
+  component: "won-image-picker",
   viewerComponent: "won-image-viewer",
   messageEnabled: true,
   parseToRDF: function({ value, identifier, contentUri }) {
@@ -115,6 +113,7 @@ export const images = {
           "s:name": image.name,
           "s:type": image.type,
           "s:data": image.data,
+          "s:representativeOfPage": image.default,
         };
 
         payload.push(img);
@@ -136,6 +135,7 @@ export const images = {
             name: get(image, "s:name"),
             type: get(image, "s:type"),
             data: get(image, "s:data"),
+            default: get(image, "s:representativeOfPage"),
           };
           if (img.name && img.type && img.data && /^image\//.test(img.type)) {
             imgs.push(img);
@@ -146,6 +146,7 @@ export const images = {
         name: get(images, "s:name"),
         type: get(images, "s:type"),
         data: get(images, "s:data"),
+        default: get(images, "s:representativeOfPage"),
       };
       if (img.name && img.type && img.data && /^image\//.test(img.type)) {
         return Immutable.fromJS([img]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
@@ -4,58 +4,66 @@
 won-image-viewer {
   @include won-detail-viewer("imagev");
 
+  .imagev__content {
+    .imagev__content__selected {
+      background: white;
+      border: $thinGrayBorder;
+
+      .imagev__content__selected__image {
+        &:hover {
+          cursor: pointer;
+        }
+        height: 100%;
+        width: 100%;
+        object-fit: scale-down;
+      }
+    }
+
+    .imagev__content__thumbnails {
+      display: grid;
+      background: $won-lighter-gray;
+      border: $thinGrayBorder;
+      border-top: 0;
+      padding: 0.5rem;
+      grid-gap: 0.5rem;
+
+      .imagev__content__thumbnails__thumbnail {
+        background: white;
+        height: $postIconSize;
+        border: $thinGrayBorder;
+        opacity: 0.5;
+        &--selected {
+          border-color: $won-primary-color;
+          opacity: 1;
+
+          &:hover {
+            cursor: default;
+            opacity: 1;
+          }
+        }
+
+        &:hover {
+          cursor: pointer;
+          opacity: 0.75;
+        }
+
+        .imagev__content__thumbnails__thumbnail__image {
+          height: 100%;
+          width: 100%;
+          object-fit: cover;
+        }
+      }
+    }
+  }
+
   &.won-in-message {
     .imagev__content {
       .imagev__content__selected {
         height: 15rem;
-        background: white;
-        border: $thinGrayBorder;
-
-        .imagev__content__selected__image {
-          &:hover {
-            cursor: pointer;
-          }
-          height: 100%;
-          width: 100%;
-          object-fit: scale-down;
-        }
       }
 
       .imagev__content__thumbnails {
-        display: grid;
         grid-template-columns: 1fr 1fr 1fr 1fr;
-        background: $won-lighter-gray;
-        border: $thinGrayBorder;
-        border-top: 0;
-        padding: 0.5rem;
-        grid-gap: 0.5rem;
-
-        .imagev__content__thumbnails__thumbnail {
-          background: white;
-          height: $postIconSize;
-          border: $thinGrayBorder;
-          opacity: 0.5;
-          &--selected {
-            border-color: $won-primary-color;
-            opacity: 1;
-
-            &:hover {
-              cursor: default;
-              opacity: 1;
-            }
-          }
-
-          &:hover {
-            cursor: pointer;
-            opacity: 0.75;
-          }
-
-          .imagev__content__thumbnails__thumbnail__image {
-            height: 100%;
-            width: 100%;
-            object-fit: cover;
-          }
-        }
       }
     }
   }
@@ -69,59 +77,14 @@ won-image-viewer {
         @media (min-width: $responsivenessBreakPoint) {
           height: 25rem;
         }
-        background: white;
-        border: $thinGrayBorder;
-
-        .imagev__content__selected__image {
-          &:hover {
-            cursor: pointer;
-          }
-          height: 100%;
-          width: 100%;
-          object-fit: scale-down;
-        }
       }
 
       .imagev__content__thumbnails {
-        display: grid;
         @media (max-width: $responsivenessBreakPoint) {
           grid-template-columns: 1fr 1fr 1fr 1fr;
         }
         @media (min-width: $responsivenessBreakPoint) {
           grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-        }
-
-        background: $won-lighter-gray;
-        border: $thinGrayBorder;
-        border-top: 0;
-        padding: 0.5rem;
-        grid-gap: 0.5rem;
-
-        .imagev__content__thumbnails__thumbnail {
-          background: white;
-          height: $postIconSize;
-          border: $thinGrayBorder;
-          opacity: 0.5;
-          &--selected {
-            border-color: $won-primary-color;
-            opacity: 1;
-
-            &:hover {
-              cursor: default;
-              opacity: 1;
-            }
-          }
-
-          &:hover {
-            cursor: pointer;
-            opacity: 0.75;
-          }
-
-          .imagev__content__thumbnails__thumbnail__image {
-            height: 100%;
-            width: 100%;
-            object-fit: cover;
-          }
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
@@ -1,0 +1,117 @@
+@import "won-config";
+@import "sizing-utils";
+
+won-image-viewer {
+  @include won-detail-viewer("imagev");
+
+  &.won-in-message {
+    .imagev__content {
+      .imagev__content__selected {
+        padding: 0.5rem;
+        height: 15rem;
+        background: $won-light-gray;
+        border: $thinGrayBorder;
+
+        .imagev__content__selected__image {
+          &:hover {
+            cursor: pointer;
+          }
+          height: 100%;
+          width: 100%;
+          object-fit: scale-down;
+        }
+      }
+
+      .imagev__content__thumbnails {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+        background: $won-lighter-gray;
+        border: $thinGrayBorder;
+        border-top: 0;
+        padding: 0.5rem;
+        grid-gap: 0.5rem;
+
+        .imagev__content__thumbnails__thumbnail {
+          height: $postIconSize;
+          border: $thinGrayBorder;
+
+          &:hover {
+            cursor: pointer;
+          }
+
+          .imagev__content__thumbnails__thumbnail__image {
+            height: 100%;
+            width: 100%;
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
+
+  &:not(.won-in-message) {
+    .imagev__content {
+      .imagev__content__selected {
+        padding: 0.5rem;
+        @media (max-width: $responsivenessBreakPoint) {
+          height: 15rem;
+        }
+        @media (min-width: $responsivenessBreakPoint) {
+          height: 25rem;
+        }
+        background: $won-light-gray;
+        border: $thinGrayBorder;
+
+        .imagev__content__selected__image {
+          &:hover {
+            cursor: pointer;
+          }
+          height: 100%;
+          width: 100%;
+          object-fit: scale-down;
+        }
+      }
+
+      .imagev__content__thumbnails {
+        display: grid;
+        @media (max-width: $responsivenessBreakPoint) {
+          grid-template-columns: 1fr 1fr 1fr 1fr;
+        }
+        @media (min-width: $responsivenessBreakPoint) {
+          grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+        }
+
+        background: $won-lighter-gray;
+        border: $thinGrayBorder;
+        border-top: 0;
+        padding: 0.5rem;
+        grid-gap: 0.5rem;
+
+        .imagev__content__thumbnails__thumbnail {
+          height: $postIconSize;
+          border: $thinGrayBorder;
+
+          &:hover {
+            cursor: pointer;
+          }
+
+          .imagev__content__thumbnails__thumbnail__image {
+            height: 100%;
+            width: 100%;
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
+}
+
+won-send-request won-image-viewer:not(.won-in-message) .imagev__content > {
+  //Send Request view should have a different thumbnail height if not mobile
+
+  @media (min-width: $responsivenessBreakPoint) {
+    .imagev__content__thumbnails > .imagev__content__thumbnails__thumbnail {
+      height: $hugeiconSize;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
@@ -31,11 +31,23 @@ won-image-viewer {
         grid-gap: 0.5rem;
 
         .imagev__content__thumbnails__thumbnail {
+          background: white;
           height: $postIconSize;
           border: $thinGrayBorder;
+          opacity: 0.5;
+          &--selected {
+            border-color: $won-primary-color;
+            opacity: 1;
+
+            &:hover {
+              cursor: default;
+              opacity: 1;
+            }
+          }
 
           &:hover {
             cursor: pointer;
+            opacity: 0.75;
           }
 
           .imagev__content__thumbnails__thumbnail__image {
@@ -86,11 +98,23 @@ won-image-viewer {
         grid-gap: 0.5rem;
 
         .imagev__content__thumbnails__thumbnail {
+          background: white;
           height: $postIconSize;
           border: $thinGrayBorder;
+          opacity: 0.5;
+          &--selected {
+            border-color: $won-primary-color;
+            opacity: 1;
+
+            &:hover {
+              cursor: default;
+              opacity: 1;
+            }
+          }
 
           &:hover {
             cursor: pointer;
+            opacity: 0.75;
           }
 
           .imagev__content__thumbnails__thumbnail__image {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_image-viewer.scss
@@ -7,9 +7,8 @@ won-image-viewer {
   &.won-in-message {
     .imagev__content {
       .imagev__content__selected {
-        padding: 0.5rem;
         height: 15rem;
-        background: $won-light-gray;
+        background: white;
         border: $thinGrayBorder;
 
         .imagev__content__selected__image {
@@ -52,14 +51,13 @@ won-image-viewer {
   &:not(.won-in-message) {
     .imagev__content {
       .imagev__content__selected {
-        padding: 0.5rem;
         @media (max-width: $responsivenessBreakPoint) {
           height: 15rem;
         }
         @media (min-width: $responsivenessBreakPoint) {
           height: 25rem;
         }
-        background: $won-light-gray;
+        background: white;
         border: $thinGrayBorder;
 
         .imagev__content__selected__image {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_imagepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_imagepicker.scss
@@ -1,0 +1,83 @@
+@import "won-config";
+@import "sizing-utils";
+@import "positioning-utils";
+
+won-image-picker {
+  display: grid;
+  grid-gap: 0.5rem;
+
+  .imagep__header {
+    font-size: $smallFontSize;
+  }
+
+  .imagep__preview {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: 0.5rem;
+
+    .imagep__preview__item {
+      display: grid;
+      grid-template-columns: 1fr min-content;
+      grid-template-rows: min-content 1fr min-content;
+      border: $thinGrayBorder;
+      border-radius: 0.19rem;
+      height: 7.5rem;
+      background: $won-lighter-gray;
+      grid-gap: 0.25rem;
+      padding: 0.25rem;
+      justify-items: left;
+      align-items: center;
+
+      &--default {
+        border-color: $won-primary-color;
+      }
+
+      &:hover {
+        border-color: $won-primary-color-light;
+      }
+
+      .imagep__preview__item__label {
+        grid-row: 1 / span 1;
+        grid-column: 1 / span 1;
+        font-size: $smallFontSize;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        max-width: 100%;
+        white-space: nowrap;
+        cursor: pointer;
+      }
+
+      .imagep__preview__item__remove {
+        grid-row: 1 / span 1;
+        grid-column: 2 / span 1;
+        cursor: pointer;
+        @include fixed-square(1rem);
+
+        --local-primary: #{$won-primary-text-color};
+
+        &:hover {
+          --local-primary: #{$won-primary-color};
+        }
+      }
+
+      .imagep__preview__item__image {
+        grid-row: 2 / span 1;
+        grid-column: 1 / span 2;
+        object-fit: contain;
+        width: 100%;
+        height: 100%;
+        background: white;
+        border: $thinGrayBorder;
+        cursor: pointer;
+      }
+
+      .imagep__preview__item__default {
+        grid-row: 3 / span 1;
+        grid-column: 1 / span 2;
+        font-size: $smallFontSize;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_sizing-utils.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_sizing-utils.scss
@@ -135,7 +135,9 @@
     }
 
     .#{$prefix}__content {
-      padding-left: calc(0.25rem + #{$contentInfoHeaderIconSize});
+      @media (min-width: $responsivenessBreakPoint) {
+        padding-left: calc(0.25rem + #{$contentInfoHeaderIconSize});
+      }
       box-sizing: border-box;
     }
   }


### PR DESCRIPTION
- Implemented sep. image-viewer instead of file-viewer for images detail (in post-infos or as a message)
- Implement sep. image-picker with the ability to set a default image (default image is set per default to the first image that is uploaded or the first image that remains after an image has been removed) -> fixes #2811 

fixes #2821
fixes #2814 -> please check this was not reproducible on my machine
Caveat: currently there is no option in the picker to NOT have a default image -> not sure if this is something that we have to worry about though. 

