### PR TITLE
Find JobPostings within WhatsAround

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/util/DefaultAtomModelWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/DefaultAtomModelWrapper.java
@@ -164,13 +164,40 @@ public class DefaultAtomModelWrapper extends AtomModelWrapper {
     }
 
     public Coordinate getLocationCoordinate(Resource contentNode) {
+        return getLocationCoordinate(contentNode, SCHEMA.LOCATION, WON.location);
+    }
+
+    public Coordinate getJobLocationCoordinate() {
+        return getJobLocationCoordinate(getAtomContentNode());
+    }
+
+    public Coordinate getJobLocationCoordinate(Resource contentNode) {
+        return getLocationCoordinate(contentNode, SCHEMA.JOBLOCATION);
+    }
+
+    private Coordinate getLocationCoordinate(Resource contentNode, Property locationProperty) {
+        return getLocationCoordinate(contentNode, locationProperty, null);
+    }
+
+    /**
+     * Tries to retrieve the coordinates of the location stored in the contentNode
+     * within the given locationProperty
+     * 
+     * @param contentNode contentNode in which the locationProperty is searched for
+     * @param locationProperty e.g SCHEMA.LOCATION or SCHEMA.JOBLOCATION
+     * @param fallbackProperty nullable, will be checked if locationProperty itself
+     * is not present in the contentNode
+     * @return Coordinate if found otherwise null
+     */
+    private Coordinate getLocationCoordinate(Resource contentNode, Property locationProperty,
+                    Property fallbackProperty) {
         Model atomModel = getAtomModel();
         Property geoProperty = atomModel.createProperty("http://schema.org/", "geo");
         Property longitudeProperty = atomModel.createProperty("http://schema.org/", "longitude");
         Property latitudeProperty = atomModel.createProperty("http://schema.org/", "latitude");
-        RDFNode locationNode = RdfUtils.findOnePropertyFromResource(atomModel, contentNode, SCHEMA.LOCATION);
-        if (locationNode == null) {
-            locationNode = RdfUtils.findOnePropertyFromResource(atomModel, contentNode, WON.location);
+        RDFNode locationNode = RdfUtils.findOnePropertyFromResource(atomModel, contentNode, locationProperty);
+        if (fallbackProperty != null && locationNode == null) {
+            locationNode = RdfUtils.findOnePropertyFromResource(atomModel, contentNode, fallbackProperty);
         }
         RDFNode geoNode = (locationNode != null && locationNode.isResource())
                         ? RdfUtils.findOnePropertyFromResource(atomModel, locationNode.asResource(), geoProperty)

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/pojo/AtomPojo.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/pojo/AtomPojo.java
@@ -28,6 +28,7 @@ public class AtomPojo {
     private Collection<URI> types;
     private Collection<URI> seeksTypes;
     private Coordinate location;
+    private Coordinate jobLocation;
     @JsonIgnore
     private ZonedDateTime creationZonedDateTime;
     private String creationDate;
@@ -52,6 +53,7 @@ public class AtomPojo {
         creationZonedDateTime = atom.getCreationDate();
         creationDate = creationZonedDateTime.toString();
         location = atom.getLocationCoordinate();
+        jobLocation = atom.getJobLocationCoordinate();
         flags = atom.getAllFlags();
         types = atom.getContentTypes();
         seeksTypes = atom.getSeeksTypes();
@@ -93,6 +95,14 @@ public class AtomPojo {
 
     public void setLocation(Coordinate location) {
         this.location = location;
+    }
+
+    public Coordinate getJobLocation() {
+        return jobLocation;
+    }
+
+    public void setJobLocation(Coordinate jobLocation) {
+        this.jobLocation = jobLocation;
     }
 
     public ZonedDateTime getCreationZonedDateTime() {

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestAtomController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestAtomController.java
@@ -166,7 +166,8 @@ public class RestAtomController {
                                 && ((modifiedAfter == null) || modifiedAfter.isBefore(atom.getModifiedZonedDateTime()))
                                 && ((createdAfter == null) || createdAfter.isBefore(atom.getCreationZonedDateTime()))
                                 && ((nearLocation == null)
-                                                || (isNearLocation(nearLocation, atom.getLocation(), maxDistance)))) {
+                                                || isNearLocation(nearLocation, atom.getLocation(), maxDistance)
+                                                || isNearLocation(nearLocation, atom.getJobLocation(), maxDistance))) {
                     atomMap.put(atom.getUri(), atom);
                     if (limit > 0 && atomMap.size() >= limit)
                         break; // break fetching if the limit has been reached

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
@@ -72,20 +72,40 @@ export function hasImages(atom) {
 
 export function hasLocation(atom) {
   return (
+    !!getIn(atom, ["content", "jobLocation"]) ||
     !!getIn(atom, ["content", "location"]) ||
+    !!getIn(atom, ["seeks", "jobLocation"]) ||
     !!getIn(atom, ["seeks", "location"])
   );
 }
 
+/**
+ * Returns the first location found in the content of the atom
+ * jobLocation has priority over "default" location
+ * If no location is present undefined will be returned
+ * @param atom
+ * @returns {*}
+ */
 export function getLocation(atom) {
   if (hasLocation(atom)) {
     return (
-      getIn(atom, ["content", "location"]) || getIn(atom, ["seeks", "location"])
+      getIn(atom, ["content", "jobLocation"]) ||
+      getIn(atom, ["content", "location"]) ||
+      getIn(atom, ["seeks", "jobLocation"]) ||
+      getIn(atom, ["seeks", "location"])
     );
   }
   return undefined;
 }
 
+/**
+ * Get distance between the first found atomLocation and the location (parameter)
+ * Distance in meters, undefined if atom has no location or location parameter is undefined
+ * Priority of atomLocation is defined within getLocation
+ * @param atom
+ * @param location
+ * @returns {*}
+ */
 export function getDistanceFrom(atom, location) {
   const atomLocation = getLocation(atom);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
@@ -149,6 +149,7 @@ export function parseMetaAtom(metaAtom) {
         type: extractTypes(get(metaAtomImm, "types")),
         flags: extractFlags(get(metaAtomImm, "flags")),
         location: extractLocation(get(metaAtomImm, "location")),
+        jobLocation: extractLocation(get(metaAtomImm, "jobLocation")),
       },
       seeks: {
         type: extractTypes(get(metaAtomImm, "seeksTypes")),

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-card.scss
@@ -23,13 +23,13 @@ won-atom-card {
     }
 
     .card__main__subtitle__type {
-      height: calc(#{$smallFontSize} - 0.1rem);
+      height: $smallFontSize - 0.1rem;
       width: 5rem;
       background-color: $won-skeleton-color;
     }
 
     .card__main__topline__title {
-      height: calc(#{$smallFontSize} - 0.05rem);
+      height: $smallFontSize - 0.05rem;
       width: 7rem;
       background-color: $won-skeleton-color;
     }
@@ -71,14 +71,15 @@ won-atom-card {
       display: flex;
       align-items: center;
       justify-content: center;
-      @include fixed-square(5rem);
+      $cardIdenticonSize: 5rem;
+      @include fixed-square(#{$cardIdenticonSize});
 
       &.usecaseimage {
         box-sizing: border-box;
         padding: 0.25rem;
 
         > svg {
-          @include fixed-square(calc(#{5rem}-0.5rem));
+          @include fixed-square(#{$cardIdenticonSize - 0.5rem});
           --local-primary: #{$won-secondary-text-color};
         }
       }
@@ -205,10 +206,15 @@ won-atom-card {
       align-items: center;
       @include fixed-square($postIconSize);
 
-      &__usecaseimage > svg {
-        @include fixed-square(calc(#{$postIconSize}-0.5rem));
-        --local-primary: #{$won-secondary-text-color};
+      &__usecaseimage {
+        display: grid;
+
+        > svg {
+          @include fixed-square(#{$postIconSize - 0.5rem});
+          --local-primary: #{$won-secondary-text-color};
+        }
       }
+
       &__identicon {
         @include fixed-square($postIconSize);
       }


### PR DESCRIPTION
- Added the jobLocation of JobPostings to the responseMetaAtoms and include a maxDistance check for this location within the getAllAtoms (rest/atoms/all) endpoints

HowToTest: (Any node that has JobPostings, e.g. integration-test)
- Click What's Around -> atom-cards of jobPostings should show up (atom-card displays the jobLocation directly within the card)
- Click What's New -> see that atom-cards of jobPostings display the jobLocation directly within the card as well

AtomCard/WhatsAround Behaviour:
- measuring and sorting distance between given Location and atomLocation also includes the jobLocation now, if an atom has both a location and a jobLocation the jobLocation is "defined" as the preferred or prioritized location and will be used for calculations -> see `atom-utils.js getLocation`-function