### PR TITLE
Disable the ability of adHoc requests for atoms that have enabled or reaction UseCases

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
@@ -37,8 +37,18 @@ export function getReactionUseCases(atom) {
   return getIn(atom, ["matchedUseCase", "reactionUseCases"]);
 }
 
+export function hasReactionUseCases(atom) {
+  const reactionUseCases = getReactionUseCases(atom);
+  return !!reactionUseCases && reactionUseCases.size > 0;
+}
+
 export function getEnabledUseCases(atom) {
   return getIn(atom, ["matchedUseCase", "enabledUseCases"]);
+}
+
+export function hasEnabledUseCases(atom) {
+  const enabledUseCases = getEnabledUseCases(atom);
+  return !!enabledUseCases && enabledUseCases.size > 0;
 }
 
 export function hasMatchedUseCase(atom) {
@@ -114,6 +124,14 @@ export function getDefaultImage(atom) {
  */
 export function isInactive(atom) {
   return get(atom, "state") && get(atom, "state") === won.WON.InactiveCompacted;
+}
+
+/**
+ * If an atom is active and has the chat or the group socket we can connect to it.
+ * @param atom
+ */
+export function isConnectible(atom) {
+  return isActive(atom) && (hasChatSocket(atom) || hasGroupSocket(atom));
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -33,19 +33,16 @@ function genComponentConf() {
         <div class="cp__header">
             <a class="cp__header__back clickable"
                 ng-click="self.router__back()">
-                <svg style="--local-primary:var(--won-primary-color);"
-                    class="cp__header__back__icon show-in-responsive">
+                <svg class="cp__header__back__icon show-in-responsive">
                     <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
-                <svg style="--local-primary:var(--won-primary-color);"
-                    class="cp__header__back__icon hide-in-responsive">
+                <svg class="cp__header__back__icon hide-in-responsive">
                     <use xlink:href="#ico36_close" href="#ico36_close"></use>
                 </svg>
             </a>
             <svg class="cp__header__icon"
                 title="{{self.useCase['label']}}"
-                ng-if="self.useCase['icon']"
-                style="--local-primary:var(--won-primary-color);">
+                ng-if="self.useCase['icon']">
                     <use xlink:href="{{self.useCase['icon']}}" href="{{self.useCase['icon']}}"></use>
             </svg>
             <span class="cp__header__title" ng-if="!self.isCreateFromAtom && !self.isEditFromAtom">{{self.useCase.label}}</span>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-messages.js
@@ -11,11 +11,9 @@ import labelledHrModule from "./labelled-hr.js";
 import connectionContextDropdownModule from "./connection-context-dropdown.js";
 import { connect2Redux } from "../won-utils.js";
 import { attach, delay, getIn, get } from "../utils.js";
-import * as atomUtils from "../atom-utils.js";
 import * as processUtils from "../process-utils.js";
 import * as connectionUtils from "../connection-utils.js";
 import * as messageUtils from "../message-utils.js";
-import { getUseCaseIcon, getUseCaseLabel } from "../usecase-utils.js";
 import {
   fetchAgreementProtocolUris,
   fetchPetriNetUris,
@@ -260,27 +258,6 @@ function genComponentConf() {
             <button class="pm__footer__button won-button--filled black" ng-click="self.closeConnection(true)">
                 Bad match - remove!
             </button>
-            <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasReactionUseCases"></won-labelled-hr>
-            <!-- Reaction Use Cases -->
-            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;"
-                    ng-if="self.hasReactionUseCases"
-                    ng-repeat="ucIdentifier in self.reactionUseCasesArray"
-                    ng-click="self.selectUseCase(ucIdentifier)">
-                    <svg class="won-button-icon" style="--local-primary:white;" ng-if="self.getUseCaseIcon(ucIdentifier)">
-                        <use xlink:href="{{ self.getUseCaseIcon(ucIdentifier) }}" href="{{ self.getUseCaseIcon(ucIdentifier) }}"></use>
-                    </svg>
-                    <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
-            </button>
-            <won-labelled-hr label="::'Or'" class="pm__footer__labelledhr"  ng-if="self.hasEnabledUseCases"></won-labelled-hr>
-            <button class="pm__footer__button won-button--filled red" style="margin: 0rem 0rem .3rem 0rem;"
-                    ng-if="self.hasEnabledUseCases"
-                    ng-repeat="ucIdentifier in self.enabledUseCasesArray"
-                    ng-click="self.selectUseCase(ucIdentifier)">
-                    <svg class="won-button-icon" style="--local-primary:white;" ng-if="self.getUseCaseIcon(ucIdentifier)">
-                        <use xlink:href="{{ self.getUseCaseIcon(ucIdentifier) }}" href="{{ self.getUseCaseIcon(ucIdentifier) }}"></use>
-                    </svg>
-                    <span>{{ self.getUseCaseLabel(ucIdentifier) }}</span>
-            </button>
         </div>
     `;
 
@@ -375,33 +352,12 @@ function genComponentConf() {
 
         const process = get(state, "process");
 
-        const isTargetAtomOwned = generalSelectors.isAtomOwned(
-          state,
-          targetAtomUri
-        );
-        const reactionUseCases =
-          targetAtom &&
-          !isTargetAtomOwned &&
-          atomUtils.getReactionUseCases(targetAtom);
-        const hasReactionUseCases =
-          reactionUseCases && reactionUseCases.size > 0;
-
-        const enabledUseCases =
-          targetAtom &&
-          isTargetAtomOwned &&
-          atomUtils.getEnabledUseCases(targetAtom);
-        const hasEnabledUseCases = enabledUseCases && enabledUseCases.size > 0;
-
         return {
           ownedAtom,
           targetAtom,
           targetAtomUri,
           selectedConnectionUri,
           connection,
-          hasReactionUseCases,
-          reactionUseCasesArray: reactionUseCases && reactionUseCases.toArray(),
-          hasEnabledUseCases,
-          enabledUseCasesArray: enabledUseCases && enabledUseCases.toArray(),
           sortedMessageUris: sortedMessages && [
             ...sortedMessages.flatMap(msg => msg.get("uri")),
           ],
@@ -511,14 +467,6 @@ function genComponentConf() {
         () => this.connectionOrAtomsLoading,
         this
       );
-    }
-
-    getUseCaseIcon(ucIdentifier) {
-      return getUseCaseIcon(ucIdentifier);
-    }
-
-    getUseCaseLabel(ucIdentifier) {
-      return getUseCaseLabel(ucIdentifier);
     }
 
     ensureMessagesAreLoaded() {
@@ -929,18 +877,6 @@ function genComponentConf() {
       } else {
         this.router__stateGoCurrent({ connectionUri: null });
       }
-    }
-
-    selectUseCase(ucIdentifier) {
-      this.router__stateGoCurrent({
-        useCase: ucIdentifier,
-        useCaseGroup: undefined,
-        postUri: undefined,
-        fromAtomUri: this.targetAtomUri,
-        viewAtomUri: undefined,
-        viewConnUri: undefined,
-        mode: "CONNECT",
-      });
     }
 
     selectMessage(msgUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.js
@@ -22,12 +22,10 @@ function genComponentConf() {
       <div class="ucg__header">
           <a class="cp__header__back clickable"
               ng-click="self.router__back()">
-              <svg style="--local-primary:var(--won-primary-color);"
-                  class="ucg__header__back__icon show-in-responsive">
+              <svg class="ucg__header__back__icon show-in-responsive">
                   <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
               </svg>
-              <svg style="--local-primary:var(--won-primary-color);"
-                  class="ucg__header__back__icon hide-in-responsive">
+              <svg class="ucg__header__back__icon hide-in-responsive">
                   <use xlink:href="#ico36_close" href="#ico36_close"></use>
               </svg>
           </a>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.js
@@ -28,12 +28,10 @@ function genComponentConf() {
         <div class="ucp__header" ng-if="self.showAll">
             <a class="ucp__header__back clickable"
                 ng-click="self.router__stateGoCurrent({useCase: undefined, useCaseGroup: undefined})">
-                <svg style="--local-primary:var(--won-primary-color);"
-                    class="ucp__header__back__icon show-in-responsive">
+                <svg class="ucp__header__back__icon show-in-responsive">
                     <use xlink:href="#ico36_backarrow" href="#ico36_backarrow"></use>
                 </svg>
-                <svg style="--local-primary:var(--won-primary-color);"
-                    class="ucp__header__back__icon hide-in-responsive">
+                <svg class="ucp__header__back__icon hide-in-responsive">
                     <use xlink:href="#ico36_close" href="#ico36_close"></use>
                 </svg>
             </a>
@@ -44,7 +42,7 @@ function genComponentConf() {
         <div class="ucp__createx">
             <button class="won-button--filled red ucp__createx__button"
                     ng-click="self.viewWhatsAround()">
-                <svg class="won-button-icon" style="--local-primary:white;">
+                <svg class="won-button-icon">
                     <use xlink:href="#ico36_location_current" href="#ico36_location_current"></use>
                 </svg>
                 <span>What's in your Area?</span>
@@ -62,7 +60,6 @@ function genComponentConf() {
         <!-- SEARCH FIELD -->
         <div class="ucp__main__search">
           <svg class="ucp__main__search__icon clickable"
-              style="--local-primary:var(--won-primary-color);"
               ng-if="self.showResetButton"
               ng-click="self.resetSearch()">
               <use xlink:href="#ico36_close" href="#ico36_close"></use>

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-academic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-academic.js
@@ -12,7 +12,7 @@ import { consortiumOffer } from "./uc-consortium-offer.js";
 export const academicGroup = {
   identifier: "academicGroup",
   label: "Academia",
-  icon: undefined,
+  icon: "#ico36_uc_phd",
   subItems: {
     phdOffer: phdOffer,
     phdSearch: phdSearch,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-artists.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-artists.js
@@ -7,7 +7,7 @@ import { rehearsalRoomSearch } from "./uc-rehearsal-room-search.js";
 export const artistGroup = {
   identifier: "artistgroup",
   label: "Music",
-  icon: undefined,
+  icon: "#ico36_detail_instrument",
   subItems: {
     bandSearch: bandSearch,
     musicianSearch: musicianSearch,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-classifieds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-classifieds.js
@@ -11,7 +11,7 @@ TODO: create use case icons
 export const classifiedsGroup = {
   identifier: "classifiedsgroup",
   label: "Buy & Sell",
-  icon: undefined,
+  icon: "#ico36_detail_price",
   subItems: {
     goodsOffer: goodsOffer,
     goodsServiceSearch: goodsServiceSearch,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-other.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-other.js
@@ -10,7 +10,7 @@ import { details, mergeInEmptyDraft } from "../detail-definitions.js";
 export const otherGroup = {
   identifier: "othergroup",
   label: "More...",
-  icon: undefined,
+  icon: "#ico36_plus",
   subItems: {
     complain: complain,
     handleComplaint: handleComplaint,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-personal-mobility.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-personal-mobility.js
@@ -5,7 +5,7 @@ import { personalTransportSearch } from "./uc-personal-transport-search.js";
 export const personalMobilityGroup = {
   identifier: "mobilitygroup",
   label: "Mobility",
-  icon: undefined,
+  icon: "#ico36_uc_route_demand",
   subItems: {
     personalTransportSearch: personalTransportSearch,
     taxiOffer: taxiOffer,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-real-estate.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-real-estate.js
@@ -6,7 +6,7 @@ import { rehearsalRoomSearch } from "./uc-rehearsal-room-search.js";
 export const realEstateGroup = {
   identifier: "realestategroup",
   label: "Homes",
-  icon: undefined,
+  icon: "#ico36_uc_realestate",
   subItems: {
     rentRealEstateSearch: rentRealEstateSearch,
     rentRealEstateOffer: rentRealEstateOffer,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-social.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-social.js
@@ -8,7 +8,7 @@ import { handleComplaint } from "./uc-handle-complaint";
 export const socialGroup = {
   identifier: "socialgroup",
   label: "Social",
-  icon: undefined,
+  icon: "#ico36_uc_find_people",
   subItems: {
     getBreakfast: getBreakfast,
     afterparty: afterparty,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-transport.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-transport.js
@@ -7,7 +7,7 @@ import { goodsTransportOffer } from "./uc-goods-transport-offer.js";
 export const transportGroup = {
   identifier: "transportgroup",
   label: "Transport",
-  icon: undefined,
+  icon: "#ico36_uc_transport_offer",
   subItems: {
     personalTransportSearch: personalTransportSearch,
     taxiOffer: taxiOffer,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-work.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-work.js
@@ -8,7 +8,7 @@ import { postdocSearch } from "./uc-postdoc-search.js";
 export const workGroup = {
   identifier: "workgroup",
   label: "Jobs",
-  icon: undefined,
+  icon: "#ico36_uc_consortium-search", //TODO proper icon
   subItems: {
     jobSearch: jobSearch,
     jobOffer: jobOffer,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
@@ -37,6 +37,7 @@ export const bandSearch = {
     instruments: {
       ...instrumentsDetail,
     },
+    images: { ...details.images },
   },
   seeksDetails: {
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
@@ -30,6 +30,7 @@ export const bandSearch = {
       },
     }),
   },
+  reactionUseCases: ["musicianSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
@@ -22,6 +22,7 @@ export const complain = {
       },
     }),
   },
+  reactionUseCases: ["handleComplaint"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
@@ -28,6 +28,7 @@ export const complain = {
     description: { ...details.description },
     location: { ...details.location },
     tags: { ...details.tags },
+    images: { ...details.images },
   },
   seeksDetails: undefined,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
@@ -20,6 +20,7 @@ export const consortiumOffer = {
       },
     }),
   },
+  reactionUseCases: ["consortiumSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
@@ -20,6 +20,7 @@ export const consortiumSearch = {
       },
     }),
   },
+  reactionUseCases: ["consortiumOffer"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-get-to-know.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-get-to-know.js
@@ -27,6 +27,7 @@ export const getToKnow = {
     person: { ...details.person },
     skills: { ...skillsDetail },
     interests: { ...interestsDetail },
+    images: { ...details.images },
   },
   seeksDetails: {
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
@@ -18,6 +18,7 @@ export const goodsOffer = {
       },
     }),
   },
+  reactionUseCases: ["goodsServiceSearch"],
   details: {
     title: { ...details.title, mandatory: true },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -27,6 +27,7 @@ export const goodsServiceSearch = {
       },
     }),
   },
+  reactionUseCases: ["serviceOffer", "goodsOffer"],
   seeksDetails: {
     title: { ...details.title },
     tags: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -24,6 +24,7 @@ export const goodsServiceSearch = {
       },
       seeks: {
         type: ["s:Offer"],
+        images: { ...details.images },
       },
     }),
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -24,7 +24,6 @@ export const goodsServiceSearch = {
       },
       seeks: {
         type: ["s:Offer"],
-        images: { ...details.images },
       },
     }),
   },
@@ -39,6 +38,7 @@ export const goodsServiceSearch = {
     priceRange: { ...details.pricerange },
     description: { ...details.description },
     location: { ...details.location },
+    images: { ...details.images },
   },
   generateQuery: (draft, resultName) => {
     let subQueries = [];

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
@@ -249,6 +249,7 @@ export const goodsTransportSearch = {
       },
     },
     tags: { ...details.tags },
+    images: { ...details.images },
   },
   seeksDetails: {
     travelAction: { ...details.travelAction },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
@@ -22,6 +22,7 @@ export const handleComplaint = {
       },
     }),
   },
+  reactionUseCases: ["complain"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
@@ -31,6 +31,7 @@ export const jobOffer = {
       },
     }),
   },
+  reactionUseCases: ["jobSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
@@ -36,6 +36,7 @@ export const jobSearch = {
       },
     }),
   },
+  reactionUseCases: ["jobOffer"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
@@ -35,6 +35,7 @@ export const musicianSearch = {
     title: { ...details.title },
     description: { ...details.description },
     genres: { ...genresDetail },
+    images: { ...details.images },
     location: {
       ...details.location,
       mandatory: true,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
@@ -30,6 +30,7 @@ export const musicianSearch = {
       },
     }),
   },
+  reactionUseCases: ["bandSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
@@ -20,6 +20,7 @@ export const phdOffer = {
       },
     }),
   },
+  reactionUseCases: ["phdSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
@@ -23,6 +23,7 @@ export const phdSearch = {
       },
     }),
   },
+  reactionUseCases: ["phdOffer"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
@@ -20,6 +20,7 @@ export const postdocOffer = {
       },
     }),
   },
+  reactionUseCases: ["postdocSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
@@ -23,6 +23,7 @@ export const postdocSearch = {
       },
     }),
   },
+  reactionUseCases: ["postdocOffer"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
@@ -60,6 +60,7 @@ export const rehearsalRoomOffer = {
     },
     fromDatetime: { ...details.fromDatetime },
     throughDatetime: { ...details.throughDatetime },
+    images: { ...details.images },
   },
 
   seeksDetails: undefined,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
@@ -34,6 +34,7 @@ export const rehearsalRoomOffer = {
       },
     }),
   },
+  reactionUseCases: ["rehearsalRoomSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
@@ -34,6 +34,7 @@ export const rehearsalRoomSearch = {
       },
     }),
   },
+  reactionUseCases: ["rehearsalRoomOffer"],
   details: undefined,
   seeksDetails: {
     location: { ...details.location },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -37,6 +37,7 @@ export const rentRealEstateOffer = {
       },
     }),
   },
+  reactionUseCases: ["rentRealEstateSearch"],
   details: {
     title: { ...details.title },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -58,6 +58,7 @@ export const rentRealEstateOffer = {
       ...realEstateRentDetail,
       mandatory: true,
     },
+    images: { ...details.images },
   },
   seeksDetails: undefined,
   generateQuery: (draft, resultName) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -59,6 +59,7 @@ export const rentRealEstateOffer = {
       mandatory: true,
     },
     images: { ...details.images },
+    files: { ...details.files },
   },
   seeksDetails: undefined,
   generateQuery: (draft, resultName) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
@@ -37,6 +37,7 @@ export const rentRealEstateSearch = {
       },
     }),
   },
+  reactionUseCases: ["rentRealEstateOffer"],
   details: undefined,
   seeksDetails: {
     location: { ...details.location },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
@@ -32,6 +32,7 @@ export const rideShareOffer = {
     fromDatetime: { ...details.fromDatetime },
     throughDatetime: { ...details.throughDatetime },
     travelAction: { ...details.travelAction },
+    images: { ...details.images },
   },
   generateQuery: (draft, resultName) => {
     const fromLocation = getIn(draft, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
@@ -22,6 +22,7 @@ export const serviceOffer = {
     price: { ...details.price, mandatory: true },
     tags: { ...details.tags },
     location: { ...details.location },
+    images: { ...details.images },
   },
   // TODO: what should this match on?
   // generateQuery: (draft, resultName) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
@@ -15,6 +15,7 @@ export const serviceOffer = {
       },
     }),
   },
+  reactionUseCases: ["goodsServiceSearch"],
   details: {
     title: { ...details.title, mandatory: true },
     description: { ...details.description },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
@@ -23,6 +23,7 @@ export const taxiOffer = {
     title: { ...details.title },
     description: { ...details.description },
     location: { ...details.location },
+    images: { ...details.images },
   },
   generateQuery: (draft, resultName) => {
     const location = getIn(draft, ["content", "location"]);

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_button.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_button.scss
@@ -16,6 +16,10 @@
     background: lightgrey;
     cursor: default;
   }
+
+  .won-button-icon {
+    --local-primary: #{$color};
+  }
 }
 
 @mixin outline-button-color($color) {
@@ -39,6 +43,10 @@
     color: white;
     background: $won-disabled-color;
     cursor: default;
+  }
+
+  .won-button-icon {
+    --local-primary: #{$color};
   }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_create-post.scss
@@ -45,6 +45,7 @@ won-create-search {
     }
 
     &__icon {
+      --local-primary: #{$won-subtitle-gray};
       grid-area: header_icon;
       @include fixed-square($postIconSize);
     }
@@ -52,6 +53,7 @@ won-create-search {
     &__back {
       grid-area: header_back;
       &__icon {
+        --local-primary: #{$won-primary-color};
         @include fixed-square($backIconSize);
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post-info.scss
@@ -67,15 +67,12 @@ won-post-info {
   }
 
   .post-info__footer {
-    padding: 0 0.5rem 0.5rem 0.5rem;
-    box-sizing: border-box;
     grid-area: footer;
+    display: grid;
+    grid-gap: 0.5rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
     border-top: $thinGrayBorder;
-    padding-top: 0.5rem;
-
-    &__labelledhr span {
-      background: white;
-    }
 
     &__button {
       width: 100%;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-group.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-group.scss
@@ -46,12 +46,14 @@ won-usecase-group {
 
     &__icon {
       grid-area: header_icon;
+      --local-primary: #{$won-subtitle-gray};
       @include fixed-square($postIconSize);
     }
 
     &__back {
       grid-area: header_back;
       &__icon {
+        --local-primary: #{$won-primary-color};
         @include fixed-square($backIconSize);
       }
     }
@@ -69,22 +71,25 @@ won-usecase-group {
     overflow: auto;
 
     &__usecase {
-      display: flex;
+      display: grid;
+      grid-template-columns: min-content 1fr;
+      grid-template-areas: "ucgi__icon ucgi__label";
+
       align-items: center;
-      flex-direction: column;
-      justify-content: center;
       padding: 0.5rem;
       border-radius: 0.19rem;
       background: $won-secondary-color-light;
 
       &__icon {
+        grid-area: ucgi__icon;
         @include fixed-square($iconSize);
         --local-primary: #{$won-secondary-text-color};
+        margin-right: 0.5rem;
       }
 
       &__label {
+        grid-area: ucgi__label;
         color: $won-secondary-text-color;
-        text-align: center;
       }
 
       &:hover {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_usecase-picker.scss
@@ -51,9 +51,7 @@ won-usecase-picker {
     &__back {
       grid-area: header_back;
       &__icon {
-        /*@media (max-width: $responsivenessBreakPoint) {
-          @include fixed-square(2.5rem);
-        }*/
+        --local-primary: #{$won-primary-color};
         @include fixed-square($backIconSize);
       }
     }
@@ -74,9 +72,6 @@ won-usecase-picker {
       @media (min-width: $responsivenessBreakPoint) {
         white-space: nowrap;
       }
-    }
-
-    &__button {
       white-space: normal;
     }
 
@@ -129,6 +124,7 @@ won-usecase-picker {
       }
 
       &__icon {
+        --local-primary: #{$won-primary-color};
         @include fixed-square($bigiconSize);
         position: absolute;
         right: 0.5rem;
@@ -145,26 +141,28 @@ won-usecase-picker {
     &__newcustom,
     &__searchresult,
     &__usecase-group {
-      display: flex;
+      display: grid;
+      grid-template-columns: min-content 1fr;
+      grid-template-areas: "ucpi__icon ucpi__label";
+
       align-items: center;
-      flex-direction: column;
-      justify-content: center;
       padding: 0.5rem;
       border-radius: 0.19rem;
       background: $won-secondary-color-light;
-      min-height: $iconSize + $normalFontSize + 0.5rem; // icon + label + 0.5rem padding
 
       &:hover {
         filter: brightness(85%);
       }
 
       &__icon {
+        grid-area: ucpi__icon;
         @include fixed-square($iconSize);
         --local-primary: #{$won-secondary-text-color};
+        margin-right: 0.5rem;
       }
       &__label {
+        grid-area: ucpi__label;
         color: $won-secondary-text-color;
-        text-align: center;
       }
     }
 


### PR DESCRIPTION
this pr includes the changes made in #2923

What has been done to the post-info view (aka visitor view)?
- remove the ability to request via adHoc atom if there are enabled useCases and the atom is owned
- remove the ability to request via adHoc atom if there are reaction useCases and the atom is NOT owned
- refactoring of the component so that it uses less duplicate selections and changes the naming from post to atom etc.
- refactors styling by removing inline styles from the component to the scss (margin was used, was changed to a grid gap in the footer)

One can either merge #2923 before hand or test/merge both PRs from here, either way is fine with me