### PR TITLE
Feat  deuglify activemq properties

### DIFF
--- a/webofneeds/conf/node.properties
+++ b/webofneeds/conf/node.properties
@@ -60,6 +60,7 @@ activemq.queuename.matcher.incoming=MatcherProtocol.in
 activemq.matcher.outgoing.topicname.atom.created = MatcherProtocol.Out.Atom
 activemq.matcher.outgoing.topicname.atom.activated = MatcherProtocol.Out.Atom
 activemq.matcher.outgoing.topicname.atom.deactivated = MatcherProtocol.Out.Atom
+activemq.matcher.outgoing.topicname.atom.deleted = MatcherProtocol.Out.Atom
 activemq.matcher.outgoing.topicname.matcher.registered = MatcherProtocol.Out.Matcher
 activemq.broker.keystore=/usr/local/tomcat/conf/ssl/t-keystore.jks
 activemq.broker.keystore.password=${CERTIFICATE_PASSWORD}

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/ActiveMQServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/ActiveMQServiceImpl.java
@@ -38,9 +38,9 @@ import won.protocol.vocabulary.WON;
 public class ActiveMQServiceImpl implements ActiveMQService {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final String PATH_OWNER_PROTOCOL_QUEUE_NAME = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQOwnerProtocolQueueName + ">";
+                    + WON.ownerQueue + ">";
     private static final String PATH_ATOM_PROTOCOL_QUEUE_NAME = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQAtomProtocolQueueName + ">";
+                    + WON.nodeQueue + ">";
     private static final String PATH_BROKER_URI = "<" + WON.supportsWonProtocolImpl + ">/<" + WON.brokerUri + ">";
     protected String queueNamePath;
     private List<String> matcherProtocolTopicList;

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/MatcherActiveMQServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/MatcherActiveMQServiceImpl.java
@@ -36,15 +36,13 @@ public class MatcherActiveMQServiceImpl extends ActiveMQServiceImpl implements M
     private List<String> matcherProtocolTopicList;
     private String pathInformation;
     private static final String PATH_MATCHER_PROTOCOL_OUT_ATOM_CREATED = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQMatcherProtocolOutAtomCreatedTopicName + ">";
+                    + WON.atomCreatedTopic + ">";
     private static final String PATH_MATCHER_PROTOCOL_OUT_ATOM_ACTIVATED = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQMatcherProtocolOutAtomActivatedTopicName + ">";
+                    + WON.atomActivatedTopic + ">";
     private static final String PATH_MATCHER_PROTOCOL_OUT_ATOM_DEACTIVATED = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQMatcherProtocolOutAtomDeactivatedTopicName + ">";
-    private static final String PATH_MATCHER_PROTOCOL_OUT_MATCHER_REGISTERED = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQMatcherProtocolOutMatcherRegisteredTopicName + ">";
+                    + WON.atomDeactivatedTopic + ">";
     private static final String PATH_MATCHER_PROTOCOL_QUEUE_NAME = "<" + WON.supportsWonProtocolImpl + ">/<"
-                    + WON.activeMQMatcherProtocolQueueName + ">";
+                    + WON.matcherQueue + ">";
 
     public MatcherActiveMQServiceImpl(ProtocolType type) {
         super(type);

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -28,25 +28,13 @@ public class WON {
     public static final Resource Atom = m.createResource(BASE_URI + "Atom");
     public static final Property wonNode = m.createProperty(BASE_URI, "wonNode");
     public static final Property defaultGraphSigningMethod = m.createProperty(BASE_URI, "defaultGraphSigningMethod");
-    public static final Property atomProtocolEndpoint = m.createProperty(BASE_URI, "atomProtocolEndpoint");
-    public static final Property matcherProtocolEndpoint = m.createProperty(BASE_URI, "matcherProtocolEndpoint");
-    public static final Property ownerProtocolEndpoint = m.createProperty(BASE_URI, "ownerProtocolEndpoint");
-    public static final Property activeMQAtomProtocolQueueName = m.createProperty(BASE_URI,
-                    "activeMQAtomProtocolQueueName");
-    public static final Property activeMQOwnerProtocolQueueName = m.createProperty(BASE_URI,
-                    "activeMQOwnerProtocolQueueName");
-    public static final Property activeMQMatcherProtocolQueueName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolQueueName");
-    public static final Property activeMQMatcherProtocolOutAtomCreatedTopicName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolOutAtomCreatedTopicName");
-    public static final Property activeMQMatcherProtocolOutAtomActivatedTopicName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolOutAtomActivatedTopicName");
-    public static final Property activeMQMatcherProtocolOutAtomDeactivatedTopicName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolOutAtomDeactivatedTopicName");
-    public static final Property activeMQMatcherProtocolOutAtomDeletedTopicName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolOutAtomDeletedTopicName");
-    public static final Property activeMQMatcherProtocolOutMatcherRegisteredTopicName = m.createProperty(BASE_URI,
-                    "activeMQMatcherProtocolOutMatcherRegisteredTopicName");
+    public static final Property nodeQueue = m.createProperty(BASE_URI, "nodeQueue");
+    public static final Property ownerQueue = m.createProperty(BASE_URI, "ownerQueue");
+    public static final Property matcherQueue = m.createProperty(BASE_URI, "matcherQueue");
+    public static final Property atomCreatedTopic = m.createProperty(BASE_URI, "atomCreatedTopic");
+    public static final Property atomActivatedTopic = m.createProperty(BASE_URI, "atomActivatedTopic");
+    public static final Property atomDeactivatedTopic = m.createProperty(BASE_URI, "atomDeactivatedTopic");
+    public static final Property atomDeletedTopic = m.createProperty(BASE_URI, "atomDeletedTopic");
     public static final Property uriPrefixSpecification = m.createProperty(BASE_URI, "uriPrefixSpecification");
     public static final Property atomUriPrefix = m.createProperty(BASE_URI, "atomUriPrefix");
     public static final Property connectionUriPrefix = m.createProperty(BASE_URI, "connectionUriPrefix");

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/config/ActiveMqWonNodeConnectionFactory.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/config/ActiveMqWonNodeConnectionFactory.java
@@ -50,14 +50,12 @@ public class ActiveMqWonNodeConnectionFactory {
         // read won node info
         String activeMq = WON.WonOverActiveMq.toString();
         String brokerUri = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq, WON.brokerUri.toString());
-        String createdTopic = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq,
-                        WON.activeMQMatcherProtocolOutAtomCreatedTopicName.toString());
+        String createdTopic = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq, WON.atomCreatedTopic.toString());
         String activatedTopic = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq,
-                        WON.activeMQMatcherProtocolOutAtomActivatedTopicName.toString());
+                        WON.atomActivatedTopic.toString());
         String deactivatedTopic = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq,
