### PR TITLE
Create letsencrypt cronjob

### DIFF
--- a/documentation/letsencrypt/README.md
+++ b/documentation/letsencrypt/README.md
@@ -2,7 +2,7 @@
 
 letsencrypt container (see [docker-compose live deployment](https://github.com/researchstudio-sat/webofneeds/blob/master/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml)) that helps renew the matchat.org (including match.org and node.matchat.org) certificate.
 It is used by the nginx (external matchat representation of owner) and the wonnode.
-This is only used around every 90 days to manually renew the certificate.
+Certificate renewal happens automatically via a cronjob.
 
 # Certificate Renewal
 
@@ -10,8 +10,9 @@ To renew the certificate note the following things:
 - all involved containers (letsencrypt, nginx, wonnode) are configured to mount the right folders
 - the certificate folder on the host is configured to be `$base_folder/letsencrypt/certs/live/matchat.org"`
 - nginx must be running so that the acme challenge can be executed (for a new creation of the certificate you can start nginx with the nginx-http-only.conf which doesn't need a certificate file for startup)
-- execute `docker exec livesatvm01_letsencrypt_1 bash //usr/local/bin/certificate-request-and-renew.sh` for certificate renewal on host satvm01
-- this script can be changed for testing e.g. by adding parameters like `--dry-run or --test-cert` to the certbot
+- execute `docker start livesatvm01_letsencrypt_1` for certificate renewal on host satvm01 (this should happen once a day via cronjob)
+- to manually renew the certificates, execute  `docker exec livesatvm01_letsencrypt1 bash //usr/local/bin/certificate-request-and-renew.sh`
+- this script can be changed for testing e.g. by adding parameters like `--dry-run or --test-cert` to the certbot commands
 - this should renew the letsencrypt certificate in `$base_folder/letsencrypt/certs/live/matchat.org` on the host
 - check if the .pem files and the java key store files (.jks and .pfx) in the same folder have also been updated. These are symlinks into `../../archive/<domainname>/`, you might want to follow those symlinks and check that they are pointing to new files
 - delete all (trust store) files in directory `$base_folder/won-client-certs/` on all hosts (satvm01)

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -2,16 +2,14 @@ version: "2"
 services:
   # letsencrypt container that helps renew the matchat.org (including www.match.org and node.matchat.org) certificate.
   # It is used by the nginx (external matchat representation of owner) and the wonnode.
-  # This is only used around every 90 days to manually renew the certificate.
+  # This is used once a day by a cronjob on satvm01 to check and renew the certificate.
   # To renew the certificate note the following things:
   # - all involved containers (letsencrypt, nginx, wonnode) are configured to mount the right folders
   # - the certificate folder on the host is configured to be "$base_folder/letsencrypt/certs/live/matchat.org"
   # - nginx must be running so that the acme challenge can be executed
   #   (for a new creation of the certificate you can start nginx with the nginx-http-only.conf which doesnt need
   #   certificate file for startup)
-  # - execute "docker exec livesatvm01_letsencrypt_1 bash //usr/local/bin/certificate-request-and-renew.sh" for
-  #   certificate renewal on host satvm01
-  # - this script can be changed for testing e.g. by adding parameters like --dry-run or --test-cert to the certbot
+  # - execute "docker start livesatvm01_letsencrypt_1" for certificate renewal on host satvm01
   # - this should renew the letsencrypt certificate in "$base_folder/letsencrypt/certs/live/matchat.org" on the host
   # - check if the .pem files and the java key store files (.jks and .pfx) in the same folder have also been updated
   # - delete all (trust store) files in directory $base_folder/won-client-certs/ on all hosts (satvm01)

--- a/webofneeds/won-docker/image/letsencrypt/Dockerfile
+++ b/webofneeds/won-docker/image/letsencrypt/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8u121-jdk
 
 # install certbot
 ADD ./jessie-backports.list /etc/apt/sources.list.d/jessie-backports.list
-RUN apt-get update && apt-get install -y certbot -t jessie-backports dos2unix cron
+RUN apt-get update && apt-get install -y certbot -t jessie-backports dos2unix
 
 # main directory where the certificates are generated. This directory should be mounted to the host since other
 # directories inside (e.g. "live") use symlinks which should not be broken by mounting
@@ -35,6 +35,8 @@ RUN chmod +x /usr/local/bin/certificate-request-and-renew.sh
 RUN dos2unix /usr/local/bin/certificate-request-and-renew.sh
 
 # execute cron to keep container running
-RUN touch /var/log/cron.log
-CMD cron && tail -f /var/log/cron.log
+#RUN touch /var/log/cron.log
+#CMD cron && tail -f /var/log/cron.log
 
+# try to renew letsencrypt certificates
+RUN /usr/local/bin/certificate-request-and-renew.sh


### PR DESCRIPTION
Instead of having a letsencrypt docker container run permanently with a cronjob being executed within, this moves the cronjob to satvm01. The cronjob inside the docker container is created by installing certbot and cannot be edited. Instead of using this cronjob, cron is no longer installed inside the docker container.

After merging these changes, starting the letsencrypt container(s) should run the certificate renewal script from won-docker before shutting down again. There are now cronjobs that start both letsencrypt containers once daily (at around noon).