### PR TITLE
Refactor ontologies

### DIFF
--- a/webofneeds/won-vocab/src/main/resources/ontology/ext/won-ext-hold.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/ext/won-ext-hold.ttl
@@ -14,24 +14,16 @@
 #    Annotation properties
 #################################################################
 
-###  https://w3id.org/won/core#allowedTargetSocket
-won:allowedTargetSocket rdf:type owl:AnnotationProperty .
+###  https://w3id.org/won/ext/hold#heldBy
+:heldBy rdf:type owl:AnnotationProperty ;
+        rdfs:range won:Atom ;
+        rdfs:domain won:Atom .
 
 
-###  https://w3id.org/won/core#autoOpen
-won:autoOpen rdf:type owl:AnnotationProperty .
-
-
-###  https://w3id.org/won/core#compatibleSocketType
-won:compatibleSocketType rdf:type owl:AnnotationProperty .
-
-
-###  https://w3id.org/won/core#derivesAtomProperty
-won:derivesAtomProperty rdf:type owl:AnnotationProperty .
-
-
-###  https://w3id.org/won/core#socketCapacity
-won:socketCapacity rdf:type owl:AnnotationProperty .
+###  https://w3id.org/won/ext/hold#holds
+:holds rdf:type owl:AnnotationProperty ;
+       rdfs:range won:Atom ;
+       rdfs:domain won:Atom .
 
 
 #################################################################
@@ -39,99 +31,44 @@ won:socketCapacity rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  https://w3id.org/won/ext/hold#heldBy
-:heldBy rdf:type owl:ObjectProperty ;
-        owl:inverseOf :holds ;
-        rdfs:domain won:Atom ;
-        rdfs:range won:Atom .
+:heldBy rdf:type owl:ObjectProperty .
 
 
 ###  https://w3id.org/won/ext/hold#holds
-:holds rdf:type owl:ObjectProperty ;
-       rdfs:domain won:Atom ,
-                   :Holder ;
-       rdfs:range won:Atom ,
-                  :Holdable .
-
-
-#################################################################
-#    Classes
-#################################################################
-
-###  https://w3id.org/won/ext/hold#Holdable
-:Holdable rdf:type owl:Class ;
-          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                owl:onProperty won:socket ;
-                                owl:someValuesFrom :HoldableSocket
-                              ] ;
-          rdfs:comment "An Atom that does not represent an agent. May be connected to a Holder Atom via the heldBy property."@en .
-
-
-###  https://w3id.org/won/ext/hold#HoldableSocket
-:HoldableSocket rdf:type owl:Class ;
-                owl:equivalentClass [ rdf:type owl:Restriction ;
-                                      owl:onProperty won:socketConfiguration ;
-                                      owl:hasValue :HoldableSocketConfiguration
-                                    ] ;
-                rdfs:subClassOf won:Socket ;
-                rdfs:comment "An Atom uses this Socket to connect to the Persona Atom that holds it. Can be asserted explicitly, but is also inferrable for individuals that have socketConfiguration HoldableSocketConfiguration."@en .
-
-
-###  https://w3id.org/won/ext/hold#Holder
-:Holder rdf:type owl:Class ;
-        owl:equivalentClass [ rdf:type owl:Restriction ;
-                              owl:onProperty won:socket ;
-                              owl:someValuesFrom :HolderSocket
-                            ] ;
-        rdfs:comment "Represents an agent. Is linked to other Atoms the agent controls via the holds property."@en .
-
-
-###  https://w3id.org/won/ext/hold#HolderSocket
-:HolderSocket rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty won:socketConfiguration ;
-                                    owl:hasValue :HolderSocketConfiguration
-                                  ] ;
-              rdfs:subClassOf won:Socket ;
-              rdfs:comment "A Persona Atom uses this Socket to connect to Atoms it holds. Can be asserted explicitly, but is also inferrable for individuals that have socketConfiguration HolderSocketConfiguration."@en .
+:holds rdf:type owl:ObjectProperty .
 
 
 #################################################################
 #    Individuals
 #################################################################
 
