### PR TITLE
Feat  enhance need card

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -143,7 +143,6 @@ const actionHierarchy = {
   needs: {
     received: INJ_DEFAULT,
     connectionsReceived: INJ_DEFAULT,
-    clean: INJ_DEFAULT,
     create: needCreate,
     edit: needEdit,
     editSuccessful: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -117,8 +117,8 @@ function genComponentConf() {
           <div class="card__persona__websitelabel" ng-if="self.personaWebsite">Website:</div>
           <a class="card__persona__websitelink" target="_blank" href="{{self.personaWebsite}}" ng-if="self.personaWebsite">{{ self.personaWebsite }}</a>
     </div>
-    <div class="card__nopersona" ng-if="self.needLoaded && !self.persona">
-        <span class="card__nopersona__label">No Persona attached</span>
+    <div class="card__nopersona" ng-if="(self.needLoaded && !self.persona) || !self.needLoaded">
+        <span class="card__nopersona__label" ng-if="self.needLoaded">No Persona attached</span>
     </div>
     <div class="card__main" ng-if="self.needFailedToLoad">
         <div class="card__main__topline">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -117,6 +117,9 @@ function genComponentConf() {
           <div class="card__persona__websitelabel" ng-if="self.personaWebsite">Website:</div>
           <a class="card__persona__websitelink" target="_blank" href="{{self.personaWebsite}}" ng-if="self.personaWebsite">{{ self.personaWebsite }}</a>
     </div>
+    <div class="card__nopersona" ng-if="self.needLoaded && !self.persona">
+        <span class="card__nopersona__label">No Persona attached</span>
+    </div>
     <div class="card__main" ng-if="self.needFailedToLoad">
         <div class="card__main__topline">
             <div class="card__main__topline__notitle">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -27,6 +27,7 @@ function genComponentConf() {
         ng-class="{
           'won-is-persona': self.isPersona,
           'inactive': self.isInactive,
+          'card__icon--map': self.showMap,
         }"
         ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})">
         <div class="identicon usecaseimage"
@@ -43,7 +44,7 @@ function genComponentConf() {
             ng-if="self.needImage"
             alt="{{self.needImage.get('name')}}"
             ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
-        <won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation" disable-controls default-layer-only add-current-location>
+        <won-need-map class="location" locations="[self.needLocation]" ng-if="self.showMap" disable-controls default-layer-only add-current-location>
         </won-need-map>
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
@@ -211,6 +212,7 @@ function genComponentConf() {
           needImage,
           needLocation,
           showDefaultIcon: !needImage && !needLocation, //if no image and no location are present we display the defaultIcon in the card__icon area, instead of next to the title
+          showMap: !needImage && needLocation, //if no image is present but a location is, we display a map instead
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/need-card.js
@@ -20,6 +20,7 @@ import "style/_need-card.scss";
 const serviceDependencies = ["$ngRedux", "$scope", "$element"];
 function genComponentConf() {
   let template = `
+    <!-- Icon Information -->
     <div class="card__icon clickable"
         ng-if="self.needLoaded"
         style="background-color: {{self.showDefaultIcon && self.iconBackground}}"
@@ -42,12 +43,13 @@ function genComponentConf() {
             ng-if="self.needImage"
             alt="{{self.needImage.get('name')}}"
             ng-src="data:{{self.needImage.get('type')}};base64,{{self.needImage.get('data')}}"/>
-        <!--won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation">
-        </won-need-map-->
+        <won-need-map class="location" locations="[self.needLocation]" ng-if="!self.needImage && self.needLocation" disable-controls default-layer-only add-current-location>
+        </won-need-map>
     </div>
     <div class="card__icon__skeleton" ng-if="!self.needLoaded"
       in-view="$inview && self.needToLoad && self.ensureNeedIsLoaded()">
     </div>
+    <!-- Main Information -->
     <div class="card__main clickable"
         ng-if="self.needLoaded" ng-click="self.router__stateGo('post', {postUri: self.need.get('uri')})"
         ng-class="{
@@ -94,31 +96,6 @@ function genComponentConf() {
                 {{ self.friendlyTimestamp }}
             </div>
         </div>
-        <div class="card__main__location" ng-if="self.needLocation">
-          <svg class="card__main__location__icon">
-              <use xlink:href="#ico36_detail_location" href="#ico36_detail_location"></use>
-          </svg>
-          <span class="card__main__location__address">
-              {{ self.needLocation.get('address') }}
-          </span>
-        </div>
-    </div>
-    <div class="card__persona clickable" ng-if="self.needLoaded && self.persona" ng-click="self.router__stateGoCurrent({viewNeedUri: self.personaUri})">
-          <img class="card__persona__icon"
-              ng-if="::self.personaIdenticonSvg"
-              alt="Auto-generated title image for persona that holds the need"
-              ng-src="data:image/svg+xml;base64,{{::self.personaIdenticonSvg}}"/>
-          <div class="card__persona__name"
-              ng-if="self.personaName">
-              <span class="card__persona__name__label">{{ self.personaName }}</span>
-              <span class="card__persona__name__verification card__persona__name__verification--verified" ng-if="self.personaVerified" title="The Persona-Relation of this Post is verified by the Persona">Verified</span>
-              <span class="card__persona__name__verification card__persona__name__verification--unverified" ng-if="!self.personaVerified" title="The Persona-Relation of this Post is NOT verified by the Persona">Unverified!</span>
-          </div>
-          <div class="card__persona__websitelabel" ng-if="self.personaWebsite">Website:</div>
-          <a class="card__persona__websitelink" target="_blank" href="{{self.personaWebsite}}" ng-if="self.personaWebsite">{{ self.personaWebsite }}</a>
-    </div>
-    <div class="card__nopersona" ng-if="(self.needLoaded && !self.persona) || !self.needLoaded">
-        <span class="card__nopersona__label" ng-if="self.needLoaded">No Persona attached</span>
     </div>
     <div class="card__main" ng-if="self.needFailedToLoad">
         <div class="card__main__topline">
@@ -139,6 +116,24 @@ function genComponentConf() {
         <div class="card__main__subtitle">
             <span class="card__main__subtitle__type"></span>
         </div>
+    </div>
+    <!-- Attached Persona Info -->
+    <div class="card__persona clickable" ng-if="self.needLoaded && self.persona && self.needHasHoldableFacet" ng-click="self.router__stateGoCurrent({viewNeedUri: self.personaUri})">
+          <img class="card__persona__icon"
+              ng-if="::self.personaIdenticonSvg"
+              alt="Auto-generated title image for persona that holds the need"
+              ng-src="data:image/svg+xml;base64,{{::self.personaIdenticonSvg}}"/>
+          <div class="card__persona__name"
+              ng-if="self.personaName">
+              <span class="card__persona__name__label">{{ self.personaName }}</span>
+              <span class="card__persona__name__verification card__persona__name__verification--verified" ng-if="self.personaVerified" title="The Persona-Relation of this Post is verified by the Persona">Verified</span>
+              <span class="card__persona__name__verification card__persona__name__verification--unverified" ng-if="!self.personaVerified" title="The Persona-Relation of this Post is NOT verified by the Persona">Unverified!</span>
+          </div>
+          <div class="card__persona__websitelabel" ng-if="self.personaWebsite">Website:</div>
+          <a class="card__persona__websitelink" target="_blank" href="{{self.personaWebsite}}" ng-if="self.personaWebsite">{{ self.personaWebsite }}</a>
+    </div>
+    <div class="card__nopersona" ng-if="(self.needLoaded && !self.persona && self.needHasHoldableFacet) || !self.needLoaded">
+        <span class="card__nopersona__label" ng-if="self.needLoaded">No Persona attached</span>
     </div>
     `;
 
@@ -188,6 +183,8 @@ function genComponentConf() {
           persona,
           personaName,
           personaVerified,
+          needHasHolderFacet: needUtils.hasHolderFacet(need),
+          needHasHoldableFacet: needUtils.hasHoldableFacet(need),
           needLoaded: processUtils.isNeedLoaded(process, this.needUri),
           needLoading: processUtils.isNeedLoading(process, this.needUri),
           needToLoad: processUtils.isNeedToLoad(process, this.needUri),
@@ -213,7 +210,7 @@ function genComponentConf() {
           personaIdenticonSvg,
           needImage,
           needLocation,
-          showDefaultIcon: !needImage /*&& !needLocation*/, //if no image and no location are present we display the defaultIcon in the card__icon area, instead of next to the title
+          showDefaultIcon: !needImage && !needLocation, //if no image and no location are present we display the defaultIcon in the card__icon area, instead of next to the title
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/overview/overview.js
@@ -13,7 +13,6 @@ import postHeaderModule from "../post-header.js";
 import * as generalSelectors from "../../selectors/general-selectors.js";
 import * as viewSelectors from "../../selectors/view-selectors.js";
 import * as processUtils from "../../process-utils.js";
-import * as srefUtils from "../../sref-utils.js";
 import * as wonLabelUtils from "../../won-label-utils.js";
 
 import "style/_overview.scss";
@@ -27,7 +26,6 @@ class Controller {
     this.selection = 0;
     window.overview4dbg = this;
     this.WON = won.WON;
-    Object.assign(this, srefUtils); // bind srefUtils to scope
 
     const selectFromState = state => {
       const viewNeedUri = generalSelectors.getViewNeedUriFromRoute(state);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/need-utils.js
@@ -68,7 +68,7 @@ export function getLocation(need) {
 }
 
 /**
- * Returns the "Default" Image (currently the first one, branch content is checked before seeks) of a need
+ * Returns the "Default" Image (currently the content branch is checked before seeks) of a need
  * if the need does not have any images we return undefined
  * @param need
  */
@@ -77,13 +77,25 @@ export function getDefaultImage(need) {
     const contentImages = getIn(need, ["content", "images"]);
 
     if (contentImages) {
-      return contentImages.first();
+      const defaultImage = contentImages.find(image => get(image, "default"));
+
+      if (defaultImage) {
+        return defaultImage;
+      }
     }
 
     const seeksImages = getIn(need, ["content", "images"]);
 
     if (seeksImages) {
-      return seeksImages.first();
+      const defaultImage = seeksImages.find(image => get(image, "default"));
+
+      if (defaultImage) {
+        return defaultImage;
+      } else {
+        return seeksImages.first();
+      }
+    } else {
+      return contentImages.first();
     }
   }
   return undefined;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/message-reducers.js
@@ -15,6 +15,9 @@ const initialState = Immutable.fromJS({
 });
 export function messagesReducer(messages = initialState, action = {}) {
   switch (action.type) {
+    case actionTypes.account.reset:
+      return initialState;
+
     case actionTypes.connections.open:
     case actionTypes.connections.sendChatMessage:
     case actionTypes.connections.rate:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/need-reducer/need-reducer-main.js
@@ -49,7 +49,6 @@ const initialState = Immutable.fromJS({});
 export default function(allNeedsInState = initialState, action = {}) {
   switch (action.type) {
     case actionTypes.account.reset:
-    case actionTypes.needs.clean:
       return initialState;
 
     case actionTypes.account.loginStarted:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -110,6 +110,9 @@ function updateMessageProcess(processState, connUri, messageUri, payload) {
 
 export default function(processState = initialState, action = {}) {
   switch (action.type) {
+    case actionTypes.account.reset:
+      return initialState;
+
     case actionTypes.needs.edit: {
       const needUri = action.payload.needUri;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/reducers.js
@@ -17,6 +17,13 @@ import processReducer from "./process-reducer.js";
  */
 import { router } from "redux-ui-router";
 
+const initialOwnerState = Immutable.fromJS({
+  needUris: Immutable.Set(),
+  lastNeedUrisUpdateTime: undefined,
+});
+
+const initialConfigState = Immutable.fromJS({ theme: { name: "current" } });
+
 const reducers = {
   router,
 
@@ -44,10 +51,7 @@ const reducers = {
   // lastUpdateTime: (state = Date.now(), action = {}) => Date.now(),
   lastUpdateTime: () => Date.now(),
 
-  config: (
-    config = Immutable.fromJS({ theme: { name: "current" } }),
-    action = {}
-  ) => {
+  config: (config = initialConfigState, action = {}) => {
     switch (action.type) {
       case actionTypes.config.init:
       case actionTypes.config.update:
@@ -57,14 +61,11 @@ const reducers = {
         return config;
     }
   },
-  owner: (
-    owner = Immutable.fromJS({
-      needUris: Immutable.Set(),
-      lastNeedUrisUpdateTime: undefined,
-    }),
-    action = {}
-  ) => {
+  owner: (owner = initialOwnerState, action = {}) => {
     switch (action.type) {
+      case actionTypes.account.reset:
+        return initialOwnerState;
+
       case actionTypes.needs.storeNeedUrisFromOwner: {
         const fetchedNeedUris = action.payload.get("uris");
         let ownerNeedUris = owner.get("needUris");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -29,7 +29,11 @@ import * as useCaseUtils from "./usecase-utils.js";
 
 import won from "./won-es6.js";
 
-export function initLeaflet(mapMount) {
+export function initLeaflet(
+  mapMount,
+  overrideOptions,
+  defaultLayerOnly = false
+) {
   if (!L) {
     throw new Error(
       "Tried to initialize a leaflet widget while leaflet wasn't loaded."
@@ -39,16 +43,24 @@ export function initLeaflet(mapMount) {
 
   const baseMaps = initLeafletBaseMaps();
 
-  const map = L.map(mapMount, {
-    center: [37.44, -42.89], //centered on north-west africa
-    zoom: 1, //world-map
-    layers: [baseMaps["Detailed default map"]], //initially visible layers
-  }); //.setView([51.505, -0.09], 13);
+  const map = L.map(
+    mapMount,
+    Object.assign(
+      {
+        center: [37.44, -42.89], //centered on north-west africa
+        zoom: 1, //world-map
+        layers: [baseMaps["Detailed default map"]], //initially visible layers
+      },
+      overrideOptions
+    )
+  ); //.setView([51.505, -0.09], 13);
 
   //map.fitWorld() // shows every continent twice :|
   map.fitBounds([[-80, -190], [80, 190]]); // fitWorld without repetition
 
-  L.control.layers(baseMaps).addTo(map);
+  if (!defaultLayerOnly) {
+    L.control.layers(baseMaps).addTo(map);
+  }
 
   // Force it to adapt to actual size
   // for some reason this doesn't happen by default

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/files.js
@@ -135,7 +135,7 @@ export const images = {
             name: get(image, "s:name"),
             type: get(image, "s:type"),
             data: get(image, "s:data"),
-            default: get(image, "s:representativeOfPage"),
+            default: JSON.parse(get(image, "s:representativeOfPage")),
           };
           if (img.name && img.type && img.data && /^image\//.test(img.type)) {
             imgs.push(img);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -42,9 +42,18 @@ won-need-card {
 
   .card__icon {
     grid-area: card__icon;
-    display: grid;
-    justify-content: center;
-    align-items: center;
+
+    &:not(.card__icon--map) {
+      display: grid;
+      justify-content: center;
+      align-items: center;
+    }
+
+    &.card__icon--map {
+      display: block;
+      width: 100%;
+    }
+
     margin-bottom: 0.5rem;
     user-select: none;
     height: 10rem;
@@ -75,9 +84,8 @@ won-need-card {
       }
     }
 
-    & .image {
-      object-fit: cover;
-
+    & .image,
+    & won-need-map.location {
       @media (max-width: $responsivenessBreakPoint) {
         width: 100%;
         height: 10rem;
@@ -89,10 +97,12 @@ won-need-card {
       }
     }
 
+    & .image {
+      object-fit: cover;
+    }
+
     & won-need-map.location {
       display: block;
-      width: 15rem;
-      height: 10rem;
 
       .need-map__mapmount {
         width: 100%;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -176,14 +176,14 @@ won-need-card {
   .card__main {
     grid-area: card__main;
     display: grid;
-    grid-template-areas: "card__main__topline" "card__main__subtitle" "card__main__location";
+    grid-template-areas: "card__main__topline" "card__main__subtitle";
     grid-template-columns: 1fr;
     grid-template-rows: min-content min-content min-content;
     width: 15rem;
     max-width: 15rem;
 
     &--showIcon {
-      grid-template-areas: "card__main__icon card__main__topline" "card__main__icon card__main__subtitle" "card__main__location card__main__location";
+      grid-template-areas: "card__main__icon card__main__topline" "card__main__icon card__main__subtitle";
       grid-template-columns: min-content 1fr;
       grid-column-gap: 0.5rem;
     }
@@ -248,27 +248,6 @@ won-need-card {
         white-space: nowrap;
         padding-left: 0.5rem;
         min-width: 0;
-      }
-    }
-
-    &__location {
-      grid-area: card__main__location;
-      display: grid;
-      grid-template-columns: min-content 1fr;
-      margin-top: 0.5rem;
-      grid-column-gap: 0.25rem;
-
-      &__address {
-        white-space: nowrap;
-        font-size: $smallFontSize;
-        text-overflow: ellipsis;
-        color: $won-subtitle-gray;
-        overflow: hidden;
-      }
-
-      &__icon {
-        @include fixed-square($normalFontSize);
-        --local-primary: #{$won-subtitle-gray};
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -259,9 +259,11 @@ won-need-card {
       grid-column-gap: 0.25rem;
 
       &__address {
+        white-space: nowrap;
         font-size: $smallFontSize;
         text-overflow: ellipsis;
         color: $won-subtitle-gray;
+        overflow: hidden;
       }
 
       &__icon {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_need-card.scss
@@ -5,7 +5,7 @@
 won-need-card {
   display: grid;
   grid-template-areas: "card__icon" "card__main" "card__persona";
-  grid-template-rows: max-content min-content min-content;
+  grid-template-rows: max-content 1fr min-content;
   padding: 0.5rem;
   color: black;
 
@@ -101,6 +101,26 @@ won-need-card {
     }
   }
 
+  // Defines the height of the (no)persona-div, so that they no-persona is the same height as attached personas
+  --persona-height: 2.5rem;
+
+  .card__nopersona {
+    grid-area: card__persona;
+    margin-top: 0.5rem;
+    display: grid;
+    grid-column-gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: $thinGrayBorder;
+    justify-items: center;
+    align-items: center;
+    height: var(--persona-height);
+
+    &__label {
+      font-size: $smallFontSize;
+      color: $won-line-gray;
+    }
+  }
+
   .card__persona {
     grid-area: card__persona;
     margin-top: 0.5rem;
@@ -109,7 +129,7 @@ won-need-card {
     grid-template-areas:
       "card__persona__icon card__persona__name card__persona__name"
       "card__persona__icon card__persona__websitelabel card__persona__websitelink";
-    grid-template-columns: $postIconSize max-content 1fr;
+    grid-template-columns: var(--persona-height) max-content 1fr;
     grid-column-gap: 0.5rem;
     padding-top: 0.5rem;
     border-top: $thinGrayBorder;
@@ -118,7 +138,7 @@ won-need-card {
       grid-area: card__persona__icon;
 
       border-radius: 100%;
-      @include fixed-square($postIconSize);
+      @include fixed-square(var(--persona-height));
     }
 
     &__name {
@@ -158,6 +178,7 @@ won-need-card {
     display: grid;
     grid-template-areas: "card__main__topline" "card__main__subtitle" "card__main__location";
     grid-template-columns: 1fr;
+    grid-template-rows: min-content min-content min-content;
     width: 15rem;
     max-width: 15rem;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -166,3 +166,10 @@ svg {
 //TODO in topnav, make create-button black when the dialog is open
 //TODO the :hover isn't usable on touch displays (require alternate path to get to the help text) - dog-ears + peel-slide?
 //TODO enable keyboard selection. add aria-information
+
+.wonCurrentLocationMarkerIcon {
+  width: 15px;
+  height: 15px;
+  background-color: $won-primary-color;
+  border-radius: 100%;
+}


### PR DESCRIPTION
- Uses actual default Image instead of the first Image of the images detail (checks for "default" in state of the images -> look at `parseFromRDF` in `files.js` images-detail to see the RDF representation
- Shows "nopersona attached"-label if the need has a holdableFacet but no persona attached (in whats new overview need-cards)
- Added attributes to the need-map component
   - `disable-controls`: disables zoom, pan, drag etc.
   - `default-layer-only`: does not add any other layers (e.g. transit) to the leaflet map
   - `add-current-location` : adds a marker with the current geolocation of the user
- The map initialization was enhanced so that you can provide the overrideOptions as a function parameter (used for `disable-controls` in need-map, and need-card component)
- Adds a markerIcon css-class in `won.scss` to display a different marker for the currentLocation

- fixes #2880 -> "whats new"-view still works after a logout (happened because we did not reset all the redux states correctly)