### PR TITLE
Spoco Pokemon Go UseCases and Details

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -326,17 +326,6 @@ function connectReactionAtom(
     const connectoToAtom = getIn(state, ["atoms", connectToAtomUri]);
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
 
-    //add flags
-    atomDraft.content.flags
-      ? atomDraft.content.flags.push(
-          "won:NoHintForCounterpart",
-          "won:NoHintForMe"
-        )
-      : (atomDraft.content.flags = [
-          "won:NoHintForCounterpart",
-          "won:NoHintForMe",
-        ]);
-
     // create new atom
     const { message, eventUri, atomUri } = await buildCreateMessage(
       atomDraft,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.js
@@ -16,6 +16,7 @@ import {
 import { doneTypingBufferNg, DomCache } from "../../../cstm-ng-utils.js";
 
 import { initLeaflet, leafletBounds } from "../../../won-utils.js";
+import titlePickerModule from "./title-picker.js";
 
 import "style/_locationpicker.scss";
 
@@ -80,7 +81,16 @@ function genComponentConf() {
                 </a>
             </li>
         </ul>
+        <!-- MAP VIEW -->
         <div class="lp__mapmount" in-view="$inview && self.mapInView($inviewInfo)"></div>
+        <!-- ADDRESS OVERRIDE -->
+        <won-title-picker
+          ng-if="self.pickedLocation"
+          class="lp__addressoverride"
+          initial-value="self.alternativeName"
+          on-update="self.updateAddressName(value)"
+          detail="self.detail && self.detail.overrideAddressDetail">
+        </won-title-picker>
             `;
 
   class Controller {
@@ -93,6 +103,7 @@ function genComponentConf() {
 
       this.locationIsSaved = !!this.initialValue;
       this.pickedLocation = this.initialValue;
+      this.alternativeName = undefined;
       this.previousLocation = undefined;
       this.showResetButton = false;
 
@@ -114,6 +125,17 @@ function genComponentConf() {
         this.onUpdate({ value: location });
       } else {
         this.onUpdate({ value: undefined });
+      }
+    }
+
+    updateAddressName(name) {
+      if (this.pickedLocation) {
+        if (name) {
+          this.pickedLocation.name = name;
+        } else {
+          this.pickedLocation.name = this.textfield().value;
+        }
+        this.onUpdate({ value: this.pickedLocation });
       }
     }
 
@@ -156,6 +178,7 @@ function genComponentConf() {
 
       this.locationIsSaved = false;
       this.pickedLocation = undefined;
+      this.alternativeName = undefined;
       this.placeMarkers([]);
       this.showResetButton = false;
 
@@ -167,6 +190,7 @@ function genComponentConf() {
       this.update(location);
       this.locationIsSaved = true;
       this.pickedLocation = location;
+      this.alternativeName = undefined;
 
       this.resetSearchResults(); // picked one, can hide the rest if they were there
       this.textfield().value = location.name;
@@ -220,6 +244,7 @@ function genComponentConf() {
         this.map.invalidateSize();
 
         this.textfield().value = this.pickedLocation.name;
+        this.alternativeName = undefined;
         this.showResetButton = true;
         this.placeMarkers([this.pickedLocation]);
         this.markers[0].openPopup();
@@ -342,7 +367,7 @@ function onMapClick(e, ctrl) {
 }
 
 export default angular
-  .module("won.owner.components.locationPicker", [])
+  .module("won.owner.components.locationPicker", [titlePickerModule])
   .directive("wonLocationPicker", genComponentConf).name;
 
 window.searchNominatim4dbg = searchNominatim;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
@@ -21,6 +21,7 @@ import reviewPickerModule from "./review-picker.js";
 import suggestPostPickerModule from "./suggestpost-picker.js";
 import paypalPaymentPickerModule from "./paypal-payment-picker.js";
 import pokemonRaidbossPickerModule from "./pokemon-raidboss-picker.js";
+import pokemonGymPickerModule from "./pokemon-gym-picker.js";
 
 /**
  * module names for angular's module system
@@ -49,4 +50,5 @@ export default [
   suggestPostPickerModule,
   paypalPaymentPickerModule,
   pokemonRaidbossPickerModule,
+  pokemonGymPickerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pickers.js
@@ -20,6 +20,7 @@ import petrinettransitionPickerModule from "./petrinettransition-picker.js";
 import reviewPickerModule from "./review-picker.js";
 import suggestPostPickerModule from "./suggestpost-picker.js";
 import paypalPaymentPickerModule from "./paypal-payment-picker.js";
+import pokemonRaidbossPickerModule from "./pokemon-raidboss-picker.js";
 
 /**
  * module names for angular's module system
@@ -47,4 +48,5 @@ export default [
   reviewPickerModule,
   suggestPostPickerModule,
   paypalPaymentPickerModule,
+  pokemonRaidbossPickerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
@@ -1,29 +1,12 @@
 import angular from "angular";
 import { attach, delay } from "../../../utils.js";
 import { DomCache } from "../../../cstm-ng-utils.js";
-import locationPickerModule from "./location-picker.js";
-import descriptionPickerModule from "./description-picker.js";
-import titlePickerModule from "./title-picker.js";
 
 import "style/_pokemongympicker.scss";
 
 const serviceDependencies = ["$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <label class="pgp__label">Name:</label>
-      <won-title-picker
-          class="pgp__name"
-          initial-value="self.pokemonGym.name"
-          on-update="self.updateName(value)"
-          detail="self.detail && self.detail.nameDetail">
-      </won-title-picker>
-      <label class="pgp__label">Location:</label>
-      <won-location-picker
-          class="pgp__location pgp__label--location"
-          initial-value="self.pokemonGym.location"
-          on-update="self.updateLocation(value)"
-          detail="self.detail && self.detail.locationDetail">
-      </won-location-picker>
       <label for="pgp__ex" class="pgp__label">Gym Ex:</label>
       <input
           type="checkbox"
@@ -31,13 +14,6 @@ function genComponentConf() {
           class="pgp__ex"
           ng-model="self.pokemonGym.ex"
           ng-change="self.updateEx(self.pokemonGym.ex)"/>
-      <label class="pgp__label pgp__label--info">Additional Info:</label>
-      <won-description-picker
-          class="pgp__info"
-          initial-value="self.pokemonGym.info"
-          on-update="self.updateInfo(value)"
-          detail="self.detail && self.detail.infoDetail">
-      </won-description-picker>
     `;
 
   class Controller {
@@ -57,13 +33,8 @@ function genComponentConf() {
      */
     update(pokemonGym) {
       if (this.detail.isValid(pokemonGym)) {
-        console.debug("gym: ", pokemonGym);
-        //TODO IMPL (include an isValid of some sorts)
         this.onUpdate({
           value: {
-            name: pokemonGym.name,
-            location: pokemonGym.location,
-            info: pokemonGym.info,
             ex: pokemonGym.ex,
           },
         });
@@ -76,21 +47,6 @@ function genComponentConf() {
       this.pokemonGym = this.initialValue || {};
 
       this.$scope.$apply();
-    }
-
-    updateLocation(location) {
-      this.pokemonGym.location = location;
-      this.update(this.pokemonGym);
-    }
-
-    updateInfo(info) {
-      this.pokemonGym.info = info;
-      this.update(this.pokemonGym);
-    }
-
-    updateName(name) {
-      this.pokemonGym.name = name;
-      this.update(this.pokemonGym);
     }
 
     updateEx(ex) {
@@ -115,9 +71,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.pokemonGymPicker", [
-    titlePickerModule,
-    locationPickerModule,
-    descriptionPickerModule,
-  ])
+  .module("won.owner.components.pokemonGymPicker", [])
   .directive("pokemonGymPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
@@ -30,8 +30,7 @@ function genComponentConf() {
           id="pgp__ex"
           class="pgp__ex"
           ng-model="self.pokemonGym.ex"
-          ng-change="self.updateEx(self.pokemonGym.ex)"
-          class="prbp__hatched" />
+          ng-change="self.updateEx(self.pokemonGym.ex)"/>
       <label class="pgp__label">Additional Info:</label>
       <won-description-picker
           class="pgp__info"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
@@ -10,13 +10,6 @@ import "style/_pokemongympicker.scss";
 const serviceDependencies = ["$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <label class="pgp__label">Location:</label>
-      <won-location-picker
-          class="pgp__location"
-          initial-value="self.pokemonGym.location"
-          on-update="self.updateLocation(value)"
-          detail="self.detail && self.detail.locationDetail">
-      </won-location-picker>
       <label class="pgp__label">Name:</label>
       <won-title-picker
           class="pgp__name"
@@ -24,6 +17,13 @@ function genComponentConf() {
           on-update="self.updateName(value)"
           detail="self.detail && self.detail.nameDetail">
       </won-title-picker>
+      <label class="pgp__label">Location:</label>
+      <won-location-picker
+          class="pgp__location pgp__label--location"
+          initial-value="self.pokemonGym.location"
+          on-update="self.updateLocation(value)"
+          detail="self.detail && self.detail.locationDetail">
+      </won-location-picker>
       <label for="pgp__ex" class="pgp__label">Gym Ex:</label>
       <input
           type="checkbox"
@@ -31,7 +31,7 @@ function genComponentConf() {
           class="pgp__ex"
           ng-model="self.pokemonGym.ex"
           ng-change="self.updateEx(self.pokemonGym.ex)"/>
-      <label class="pgp__label">Additional Info:</label>
+      <label class="pgp__label pgp__label--info">Additional Info:</label>
       <won-description-picker
           class="pgp__info"
           initial-value="self.pokemonGym.info"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
@@ -1,0 +1,112 @@
+import angular from "angular";
+import { attach, delay } from "../../../utils.js";
+import { DomCache } from "../../../cstm-ng-utils.js";
+import wonInput from "../../../directives/input.js";
+import "angular-marked";
+
+import "style/_pokemongympicker.scss";
+import "style/_won-markdown.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <div class="pgp__input">
+      GYM PICKA!!! TODO: REMOVE THIS LINE!!!
+        <svg class="pgp__input__icon clickable"
+          style="--local-primary:var(--won-primary-color);"
+          ng-if="self.showResetButton"
+          ng-click="self.resetDescription()">
+          <use xlink:href="#ico36_close" href="#ico36_close"></use>
+        </svg>
+        <textarea
+          won-textarea-autogrow
+          class="pgp__input__inner"
+          won-input="::self.updateDescription()"
+          placeholder="{{self.detail.placeholder}}"></textarea>
+      </div>
+      <div class="pgp__preview__header">Preview</div>
+      <div ng-if="self.addedDescription" class="pgp__preview__content markdown" marked="self.addedDescription"></div>
+      <div ng-if="!self.addedDescription" class="pgp__preview__content--empty>Add Content to see instant preview</div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.domCache = new DomCache(this.$element);
+
+      window.pkmGymp4dbg = this;
+
+      this.addedDescription = this.initialValue;
+      this.showResetButton = false;
+
+      delay(0).then(() => this.showInitialDescription());
+    }
+
+    /**
+     * Checks validity and uses callback method
+     */
+    update(description) {
+      if (description && description.trim().length > 0) {
+        this.onUpdate({ value: description });
+      } else {
+        this.onUpdate({ value: undefined });
+      }
+    }
+
+    showInitialDescription() {
+      this.addedDescription = this.initialValue;
+
+      if (this.initialValue && this.initialValue.trim().length > 0) {
+        this.textfield().value = this.initialValue.trim();
+        this.showResetButton = true;
+      }
+
+      this.$scope.$apply();
+    }
+
+    updateDescription() {
+      const text = this.textfield().value;
+
+      if (text && text.trim().length > 0) {
+        this.addedDescription = text;
+        this.update(this.addedDescription);
+        this.showResetButton = true;
+      } else {
+        this.resetDescription();
+      }
+    }
+
+    resetDescription() {
+      this.addedDescription = undefined;
+      this.textfield().value = "";
+      this.update(undefined);
+      this.showResetButton = false;
+    }
+
+    textfieldNg() {
+      return this.domCache.ng(".pgp__input__inner");
+    }
+
+    textfield() {
+      return this.domCache.dom(".pgp__input__inner");
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      onUpdate: "&",
+      initialValue: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.pokemonGymPicker", [wonInput, "hc.marked"])
+  .directive("pokemonGymPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-gym-picker.js
@@ -1,32 +1,44 @@
 import angular from "angular";
 import { attach, delay } from "../../../utils.js";
 import { DomCache } from "../../../cstm-ng-utils.js";
-import wonInput from "../../../directives/input.js";
-import "angular-marked";
+import locationPickerModule from "./location-picker.js";
+import descriptionPickerModule from "./description-picker.js";
+import titlePickerModule from "./title-picker.js";
 
 import "style/_pokemongympicker.scss";
-import "style/_won-markdown.scss";
 
 const serviceDependencies = ["$scope", "$element"];
 function genComponentConf() {
   let template = `
-      <div class="pgp__input">
-      GYM PICKA!!! TODO: REMOVE THIS LINE!!!
-        <svg class="pgp__input__icon clickable"
-          style="--local-primary:var(--won-primary-color);"
-          ng-if="self.showResetButton"
-          ng-click="self.resetDescription()">
-          <use xlink:href="#ico36_close" href="#ico36_close"></use>
-        </svg>
-        <textarea
-          won-textarea-autogrow
-          class="pgp__input__inner"
-          won-input="::self.updateDescription()"
-          placeholder="{{self.detail.placeholder}}"></textarea>
-      </div>
-      <div class="pgp__preview__header">Preview</div>
-      <div ng-if="self.addedDescription" class="pgp__preview__content markdown" marked="self.addedDescription"></div>
-      <div ng-if="!self.addedDescription" class="pgp__preview__content--empty>Add Content to see instant preview</div>
+      <label class="pgp__label">Location:</label>
+      <won-location-picker
+          class="pgp__location"
+          initial-value="self.pokemonGym.location"
+          on-update="self.updateLocation(value)"
+          detail="self.detail && self.detail.locationDetail">
+      </won-location-picker>
+      <label class="pgp__label">Name:</label>
+      <won-title-picker
+          class="pgp__name"
+          initial-value="self.pokemonGym.name"
+          on-update="self.updateName(value)"
+          detail="self.detail && self.detail.nameDetail">
+      </won-title-picker>
+      <label for="pgp__ex" class="pgp__label">Gym Ex:</label>
+      <input
+          type="checkbox"
+          id="pgp__ex"
+          class="pgp__ex"
+          ng-model="self.pokemonGym.ex"
+          ng-change="self.updateEx(self.pokemonGym.ex)"
+          class="prbp__hatched" />
+      <label class="pgp__label">Additional Info:</label>
+      <won-description-picker
+          class="pgp__info"
+          initial-value="self.pokemonGym.info"
+          on-update="self.updateInfo(value)"
+          detail="self.detail && self.detail.infoDetail">
+      </won-description-picker>
     `;
 
   class Controller {
@@ -36,59 +48,55 @@ function genComponentConf() {
 
       window.pkmGymp4dbg = this;
 
-      this.addedDescription = this.initialValue;
-      this.showResetButton = false;
+      this.pokemonGym = this.initialValue || {};
 
-      delay(0).then(() => this.showInitialDescription());
+      delay(0).then(() => this.showInitialValues());
     }
 
     /**
      * Checks validity and uses callback method
      */
-    update(description) {
-      if (description && description.trim().length > 0) {
-        this.onUpdate({ value: description });
+    update(pokemonGym) {
+      if (this.detail.isValid(pokemonGym)) {
+        console.debug("gym: ", pokemonGym);
+        //TODO IMPL (include an isValid of some sorts)
+        this.onUpdate({
+          value: {
+            name: pokemonGym.name,
+            location: pokemonGym.location,
+            info: pokemonGym.info,
+            ex: pokemonGym.ex,
+          },
+        });
       } else {
         this.onUpdate({ value: undefined });
       }
     }
 
-    showInitialDescription() {
-      this.addedDescription = this.initialValue;
-
-      if (this.initialValue && this.initialValue.trim().length > 0) {
-        this.textfield().value = this.initialValue.trim();
-        this.showResetButton = true;
-      }
+    showInitialValues() {
+      this.pokemonGym = this.initialValue || {};
 
       this.$scope.$apply();
     }
 
-    updateDescription() {
-      const text = this.textfield().value;
-
-      if (text && text.trim().length > 0) {
-        this.addedDescription = text;
-        this.update(this.addedDescription);
-        this.showResetButton = true;
-      } else {
-        this.resetDescription();
-      }
+    updateLocation(location) {
+      this.pokemonGym.location = location;
+      this.update(this.pokemonGym);
     }
 
-    resetDescription() {
-      this.addedDescription = undefined;
-      this.textfield().value = "";
-      this.update(undefined);
-      this.showResetButton = false;
+    updateInfo(info) {
+      this.pokemonGym.info = info;
+      this.update(this.pokemonGym);
     }
 
-    textfieldNg() {
-      return this.domCache.ng(".pgp__input__inner");
+    updateName(name) {
+      this.pokemonGym.name = name;
+      this.update(this.pokemonGym);
     }
 
-    textfield() {
-      return this.domCache.dom(".pgp__input__inner");
+    updateEx(ex) {
+      this.pokemonGym.ex = ex;
+      this.update(this.pokemonGym);
     }
   }
   Controller.$inject = serviceDependencies;
@@ -108,5 +116,9 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.pokemonGymPicker", [wonInput, "hc.marked"])
+  .module("won.owner.components.pokemonGymPicker", [
+    titlePickerModule,
+    locationPickerModule,
+    descriptionPickerModule,
+  ])
   .directive("pokemonGymPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -27,8 +27,7 @@ function genComponentConf() {
           id="prbp__hatched"
           class="prbp__hatched"
           ng-model="self.pokemonRaidBoss.hatched"
-          ng-change="self.updateHatched(self.pokemonRaidBoss.hatched)"
-          class="prbp__hatched" />
+          ng-change="self.updateHatched(self.pokemonRaidBoss.hatched)"/>
       <label class="prbp__label" ng-class="{'prbp__label--disabled': self.pokemonRaidBoss.hatched}">Hatches at</label>
       <won-datetime-picker
           ng-class="{'prbp__hatches--disabled': self.pokemonRaidBoss.hatched}"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -1,0 +1,204 @@
+import angular from "angular";
+import { attach, delay } from "../../../utils.js";
+import { DomCache } from "../../../cstm-ng-utils.js";
+import datetimePickerModule from "./datetime-picker.js";
+import titlePickerModule from "./title-picker.js";
+
+import "style/_pokemonraidbosspicker.scss";
+
+const serviceDependencies = ["$scope", "$element"];
+function genComponentConf() {
+  let template = `
+      <div class="prbp__level">
+          <input id="prbp__level__1" type="radio" name="prbp__level" class="prbp__level__option" value="1" ng-checked="self.isLevelChecked(1)"/>
+          <label for="prbp__level__1" ng-click="self.updateLevel(1)">{{ self.detail.getLevelLabel(1) }}</label>
+          <input id="prbp__level__2" type="radio" name="prbp__level" class="prbp__level__option" value="2" ng-checked="self.isLevelChecked(2)"/>
+          <label for="prbp__level__2" ng-click="self.updateLevel(2)">{{ self.detail.getLevelLabel(2) }}</label>
+          <input id="prbp__level__3" type="radio" name="prbp__level" class="prbp__level__option" value="3" ng-checked="self.isLevelChecked(3)"/>
+          <label for="prbp__level__3" ng-click="self.updateLevel(3)">{{ self.detail.getLevelLabel(3) }}</label>
+          <input id="prbp__level__4" type="radio" name="prbp__level" class="prbp__level__option" value="4" ng-checked="self.isLevelChecked(4)"/>
+          <label for="prbp__level__4" ng-click="self.updateLevel(4)">{{ self.detail.getLevelLabel(4) }}</label>
+          <input id="prbp__level__5" type="radio" name="prbp__level" class="prbp__level__option" value="5" ng-checked="self.isLevelChecked(5)"/>
+          <label for="prbp__level__5" ng-click="self.updateLevel(5)">{{ self.detail.getLevelLabel(5) }}</label>
+      </div>
+      <label for="prbp__hatched">Hatched</label>
+      <input
+          type="checkbox"
+          id="prbp__hatched"
+          class="prbp__hatched"
+          ng-model="self.pokemonRaidBoss.hatched"
+          ng-change="self.updateHatched(self.pokemonRaidBoss.hatched)"
+          class="prbp__hatched" />
+      <label class="prbp__label" ng-class="{'prbp__label--disabled': self.pokemonRaidBoss.hatched}">Hatches at</label>
+      <won-datetime-picker
+          ng-class="{'prbp__hatches--disabled': self.pokemonRaidBoss.hatched}"
+          class="prbp__hatches"
+          initial-value="self.initialValue && self.initialValue.hatches"
+          on-update="self.updateHatches(value)"
+          detail="self.detail && self.detail.hatches">
+      </won-datetime-picker>
+      <label class="prbp__label">Expires at</label>
+      <won-datetime-picker
+          class="prbp__expires"
+          initial-value="self.initialValue && self.initialValue.expires"
+          on-update="self.updateExpires(value)"
+          detail="self.detail && self.detail.expires">
+      </won-datetime-picker>
+      <label class="prbp__label"
+          ng-class="{'prbp__label--disabled': !self.pokemonRaidBoss.hatched}">Pokemon</label>
+      <won-title-picker
+          ng-class="{'prbp__pokemon--disabled': !self.pokemonRaidBoss.hatched}"
+          class="prbp__pokemon"
+          initial-value="self.pokemonFilter"
+          on-update="self.updatePokemonFilter(value)"
+          detail="self.detail && self.detail.filterDetail">
+      </won-title-picker>
+      <div class="prbp__pokemonlist" ng-class="{'prbp__pokemonlist--disabled': !self.pokemonRaidBoss.hatched}">
+        <div class="prbp__pokemonlist__pokemon"
+          ng-repeat="pokemon in self.detail.pokemonList | filter:self.filterPokemon(self.pokemonFilter, self.pokemonRaidBoss.id)"
+          ng-class="{
+            'prbp__pokemonlist__pokemon--selected': self.pokemonRaidBoss.id === pokemon.id
+          }"
+          ng-click="self.updateId(pokemon.id)">
+          <img class="prbp__pokemonlist__pokemon__image" src="{{pokemon.imageUrl}}"/>
+          <div class="prbp__pokemonlist__pokemon__id">
+            #{{pokemon.id}}
+          </div>
+          <div class="prbp__pokemonlist__pokemon__name">
+            {{pokemon.name}}
+          </div>
+        </div>
+      </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      this.domCache = new DomCache(this.$element);
+
+      window.pkmRaidBossp4dbg = this;
+
+      this.pokemonRaidBoss = this.initialValue || { level: 1 };
+
+      this.pokemonFilter =
+        this.initialValue &&
+        this.detail &&
+        this.detail.getPokemonNameById(this.initialValue.id);
+
+      delay(0).then(() => this.showInitialValues());
+    }
+
+    /**
+     * Checks validity and uses callback method
+     */
+    update(pokemonRaidBoss) {
+      if (this.detail.isValid(pokemonRaidBoss)) {
+        this.onUpdate({
+          value: {
+            id: pokemonRaidBoss.hatched ? pokemonRaidBoss.id : undefined,
+            level: pokemonRaidBoss.level,
+            hatched: pokemonRaidBoss.hatched,
+            hatches: !pokemonRaidBoss.hatched
+              ? pokemonRaidBoss.hatches
+              : undefined,
+            expires: pokemonRaidBoss.expires,
+          },
+        });
+      } else {
+        this.onUpdate({ value: undefined });
+      }
+    }
+
+    filterPokemon(pokemonFilter, selectedId) {
+      return pokemon => {
+        if (pokemonFilter) {
+          const filterArray =
+            pokemonFilter &&
+            pokemonFilter
+              .trim()
+              .toLowerCase()
+              .split(" ");
+          if (filterArray && filterArray.length > 0) {
+            for (const idx in filterArray) {
+              if (
+                (selectedId && selectedId == pokemon.id) ||
+                pokemon.name.toLowerCase().includes(filterArray[idx]) ||
+                pokemon.id == filterArray[idx] ||
+                "#" + pokemon.id === filterArray[idx]
+              ) {
+                return true;
+              }
+            }
+            return false;
+          }
+        }
+        return true;
+      };
+    }
+
+    updateHatched(hatched) {
+      this.pokemonRaidBoss.hatched = hatched;
+      this.update(this.pokemonRaidBoss);
+    }
+
+    updateHatches(datetime) {
+      this.pokemonRaidBoss.hatches = datetime;
+      this.update(this.pokemonRaidBoss);
+    }
+
+    updateExpires(datetime) {
+      this.pokemonRaidBoss.expires = datetime;
+      this.update(this.pokemonRaidBoss);
+    }
+
+    updateLevel(level) {
+      this.pokemonRaidBoss.level = level;
+      this.update(this.pokemonRaidBoss);
+    }
+
+    isLevelChecked(option) {
+      return this.pokemonRaidBoss && this.pokemonRaidBoss.level === option;
+    }
+
+    updatePokemonFilter(filter) {
+      this.pokemonFilter = filter && filter.trim();
+    }
+
+    updateId(id) {
+      this.pokemonRaidBoss.id = this.pokemonRaidBoss.id != id ? id : undefined;
+      this.pokemonFilter =
+        this.detail && this.detail.getPokemonNameById(this.pokemonRaidBoss.id);
+      this.update(this.pokemonRaidBoss);
+    }
+
+    showInitialValues() {
+      this.pokemonRaidBoss = this.initialValue || { level: 1 };
+      this.pokemonFilter =
+        this.pokemonRaidBoss &&
+        this.detail &&
+        this.detail.getPokemonNameById(this.pokemonRaidBoss.id);
+      this.$scope.$apply();
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      onUpdate: "&",
+      initialValue: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.pokemonRaidbossPicker", [
+    datetimePickerModule,
+    titlePickerModule,
+  ])
+  .directive("pokemonRaidbossPicker", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.js
@@ -1,0 +1,111 @@
+import angular from "angular";
+import "ng-redux";
+import { actionCreators } from "../../../actions/actions.js";
+import { attach, get } from "../../../utils.js";
+import { connect2Redux } from "../../../won-utils.js";
+import * as generalSelectors from "../../../selectors/general-selectors.js";
+import atomMapModule from "../../atom-map.js";
+import "angular-marked";
+
+import "style/_pokemon-gym-viewer.scss";
+import "style/_won-markdown.scss";
+
+const serviceDependencies = ["$scope", "$ngRedux", "$element"];
+function genComponentConf() {
+  let template = `
+        <div class="pgv__header">
+          <svg class="pgv__header__icon" ng-if="self.detail.icon">
+              <use xlink:href={{self.detail.icon}} href={{self.detail.icon}}></use>
+          </svg>
+          <span class="pgv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
+        </div>
+        <div class="pgv__content">
+          <div class="pgv__content__label">Location:</div>
+          <div class="pgv__content__name" ng-click="self.toggleMap()">
+            <div class="pgv__content__name__label">{{ self.name }}<span class="pgv__content__name__label__ex" ng-if="self.ex">(Ex Gym)</span></div>
+            <svg class="pgv__content__name__carret">
+              <use xlink:href="#ico-filter_map" href="#ico-filter_map"></use>
+            </svg>
+            <svg class="pgv__content__name__carret" ng-show="!self.showMap">
+              <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+            </svg>
+            <svg class="pgv__content__name__carret" ng-show="self.showMap">
+               <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+            </svg>
+          </div>
+          <!-- TODO Location -->
+          <won-atom-map
+            locations="[self.location]"
+            current-location="self.currentLocation"
+            ng-if="self.location && self.showMap">
+          </won-atom-map>
+          <div class="pgv__content__label pgv__content__label--info" ng-if="self.info" ng-click="self.toggleAdditionalInfo()">
+            Additional Information
+            <svg class="pgv__content__label__carret" ng-show="!self.showAdditionalInfo">
+              <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
+            </svg>
+            <svg class="pgv__content__label__carret" ng-show="self.showAdditionalInfo">
+               <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
+            </svg>
+          </div>
+          <div class="pgv__content__info markdown" marked="self.info" ng-if="self.info && self.showAdditionalInfo"></div>
+        </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      window.paypalpaymentv4dbg = this;
+      this.showMap = false;
+      this.showAdditionalInfo = false;
+
+      const selectFromState = state => {
+        const currentLocation = generalSelectors.getCurrentLocation(state);
+
+        const ex = get(this.content, "ex");
+        const name = get(this.content, "name");
+        const info = get(this.content, "info");
+        const location = get(this.content, "location");
+
+        return {
+          currentLocation,
+          name,
+          info,
+          location,
+          ex,
+        };
+      };
+
+      connect2Redux(
+        selectFromState,
+        actionCreators,
+        ["self.content", "self.detail"],
+        this
+      );
+    }
+
+    toggleMap() {
+      this.showMap = !this.showMap;
+    }
+    toggleAdditionalInfo() {
+      this.showAdditionalInfo = !this.showAdditionalInfo;
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      content: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.pokemonGymViewer", [atomMapModule, "hc.marked"])
+  .directive("pokemonGymViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.js
@@ -3,9 +3,6 @@ import "ng-redux";
 import { actionCreators } from "../../../actions/actions.js";
 import { attach, get } from "../../../utils.js";
 import { connect2Redux } from "../../../won-utils.js";
-import * as generalSelectors from "../../../selectors/general-selectors.js";
-import atomMapModule from "../../atom-map.js";
-import "angular-marked";
 
 import "style/_pokemon-gym-viewer.scss";
 import "style/_won-markdown.scss";
@@ -20,58 +17,19 @@ function genComponentConf() {
           <span class="pgv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
         </div>
         <div class="pgv__content">
-          <div class="pgv__content__label">Location:</div>
-          <div class="pgv__content__name" ng-click="self.toggleMap()">
-            <div class="pgv__content__name__label">{{ self.name }}<span class="pgv__content__name__label__ex" ng-if="self.ex">(Ex Gym)</span></div>
-            <svg class="pgv__content__name__carret">
-              <use xlink:href="#ico-filter_map" href="#ico-filter_map"></use>
-            </svg>
-            <svg class="pgv__content__name__carret" ng-show="!self.showMap">
-              <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
-            </svg>
-            <svg class="pgv__content__name__carret" ng-show="self.showMap">
-               <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
-            </svg>
-          </div>
-          <!-- TODO Location -->
-          <won-atom-map
-            locations="[self.location]"
-            current-location="self.currentLocation"
-            ng-if="self.location && self.showMap">
-          </won-atom-map>
-          <div class="pgv__content__label pgv__content__label--info" ng-if="self.info" ng-click="self.toggleAdditionalInfo()">
-            Additional Information
-            <svg class="pgv__content__label__carret" ng-show="!self.showAdditionalInfo">
-              <use xlink:href="#ico16_arrow_down" href="#ico16_arrow_down"></use>
-            </svg>
-            <svg class="pgv__content__label__carret" ng-show="self.showAdditionalInfo">
-               <use xlink:href="#ico16_arrow_up" href="#ico16_arrow_up"></use>
-            </svg>
-          </div>
-          <div class="pgv__content__info markdown" marked="self.info" ng-if="self.info && self.showAdditionalInfo"></div>
+          <div class="pgv__content__ex" ng-if="self.ex">This is an Ex Gym!</div>
         </div>
     `;
 
   class Controller {
     constructor() {
       attach(this, serviceDependencies, arguments);
-      window.paypalpaymentv4dbg = this;
-      this.showMap = false;
-      this.showAdditionalInfo = false;
+      window.pgv4dbg = this;
 
-      const selectFromState = state => {
-        const currentLocation = generalSelectors.getCurrentLocation(state);
-
+      const selectFromState = () => {
         const ex = get(this.content, "ex");
-        const name = get(this.content, "name");
-        const info = get(this.content, "info");
-        const location = get(this.content, "location");
 
         return {
-          currentLocation,
-          name,
-          info,
-          location,
           ex,
         };
       };
@@ -82,13 +40,6 @@ function genComponentConf() {
         ["self.content", "self.detail"],
         this
       );
-    }
-
-    toggleMap() {
-      this.showMap = !this.showMap;
-    }
-    toggleAdditionalInfo() {
-      this.showAdditionalInfo = !this.showAdditionalInfo;
     }
   }
   Controller.$inject = serviceDependencies;
@@ -107,5 +58,5 @@ function genComponentConf() {
 }
 
 export default angular
-  .module("won.owner.components.pokemonGymViewer", [atomMapModule, "hc.marked"])
+  .module("won.owner.components.pokemonGymViewer", [])
   .directive("pokemonGymViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
@@ -28,7 +28,10 @@ function genComponentConf() {
           <div class="prbv__content__pokemon" ng-if="self.hatched && self.pokemon">
             <img class="prbv__content__pokemon__image" src="{{self.pokemon.imageUrl}}"/>
             <div class="prbv__content__pokemon__id">#{{self.pokemon.id}}</div>
-            <div class="prbv__content__pokemon__name">{{self.pokemon.name}}</div>
+            <div class="prbv__content__pokemon__name">
+              {{self.pokemon.name}}
+              <span class="prbv__content__pokemon__name__form" ng-if="self.form">({{ self.form }})</span>
+            </div>
           </div>
           <div class="prbv__content__pokemon" ng-if="!self.hatched || !self.pokemon">
             <img class="prbv__content__pokemon__image prbv__content__pokemon__image--unhatched" src="{{self.detail.pokemonList[0].imageUrl}}"/>
@@ -52,6 +55,7 @@ function genComponentConf() {
 
       const selectFromState = state => {
         const id = get(this.content, "id");
+        const form = get(this.content, "form");
         const level = get(this.content, "level");
         const hatches = get(this.content, "hatches");
         const expires = get(this.content, "expires");
@@ -62,7 +66,8 @@ function genComponentConf() {
             id &&
             this.detail &&
             this.detail.findPokemonById &&
-            this.detail.findPokemonById(id),
+            this.detail.findPokemonById(id, form),
+          form,
           level,
           levelLabel:
             level &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
@@ -1,0 +1,122 @@
+import angular from "angular";
+import { attach, get } from "../../../utils.js";
+import "ng-redux";
+import { actionCreators } from "../../../actions/actions.js";
+import { connect2Redux } from "../../../won-utils.js";
+import { relativeTime } from "../../../won-label-utils.js";
+import { selectLastUpdateTime } from "../../../selectors/general-selectors.js";
+import "style/_pokemon-raidboss-viewer.scss";
+
+const serviceDependencies = ["$scope", "$ngRedux", "$element"];
+function genComponentConf() {
+  let template = `
+        <div class="prbv__header">
+          <svg class="prbv__header__icon" ng-if="self.detail.icon">
+              <use xlink:href={{self.detail.icon}} href={{self.detail.icon}}></use>
+          </svg>
+          <span class="prbv__header__label" ng-if="self.detail.label">{{self.detail.label}}</span>
+        </div>
+        <div class="prbv__content">
+          <div class="prbv__content__level"
+            ng-class="{
+              'prbv__content__level--normal': self.level == 1 || self.level == 2,
+              'prbv__content__level--rare': self.level == 3 || self.level == 4,
+              'prbv__content__level--legendary': self.level == 5,
+            }">
+            {{ self.levelLabel }}
+          </div>
+          <div class="prbv__content__pokemon" ng-if="self.hatched && self.pokemon">
+            <img class="prbv__content__pokemon__image" src="{{self.pokemon.imageUrl}}"/>
+            <div class="prbv__content__pokemon__id">#{{self.pokemon.id}}</div>
+            <div class="prbv__content__pokemon__name">{{self.pokemon.name}}</div>
+          </div>
+          <div class="prbv__content__pokemon" ng-if="!self.hatched || !self.pokemon">
+            <img class="prbv__content__pokemon__image prbv__content__pokemon__image--unhatched" src="{{self.detail.pokemonList[0].imageUrl}}"/>
+            <div class="prbv__content__pokemon__id">?</div>
+            <div class="prbv__content__pokemon__name" ng-if="!self.shouldHaveHatched">Hatches {{ self.friendlyHatchesTime }}</div>
+            <div class="prbv__content__pokemon__name" ng-if="self.shouldHaveHatched">Should have hatched {{ self.friendlyHatchesTime }}</div>
+          </div>
+          <div class="prbv__content__expires prbv__content__expires--expired" ng-if="self.hasExpired">
+            Has expired {{ self.friendlyExpiresTime }}
+          </div>
+          <div class="prbv__content__expires" ng-if="!self.hasExpired">
+            Expires {{ self.friendlyExpiresTime }}
+          </div>
+          <!--div class="prbv__content__label">
+            Hatches:
+          </div>
+          <div class="prbv__content__hatches">
+            {{ self.hatches }}
+          </div>
+          <div class="prbv__content__label">
+            Hatched:
+          </div>
+          <div class="prbv__content__hatched">
+            {{ self.hatched }}
+          </div-->
+        </div>
+    `;
+
+  class Controller {
+    constructor() {
+      attach(this, serviceDependencies, arguments);
+      window.pkmv4dbg = this;
+
+      const selectFromState = state => {
+        const id = get(this.content, "id");
+        const level = get(this.content, "level");
+        const hatches = get(this.content, "hatches");
+        const expires = get(this.content, "expires");
+        const hatched = get(this.content, "hatched");
+
+        return {
+          id,
+          pokemon:
+            id &&
+            this.detail &&
+            this.detail.findPokemonById &&
+            this.detail.findPokemonById(id),
+          level,
+          levelLabel:
+            level &&
+            this.detail &&
+            this.detail.getLevelLabel &&
+            this.detail.getLevelLabel(level),
+          hatches,
+          expires,
+          hatched,
+          shouldHaveHatched: hatches && selectLastUpdateTime(state) > hatches,
+          hasExpired: expires && selectLastUpdateTime(state) > expires,
+          friendlyHatchesTime:
+            hatches && relativeTime(selectLastUpdateTime(state), hatches),
+          friendlyExpiresTime:
+            expires && relativeTime(selectLastUpdateTime(state), expires),
+        };
+      };
+
+      connect2Redux(
+        selectFromState,
+        actionCreators,
+        ["self.content", "self.detail"],
+        this
+      );
+    }
+  }
+  Controller.$inject = serviceDependencies;
+
+  return {
+    restrict: "E",
+    controller: Controller,
+    controllerAs: "self",
+    bindToController: true, //scope-bindings -> ctrl
+    scope: {
+      content: "=",
+      detail: "=",
+    },
+    template: template,
+  };
+}
+
+export default angular
+  .module("won.owner.components.pokemonRaidbossViewer", [])
+  .directive("pokemonRaidbossViewer", genComponentConf).name;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
@@ -33,27 +33,15 @@ function genComponentConf() {
           <div class="prbv__content__pokemon" ng-if="!self.hatched || !self.pokemon">
             <img class="prbv__content__pokemon__image prbv__content__pokemon__image--unhatched" src="{{self.detail.pokemonList[0].imageUrl}}"/>
             <div class="prbv__content__pokemon__id">?</div>
-            <div class="prbv__content__pokemon__name" ng-if="!self.shouldHaveHatched">Hatches {{ self.friendlyHatchesTime }}</div>
-            <div class="prbv__content__pokemon__name" ng-if="self.shouldHaveHatched">Should have hatched {{ self.friendlyHatchesTime }}</div>
+            <div class="prbv__content__pokemon__name" ng-if="!self.shouldHaveHatched">Hatches {{ self.friendlyHatchesTime }} ({{ self.hatchesLocaleString }})</div>
+            <div class="prbv__content__pokemon__name" ng-if="self.shouldHaveHatched">Should have hatched {{ self.friendlyHatchesTime }} ({{ self.hatchesLocaleString }})</div>
           </div>
           <div class="prbv__content__expires prbv__content__expires--expired" ng-if="self.hasExpired">
-            Has expired {{ self.friendlyExpiresTime }}
+            Has expired {{ self.friendlyExpiresTime }} ({{ self.expiresLocaleString }})
           </div>
           <div class="prbv__content__expires" ng-if="!self.hasExpired">
-            Expires {{ self.friendlyExpiresTime }}
+            Expires {{ self.friendlyExpiresTime }} ({{ self.expiresLocaleString }})
           </div>
-          <!--div class="prbv__content__label">
-            Hatches:
-          </div>
-          <div class="prbv__content__hatches">
-            {{ self.hatches }}
-          </div>
-          <div class="prbv__content__label">
-            Hatched:
-          </div>
-          <div class="prbv__content__hatched">
-            {{ self.hatched }}
-          </div-->
         </div>
     `;
 
@@ -70,7 +58,6 @@ function genComponentConf() {
         const hatched = get(this.content, "hatched");
 
         return {
-          id,
           pokemon:
             id &&
             this.detail &&
@@ -82,8 +69,6 @@ function genComponentConf() {
             this.detail &&
             this.detail.getLevelLabel &&
             this.detail.getLevelLabel(level),
-          hatches,
-          expires,
           hatched,
           shouldHaveHatched: hatches && selectLastUpdateTime(state) > hatches,
           hasExpired: expires && selectLastUpdateTime(state) > expires,
@@ -91,6 +76,8 @@ function genComponentConf() {
             hatches && relativeTime(selectLastUpdateTime(state), hatches),
           friendlyExpiresTime:
             expires && relativeTime(selectLastUpdateTime(state), expires),
+          hatchesLocaleString: hatches && hatches.toLocaleString(),
+          expiresLocaleString: expires && expires.toLocaleString(),
         };
       };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
@@ -19,6 +19,7 @@ import reviewViewerModule from "./review-viewer.js";
 import suggestPostViewerModule from "./suggestpost-viewer.js";
 import paypalPaymentViewerModule from "./paypal-payment-viewer.js";
 import pokemonRaidbossViewerModule from "./pokemon-raidboss-viewer.js";
+import pokemonGymViewerModule from "./pokemon-gym-viewer.js";
 
 /**
  * module names for angular's module system
@@ -45,4 +46,5 @@ export default [
   suggestPostViewerModule,
   paypalPaymentViewerModule,
   pokemonRaidbossViewerModule,
+  pokemonGymViewerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/viewers.js
@@ -18,6 +18,7 @@ import petrinettransitionViewerModule from "./petrinettransition-viewer.js";
 import reviewViewerModule from "./review-viewer.js";
 import suggestPostViewerModule from "./suggestpost-viewer.js";
 import paypalPaymentViewerModule from "./paypal-payment-viewer.js";
+import pokemonRaidbossViewerModule from "./pokemon-raidboss-viewer.js";
 
 /**
  * module names for angular's module system
@@ -43,4 +44,5 @@ export default [
   reviewViewerModule,
   suggestPostViewerModule,
   paypalPaymentViewerModule,
+  pokemonRaidbossViewerModule,
 ];

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
@@ -316,6 +316,7 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
 
     if (getIn(atomImm, ["matchedUseCase", "identifier"]) === "pokemonGoRaid") {
       let raidReadable;
+      let locationReadable;
       let gymReadable;
 
       const raidDetail = "pokemonRaid";
@@ -327,7 +328,18 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
         });
       }
 
-      const gymDetail = "pokemonGym";
+      const locationDetail = "location";
+      const locationValueImm = getIn(atomImm, ["content", locationDetail]);
+      if (locationValueImm && detailsToParse[locationDetail]) {
+        locationReadable = detailsToParse[locationDetail].generateHumanReadable(
+          {
+            value: locationValueImm.toJS(),
+            includeLabel: false,
+          }
+        );
+      }
+
+      const gymDetail = "pokemonGymInfo";
       const gymValueImm = getIn(atomImm, ["content", gymDetail]);
       if (gymValueImm && detailsToParse[gymDetail]) {
         gymReadable = detailsToParse[gymDetail].generateHumanReadable({
@@ -335,8 +347,13 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
           includeLabel: false,
         });
       }
-      if (raidReadable && gymReadable) {
-        return raidReadable + " @ " + gymReadable;
+      if (raidReadable && locationReadable) {
+        return (
+          raidReadable +
+          " @ " +
+          locationReadable +
+          (gymReadable ? " (" + gymReadable + ")" : "")
+        );
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
@@ -315,13 +315,28 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
     }
 
     if (getIn(atomImm, ["matchedUseCase", "identifier"]) === "pokemonGoRaid") {
-      const detailName = "pokemonRaid";
-      const detailValueImm = getIn(atomImm, ["content", detailName]);
-      if (detailValueImm && detailsToParse[detailName]) {
-        return detailsToParse[detailName].generateHumanReadable({
-          value: detailValueImm.toJS(),
+      let raidReadable;
+      let gymReadable;
+
+      const raidDetail = "pokemonRaid";
+      const raidValueImm = getIn(atomImm, ["content", raidDetail]);
+      if (raidValueImm && detailsToParse[raidDetail]) {
+        raidReadable = detailsToParse[raidDetail].generateHumanReadable({
+          value: raidValueImm.toJS(),
           includeLabel: false,
         });
+      }
+
+      const gymDetail = "pokemonGym";
+      const gymValueImm = getIn(atomImm, ["content", gymDetail]);
+      if (gymValueImm && detailsToParse[gymDetail]) {
+        gymReadable = detailsToParse[gymDetail].generateHumanReadable({
+          value: gymValueImm.toJS(),
+          includeLabel: false,
+        });
+      }
+      if (raidReadable && gymReadable) {
+        return raidReadable + " @ " + gymReadable;
       }
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -46,20 +46,25 @@ export const labels = deepFreeze({
  * Adapted from ["Javascript timestamp to relative time" at Stackoverflow](http://stackoverflow.com/questions/6108819/javascript-timestamp-to-relative-time-eg-2-seconds-ago-one-week-ago-etc-best)
  *
  * @param now
- * @param previous
+ * @param timeToCheck
  */
-export function relativeTime(now, previous) {
-  if (!now || !previous) {
+export function relativeTime(now, timeToCheck) {
+  if (!now || !timeToCheck) {
     return undefined;
   }
 
   const now_ = new Date(now);
-  const previous_ = new Date(previous);
-  const elapsed = now_ - previous_; // in ms
+  const timeToCheck_ = new Date(timeToCheck);
+  let elapsed = now_ - timeToCheck_; // in ms
 
   if (!isValidNumber(elapsed)) {
     // one of two dates was invalid
     return undefined;
+  }
+
+  const future = elapsed < 0;
+  if (future) {
+    elapsed = elapsed * -1;
   }
 
   const msPerMinute = 60 * 1000;
@@ -70,7 +75,9 @@ export function relativeTime(now, previous) {
 
   const labelGen = (msPerUnit, unitName) => {
     const rounded = Math.round(elapsed / msPerUnit);
-    return rounded + " " + unitName + (rounded !== 1 ? "s" : "") + " ago";
+    return future
+      ? "in " + rounded + " " + unitName + (rounded !== 1 ? "s" : "")
+      : rounded + " " + unitName + (rounded !== 1 ? "s" : "") + " ago";
   };
 
   if (elapsed < msPerMinute) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-utils.js
@@ -718,34 +718,44 @@ export function parseJsonldLeaf(val, type) {
     case "xsd:string":
       return unwrappedVal + ""; // everything can be parsed to a string in js
 
+    case "xsd:boolean": {
+      const value = unwrappedVal + "";
+      if (value === "true") {
+        return true;
+      } else if (value === "false") {
+        return false;
+      } else {
+        throwErr(`Annotated \`${type_}\` is not valid.`);
+      }
+      break;
+    }
+
     case "s:Number":
     case "s:Float":
     case "s:Integer":
     case "xsd:int":
-    case "xsd:float":
-      {
-        const parsedVal = Number(unwrappedVal);
-        if (!isValidNumber(parsedVal)) {
-          throwErr(
-            `Annotated value of type \`${type_}\` isn't parsable to a \`Number\`.`
-          );
-        } else {
-          return parsedVal;
-        }
+    case "xsd:float": {
+      const parsedVal = Number(unwrappedVal);
+      if (!isValidNumber(parsedVal)) {
+        throwErr(
+          `Annotated value of type \`${type_}\` isn't parsable to a \`Number\`.`
+        );
+      } else {
+        return parsedVal;
       }
       break;
+    }
 
     case "s:DateTime":
-    case "xsd:dateTime":
-      {
-        const parsedDateTime = parseDatetimeStrictly(unwrappedVal);
-        if (isValidDate(parsedDateTime)) {
-          return parsedDateTime;
-        } else {
-          throwErr(`Annotated \`${type_}\` isn't parsable to a \`Date\`.`);
-        }
+    case "xsd:dateTime": {
+      const parsedDateTime = parseDatetimeStrictly(unwrappedVal);
+      if (isValidDate(parsedDateTime)) {
+        return parsedDateTime;
+      } else {
+        throwErr(`Annotated \`${type_}\` isn't parsable to a \`Date\`.`);
       }
       break;
+    }
 
     case "xsd:id":
     case "xsd:ID": {
@@ -820,4 +830,157 @@ export function parseRestErrorMessage(error) {
   }
 
   return error;
+}
+
+/**
+ * Parses json-ld of an `s:Place` in a best-effort kinda style.
+ * Any data missing in the RDF will be missing in the result object.
+ * @param {*} jsonldLocation
+ */
+export function parsePlaceLeniently(jsonldLocation) {
+  if (!jsonldLocation) return undefined; // NO LOCATION PRESENT
+
+  const jsonldLocationImm = Immutable.fromJS(jsonldLocation);
+
+  const parseFloatFromLocation = path =>
+    won.parseFrom(jsonldLocationImm, path, "xsd:float");
+
+  const place = {
+    address: won.parseFrom(jsonldLocationImm, ["s:name"], "xsd:string"),
+    lat: parseFloatFromLocation(["s:geo", "s:latitude"]),
+    lng: parseFloatFromLocation(["s:geo", "s:longitude"]),
+    // nwCorner if present (see below)
+    // seCorner if present (see below)
+  };
+
+  const nwCornerLat = parseFloatFromLocation([
+    "won:boundingBox",
+    "won:northWestCorner",
+    "s:latitude",
+  ]);
+  const nwCornerLng = parseFloatFromLocation([
+    "won:boundingBox",
+    "won:northWestCorner",
+    "s:longitude",
+  ]);
+  const seCornerLat = parseFloatFromLocation([
+    "won:boundingBox",
+    "won:southEastCorner",
+    "s:latitude",
+  ]);
+  const seCornerLng = parseFloatFromLocation([
+    "won:boundingBox",
+    "won:southEastCorner",
+    "s:longitude",
+  ]);
+
+  if (nwCornerLat || nwCornerLng) {
+    place.nwCorner = {
+      lat: nwCornerLat,
+      lng: nwCornerLng,
+    };
+  }
+  if (seCornerLat || seCornerLng) {
+    place.seCorner = {
+      lat: seCornerLat,
+      lng: seCornerLng,
+    };
+  }
+  return place;
+}
+
+/**
+ * Generates rdf from given geoData (e.g. location from a location picker)
+ * @param geoData
+ * @param baseUri
+ * @returns {*}
+ */
+export function genSPlace({ geoData, baseUri }) {
+  if (!geoData) {
+    return undefined;
+  }
+  if (!geoData.lat || !geoData.lng || !geoData.name) {
+    return undefined;
+  }
+
+  return {
+    "@id": baseUri,
+    "@type": "s:Place",
+    "s:name": geoData.name,
+    "s:geo": genGeo({ lat: geoData.lat, lng: geoData.lng, baseUri }),
+    "won:boundingBox": genBoundingBox({
+      nwCorner: geoData.nwCorner,
+      seCorner: geoData.seCorner,
+      baseUri,
+    }),
+  };
+}
+
+function genGeo({ lat, lng, baseUri }) {
+  if (isNaN(lat) || isNaN(lng)) {
+    return undefined;
+  }
+  return {
+    "@id": baseUri ? baseUri + "/geo" : undefined,
+    "@type": "s:GeoCoordinates",
+    "s:latitude": lat.toFixed(6),
+    "s:longitude": lng.toFixed(6),
+    "won:geoSpatial": {
+      "@type": "http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon",
+      "@value": `${lat.toFixed(6)}#${lng.toFixed(6)}`,
+    },
+  };
+}
+
+function genBoundingBox({ nwCorner, seCorner, baseUri }) {
+  return !nwCorner || !seCorner
+    ? undefined
+    : {
+        "@id": baseUri ? baseUri + "/bounds" : undefined,
+        "won:northWestCorner": {
+          "@id": baseUri ? baseUri + "/bounds/nw" : undefined,
+          "@type": "s:GeoCoordinates",
+          "s:latitude": nwCorner.lat.toFixed(6),
+          "s:longitude": nwCorner.lng.toFixed(6),
+        },
+        "won:southEastCorner": {
+          "@id": baseUri ? baseUri + "/bounds/se" : undefined,
+          "@type": "s:GeoCoordinates",
+          "s:latitude": seCorner.lat.toFixed(6),
+          "s:longitude": seCorner.lng.toFixed(6),
+        },
+      };
+}
+
+export function genDetailBaseUri(baseUri, detailIdentifier) {
+  if (!baseUri || !detailIdentifier) {
+    return undefined;
+  }
+  const randomId = generateIdString(10);
+  return baseUri + "/" + detailIdentifier + "/" + randomId;
+}
+
+export function parseSPlace(jsonldLocation) {
+  if (!jsonldLocation) return undefined; // NO LOCATION PRESENT
+
+  const location = parsePlaceLeniently(jsonldLocation);
+
+  if (
+    location &&
+    location.address &&
+    location.lat &&
+    location.lng &&
+    location.nwCorner.lat &&
+    location.nwCorner.lng &&
+    location.seCorner.lat &&
+    location.seCorner.lng
+  ) {
+    return Immutable.fromJS(location);
+  } else {
+    console.error(
+      "Cant parse location, data is an invalid location-object: ",
+      jsonldLocation
+    );
+    return undefined;
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -83,7 +83,7 @@ export const details = {
   sockets: basicDetails.sockets,
   defaultSocket: basicDetails.defaultSocket,
   type: basicDetails.type,
-  pokemonGym: pokemonDetails.pokemonGym,
+  pokemonGymInfo: pokemonDetails.pokemonGymInfo,
   pokemonRaid: pokemonDetails.pokemonRaid,
 };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/detail-definitions.js
@@ -7,6 +7,7 @@ import * as basicDetails from "./details/basic.js";
 import * as workflowDetails from "./details/workflow.js";
 import * as reviewDetails from "./details/review.js";
 import * as paymentDetails from "./details/payment.js";
+import * as pokemonDetails from "./details/pokemon.js";
 
 import * as abstractDetails_ from "./details/abstract.js";
 export const abstractDetails = abstractDetails_; // reexport
@@ -82,6 +83,8 @@ export const details = {
   sockets: basicDetails.sockets,
   defaultSocket: basicDetails.defaultSocket,
   type: basicDetails.type,
+  pokemonGym: pokemonDetails.pokemonGym,
+  pokemonRaid: pokemonDetails.pokemonRaid,
 };
 
 export const messageDetails = {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
@@ -16,6 +16,10 @@ export const location = {
   component: "won-location-picker",
   viewerComponent: "won-location-viewer",
   messageEnabled: true,
+  overrideAddressDetail: {
+    placeholder:
+      "Alternative Address name (e.g. if doornumber should be included)",
+  },
   parseToRDF: function({ value, identifier, contentUri }) {
     return {
       "s:location": genSPlace({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/location.js
@@ -1,9 +1,10 @@
+import { get, getIn, getFromJsonLd } from "../../app/utils.js";
 import {
-  get,
-  getIn,
-  generateIdString,
-  getFromJsonLd,
-} from "../../app/utils.js";
+  genSPlace,
+  genDetailBaseUri,
+  parseSPlace,
+  parsePlaceLeniently,
+} from "../../app/won-utils.js";
 import Immutable from "immutable";
 import won from "../../app/won-es6.js";
 
@@ -217,153 +218,6 @@ export const travelAction = {
     return undefined;
   },
 };
-
-function genDetailBaseUri(baseUri, detailIdentifier) {
-  if (!baseUri || !detailIdentifier) {
-    return undefined;
-  }
-  const randomId = generateIdString(10);
-  return baseUri + "/" + detailIdentifier + "/" + randomId;
-}
-
-function genSPlace({ geoData, baseUri }) {
-  if (!geoData) {
-    return undefined;
-  }
-  if (!geoData.lat || !geoData.lng || !geoData.name) {
-    return undefined;
-  }
-
-  return {
-    "@id": baseUri,
-    "@type": "s:Place",
-    "s:name": geoData.name,
-    "s:geo": genGeo({ lat: geoData.lat, lng: geoData.lng, baseUri }),
-    "won:boundingBox": genBoundingBox({
-      nwCorner: geoData.nwCorner,
-      seCorner: geoData.seCorner,
-      baseUri,
-    }),
-  };
-}
-
-function genGeo({ lat, lng, baseUri }) {
-  if (isNaN(lat) || isNaN(lng)) {
-    return undefined;
-  }
-  return {
-    "@id": baseUri ? baseUri + "/geo" : undefined,
-    "@type": "s:GeoCoordinates",
-    "s:latitude": lat.toFixed(6),
-    "s:longitude": lng.toFixed(6),
-    "won:geoSpatial": {
-      "@type": "http://www.bigdata.com/rdf/geospatial/literals/v1#lat-lon",
-      "@value": `${lat.toFixed(6)}#${lng.toFixed(6)}`,
-    },
-  };
-}
-
-function genBoundingBox({ nwCorner, seCorner, baseUri }) {
-  return !nwCorner || !seCorner
-    ? undefined
-    : {
-        "@id": baseUri ? baseUri + "/bounds" : undefined,
-        "won:northWestCorner": {
-          "@id": baseUri ? baseUri + "/bounds/nw" : undefined,
-          "@type": "s:GeoCoordinates",
-          "s:latitude": nwCorner.lat.toFixed(6),
-          "s:longitude": nwCorner.lng.toFixed(6),
-        },
-        "won:southEastCorner": {
-          "@id": baseUri ? baseUri + "/bounds/se" : undefined,
-          "@type": "s:GeoCoordinates",
-          "s:latitude": seCorner.lat.toFixed(6),
-          "s:longitude": seCorner.lng.toFixed(6),
-        },
-      };
-}
-
-function parseSPlace(jsonldLocation) {
-  if (!jsonldLocation) return undefined; // NO LOCATION PRESENT
-
-  const location = parsePlaceLeniently(jsonldLocation);
-
-  if (
-    location &&
-    location.address &&
-    location.lat &&
-    location.lng &&
-    location.nwCorner.lat &&
-    location.nwCorner.lng &&
-    location.seCorner.lat &&
-    location.seCorner.lng
-  ) {
-    return Immutable.fromJS(location);
-  } else {
-    console.error(
-      "Cant parse location, data is an invalid location-object: ",
-      jsonldLocation
-    );
-    return undefined;
-  }
-}
-
-/**
- * Parses json-ld of an `s:Place` in a best-effort kinda style.
- * Any data missing in the RDF will be missing in the result object.
- * @param {*} jsonldLocation
- */
-function parsePlaceLeniently(jsonldLocation) {
-  if (!jsonldLocation) return undefined; // NO LOCATION PRESENT
-
-  const jsonldLocationImm = Immutable.fromJS(jsonldLocation);
-
-  const parseFloatFromLocation = path =>
-    won.parseFrom(jsonldLocationImm, path, "xsd:float");
-
-  const place = {
-    address: won.parseFrom(jsonldLocationImm, ["s:name"], "xsd:string"),
-    lat: parseFloatFromLocation(["s:geo", "s:latitude"]),
-    lng: parseFloatFromLocation(["s:geo", "s:longitude"]),
-    // nwCorner if present (see below)
-    // seCorner if present (see below)
-  };
-
-  const nwCornerLat = parseFloatFromLocation([
-    "won:boundingBox",
-    "won:northWestCorner",
-    "s:latitude",
-  ]);
-  const nwCornerLng = parseFloatFromLocation([
-    "won:boundingBox",
-    "won:northWestCorner",
-    "s:longitude",
-  ]);
-  const seCornerLat = parseFloatFromLocation([
-    "won:boundingBox",
-    "won:southEastCorner",
-    "s:latitude",
-  ]);
-  const seCornerLng = parseFloatFromLocation([
-    "won:boundingBox",
-    "won:southEastCorner",
-    "s:longitude",
-  ]);
-
-  if (nwCornerLat || nwCornerLng) {
-    place.nwCorner = {
-      lat: nwCornerLat,
-      lng: nwCornerLng,
-    };
-  }
-  if (seCornerLat || seCornerLng) {
-    place.seCorner = {
-      lat: seCornerLat,
-      lng: seCornerLng,
-    };
-  }
-  return place;
-}
 
 function sPlaceToHumanReadable({ value, label }) {
   if (value) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -18,7 +18,7 @@ export const pokemonGym = {
   icon: "#ico36_dumbbell", //TODO: Create and use better icon
   messageEnabled: false,
   component: "pokemon-gym-picker",
-  viewerComponent: "won-description-viewer", //TODO: IMPL CORRECT VIEWER
+  viewerComponent: "pokemon-gym-viewer", //TODO: IMPL CORRECT VIEWER
   locationDetail: {
     placeholder: "Search for location",
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -36,7 +36,7 @@ export const pokemonRaid = {
   icon: "#ico36_pokeball", //TODO: Create and use better icon
   messageEnabled: false,
   component: "pokemon-raidboss-picker",
-  viewerComponent: "won-title-viewer",
+  viewerComponent: "pokemon-raidboss-viewer",
   filterDetail: {
     placeholder: "Filter by (name or id)",
   },
@@ -82,7 +82,8 @@ export const pokemonRaid = {
       !value ||
       !value.level ||
       !value.expires ||
-      (!value.id && value.hatched)
+      (!value.id && value.hatched) ||
+      (!value.hatched && !value.hatches)
     )
       return false;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -13,29 +13,18 @@ export const pokemonGymInfo = {
   messageEnabled: false,
   component: "pokemon-gym-picker",
   viewerComponent: "pokemon-gym-viewer",
-  infoDetail: {
-    placeholder: "Info about this gym (not mandatory, markdown enabled)",
-  },
   isValid: function(value) {
     return value && value.ex;
   },
   parseToRDF: function({ value }) {
     if (this.isValid(value)) {
-      return {
-        "won:gym": {
-          "won:gymex": { "@value": !!value.ex, "@type": "xsd:boolean" },
-        },
-      };
+      return { "won:gymex": { "@value": !!value.ex, "@type": "xsd:boolean" } };
     }
     return undefined;
   },
   parseFromRDF: function(jsonLDImm) {
     if (jsonLDImm) {
-      const ex = won.parseFrom(
-        jsonLDImm,
-        ["won:gym", "won:gymex"],
-        "xsd:boolean"
-      );
+      const ex = won.parseFrom(jsonLDImm, ["won:gymex"], "xsd:boolean");
 
       if (ex) {
         return Immutable.fromJS({ ex });

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -2,7 +2,7 @@ import Immutable from "immutable";
 import won from "../../app/won-es6.js";
 import {
   isValidDate,
-  parseDatetimeStrictly,
+  //parseDatetimeStrictly,
   toLocalISODateString,
   getIn,
 } from "../../app/utils.js";
@@ -86,9 +86,10 @@ export const pokemonGym = {
     return undefined;
   },
   generateHumanReadable: function({ value, includeLabel }) {
-    //TODO: IMPL CORRECT FUNCTION
-    if (value) {
-      return includeLabel ? this.label + ": " + value : value;
+    if (value && value.name) {
+      let labelPart = value.name + (value.ex ? " (Ex Gym)" : "");
+
+      return includeLabel ? this.label + ": " + labelPart : labelPart;
     }
     return undefined;
   },
@@ -276,16 +277,19 @@ export const pokemonRaid = {
       if (value.hatched) {
         labelPart =
           this.getPokemonNameById(value.id, value.form) +
-          (value.form ? " (" + value.form + ")" : "") +
+          (value.form
+            ? " (" + value.form + ")"
+            : "") /* +
           ", expires at: " +
-          parseDatetimeStrictly(value.expires);
+          parseDatetimeStrictly(value.expires)*/;
       } else {
-        labelPart =
-          this.getLevelLabel(value.level) +
+        labelPart = this.getLevelLabel(
+          value.level
+        ) /* +
           " , hatches at: " +
           parseDatetimeStrictly(value.hatches) +
           ", expires at: " +
-          parseDatetimeStrictly(value.expires);
+          parseDatetimeStrictly(value.expires)*/;
       }
 
       return includeLabel ? this.label + ": " + labelPart : labelPart;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -1,5 +1,10 @@
-//import Immutable from "immutable";
+import Immutable from "immutable";
 import won from "../../app/won-es6.js";
+import {
+  isValidDate,
+  parseDatetimeStrictly,
+  toLocalISODateString,
+} from "../../app/utils.js";
 
 export const pokemonGym = {
   identifier: "pokemonGym",
@@ -30,20 +35,170 @@ export const pokemonRaid = {
   label: "Raid Boss",
   icon: "#ico36_pokeball", //TODO: Create and use better icon
   messageEnabled: false,
-  component: "won-title-picker",
+  component: "pokemon-raidboss-picker",
   viewerComponent: "won-title-viewer",
-  parseToRDF: function({ value }) {
-    const val = value ? value : undefined;
-    return {
-      "won:raid": val,
+  filterDetail: {
+    placeholder: "Filter by (name or id)",
+  },
+  pokemonList: [
+    //TODO: UPDATE LIST
+    {
+      id: 1,
+      name: "Bulbasaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
+    },
+    {
+      id: 2,
+      name: "Ivysaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
+    },
+    {
+      id: 3,
+      name: "Venusaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
+    },
+    {
+      id: 4,
+      name: "Charmander",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
+    },
+  ],
+  findPokemonById: function(id) {
+    if (id) {
+      for (const idx in this.pokemonList) {
+        if (this.pokemonList[idx].id == id) {
+          return this.pokemonList[idx];
+        }
+      }
+    }
+    return undefined;
+  },
+  getPokemonNameById: function(id) {
+    const pokemon = this.findPokemonById(id);
+    return pokemon && pokemon.name;
+  },
+  isValid: function(value) {
+    if (
+      !value ||
+      !value.level ||
+      !value.expires ||
+      (!value.id && value.hatched)
+    )
+      return false;
+
+    const isAfter = (beforeDate, afterDate) => {
+      if (beforeDate && isValidDate(beforeDate)) {
+        return isValidDate(afterDate) && beforeDate < afterDate;
+      }
+      return !!afterDate;
     };
+    return value.hatched || isAfter(value.hatches, value.expires);
+  },
+  getLevelLabel: function(level) {
+    switch (level) {
+      case 1:
+        return "Level 1 ★";
+      case 2:
+        return "Level 2 ★★";
+      case 3:
+        return "Level 3 ★★★ (Rare)";
+      case 4:
+        return "Level 4 ★★★★ (Rare)";
+      case 5:
+        return "Level 5 ★★★★★ (Legendary)";
+    }
+    return level;
+  },
+  parseToRDF: function({ value }) {
+    if (this.isValid(value)) {
+      if (value.hatched) {
+        return {
+          "won:raid": {
+            "won:level": { "@value": value.level, "@type": "xsd:int" },
+            "won:pokemonid": { "@value": value.id, "@type": "xsd:int" },
+            "s:validThrough": {
+              "@value": toLocalISODateString(value.expires),
+              "@type": "xsd:dateTime",
+            },
+          },
+        };
+      } else {
+        return {
+          "won:raid": {
+            "won:level": { "@value": value.level, "@type": "xsd:int" },
+            "s:validFrom": {
+              "@value": toLocalISODateString(value.hatches),
+              "@type": "xsd:dateTime",
+            },
+            "s:validThrough": {
+              "@value": toLocalISODateString(value.expires),
+              "@type": "xsd:dateTime",
+            },
+          },
+        };
+      }
+    }
+    return undefined;
   },
   parseFromRDF: function(jsonLDImm) {
-    return won.parseFrom(jsonLDImm, ["won:raid"], "xsd:string");
+    const level = won.parseFrom(
+      jsonLDImm,
+      ["won:raid", "won:level"],
+      "xsd:int"
+    );
+    const expires = won.parseFrom(
+      jsonLDImm,
+      ["won:raid", "s:validThrough"],
+      "xsd:dateTime"
+    );
+
+    if (level && expires) {
+      const id = won.parseFrom(
+        jsonLDImm,
+        ["won:raid", "won:pokemonid"],
+        "xsd:int"
+      );
+      const hatched = !!id;
+      const hatches =
+        !hatched &&
+        won.parseFrom(jsonLDImm, ["won:raid", "s:validFrom"], "xsd:dateTime");
+
+      if (hatched) {
+        return Immutable.fromJS({
+          id,
+          hatched,
+          level,
+          expires,
+        });
+      } else if (hatches) {
+        return Immutable.fromJS({
+          hatched,
+          level,
+          expires,
+          hatches,
+        });
+      }
+    }
+    return undefined;
   },
   generateHumanReadable: function({ value, includeLabel }) {
     if (value) {
-      return includeLabel ? this.label + ": " + value : value;
+      let labelPart = "";
+      if (value.hatched) {
+        labelPart =
+          this.getPokemonNameById(value.id) +
+          ", expires at: " +
+          parseDatetimeStrictly(value.expires);
+      } else {
+        labelPart =
+          this.getLevelLabel(value.level) +
+          " , hatches at: " +
+          parseDatetimeStrictly(value.hatches) +
+          ", expires at: " +
+          parseDatetimeStrictly(value.expires);
+      }
+
+      return includeLabel ? this.label + ": " + labelPart : labelPart;
     }
     return undefined;
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -13,6 +13,18 @@ export const pokemonGym = {
   messageEnabled: false,
   component: "pokemon-gym-picker",
   viewerComponent: "won-description-viewer", //TODO: IMPL CORRECT VIEWER
+  locationDetail: {
+    placeholder: "Search for location",
+  },
+  infoDetail: {
+    placeholder: "Info about this gym (not mandatory, markdown enabled)",
+  },
+  nameDetail: {
+    placeholder: "Name (mandatory)",
+  },
+  isValid: function(value) {
+    return value && value.location && value.name;
+  },
   parseToRDF: function({ value }) {
     //TODO: IMPL CORRECT FUNCTION
     const val = value ? value : undefined;

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -1,0 +1,50 @@
+//import Immutable from "immutable";
+import won from "../../app/won-es6.js";
+
+export const pokemonGym = {
+  identifier: "pokemonGym",
+  label: "Gym",
+  icon: "#ico36_dumbbell", //TODO: Create and use better icon
+  messageEnabled: false,
+  component: "won-title-picker",
+  viewerComponent: "won-title-viewer",
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+    return {
+      "won:gym": val,
+    };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseFrom(jsonLDImm, ["won:gym"], "xsd:string");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};
+
+export const pokemonRaid = {
+  identifier: "pokemonRaid",
+  label: "Raid Boss",
+  icon: "#ico36_pokeball", //TODO: Create and use better icon
+  messageEnabled: false,
+  component: "won-title-picker",
+  viewerComponent: "won-title-viewer",
+  parseToRDF: function({ value }) {
+    const val = value ? value : undefined;
+    return {
+      "won:raid": val,
+    };
+  },
+  parseFromRDF: function(jsonLDImm) {
+    return won.parseFrom(jsonLDImm, ["won:raid"], "xsd:string");
+  },
+  generateHumanReadable: function({ value, includeLabel }) {
+    if (value) {
+      return includeLabel ? this.label + ": " + value : value;
+    }
+    return undefined;
+  },
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -12,6 +12,7 @@ import { interestsGroup } from "./usecases/group-interests";
 
 import { lunchPlan } from "./usecases/uc-lunch.js";
 import { cyclingPlan } from "./usecases/uc-cycling.js";
+import { pokemonGoRaid } from "./usecases/uc-pokemon.js";
 
 /**
  * USE CASE REQUIREMENTS
@@ -70,6 +71,7 @@ const useCaseGroups = {
 
 // add useCases here that should not be visible in the grouped useCases (will be hidden and only accessible through reaction and enabledUseCases
 export const hiddenUseCases = {
+  pokemonGoRaid: pokemonGoRaid,
   lunchPlan: lunchPlan,
   cyclingPlan: cyclingPlan,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-interests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-interests.js
@@ -1,12 +1,14 @@
 import { cyclingInterest } from "./uc-cycling.js";
 import { lunchInterest } from "./uc-lunch.js";
+import { pokemonInterest } from "./uc-pokemon.js";
 
 export const interestsGroup = {
   identifier: "interestsgroup",
   label: "Interests",
-  icon: undefined,
+  icon: "#ico36_detail_interests",
   subItems: {
     lunchInterest: lunchInterest,
     cyclingInterest: cyclingInterest,
+    pokemonInterest: pokemonInterest,
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -1,0 +1,57 @@
+import { details, mergeInEmptyDraft } from "../detail-definitions.js";
+import won from "../../app/service/won.js";
+import { Generator } from "sparqljs";
+import { findLatestIntervallEndInJsonLdOrNowAndAddMillis } from "../../app/won-utils.js";
+
+window.SparqlGenerator4dbg = Generator;
+
+export const pokemonGoRaid = {
+  identifier: "pokemonGoRaid",
+  label: "Plan a Pokémon Raid",
+  icon: "#ico36_pokemon-raid", //TODO: Better Icon
+  doNotMatchAfter: findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+  draft: {
+    ...mergeInEmptyDraft({
+      content: {
+        type: ["s:PlanAction"],
+        eventObject: "http://dbpedia.org/resource/Pokemon_Go",
+        sockets: {
+          "#groupSocket": won.GROUP.GroupSocketCompacted,
+          "#holdableSocket": won.HOLD.HoldableSocketCompacted,
+        },
+        defaultSocket: { "#groupSocket": won.GROUP.GroupSocketCompacted },
+      },
+      seeks: {},
+    }),
+  },
+  reactionUseCases: ["pokemonInterest"],
+  details: {
+    pokemonGym: { ...details.pokemonGym, mandatory: true },
+    pokemonRaid: { ...details.pokemonRaid, mandatory: true },
+  },
+  seeksDetails: {},
+};
+
+export const pokemonInterest = {
+  identifier: "pokemonInterest",
+  label: "Add Interest in Pokémon Go",
+  icon: "#ico36_pokeball", //TODO: Better Icon
+  draft: {
+    ...mergeInEmptyDraft({
+      content: {
+        type: ["won:Interest"],
+        title: "I am interested in Pokémon Go!",
+      },
+      seeks: {
+        type: ["s:PlanAction"],
+        eventObject: "http://dbpedia.org/resource/Pokemon_Go",
+      },
+    }),
+  },
+  enabledUseCases: ["pokemonGoRaid"],
+  reactionUseCases: ["pokemonGoRaid"],
+  details: {
+    title: { ...details.title },
+  },
+  seeksDetails: {},
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -27,7 +27,9 @@ export const pokemonGoRaid = {
   reactionUseCases: ["pokemonInterest"],
   details: {
     pokemonRaid: { ...details.pokemonRaid, mandatory: true },
-    pokemonGym: { ...details.pokemonGym, mandatory: true },
+    location: { ...details.location, mandatory: true },
+    pokemonGymInfo: { ...details.pokemonGymInfo },
+    description: { ...details.description },
   },
   seeksDetails: {},
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -40,7 +40,6 @@ export const pokemonInterest = {
     ...mergeInEmptyDraft({
       content: {
         type: ["won:Interest"],
-        title: "I am interested in Pokémon Go!",
       },
       seeks: {
         type: ["s:PlanAction"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -26,8 +26,8 @@ export const pokemonGoRaid = {
   },
   reactionUseCases: ["pokemonInterest"],
   details: {
-    pokemonGym: { ...details.pokemonGym, mandatory: true },
     pokemonRaid: { ...details.pokemonRaid, mandatory: true },
+    pokemonGym: { ...details.pokemonGym, mandatory: true },
   },
   seeksDetails: {},
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_dumbbell.svg
+++ b/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_dumbbell.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="detail_time"
+   width="36px"
+   height="36px"
+   viewBox="0 0 36 36"
+   sodipodi:docname="ico36_dumbbell.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs1012" />
+  <sodipodi:namedview
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview1010"
+     showgrid="false"
+     inkscape:zoom="16.777778"
+     inkscape:cx="26.683637"
+     inkscape:cy="22.164743"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="detail_time" />
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Layer 1" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:0.54024154"
+     id="rect1445"
+     width="9.1192036"
+     height="2.1456945"
+     x="-30.032904"
+     y="-1.1149919"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:2.72422266;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1451-5"
+     width="4.1125827"
+     height="14.066225"
+     x="-20.362375"
+     y="-7.0752583"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:0.75945354"
+     id="rect1451-0"
+     width="3.874172"
+     height="10.609271"
+     x="-39.316017"
+     y="-5.3467808"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:2.72422266;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1451-5-2"
+     width="4.1125827"
+     height="14.066225"
+     x="-34.60741"
+     y="-7.0752583"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:0.75945354"
+     id="rect1451-0-8"
+     width="3.874172"
+     height="10.609271"
+     x="-15.415357"
+     y="-5.1679726"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:0.49069098"
+     id="rect1451-0-1"
+     width="2.5033112"
+     height="6.8543043"
+     x="-10.885553"
+     y="-3.290489"
+     transform="rotate(-135)" />
+  <rect
+     style="fill:var(--local-primary);fill-opacity:1;stroke-width:0.49069098"
+     id="rect1451-0-1-8"
+     width="2.5033112"
+     height="6.8543043"
+     x="-42.564362"
+     y="-3.5288999"
+     transform="rotate(-135)" />
+</svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_pokeball.svg
+++ b/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_pokeball.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="detail_time"
+   width="36px"
+   height="36px"
+   viewBox="0 0 36 36"
+   sodipodi:docname="ico36_pokeball.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs1012" />
+  <sodipodi:namedview
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview1010"
+     showgrid="false"
+     inkscape:zoom="16.777778"
+     inkscape:cx="2.3424958"
+     inkscape:cy="13.235796"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="detail_time" />
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Layer 1" />
+  <circle
+     style="fill:none"
+     id="path1016"
+     cx="17.940397"
+     cy="17.821192"
+     r="8.7913904" />
+  <path
+     style="fill:var(--local-primary)"
+     d="M 18 3.4277344 A 14.572847 14.572847 0 0 0 3.4277344 18 A 14.572847 14.572847 0 0 0 18 32.572266 A 14.572847 14.572847 0 0 0 32.572266 18 A 14.572847 14.572847 0 0 0 18 3.4277344 z M 18 5.5722656 A 12.15894 12.427153 0 0 1 30.158203 18 A 12.15894 12.427153 0 0 1 18 30.427734 A 12.15894 12.427153 0 0 1 5.8417969 18 A 12.15894 12.427153 0 0 1 18 5.5722656 z "
+     id="path850" />
+  <path
+     style="fill:var(--local-primary);stroke-width:1.43788481"
+     d="M 18.833984 4.4707031 L 10.429688 6.9140625 L 6.1992188 12.277344 L 4.6484375 17.820312 L 11.121094 17.849609 A 6.8841057 6.9139071 0 0 1 18 11.085938 A 6.8841057 6.9139071 0 0 1 24.880859 17.910156 L 31.470703 17.939453 L 28.548828 8.9394531 L 18.833984 4.4707031 z M 24.880859 17.910156 L 22.794922 17.900391 A 4.7980132 4.7980132 0 0 1 22.798828 18 A 4.7980132 4.7980132 0 0 1 18 22.798828 A 4.7980132 4.7980132 0 0 1 13.201172 18 A 4.7980132 4.7980132 0 0 1 13.208984 17.857422 L 11.121094 17.849609 A 6.8841057 6.9139071 0 0 0 11.115234 18 A 6.8841057 6.9139071 0 0 0 18 24.914062 A 6.8841057 6.9139071 0 0 0 24.884766 18 A 6.8841057 6.9139071 0 0 0 24.880859 17.910156 z M 13.208984 17.857422 L 22.794922 17.900391 A 4.7980132 4.7980132 0 0 0 18 13.201172 A 4.7980132 4.7980132 0 0 0 13.208984 17.857422 z "
+     id="path856-1" />
+</svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_pokemon-raid.svg
+++ b/webofneeds/won-owner-webapp/src/main/webapp/images/won-icons/ico36_pokemon-raid.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="detail_time"
+   width="36px"
+   height="36px"
+   viewBox="0 0 36 36"
+   sodipodi:docname="ico36_pokemon-raid.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs1012" />
+  <sodipodi:namedview
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview1010"
+     showgrid="false"
+     inkscape:zoom="16.777778"
+     inkscape:cx="2.3424958"
+     inkscape:cy="13.235796"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="detail_time" />
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Layer 1" />
+  <g
+     id="g854"
+     transform="translate(3.3675493,-1.3200072)">
+    <ellipse
+       ry="6.5619917"
+       rx="6.7597609"
+       cy="14.171171"
+       cx="14.586621"
+       id="path1016"
+       style="fill:none;stroke-width:0.75757557" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path850"
+       d="M 14.63245,3.4277344 A 11.205163,10.877335 0 0 0 3.4277344,14.304636 11.205163,10.877335 0 0 0 14.63245,25.181538 11.205163,10.877335 0 0 0 25.837167,14.304636 11.205163,10.877335 0 0 0 14.63245,3.4277344 Z m 0,1.600702 A 9.3490932,9.2757655 0 0 1 23.980977,14.304636 9.3490932,9.2757655 0 0 1 14.63245,23.580835 9.3490932,9.2757655 0 0 1 5.2839238,14.304636 9.3490932,9.2757655 0 0 1 14.63245,5.0284364 Z"
+       style="fill:var(--local-primary);stroke-width:0.75757557" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path856-1"
+       d="M 15.273706,4.2062179 8.8115851,6.0299686 5.558748,10.033182 4.3663415,14.170515 9.3432119,14.192382 A 5.2932366,5.1606173 0 0 1 14.63245,9.1439029 5.2932366,5.1606173 0 0 1 19.923191,14.237575 l 5.066976,0.02187 -2.24665,-6.7177003 z m 4.649485,10.0313571 -1.603892,-0.0073 a 3.6892256,3.5812905 0 0 1 0.003,0.07435 3.6892256,3.5812905 0 0 1 -3.689853,3.581899 3.6892256,3.5812905 0 0 1 -3.689852,-3.581899 3.6892256,3.5812905 0 0 1 0.006,-0.106422 l -1.6053931,-0.0058 a 5.2932366,5.1606173 0 0 0 -0.00451,0.112254 5.2932366,5.1606173 0 0 0 5.2937441,5.160733 5.2932366,5.1606173 0 0 0 5.293745,-5.160733 5.2932366,5.1606173 0 0 0 -0.003,-0.06706 z m -8.974586,-0.03936 7.370694,0.03207 a 3.6892256,3.5812905 0 0 0 -3.686849,-3.50755 3.6892256,3.5812905 0 0 0 -3.683845,3.475477 z"
+       style="fill:var(--local-primary);stroke-width:1.08930635" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path842"
+       d="m 14.721854,34.271524 9.238411,-14.84106 -2.80158,2.945697 -2.863055,1.759666 -4.64737,0.494155 -3.8726095,-1.227074 -4.5902201,-4.210855 z"
+       style="fill:var(--local-primary);fill-opacity:1;stroke:var(--local-primary);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_datetimepicker.scss
@@ -7,14 +7,18 @@ won-datetime-picker {
   position: relative;
   display: grid;
   grid-gap: 0.5rem;
-  grid-template-columns: auto 0.9fr 0.9fr;
+  grid-template-columns: min-content 1fr 1fr;
 
-  .datetimep__button {
-    margin-right: 0.5rem;
+  .datetimep__button.won-button--filled {
+    @media (max-width: $responsivenessBreakPoint) {
+      padding: 0.5rem;
+    }
+    padding: 0.5rem 1rem;
   }
 
   .datetimep__input {
     position: relative;
+    overflow: hidden;
 
     .datetimep__input__icon {
       @include fixed-square($bigiconSize);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_locationpicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_locationpicker.scss
@@ -26,6 +26,8 @@ won-location-picker {
     .lp__searchbox__inner {
       border: $thinGrayBorder;
       background-color: white;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
 
       @include textfieldPadding(
         $normalFontSize,
@@ -108,7 +110,8 @@ won-location-picker {
     width: 100%;
     height: 31rem;
     z-index: 0;
-    margin-top: 0.5rem;
+    border: $thinGrayBorder;
+    border-top: 0;
 
     @media (max-width: $responsivenessBreakPoint) {
       height: 15rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-gym-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-gym-viewer.scss
@@ -1,0 +1,60 @@
+@import "won-config";
+@import "sizing-utils";
+@import "animate";
+
+pokemon-gym-viewer {
+  @include won-detail-viewer("pgv");
+
+  .pgv__content {
+    display: grid;
+    grid-template-columns: min-content 1fr;
+    grid-gap: 0.5rem;
+
+    &__name {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+
+      &__label {
+        &__ex {
+          margin-left: 0.25rem;
+          color: $won-subtitle-gray;
+        }
+      }
+
+      &__carret {
+        @include fixed-square($normalFontSize);
+      }
+    }
+
+    &__label {
+      &--info {
+        cursor: pointer;
+        grid-column: span 2;
+      }
+      &__carret {
+        @include fixed-square($normalFontSize);
+      }
+    }
+
+    &__info {
+      grid-column: span 2;
+      @include slideWithOpacityAnimation(0.5s, linear, 100vh);
+    }
+
+    won-atom-map {
+      grid-column: span 2;
+      display: block;
+      @include slideWithOpacityAnimation(0.5s, linear, 20rem);
+
+      .atom-map__mapmount {
+        width: 100%;
+        height: 31rem;
+
+        @media (max-width: $responsivenessBreakPoint) {
+          height: 15rem;
+        }
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-gym-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-gym-viewer.scss
@@ -1,60 +1,21 @@
 @import "won-config";
 @import "sizing-utils";
-@import "animate";
 
 pokemon-gym-viewer {
   @include won-detail-viewer("pgv");
 
   .pgv__content {
     display: grid;
-    grid-template-columns: min-content 1fr;
     grid-gap: 0.5rem;
-
-    &__name {
-      display: flex;
-      align-items: center;
-      cursor: pointer;
-
-      &__label {
-        &__ex {
-          margin-left: 0.25rem;
-          color: $won-subtitle-gray;
-        }
-      }
-
-      &__carret {
-        @include fixed-square($normalFontSize);
-      }
+    &:not(.won-in-message) {
+      padding-left: 0;
     }
 
-    &__label {
-      &--info {
-        cursor: pointer;
-        grid-column: span 2;
-      }
-      &__carret {
-        @include fixed-square($normalFontSize);
-      }
-    }
-
-    &__info {
-      grid-column: span 2;
-      @include slideWithOpacityAnimation(0.5s, linear, 100vh);
-    }
-
-    won-atom-map {
-      grid-column: span 2;
-      display: block;
-      @include slideWithOpacityAnimation(0.5s, linear, 20rem);
-
-      .atom-map__mapmount {
-        width: 100%;
-        height: 31rem;
-
-        @media (max-width: $responsivenessBreakPoint) {
-          height: 15rem;
-        }
-      }
+    &__ex {
+      background-color: $won-primary-color;
+      color: $won-secondary-text-color;
+      padding: 0.25rem;
+      text-align: center;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
@@ -11,6 +11,7 @@ pokemon-raidboss-viewer {
     border-radius: 0.19rem;
     grid-template-areas: "prbv_level prbv_pokemon" "prbv_level prbv_expires";
     grid-template-columns: min-content 1fr;
+    grid-template-rows: 4rem min-content;
     padding-left: 0;
 
     .prbv__content__label {
@@ -29,6 +30,7 @@ pokemon-raidboss-viewer {
       background-position: center 0.5rem;
       border-right: $thinGrayBorder;
       user-select: none;
+      word-break: keep-all;
 
       &--normal {
         background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/5/5a/Egg_Raid_Normal.png/revision/latest?cb=20170620230659);
@@ -63,13 +65,14 @@ pokemon-raidboss-viewer {
       grid-template-areas: "pkmv_image pkmv_name" "pkmv_image pkmv_id";
       grid-template-columns: min-content 1fr;
       grid-column-gap: 0.5rem;
-      grid-row-gap: 0.25rem;
       padding: 0.25rem;
       background: $won-light-gray;
       border-bottom: $thinGrayBorder;
+      grid-template-rows: 1.25rem min-content;
 
       &__image {
         grid-area: pkmv_image;
+        align-self: center;
         @include fixed-square(3.5rem);
 
         &--unhatched {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
@@ -1,0 +1,92 @@
+@import "won-config";
+@import "sizing-utils";
+
+pokemon-raidboss-viewer {
+  @include won-detail-viewer("prbv");
+
+  .prbv__content.won-in-message,
+  .prbv__content:not(.won-in-message) {
+    display: grid;
+    border: $thinGrayBorder;
+    border-radius: 0.19rem;
+    grid-template-areas: "prbv_level prbv_pokemon" "prbv_level prbv_expires";
+    grid-template-columns: min-content 1fr;
+    padding-left: 0;
+
+    .prbv__content__label {
+      white-space: nowrap;
+    }
+
+    .prbv__content__level {
+      grid-area: prbv_level;
+      text-align: center;
+      font-size: $smallFontSize;
+      height: calc($postIconSize + #{$smallFontSize});
+      padding: calc(#{$postIconSize} + 0.5rem) 0.25rem 0.25rem 0.25rem;
+      background-color: $won-light-gray;
+      background-repeat: no-repeat;
+      background-size: $postIconSize;
+      background-position: center 0.5rem;
+      border-right: $thinGrayBorder;
+      user-select: none;
+
+      &--normal {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/5/5a/Egg_Raid_Normal.png/revision/latest?cb=20170620230659);
+      }
+
+      &--rare {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/e/e3/Egg_Raid_Rare.png/revision/latest?cb=20170620230126);
+      }
+
+      &--legendary {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/c/cd/Egg_Raid_Legendary.png/revision/latest?cb=20170620230139);
+      }
+    }
+
+    .prbv__content__expires {
+      background-color: $won-lighter-gray;
+      padding: 0.25rem;
+      color: var(--won-subtitle-gray);
+      font-size: $smallFontSize;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      &--expired {
+        color: $won-unread-attention;
+      }
+    }
+
+    .prbv__content__pokemon {
+      grid-area: prbv_pokemon;
+      display: grid;
+      grid-template-areas: "pkmv_image pkmv_name" "pkmv_image pkmv_id";
+      grid-template-columns: min-content 1fr;
+      grid-column-gap: 0.5rem;
+      grid-row-gap: 0.25rem;
+      padding: 0.25rem;
+      background: $won-light-gray;
+      border-bottom: $thinGrayBorder;
+
+      &__image {
+        grid-area: pkmv_image;
+        @include fixed-square(3.5rem);
+
+        &--unhatched {
+          filter: contrast(0%);
+        }
+      }
+
+      &__name {
+        grid-area: pkmv_name;
+        font-size: $normalFontSize;
+      }
+
+      &__id {
+        grid-area: pkmv_id;
+        font-size: $smallFontSize;
+        color: $won-subtitle-gray;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
@@ -63,7 +63,7 @@ pokemon-raidboss-viewer {
       grid-area: prbv_pokemon;
       display: grid;
       grid-template-areas: "pkmv_image pkmv_name" "pkmv_image pkmv_id";
-      grid-template-columns: min-content 1fr;
+      grid-template-columns: minmax(3.5rem, min-content) 1fr;
       grid-column-gap: 0.5rem;
       padding: 0.25rem;
       background: $won-light-gray;
@@ -83,6 +83,10 @@ pokemon-raidboss-viewer {
       &__name {
         grid-area: pkmv_name;
         font-size: $normalFontSize;
+        &__form {
+          color: $won-subtitle-gray;
+          margin-left: 0.25rem;
+        }
       }
 
       &__id {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
@@ -4,60 +4,28 @@
 
 pokemon-gym-picker {
   display: grid;
-  grid-row-gap: 0.25rem;
+  grid-gap: 0.5rem;
+  grid-template-columns: min-content 1fr;
+  align-items: center;
 
-  .pgp__input {
-    display: grid;
-    position: relative;
-
-    .pgp__input__icon {
-      @include fixed-square($bigiconSize);
-      position: absolute;
-      right: 0.5rem;
-      top: $formInputHeight / 2 - $bigiconSize / 2;
-      z-index: 1;
-    }
-
-    .pgp__input__inner {
-      @extend .won-txt;
-      border: $thinGrayBorder;
-
-      // @include textfieldPadding(
-      //   $normalFontSize,
-      //   22/16,
-      //   $thinBorderWidth,
-      //   $formInputHeight
-      // );
-
-      //box-sizing: border-box;
-      min-height: $formInputHeight;
-      //min-width: 0; // so a size is specified and break-word works
-      //width: 100%;
-
-      word-wrap: break-word;
-
-      $verticalPadding: calcVerticalPaddingToHeight(
-        $normalFontSize,
-        22/16,
-        $thinBorderWidth,
-        $formInputHeight
-      );
-      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
-        0.438rem;
-    }
-
-    .pgp__input__inner::-ms-clear {
-      width: 0;
-      height: 0;
-    }
-  }
-  .pgp__preview__header {
-    color: $won-primary-color;
+  .pgp__ex {
+    width: $postIconSize;
+    height: $postIconSize;
+    margin: 0;
   }
 
-  .pgp__preview__content {
-    &--empty {
-      color: $won-line-gray;
+  .pgp__location {
+    grid-column: span 2;
+  }
+  .pgp__info {
+    grid-column: span 2;
+  }
+
+  .pgp__label {
+    white-space: nowrap;
+    &--info,
+    &--location {
+      grid-column: span 2;
     }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
@@ -1,0 +1,63 @@
+@import "won-config";
+@import "textfield";
+@import "sizing-utils";
+
+pokemon-gym-picker {
+  display: grid;
+  grid-row-gap: 0.25rem;
+
+  .pgp__input {
+    display: grid;
+    position: relative;
+
+    .pgp__input__icon {
+      @include fixed-square($bigiconSize);
+      position: absolute;
+      right: 0.5rem;
+      top: $formInputHeight / 2 - $bigiconSize / 2;
+      z-index: 1;
+    }
+
+    .pgp__input__inner {
+      @extend .won-txt;
+      border: $thinGrayBorder;
+
+      // @include textfieldPadding(
+      //   $normalFontSize,
+      //   22/16,
+      //   $thinBorderWidth,
+      //   $formInputHeight
+      // );
+
+      //box-sizing: border-box;
+      min-height: $formInputHeight;
+      //min-width: 0; // so a size is specified and break-word works
+      //width: 100%;
+
+      word-wrap: break-word;
+
+      $verticalPadding: calcVerticalPaddingToHeight(
+        $normalFontSize,
+        22/16,
+        $thinBorderWidth,
+        $formInputHeight
+      );
+      padding: $verticalPadding 0.438rem + $bigiconSize $verticalPadding
+        0.438rem;
+    }
+
+    .pgp__input__inner::-ms-clear {
+      width: 0;
+      height: 0;
+    }
+  }
+  .pgp__preview__header {
+    color: $won-primary-color;
+  }
+
+  .pgp__preview__content {
+    &--empty {
+      color: $won-line-gray;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemongympicker.scss
@@ -8,24 +8,13 @@ pokemon-gym-picker {
   grid-template-columns: min-content 1fr;
   align-items: center;
 
+  .pgp__label {
+    white-space: nowrap;
+  }
+
   .pgp__ex {
     width: $postIconSize;
     height: $postIconSize;
     margin: 0;
-  }
-
-  .pgp__location {
-    grid-column: span 2;
-  }
-  .pgp__info {
-    grid-column: span 2;
-  }
-
-  .pgp__label {
-    white-space: nowrap;
-    &--info,
-    &--location {
-      grid-column: span 2;
-    }
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemonraidbosspicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemonraidbosspicker.scss
@@ -69,6 +69,11 @@ pokemon-raidboss-picker {
       &__name {
         grid-area: pkm_name;
         font-size: $normalFontSize;
+
+        &__form {
+          margin-left: 0.25rem;
+          color: $won-subtitle-gray;
+        }
       }
 
       &__id {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemonraidbosspicker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemonraidbosspicker.scss
@@ -1,0 +1,161 @@
+@import "won-config";
+@import "textfield";
+@import "sizing-utils";
+
+pokemon-raidboss-picker {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: min-content 1fr;
+  align-items: center;
+
+  @media (max-width: $responsivenessBreakPoint) {
+    .prbp__label,
+    .prbp__pokemon,
+    .prbp__expires,
+    .prbp__hatches {
+      grid-column: span 2;
+    }
+  }
+
+  .prbp__pokemon,
+  .prbp__hatches {
+    transition: opacity linear 0.5s;
+    opacity: 1;
+
+    &--disabled {
+      transition: opacity linear 0.5s;
+      opacity: 0.25;
+      user-select: none;
+      pointer-events: none;
+    }
+  }
+
+  .prbp__pokemonlist {
+    grid-column: span 2;
+    transition: opacity linear 0.5s, max-height linear 0.5s;
+    opacity: 1;
+    max-height: 15rem;
+    overflow-y: auto;
+    border: $thinGrayBorder;
+
+    &--disabled {
+      transition: opacity linear 0.5s, max-height linear 0.5s;
+      max-height: 0;
+      opacity: 0.25;
+      user-select: none;
+      pointer-events: none;
+      border-top: none;
+      border-bottom: none;
+    }
+    &__pokemon {
+      display: grid;
+      grid-template-areas: "pkm_image pkm_name" "pkm_image pkm_id";
+      grid-template-columns: min-content 1fr;
+      grid-column-gap: 0.5rem;
+      grid-row-gap: 0.25rem;
+      border-bottom: $thinGrayBorder;
+      padding: 0.25rem 0.5rem;
+      background: white;
+
+      &:last-of-type {
+        border-bottom: 0;
+      }
+
+      &__image {
+        grid-area: pkm_image;
+        @include fixed-square($postIconSize);
+      }
+
+      &__name {
+        grid-area: pkm_name;
+        font-size: $normalFontSize;
+      }
+
+      &__id {
+        grid-area: pkm_id;
+        font-size: $smallFontSize;
+        color: $won-subtitle-gray;
+      }
+
+      &:hover {
+        cursor: pointer;
+      }
+      &--selected {
+        background: $won-primary-color-light;
+      }
+    }
+  }
+
+  .prbp__label {
+    white-space: nowrap;
+    transition: opacity linear 0.5s;
+    opacity: 1;
+
+    &--disabled {
+      transition: opacity linear 0.5s;
+      opacity: 0.25;
+      user-select: none;
+      pointer-events: none;
+    }
+  }
+
+  .prbp__hatched {
+    width: $postIconSize;
+    height: $postIconSize;
+    margin: 0;
+  }
+
+  .prbp__level {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-gap: 0.25rem;
+    @media (max-width: $responsivenessBreakPoint) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    grid-column: span 2;
+
+    .prbp__level__option {
+      display: none;
+
+      &:checked + label {
+        cursor: default;
+        border-color: $won-primary-color;
+        background-color: $won-primary-color-light;
+      }
+
+      & + label {
+        text-align: center;
+        font-size: $smallFontSize;
+        height: calc($postIconSize + #{$smallFontSize});
+        cursor: pointer;
+        padding: calc(#{$postIconSize} + 0.5rem) 0.25rem 0.25rem 0.25rem;
+        background-color: white;
+        background-repeat: no-repeat;
+        background-size: $postIconSize;
+        background-position: center 0.5rem;
+        border: $thinGrayBorder;
+        border-radius: 0.19rem;
+        user-select: none;
+      }
+
+      &[value="1"] + label,
+      &[value="2"] + label {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/5/5a/Egg_Raid_Normal.png/revision/latest?cb=20170620230659);
+      }
+
+      &[value="3"] + label,
+      &[value="4"] + label {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/e/e3/Egg_Raid_Rare.png/revision/latest?cb=20170620230126);
+      }
+
+      &[value="5"] + label {
+        background-image: url(https://vignette.wikia.nocookie.net/pokemongo/images/c/cd/Egg_Raid_Legendary.png/revision/latest?cb=20170620230139);
+
+        @media (max-width: $responsivenessBreakPoint) {
+          grid-column: span 2;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds 2 new UseCases:
  - Pokemon Go Raid (GroupChat)
     - includes location detail (for gym location)
     - includes description detail (for gym info)
     - includes gyminfo detail (for if gym is an ex gym)
     - includes raidboss detail (pick pokemon hatchtime, level etc)
  - Pokemon Go Raid Interest
     - does not include any special filter detail (yet)
     - once created enables users to create pokemon go raids
- Adds 2 new Details:
  - pokemon RaidBoss Detail
  - pokemon Info Detail
- Fixes #2813 by allowing a user to set an alternative address name after the location has been chosen, that way we can name locations and include their door numbers, or name locations based on a user chosen string (e.g. for pokemongo gym/arena names)

Caveat:
- the 2 new usecases do not yet create any sparql queries for matching (how matching is going to be done is still in discussion)
- the interest usecase does not allow filtering for any specific raid attributes yet
- not all the available pokemon are in the list, only a set of 6 random ones have been chosen (suffices for debug/testing purposes)