-###  http://example.com/won/ext/hold#MyAdditionalSocketConfig
-<http://example.com/won/ext/hold#MyAdditionalSocketConfig> rdf:type owl:NamedIndividual ;
-                                                           won:socketCapacity 5 .
-
-
 ###  http://example.com/won/ext/hold#MyConcreteHoldableSocket
-<http://example.com/won/ext/hold#MyConcreteHoldableSocket> rdf:type owl:NamedIndividual ,
-                                                                    :HoldableSocket ;
-                                                           won:socketConfiguration :HoldableSocketConfiguration .
+<http://example.com/won/ext/hold#MyConcreteHoldableSocket> rdf:type owl:NamedIndividual ;
+                                                           won:socketDefinition :HoldableSocketDefinition .
 
 
 ###  http://example.com/won/ext/hold#MyConcreteHolderSocket
-<http://example.com/won/ext/hold#MyConcreteHolderSocket> rdf:type owl:NamedIndividual ,
-                                                                  :HolderSocket ;
-                                                         won:socketConfiguration <http://example.com/won/ext/hold#MyAdditionalSocketConfig> ,
-                                                                                 :HolderSocketConfiguration .
+<http://example.com/won/ext/hold#MyConcreteHolderSocket> rdf:type owl:NamedIndividual ;
+                                                         won:socketDefinition :HolderSocketDefinition .
 
 
-###  https://w3id.org/won/ext/hold#HoldableSocketConfiguration
-:HoldableSocketConfiguration rdf:type owl:NamedIndividual ;
-                             rdfs:comment "An Atom uses a Socket with this configuration to connect to the Persona Atom that holds it."@en ;
-                             won:autoOpen "false"^^xsd:boolean ;
-                             won:compatibleSocketType :HolderSocket ;
-                             won:derivesAtomProperty :holds ;
-                             won:socketCapacity 1 .
+###  https://w3id.org/won/ext/hold#HoldableSocket
+:HoldableSocket rdf:type owl:NamedIndividual ,
+                         won:SocketDefinition ;
+                rdfs:comment "An Atom uses a Socket with this configuration to connect to the Persona Atom that holds it."@en ;
+                won:autoOpen "false"^^xsd:boolean ;
+                won:compatibleSocketDefinition :HolderSocketDefinition ;
+                won:derivesAtomProperty :holds ;
+                won:socketCapacity 1 .
 
 
-###  https://w3id.org/won/ext/hold#HolderSocketConfiguration
-:HolderSocketConfiguration rdf:type owl:NamedIndividual ;
-                           rdfs:comment "A Persona Atom uses a Socket with this configuration to connect to Atoms it holds."@en ;
-                           won:autoOpen "false"^^xsd:boolean ;
-                           won:compatibleSocketType :HoldableSocket ;
-                           won:derivesAtomProperty :heldBy .
+###  https://w3id.org/won/ext/hold#HolderSocket
+:HolderSocket rdf:type owl:NamedIndividual ,
+                       won:SocketDefinition ;
+              rdfs:comment "A Persona Atom uses a Socket with this configuration to connect to Atoms it holds."@en ;
+              won:autoOpen "false"^^xsd:boolean ;
+              won:compatibleSocketDefinition :HoldableSocketDefinition ;
+              won:derivesAtomProperty :heldBy .
 
 
 ###  https://w3id.org/won/ext/hold#heldBy

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
@@ -61,9 +61,10 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:isDefinedBy <https://w3id.org/won/core> .
 
 
-###  https://w3id.org/won/core#compatibleSocketType
-:compatibleSocketType rdf:type owl:ObjectProperty ;
-                      rdfs:domain :SocketConfiguration .
+###  https://w3id.org/won/core#compatibleSocketDefinition
+:compatibleSocketDefinition rdf:type owl:ObjectProperty ;
+                            rdfs:domain :SocketDefinition ;
+                            rdfs:range :SocketDefinition .
 
 
 ###  https://w3id.org/won/core#connectionState