-                        WON.activeMQMatcherProtocolOutAtomDeactivatedTopicName.toString());
-        String hintQueue = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq,
-                        WON.activeMQMatcherProtocolQueueName.toString());
+                        WON.atomDeactivatedTopic.toString());
+        String hintQueue = wonNodeInfo.getSupportedProtocolImplParamValue(activeMq, WON.matcherQueue.toString());
         // create the activemq component for this won node
         String uuid = UUID.randomUUID().toString();
         String componentName = "activemq-" + uuid;

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -315,20 +315,17 @@ public class LinkedDataServiceImpl implements LinkedDataService {
         res.addProperty(WON.supportsWonProtocolImpl, blankNodeActiveMq);
         blankNodeActiveMq.addProperty(RDF.type, WON.WonOverActiveMq)
                         .addProperty(WON.brokerUri, model.createResource(this.activeMqEndpoint))
-                        .addProperty(WON.activeMQOwnerProtocolQueueName, this.activeMqOwnerProtcolQueueName,
+                        .addProperty(WON.ownerQueue, this.activeMqOwnerProtcolQueueName, XSDDatatype.XSDstring)
+                        .addProperty(WON.nodeQueue, this.activeMqAtomProtcolQueueName, XSDDatatype.XSDstring)
+                        .addProperty(WON.matcherQueue, this.activeMqMatcherPrtotocolQueueName, XSDDatatype.XSDstring)
+                        .addProperty(WON.atomActivatedTopic, this.activeMqMatcherProtocolTopicNameAtomActivated,
                                         XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQAtomProtocolQueueName, this.activeMqAtomProtcolQueueName,
+                        .addProperty(WON.atomDeactivatedTopic, this.activeMqMatcherProtocolTopicNameAtomDeactivated,
                                         XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQMatcherProtocolQueueName, this.activeMqMatcherPrtotocolQueueName,
+                        .addProperty(WON.atomDeletedTopic, this.activeMqMatcherProtocolTopicNameAtomDeleted,
                                         XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQMatcherProtocolOutAtomActivatedTopicName,
-                                        this.activeMqMatcherProtocolTopicNameAtomActivated, XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQMatcherProtocolOutAtomDeactivatedTopicName,
-                                        this.activeMqMatcherProtocolTopicNameAtomDeactivated, XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQMatcherProtocolOutAtomDeletedTopicName,
-                                        this.activeMqMatcherProtocolTopicNameAtomDeleted, XSDDatatype.XSDstring)
-                        .addProperty(WON.activeMQMatcherProtocolOutAtomCreatedTopicName,
-                                        this.activeMqMatcherProtocolTopicNameAtomCreated, XSDDatatype.XSDstring);
+                        .addProperty(WON.atomCreatedTopic, this.activeMqMatcherProtocolTopicNameAtomCreated,
+                                        XSDDatatype.XSDstring);
         Resource blankNodeUriSpec = model.createResource();
         res.addProperty(WON.uriPrefixSpecification, blankNodeUriSpec);
         blankNodeUriSpec.addProperty(WON.atomUriPrefix, model.createLiteral(this.atomResourceURIPrefix));


### PR DESCRIPTION
Renamed the RDF properties used to specify how to connect to the WoN node via activemq.

How to test:
* Check https://satvm05.researchstudio.at/won/resource (on integrationtest). The new properties look like this:
```
 won:supportsWonProtocolImpl  [ a                         won:WonOverActiveMq ;
                                           won:atomActivatedTopic    "MatcherProtocol.Out.Atom" ;
                                           won:atomCreatedTopic      "MatcherProtocol.Out.Atom" ;
                                           won:atomDeactivatedTopic  "MatcherProtocol.Out.Atom" ;
                                           won:atomDeletedTopic      "MatcherProtocol.Out.Atom" ;
                                           won:brokerUri             <ssl://satvm05.researchstudio.at:61617> ;
                                           won:matcherQueue          "MatcherProtocol.in" ;
                                           won:nodeQueue             "AtomProtocol.in" ;
                                           won:ownerQueue            "OwnerProtocol.in"
```
If you see these, you're running the PR's code

The change is successful if owner, matching and debugbot all work.