@@ -93,7 +94,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  https://w3id.org/won/core#derivesAtomProperty
 :derivesAtomProperty rdf:type owl:ObjectProperty ;
-                     rdfs:domain :SocketConfiguration ;
+                     rdfs:domain :SocketDefinition ;
                      rdfs:comment "Defines a property to be 'derived' when the connection is established. The property will be used to derive a triple '[sourceAtom] [property] [targetAtom]'."@en .
 
 
@@ -136,11 +137,6 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:isDefinedBy <https://w3id.org/won/core> .
 
 
-###  https://w3id.org/won/core#overloadPolicy
-:overloadPolicy rdf:type owl:ObjectProperty ;
-                rdfs:domain :SocketConfiguration .
-
-
 ###  https://w3id.org/won/core#owner
 :owner rdf:type owl:ObjectProperty ,
                 owl:FunctionalProperty ;
@@ -153,11 +149,6 @@ xsd:duration rdf:type rdfs:Datatype .
 :ownerProtocolEndpoint rdf:type owl:ObjectProperty ;
                        rdfs:comment "Points to the ownerProtocol webservice endpoint of the atom. I.e., owner applications can communicate with the atom through this endpoint."@en ;
                        rdfs:isDefinedBy <https://w3id.org/won/core> .
-
-
-###  https://w3id.org/won/core#schedulingPolicy
-:schedulingPolicy rdf:type owl:ObjectProperty ;
-                  rdfs:domain :SocketConfiguration .
 
 
 ###  https://w3id.org/won/core#seeks
@@ -176,10 +167,11 @@ sought to fulfill the atom in contrast to the part that is available.""" ;
         rdfs:isDefinedBy <https://w3id.org/won/core> .
 
 
-###  https://w3id.org/won/core#socketConfiguration
-:socketConfiguration rdf:type owl:ObjectProperty ;
-                     rdfs:domain :Socket ;
-                     rdfs:range :SocketConfiguration .
+###  https://w3id.org/won/core#socketDefinition
+:socketDefinition rdf:type owl:ObjectProperty ;
+                  rdfs:domain :Socket ;
+                  rdfs:range :SocketDefinition ;
+                  rdfs:comment "Links the socket to its definition. A socket must have exactly one definition."@en .
 
 
 ###  https://w3id.org/won/core#supportsWonProtocolImpl
@@ -271,7 +263,7 @@ sought to fulfill the atom in contrast to the part that is available.""" ;
 
 ###  https://w3id.org/won/core#autoOpen
 :autoOpen rdf:type owl:DatatypeProperty ;
-          rdfs:domain :SocketConfiguration ;
+          rdfs:domain :SocketDefinition ;
           rdfs:range xsd:boolean ;
           rdfs:comment "Indicates that any incoming CONNECT/OPEN message will be answered with OPEN unless the facet configuration forbids it."@en .
 
@@ -332,7 +324,7 @@ sought to fulfill the atom in contrast to the part that is available.""" ;
 
 ###  https://w3id.org/won/core#socketCapacity
 :socketCapacity rdf:type owl:DatatypeProperty ;
-                rdfs:domain :SocketConfiguration ;
+                rdfs:domain :SocketDefinition ;
                 rdfs:range xsd:integer ;
                 rdfs:comment "Defines the maximum number of established connections supported by the socket."@en .
 
@@ -441,8 +433,9 @@ It specifies a content - what the atom is about, which may be something that is 
         rdfs:isDefinedBy <https://w3id.org/won/core> .
 
 
-###  https://w3id.org/won/core#SocketConfiguration
-:SocketConfiguration rdf:type owl:Class .
+###  https://w3id.org/won/core#SocketDefinition
+:SocketDefinition rdf:type owl:Class ;
+                  rdfs:comment "A Socket's definition."@en .
 
 
 ###  https://w3id.org/won/core#TimeSpecification


### PR DESCRIPTION
To avoid having to either perform inference or annotate each socket with
its type and its configuration, the distinction of type and
configuraiton was removed. A socket's socket type is now its definition;
SocketDefinitions are individuals.