### PR TITLE
Feat fetch pokemon from service

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -204,7 +204,7 @@ function genComponentConf() {
 
     getCurrentPokemon() {
       // TODO: change this URL for any live system
-      const url = "http://localhost:1234/all";
+      const url = "http://localhost:1234/current";
 
       return fetch(url)
         .then(response => {
@@ -216,14 +216,14 @@ function genComponentConf() {
         .then(jsonResponse => this.formatPokemonJson(jsonResponse))
         .catch(error => {
           console.log("Pokemon Data could not be fetched: ", error.message);
-          return this.detail.fallbackPokemonList;
+          return this.detail.fullPokemonList;
         });
     }
 
     formatPokemonJson(jsonList) {
       if (!jsonList || jsonList.length == 0) {
-        console.log("jsonList is: " + jsonList);
-        return this.detail.fallbackPokemonList;
+        console.debug("jsonList is: " + jsonList);
+        return this.detail.fullPokemonList;
       }
       let formattedList = { array: [] };
       for (let entry of jsonList) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -202,10 +202,49 @@ function genComponentConf() {
       this.update(this.pokemonRaidBoss);
     }
 
+    getCurrentPokemon() {
+      // TODO: change this URL for any live system
+      const url = "http://localhost:1234/all";
+
+      return fetch(url)
+        .then(response => {
+          if (response.ok) {
+            return response.json();
+          }
+          throw new Error("HTTP Error: ", response.status);
+        })
+        .then(jsonResponse => this.formatPokemonJson(jsonResponse))
+        .catch(error => {
+          console.log("Pokemon Data could not be fetched: ", error.message);
+          return this.detail.fallbackPokemonList;
+        });
+    }
+
+    formatPokemonJson(jsonList) {
+      if (!jsonList || jsonList.length == 0) {
+        console.log("jsonList is: " + jsonList);
+        return this.detail.fallbackPokemonList;
+      }
+      let formattedList = { array: [] };
+      for (let entry of jsonList) {
+        let pokemon = {};
+        pokemon.id = entry.PokemonId;
+        pokemon.name = entry.Pokemons[0].Name;
+        pokemon.imageUrl = entry.Pokemons[0].PokemonPictureFileNameLink;
+        pokemon.isShiny = entry.Pokemons[0].isShiny;
+        if (entry.Pokemons[0].HasForm) {
+          pokemon.form = entry.Pokemons[0].Form;
+        }
+
+        formattedList["array"].push(pokemon);
+      }
+      return formattedList["array"];
+    }
+
     showInitialValues() {
       this.pokemonRaidBoss = this.initialValue || { level: 1 };
       // populate pokemonlist
-      getCurrentPokemon().then(pokemonList => {
+      this.getCurrentPokemon().then(pokemonList => {
         this.pokemonList = pokemonList;
         this.$scope.$apply();
       });
@@ -225,41 +264,6 @@ function genComponentConf() {
     },
     template: template,
   };
-}
-
-function getCurrentPokemon() {
-  // TODO: change this URL for any live system
-  // TODO: add hardcoded fallback list
-  const url = "http://localhost:1234/current";
-  //let pokeList = "not available";
-
-  // TODO: error catching - check if response.status is 200
-
-  // edit list to fit "our" format
-  // return result
-  return fetch(url)
-    .then(response => response.json())
-    .then(r => formatPokemonJson(r));
-}
-
-function formatPokemonJson(jsonList) {
-  if (!jsonList || jsonList.length == 0) {
-    // return fallbackPokemonList;
-  }
-  let formattedList = { array: [] };
-  for (let entry of jsonList) {
-    let pokemon = {};
-    pokemon.id = entry.PokemonId;
-    pokemon.name = entry.Pokemons[0].Name;
-    pokemon.imageUrl = entry.Pokemons[0].PokemonPictureFileNameLink;
-    pokemon.isShiny = entry.Pokemons[0].isShiny;
-    if (entry.Pokemons[0].HasForm) {
-      pokemon.form = entry.Pokemons[0].Form;
-    }
-
-    formattedList["array"].push(pokemon);
-  }
-  return formattedList["array"];
 }
 
 export default angular

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -235,7 +235,10 @@ function genComponentConf() {
         pokemon.name = entry.Pokemons[0].Name;
         pokemon.imageUrl = entry.Pokemons[0].PokemonPictureFileNameLink;
         pokemon.isShiny = entry.Pokemons[0].isShiny;
-        if (entry.Pokemons[0].HasForm) {
+        if (
+          entry.Pokemons[0].HasForm &&
+          entry.Pokemons[0].Form !== "Standardform"
+        ) {
           pokemon.form = entry.Pokemons[0].Form;
         }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -21,6 +21,7 @@ function genComponentConf() {
           <input id="prbp__level__5" type="radio" name="prbp__level" class="prbp__level__option" value="5" ng-checked="self.isLevelChecked(5)"/>
           <label for="prbp__level__5" ng-click="self.updateLevel(5)">{{ self.detail.getLevelLabel(5) }}</label>
       </div>
+
       <label for="prbp__hatched">Hatched</label>
       <input
           type="checkbox"
@@ -28,6 +29,7 @@ function genComponentConf() {
           class="prbp__hatched"
           ng-model="self.pokemonRaidBoss.hatched"
           ng-change="self.updateHatched(self.pokemonRaidBoss.hatched)"/>
+
       <label class="prbp__label" ng-class="{'prbp__label--disabled': self.pokemonRaidBoss.hatched}">Hatches at</label>
       <won-datetime-picker
           ng-class="{'prbp__hatches--disabled': self.pokemonRaidBoss.hatched}"
@@ -36,6 +38,7 @@ function genComponentConf() {
           on-update="self.updateHatches(value)"
           detail="self.detail && self.detail.hatches">
       </won-datetime-picker>
+
       <label class="prbp__label">Expires at</label>
       <won-datetime-picker
           class="prbp__expires"
@@ -43,8 +46,10 @@ function genComponentConf() {
           on-update="self.updateExpires(value)"
           detail="self.detail && self.detail.expires">
       </won-datetime-picker>
+
       <label class="prbp__label"
           ng-class="{'prbp__label--disabled': !self.pokemonRaidBoss.hatched}">Pokemon</label>
+      <!-- POKEMON NAME -->
       <won-title-picker
           ng-class="{'prbp__pokemon--disabled': !self.pokemonRaidBoss.hatched}"
           class="prbp__pokemon"
@@ -52,6 +57,7 @@ function genComponentConf() {
           on-update="self.updatePokemonFilter(value)"
           detail="self.detail && self.detail.filterDetail">
       </won-title-picker>
+      <!-- POKEMON LIST -->
       <div class="prbp__pokemonlist" ng-class="{'prbp__pokemonlist--disabled': !self.pokemonRaidBoss.hatched}">
         <div class="prbp__pokemonlist__pokemon"
           ng-repeat="pokemon in self.detail.pokemonList | filter:self.filterPokemon(self.pokemonFilter, self.pokemonRaidBoss.id, self.pokemonRaidBoss.form)"
@@ -81,6 +87,8 @@ function genComponentConf() {
       this.pokemonRaidBoss = this.initialValue || { level: 1 };
 
       this.pokemonFilter = undefined;
+
+      this.pokemonList = getCurrentPokemon();
 
       delay(0).then(() => this.showInitialValues());
     }
@@ -216,6 +224,37 @@ function genComponentConf() {
     },
     template: template,
   };
+}
+
+function getCurrentPokemon() {
+  // TODO: change this URL for any live system
+  // TODO: add hardcoded fallback list
+  const url = "http://localhost:1234/current";
+  let pokeList = "not available";
+
+  // TODO: error catching - check if response.status is 200
+  pokeList = fetch(url).then(async response =>
+    formatPokemonJson(await response.json())
+  );
+  // edit list to fit "our" format
+  // return result
+  return pokeList;
+}
+
+function formatPokemonJson(jsonList) {
+  if (!jsonList || jsonList.length == 0) {
+    // TODO: return some sort of error
+  }
+  let formattedList = { array: [] };
+  for (let entry of jsonList) {
+    formattedList["array"].push({
+      id: entry.PokemonId,
+      name: entry.Pokemons[0].Name,
+      imageUrl: entry.Pokemons[0].PokemonPictureFileNameLink,
+    });
+  }
+  console.log(formattedList["array"]);
+  return formattedList["array"];
 }
 
 export default angular

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -65,7 +65,7 @@ function genComponentConf() {
             'prbp__pokemonlist__pokemon--selected': self.pokemonRaidBoss.id == pokemon.id && (!self.pokemonRaidBoss.form || self.pokemonRaidBoss.form == pokemon.form)
           }"
           ng-click="self.updatePokemon(pokemon.id, pokemon.form)">
-          <img class="prbp__pokemonlist__pokemon__image" src={{pokemon.imageUrl}}/>
+          <img class="prbp__pokemonlist__pokemon__image" src="{{pokemon.imageUrl}}"/>
           <div class="prbp__pokemonlist__pokemon__id">
             #{{pokemon.id}}
           </div>
@@ -215,7 +215,10 @@ function genComponentConf() {
         })
         .then(jsonResponse => this.formatPokemonJson(jsonResponse))
         .catch(error => {
-          console.log("Pokemon Data could not be fetched: ", error.message);
+          console.warn(
+            "Pokemon Data could not be fetched, using fallback list."
+          );
+          console.debug(error);
           return this.detail.fullPokemonList;
         });
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/pokemon-raidboss-picker.js
@@ -204,7 +204,7 @@ function genComponentConf() {
 
     getCurrentPokemon() {
       // TODO: change this URL for any live system
-      const url = "http://localhost:1234/current";
+      const url = "https://pokemon.socialmicrolearning.com/current";
 
       return fetch(url)
         .then(response => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
@@ -36,7 +36,7 @@ function genComponentConf() {
             </div>
           </div>
           <div class="prbv__content__pokemon" ng-if="!self.hatched || !self.pokemon">
-            <img class="prbv__content__pokemon__image prbv__content__pokemon__image--unhatched" src="{{self.detail.pokemonList[0].imageUrl}}"/>
+            <img class="prbv__content__pokemon__image prbv__content__pokemon__image--unhatched" src="{{self.detail.fullPokemonList[0].imageUrl}}"/>
             <div class="prbv__content__pokemon__id">?</div>
             <div class="prbv__content__pokemon__name" ng-if="!self.shouldHaveHatched">Hatches {{ self.friendlyHatchesTime }} ({{ self.hatchesLocaleString }})</div>
             <div class="prbv__content__pokemon__name" ng-if="self.shouldHaveHatched">Should have hatched {{ self.friendlyHatchesTime }} ({{ self.hatchesLocaleString }})</div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-raidboss-viewer.js
@@ -19,6 +19,7 @@ function genComponentConf() {
         </div>
         <div class="prbv__content">
           <div class="prbv__content__level"
+            ng-if="self.level"
             ng-class="{
               'prbv__content__level--normal': self.level == 1 || self.level == 2,
               'prbv__content__level--rare': self.level == 3 || self.level == 4,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -147,7 +147,7 @@ export const pokemonRaid = {
       "xsd:dateTime"
     );
 
-    if (level && expires) {
+    if (expires) {
       const id = won.parseFrom(
         jsonLDImm,
         ["won:raid", "won:pokemonid"],
@@ -337,7 +337,6 @@ export const pokemonRaid = {
     },
     {
       id: 19,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/019-01.png",
       name: "Rattfratz",
@@ -353,7 +352,6 @@ export const pokemonRaid = {
     },
     {
       id: 20,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/020-01.png",
       name: "Rattikarl",
@@ -404,7 +402,6 @@ export const pokemonRaid = {
     },
     {
       id: 26,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/026-01.png",
       name: "Raichu",
@@ -420,7 +417,6 @@ export const pokemonRaid = {
     },
     {
       id: 27,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/027-00.png",
       name: "Sandan",
@@ -436,7 +432,6 @@ export const pokemonRaid = {
     },
     {
       id: 28,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/028-00.png",
       name: "Sandamer",
@@ -508,7 +503,6 @@ export const pokemonRaid = {
     },
     {
       id: 37,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/037-00.png",
       name: "Vulpix",
@@ -524,7 +518,6 @@ export const pokemonRaid = {
     },
     {
       id: 38,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/038-00.png",
       name: "Vulnona",
@@ -617,7 +610,6 @@ export const pokemonRaid = {
     },
     {
       id: 50,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/050-00.png",
       name: "Digda",
@@ -633,7 +625,6 @@ export const pokemonRaid = {
     },
     {
       id: 51,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/051-00.png",
       name: "Digdri",
@@ -649,7 +640,6 @@ export const pokemonRaid = {
     },
     {
       id: 52,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/052-00.png",
       name: "Mauzi",
@@ -665,7 +655,6 @@ export const pokemonRaid = {
     },
     {
       id: 53,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/053-00.png",
       name: "Snobilikat",
@@ -821,7 +810,6 @@ export const pokemonRaid = {
     },
     {
       id: 74,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/074-00.png",
       name: "Kleinstein",
@@ -837,7 +825,6 @@ export const pokemonRaid = {
     },
     {
       id: 75,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/075-00.png",
       name: "Georok",
@@ -853,7 +840,6 @@ export const pokemonRaid = {
     },
     {
       id: 76,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/076-00.png",
       name: "Geowaz",
@@ -946,7 +932,6 @@ export const pokemonRaid = {
     },
     {
       id: 88,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/088-00.png",
       name: "Sleima",
@@ -962,7 +947,6 @@ export const pokemonRaid = {
     },
     {
       id: 89,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/089-00.png",
       name: "Sleimok",
@@ -1069,7 +1053,6 @@ export const pokemonRaid = {
     },
     {
       id: 103,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/103-00.png",
       name: "Kokowei",
@@ -1092,7 +1075,6 @@ export const pokemonRaid = {
     },
     {
       id: 105,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/105-00.png",
       name: "Knogga",
@@ -2823,7 +2805,6 @@ export const pokemonRaid = {
     },
     {
       id: 351,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/351-01.png",
       name: "Formeo",
@@ -3786,7 +3767,6 @@ export const pokemonRaid = {
     },
     {
       id: 479,
-      form: "Standardform",
       imageUrl:
         "https://files.pokefans.net/images/pokemon-go/modelle/479-00.png",
       name: "Rotom",

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -50,41 +50,41 @@ export const pokemonRaid = {
   filterDetail: {
     placeholder: "Filter by (name or id)",
   },
-  pokemonList: [
-    //TODO: UPDATE LIST OR EXTRACT INTO SEPARATE FILE OR FIND WS that supplies these
-    {
-      id: 1,
-      name: "Bulbasaur",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
-    },
-    {
-      id: 2,
-      name: "Ivysaur",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
-    },
-    {
-      id: 3,
-      name: "Venusaur",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
-    },
-    {
-      id: 4,
-      name: "Charmander",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
-    },
-    {
-      id: 386,
-      name: "Deoxys",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/386.png",
-    },
-    {
-      id: 386,
-      form: "init",
-      name: "Deoxys",
-      imageUrl:
-        "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
-    },
-  ],
+  // pokemonList: [
+  //   //TODO: UPDATE LIST OR EXTRACT INTO SEPARATE FILE OR FIND WS that supplies these
+  //   {
+  //     id: 1,
+  //     name: "Bulbasaur",
+  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
+  //   },
+  //   {
+  //     id: 2,
+  //     name: "Ivysaur",
+  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
+  //   },
+  //   {
+  //     id: 3,
+  //     name: "Venusaur",
+  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
+  //   },
+  //   {
+  //     id: 4,
+  //     name: "Charmander",
+  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
+  //   },
+  //   {
+  //     id: 386,
+  //     name: "Deoxys",
+  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/386.png",
+  //   },
+  //   {
+  //     id: 386,
+  //     form: "init",
+  //     name: "Deoxys",
+  //     imageUrl:
+  //       "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
+  //   },
+  // ],
   findPokemonById: function(id, form) {
     if (id) {
       for (const idx in this.pokemonList) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -54,7 +54,7 @@ export const pokemonRaid = {
     //TODO: move to separate file and include all pokemon
     {
       id: 1,
-      name: "Bulbasaur",
+      name: "TESTY",
       imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
     },
     {
@@ -87,13 +87,13 @@ export const pokemonRaid = {
   ],
   findPokemonById: function(id, form) {
     if (id) {
-      for (const idx in this.pokemonList) {
+      for (const idx in this.fallbackPokemonList) {
         if (
-          this.pokemonList[idx].id == id &&
-          ((form && this.pokemonList[idx].form === form) ||
-            (!form && !this.pokemonList[idx].form))
+          this.fallbackPokemonList[idx].id == id &&
+          ((form && this.fallbackPokemonList[idx].form === form) ||
+            (!form && !this.fallbackPokemonList[idx].form))
         ) {
-          return this.pokemonList[idx];
+          return this.fallbackPokemonList[idx];
         }
       }
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -50,41 +50,41 @@ export const pokemonRaid = {
   filterDetail: {
     placeholder: "Filter by (name or id)",
   },
-  // pokemonList: [
-  //   //TODO: UPDATE LIST OR EXTRACT INTO SEPARATE FILE OR FIND WS that supplies these
-  //   {
-  //     id: 1,
-  //     name: "Bulbasaur",
-  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
-  //   },
-  //   {
-  //     id: 2,
-  //     name: "Ivysaur",
-  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
-  //   },
-  //   {
-  //     id: 3,
-  //     name: "Venusaur",
-  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
-  //   },
-  //   {
-  //     id: 4,
-  //     name: "Charmander",
-  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
-  //   },
-  //   {
-  //     id: 386,
-  //     name: "Deoxys",
-  //     imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/386.png",
-  //   },
-  //   {
-  //     id: 386,
-  //     form: "init",
-  //     name: "Deoxys",
-  //     imageUrl:
-  //       "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
-  //   },
-  // ],
+  fallbackPokemonList: [
+    //TODO: move to separate file and include all pokemon
+    {
+      id: 1,
+      name: "Bulbasaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
+    },
+    {
+      id: 2,
+      name: "Ivysaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
+    },
+    {
+      id: 3,
+      name: "Venusaur",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
+    },
+    {
+      id: 4,
+      name: "Charmander",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
+    },
+    {
+      id: 386,
+      name: "Deoxys",
+      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/386.png",
+    },
+    {
+      id: 386,
+      form: "init",
+      name: "Deoxys",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
+    },
+  ],
   findPokemonById: function(id, form) {
     if (id) {
       for (const idx in this.pokemonList) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -50,50 +50,15 @@ export const pokemonRaid = {
   filterDetail: {
     placeholder: "Filter by (name or id)",
   },
-  fallbackPokemonList: [
-    //TODO: move to separate file and include all pokemon
-    {
-      id: 1,
-      name: "TESTY",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/001.png",
-    },
-    {
-      id: 2,
-      name: "Ivysaur",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/002.png",
-    },
-    {
-      id: 3,
-      name: "Venusaur",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/003.png",
-    },
-    {
-      id: 4,
-      name: "Charmander",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/004.png",
-    },
-    {
-      id: 386,
-      name: "Deoxys",
-      imageUrl: "https://files.pokefans.net/images/pokemon-go/modelle/386.png",
-    },
-    {
-      id: 386,
-      form: "init",
-      name: "Deoxys",
-      imageUrl:
-        "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
-    },
-  ],
   findPokemonById: function(id, form) {
     if (id) {
-      for (const idx in this.fallbackPokemonList) {
+      for (const idx in this.fullPokemonList) {
         if (
-          this.fallbackPokemonList[idx].id == id &&
-          ((form && this.fallbackPokemonList[idx].form === form) ||
-            (!form && !this.fallbackPokemonList[idx].form))
+          this.fullPokemonList[idx].id == id &&
+          ((form && this.fullPokemonList[idx].form === form) ||
+            (!form && !this.fullPokemonList[idx].form))
         ) {
-          return this.fallbackPokemonList[idx];
+          return this.fullPokemonList[idx];
         }
       }
     }
@@ -241,4 +206,2507 @@ export const pokemonRaid = {
     }
     return undefined;
   },
+  // FIXME: replace pokeball icon with working pokemon image links
+  // current icon is a placeholder from the noun project due to broken links
+  fullPokemonList: [
+    {
+      id: 1,
+      name: "Bisasam",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 2,
+      name: "Bisaknosp",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 3,
+      name: "Bisaflor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 4,
+      name: "Glumanda",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 5,
+      name: "Glutexo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 6,
+      name: "Glurak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 7,
+      name: "Schiggy",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 8,
+      name: "Schillok",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 9,
+      name: "Turtok",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 10,
+      name: "Raupy",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 11,
+      name: "Safcon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 12,
+      name: "Smettbo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 13,
+      name: "Hornliu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 14,
+      name: "Kokuna",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 15,
+      name: "Bibor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 16,
+      name: "Taubsi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 17,
+      name: "Tauboga",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 18,
+      name: "Tauboss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 19,
+      name: "Rattfratz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 20,
+      name: "Rattikarl",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 21,
+      name: "Habitak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 22,
+      name: "Ibitak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 23,
+      name: "Rettan",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 24,
+      name: "Arbok",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 25,
+      name: "Pikachu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 26,
+      name: "Raichu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 27,
+      name: "Sandan",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 28,
+      name: "Sandamer",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 29,
+      name: "Nidoran?",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 30,
+      name: "Nidorina",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 31,
+      name: "Nidoqueen",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 32,
+      name: "Nidoran?",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 33,
+      name: "Nidorino",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 34,
+      name: "Nidoking",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 35,
+      name: "Piepi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 36,
+      name: "Pixi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 37,
+      name: "Vulpix",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 38,
+      name: "Vulnona",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 39,
+      name: "Pummeluff",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 40,
+      name: "Knuddeluff",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 41,
+      name: "Zubat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 42,
+      name: "Golbat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 43,
+      name: "Myrapla",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 44,
+      name: "Duflor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 45,
+      name: "Giflor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 46,
+      name: "Paras",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 47,
+      name: "Parasek",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 48,
+      name: "Bluzuk",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 49,
+      name: "Omot",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 50,
+      name: "Digda",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 51,
+      name: "Digdri",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 52,
+      name: "Mauzi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 53,
+      name: "Snobilikat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 54,
+      name: "Enton",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 55,
+      name: "Entoron",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 56,
+      name: "Menki",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 57,
+      name: "Rasaff",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 58,
+      name: "Fukano",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 59,
+      name: "Arkani",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 60,
+      name: "Quapsel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 61,
+      name: "Quaputzi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 62,
+      name: "Quappo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 63,
+      name: "Abra",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 64,
+      name: "Kadabra",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 65,
+      name: "Simsala",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 66,
+      name: "Machollo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 67,
+      name: "Maschock",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 68,
+      name: "Machomei",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 69,
+      name: "Knofensa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 70,
+      name: "Ultrigaria",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 71,
+      name: "Sarzenia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 72,
+      name: "Tentacha",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 73,
+      name: "Tentoxa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 74,
+      name: "Kleinstein",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 75,
+      name: "Georok",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 76,
+      name: "Geowaz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 77,
+      name: "Ponita",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 78,
+      name: "Gallopa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 79,
+      name: "Flegmon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 80,
+      name: "Lahmus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 81,
+      name: "Magnetilo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 82,
+      name: "Magneton",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 83,
+      name: "Porenta",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 84,
+      name: "Dodu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 85,
+      name: "Dodri",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 86,
+      name: "Jurob",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 87,
+      name: "Jugong",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 88,
+      name: "Sleima",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 89,
+      name: "Sleimok",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 90,
+      name: "Muschas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 91,
+      name: "Austos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 92,
+      name: "Nebulak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 93,
+      name: "Alpollo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 94,
+      name: "Gengar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 95,
+      name: "Onix",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 96,
+      name: "Traumato",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 97,
+      name: "Hypno",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 98,
+      name: "Krabby",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 99,
+      name: "Kingler",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 100,
+      name: "Voltobal",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 101,
+      name: "Lektrobal",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 102,
+      name: "Owei",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 103,
+      name: "Kokowei",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 104,
+      name: "Tragosso",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 105,
+      name: "Knogga",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 106,
+      name: "Kicklee",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 107,
+      name: "Nockchan",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 108,
+      name: "Schlurp",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 109,
+      name: "Smogon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 110,
+      name: "Smogmog",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 111,
+      name: "Rihorn",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 112,
+      name: "Rizeros",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 113,
+      name: "Chaneira",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 114,
+      name: "Tangela",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 115,
+      name: "Kangama",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 116,
+      name: "Seeper",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 117,
+      name: "Seemon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 118,
+      name: "Goldini",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 119,
+      name: "Golking",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 120,
+      name: "Sterndu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 121,
+      name: "Starmie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 122,
+      name: "Pantimos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 123,
+      name: "Sichlor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 124,
+      name: "Rossana",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 125,
+      name: "Elektek",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 126,
+      name: "Magmar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 127,
+      name: "Pinsir",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 128,
+      name: "Tauros",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 129,
+      name: "Karpador",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 130,
+      name: "Garados",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 131,
+      name: "Lapras",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 132,
+      name: "Ditto",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 133,
+      name: "Evoli",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 134,
+      name: "Aquana",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 135,
+      name: "Blitza",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 136,
+      name: "Flamara",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 137,
+      name: "Porygon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 138,
+      name: "Amonitas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 139,
+      name: "Amoroso",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 140,
+      name: "Kabuto",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 141,
+      name: "Kabutops",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 142,
+      name: "Aerodactyl",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 143,
+      name: "Relaxo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 144,
+      name: "Arktos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 145,
+      name: "Zapdos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 146,
+      name: "Lavados",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 147,
+      name: "Dratini",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 148,
+      name: "Dragonir",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 149,
+      name: "Dragoran",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 150,
+      name: "Mewtu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 151,
+      name: "Mew",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 152,
+      name: "Endivie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 153,
+      name: "Lorblatt",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 154,
+      name: "Meganie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 155,
+      name: "Feurigel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 156,
+      name: "Igelavar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 157,
+      name: "Tornupto",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 158,
+      name: "Karnimani",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 159,
+      name: "Tyracroc",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 160,
+      name: "Impergator",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 161,
+      name: "Wiesor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 162,
+      name: "Wiesenior",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 163,
+      name: "Hoothoot",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 164,
+      name: "Noctuh",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 165,
+      name: "Ledyba",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 166,
+      name: "Ledian",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 167,
+      name: "Webarak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 168,
+      name: "Ariados",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 169,
+      name: "Iksbat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 170,
+      name: "Lampi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 171,
+      name: "Lanturn",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 172,
+      name: "Pichu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 173,
+      name: "Pii",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 174,
+      name: "Fluffeluff",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 175,
+      name: "Togepi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 176,
+      name: "Togetic",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 177,
+      name: "Natu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 178,
+      name: "Xatu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 179,
+      name: "Voltilamm",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 180,
+      name: "Waaty",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 181,
+      name: "Ampharos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 182,
+      name: "Blubella",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 183,
+      name: "Marill",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 184,
+      name: "Azumarill",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 185,
+      name: "Mogelbaum",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 186,
+      name: "Quaxo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 187,
+      name: "Hoppspross",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 188,
+      name: "Hubelupf",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 189,
+      name: "Papungha",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 190,
+      name: "Griffel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 191,
+      name: "Sonnkern",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 192,
+      name: "Sonnflora",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 193,
+      name: "Yanma",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 194,
+      name: "Felino",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 195,
+      name: "Morlord",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 196,
+      name: "Psiana",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 197,
+      name: "Nachtara",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 198,
+      name: "Kramurx",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 199,
+      name: "Laschoking",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 200,
+      name: "Traunfugil",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 201,
+      name: "Icognito",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 202,
+      name: "Woingenau",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 203,
+      name: "Girafarig",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 204,
+      name: "Tannza",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 205,
+      name: "Forstellka",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 206,
+      name: "Dummisel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 207,
+      name: "Skorgla",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 208,
+      name: "Stahlos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 209,
+      name: "Snubbull",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 210,
+      name: "Granbull",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 211,
+      name: "Baldorfish",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 212,
+      name: "Scherox",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 213,
+      name: "Pottrott",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 214,
+      name: "Skaraborn",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 215,
+      name: "Sniebel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 216,
+      name: "Teddiursa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 217,
+      name: "Ursaring",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 218,
+      name: "Schneckmag",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 219,
+      name: "Magcargo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 220,
+      name: "Quiekel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 221,
+      name: "Keifel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 222,
+      name: "Corasonn",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 223,
+      name: "Remoraid",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 224,
+      name: "Octillery",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 225,
+      name: "Botogel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 226,
+      name: "Mantax",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 227,
+      name: "Panzaeron",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 228,
+      name: "Hunduster",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 229,
+      name: "Hundemon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 230,
+      name: "Seedraking",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 231,
+      name: "Phanpy",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 232,
+      name: "Donphan",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 233,
+      name: "Porygon2",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 234,
+      name: "Damhirplex",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 235,
+      name: "Farbeagle",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 236,
+      name: "Rabauz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 237,
+      name: "Kapoera",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 238,
+      name: "Kussilla",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 239,
+      name: "Elekid",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 240,
+      name: "Magby",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 241,
+      name: "Miltank",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 242,
+      name: "Heiteira",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 243,
+      name: "Raikou",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 244,
+      name: "Entei",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 245,
+      name: "Suicune",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 246,
+      name: "Larvitar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 247,
+      name: "Pupitar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 248,
+      name: "Despotar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 249,
+      name: "Lugia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 250,
+      name: "Ho-Oh",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 251,
+      name: "Celebi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 252,
+      name: "Geckarbor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 253,
+      name: "Reptain",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 254,
+      name: "Gewaldro",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 255,
+      name: "Flemmli",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 256,
+      name: "Jungglut",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 257,
+      name: "Lohgock",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 258,
+      name: "Hydropi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 259,
+      name: "Moorabbel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 260,
+      name: "Sumpex",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 261,
+      name: "Fiffyen",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 262,
+      name: "Magnayen",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 263,
+      name: "Zigzachs",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 264,
+      name: "Geradaks",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 265,
+      name: "Waumpel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 266,
+      name: "Schaloko",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 267,
+      name: "Papinella",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 268,
+      name: "Panekon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 269,
+      name: "Pudox",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 270,
+      name: "Loturzel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 271,
+      name: "Lombrero",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 272,
+      name: "Kappalores",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 273,
+      name: "Samurzel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 274,
+      name: "Blanas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 275,
+      name: "Tengulist",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 276,
+      name: "Schwalbini",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 277,
+      name: "Schwalboss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 278,
+      name: "Wingull",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 279,
+      name: "Pelipper",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 280,
+      name: "Trasla",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 281,
+      name: "Kirlia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 282,
+      name: "Guardevoir",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 283,
+      name: "Gehweiher",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 284,
+      name: "Maskeregen",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 285,
+      name: "Knilz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 286,
+      name: "Kapilz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 287,
+      name: "Bummelz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 288,
+      name: "Muntier",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 289,
+      name: "Letarking",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 290,
+      name: "Nincada",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 291,
+      name: "Ninjask",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 292,
+      name: "Ninjatom",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 293,
+      name: "Flurmel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 294,
+      name: "Krakeelo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 295,
+      name: "Krawumms",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 296,
+      name: "Makuhita",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 297,
+      name: "Hariyama",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 298,
+      name: "Azurill",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 299,
+      name: "Nasgnet",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 300,
+      name: "Eneco",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 301,
+      name: "Enekoro",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 302,
+      name: "Zobiris",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 303,
+      name: "Flunkifer",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 304,
+      name: "Stollunior",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 305,
+      name: "Stollrak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 306,
+      name: "Stolloss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 307,
+      name: "Meditie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 308,
+      name: "Meditalis",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 309,
+      name: "Frizelbliz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 310,
+      name: "Voltenso",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 311,
+      name: "Plusle",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 312,
+      name: "Minun",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 313,
+      name: "Volbeat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 314,
+      name: "Illumise",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 315,
+      name: "Roselia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 316,
+      name: "Schluppuck",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 317,
+      name: "Schlukwech",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 318,
+      name: "Kanivanha",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 319,
+      name: "Tohaido",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 320,
+      name: "Wailmer",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 321,
+      name: "Wailord",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 322,
+      name: "Camaub",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 323,
+      name: "Camerupt",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 324,
+      name: "Qurtel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 325,
+      name: "Spoink",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 326,
+      name: "Groink",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 327,
+      name: "Pandir",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 328,
+      name: "Knacklion",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 329,
+      name: "Vibrava",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 330,
+      name: "Libelldra",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 331,
+      name: "Tuska",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 332,
+      name: "Noktuska",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 333,
+      name: "Wablu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 334,
+      name: "Altaria",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 335,
+      name: "Sengo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 336,
+      name: "Vipitis",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 337,
+      name: "Lunastein",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 338,
+      name: "Sonnfel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 339,
+      name: "Schmerbe",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 340,
+      name: "Welsar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 341,
+      name: "Krebscorps",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 342,
+      name: "Krebutack",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 343,
+      name: "Puppance",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 344,
+      name: "Lepumentas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 345,
+      name: "Liliep",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 346,
+      name: "Wielie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 347,
+      name: "Anorith",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 348,
+      name: "Armaldo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 349,
+      name: "Barschwa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 350,
+      name: "Milotic",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 351,
+      name: "Formeo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 352,
+      name: "Kecleon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 353,
+      name: "Shuppet",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 354,
+      name: "Banette",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 355,
+      name: "Zwirrlicht",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 356,
+      name: "Zwirrklop",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 357,
+      name: "Tropius",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 358,
+      name: "Palimpalim",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 359,
+      name: "Absol",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 360,
+      name: "Isso",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 361,
+      name: "Schneppke",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 362,
+      name: "Firnontor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 363,
+      name: "Seemops",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 364,
+      name: "Seejong",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 365,
+      name: "Walraisa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 366,
+      name: "Perlu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 367,
+      name: "Aalabyss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 368,
+      name: "Saganabyss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 369,
+      name: "Relicanth",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 370,
+      name: "Liebiskus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 371,
+      name: "Kindwurm",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 372,
+      name: "Draschel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 373,
+      name: "Brutalanda",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 374,
+      name: "Tanhel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 375,
+      name: "Metang",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 376,
+      name: "Metagross",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 377,
+      name: "Regirock",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 378,
+      name: "Regice",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 379,
+      name: "Registeel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 380,
+      name: "Latias",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 381,
+      name: "Latios",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 382,
+      name: "Kyogre",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 383,
+      name: "Groudon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 384,
+      name: "Rayquaza",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 385,
+      name: "Jirachi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 386,
+      name: "Deoxys",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Normalform",
+    },
+    {
+      id: 387,
+      name: "Chelast",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 388,
+      name: "Chelcarain",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 389,
+      name: "Chelterrar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 390,
+      name: "Panflam",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 391,
+      name: "Panpyro",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 392,
+      name: "Panferno",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 393,
+      name: "Plinfa",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 394,
+      name: "Pliprin",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 395,
+      name: "Impoleon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 396,
+      name: "Staralili",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 397,
+      name: "Staravia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 398,
+      name: "Staraptor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 399,
+      name: "Bidiza",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 400,
+      name: "Bidifas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 401,
+      name: "Zirpurze",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 402,
+      name: "Zirpeise",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 403,
+      name: "Sheinux",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 404,
+      name: "Luxio",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 405,
+      name: "Luxtra",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 406,
+      name: "Knospi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 407,
+      name: "Roserade",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 408,
+      name: "Koknodon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 409,
+      name: "Rameidon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 410,
+      name: "Schilterus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 411,
+      name: "Bollterus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 412,
+      name: "Burmy",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 413,
+      name: "Burmadame",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Pflanzenumhang",
+    },
+    {
+      id: 414,
+      name: "Moterpel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 415,
+      name: "Wadribie",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 416,
+      name: "Honweisel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 417,
+      name: "Pachirisu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 418,
+      name: "Bamelin",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 419,
+      name: "Bojelin",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 420,
+      name: "Kikugi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 421,
+      name: "Kinoso",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 422,
+      name: "Schalellos",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 423,
+      name: "Gastrodon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 424,
+      name: "Ambidiffel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 425,
+      name: "Driftlon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 426,
+      name: "Drifzepeli",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 427,
+      name: "Haspiror",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 428,
+      name: "Schlapor",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 429,
+      name: "Traunmagil",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 430,
+      name: "Kramshef",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 431,
+      name: "Charmian",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 432,
+      name: "Shnurgarst",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 433,
+      name: "Klingplim",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 434,
+      name: "Skunkapuh",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 435,
+      name: "Skuntank",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 436,
+      name: "Bronzel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 437,
+      name: "Bronzong",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 438,
+      name: "Mobai",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 439,
+      name: "Pantimimi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 440,
+      name: "Wonneira",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 441,
+      name: "Plaudagei",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 442,
+      name: "Kryppuk",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 443,
+      name: "Kaumalat",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 444,
+      name: "Knarksel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 445,
+      name: "Knakrack",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 446,
+      name: "Mampfaxo",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 447,
+      name: "Riolu",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 448,
+      name: "Lucario",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 449,
+      name: "Hippopotas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 450,
+      name: "Hippoterus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 451,
+      name: "Pionskora",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 452,
+      name: "Piondragi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 453,
+      name: "Glibunkel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 454,
+      name: "Toxiquak",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 455,
+      name: "Venuflibis",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 456,
+      name: "Finneon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 457,
+      name: "Lumineon",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 458,
+      name: "Mantirps",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 459,
+      name: "Shnebedeck",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 460,
+      name: "Rexblisar",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 461,
+      name: "Snibunna",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 462,
+      name: "Magnezone",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 463,
+      name: "Schlurplek",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 464,
+      name: "Rihornior",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 465,
+      name: "Tangoloss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 466,
+      name: "Elevoltek",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 467,
+      name: "Magbrant",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 468,
+      name: "Togekiss",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 469,
+      name: "Yanmega",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 470,
+      name: "Folipurba",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 471,
+      name: "Glaziola",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 472,
+      name: "Skorgro",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 473,
+      name: "Mamutel",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 474,
+      name: "Porygon-Z",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 475,
+      name: "Galagladi",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 476,
+      name: "Voluminas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 477,
+      name: "Zwirrfinst",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 478,
+      name: "Frosdedje",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 479,
+      name: "Rotom",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Standardform",
+    },
+    {
+      id: 480,
+      name: "Selfe",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 481,
+      name: "Vesprit",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 482,
+      name: "Tobutz",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 483,
+      name: "Dialga",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 484,
+      name: "Palkia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 485,
+      name: "Heatran",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 486,
+      name: "Regigigas",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 487,
+      name: "Giratina",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Wandelform",
+    },
+    {
+      id: 488,
+      name: "Cresselia",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 489,
+      name: "Phione",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 490,
+      name: "Manaphy",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 491,
+      name: "Darkrai",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 492,
+      name: "Shaymin",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      form: "Landform",
+    },
+    {
+      id: 493,
+      name: "Arceus",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 808,
+      name: "Meltan",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+    {
+      id: 809,
+      name: "Melmetal",
+      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+    },
+  ],
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -71,9 +71,9 @@ export const pokemonRaid = {
   isValid: function(value) {
     if (
       !value ||
-      !value.level ||
       !value.expires ||
       (!value.id && value.hatched) ||
+      (!value.level && value.hatched) ||
       (!value.hatched && !value.hatches)
     )
       return false;
@@ -192,7 +192,7 @@ export const pokemonRaid = {
             : "") /* +
           ", expires at: " +
           parseDatetimeStrictly(value.expires)*/;
-      } else {
+      } else if (value.level) {
         labelPart = this.getLevelLabel(
           value.level
         ) /* +

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/pokemon.js
@@ -211,2502 +211,3756 @@ export const pokemonRaid = {
   fullPokemonList: [
     {
       id: 1,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/001-00.png",
       name: "Bisasam",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 2,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/002-00.png",
       name: "Bisaknosp",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 3,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/003-00.png",
       name: "Bisaflor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 4,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/004-00.png",
       name: "Glumanda",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 5,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/005-00.png",
       name: "Glutexo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 6,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/006-00.png",
       name: "Glurak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 7,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/007-00.png",
       name: "Schiggy",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 8,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/008-00.png",
       name: "Schillok",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 9,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/009-00.png",
       name: "Turtok",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 10,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/010-00.png",
       name: "Raupy",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 11,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/011-00.png",
       name: "Safcon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 12,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/012-00.png",
       name: "Smettbo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 13,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/013-00.png",
       name: "Hornliu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 14,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/014-00.png",
       name: "Kokuna",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 15,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/015-00.png",
       name: "Bibor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 16,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/016-00.png",
       name: "Taubsi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 17,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/017-00.png",
       name: "Tauboga",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 18,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/018-00.png",
       name: "Tauboss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 19,
-      name: "Rattfratz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/019-01.png",
+      name: "Rattfratz",
+      isShiny: false,
+    },
+    {
+      id: 19,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/019-61.png",
+      name: "Rattfratz",
+      isShiny: false,
     },
     {
       id: 20,
-      name: "Rattikarl",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/020-01.png",
+      name: "Rattikarl",
+      isShiny: false,
+    },
+    {
+      id: 20,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/020-61.png",
+      name: "Rattikarl",
+      isShiny: false,
     },
     {
       id: 21,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/021-00.png",
       name: "Habitak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 22,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/022-00.png",
       name: "Ibitak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 23,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/023-00.png",
       name: "Rettan",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 24,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/024-00.png",
       name: "Arbok",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 25,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/025-00.png",
       name: "Pikachu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 26,
-      name: "Raichu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/026-01.png",
+      name: "Raichu",
+      isShiny: false,
+    },
+    {
+      id: 26,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/026-61.png",
+      name: "Raichu",
+      isShiny: false,
     },
     {
       id: 27,
-      name: "Sandan",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/027-00.png",
+      name: "Sandan",
+      isShiny: false,
+    },
+    {
+      id: 27,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/027-61.png",
+      name: "Sandan",
+      isShiny: false,
     },
     {
       id: 28,
-      name: "Sandamer",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/028-00.png",
+      name: "Sandamer",
+      isShiny: false,
+    },
+    {
+      id: 28,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/028-61.png",
+      name: "Sandamer",
+      isShiny: false,
     },
     {
       id: 29,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/029-00.png",
       name: "Nidoran?",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 30,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/030-00.png",
       name: "Nidorina",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 31,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/031-00.png",
       name: "Nidoqueen",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 32,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/032-00.png",
       name: "Nidoran?",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 33,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/033-00.png",
       name: "Nidorino",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 34,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/034-00.png",
       name: "Nidoking",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 35,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/035-00.png",
       name: "Piepi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 36,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/036-00.png",
       name: "Pixi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 37,
-      name: "Vulpix",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/037-00.png",
+      name: "Vulpix",
+      isShiny: false,
+    },
+    {
+      id: 37,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/037-61.png",
+      name: "Vulpix",
+      isShiny: false,
     },
     {
       id: 38,
-      name: "Vulnona",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/038-00.png",
+      name: "Vulnona",
+      isShiny: false,
+    },
+    {
+      id: 38,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/038-61.png",
+      name: "Vulnona",
+      isShiny: false,
     },
     {
       id: 39,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/039-00.png",
       name: "Pummeluff",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 40,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/040-00.png",
       name: "Knuddeluff",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 41,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/041-00.png",
       name: "Zubat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 42,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/042-00.png",
       name: "Golbat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 43,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/043-00.png",
       name: "Myrapla",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 44,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/044-00.png",
       name: "Duflor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 45,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/045-00.png",
       name: "Giflor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 46,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/046-00.png",
       name: "Paras",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 47,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/047-00.png",
       name: "Parasek",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 48,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/048-00.png",
       name: "Bluzuk",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 49,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/049-00.png",
       name: "Omot",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 50,
-      name: "Digda",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/050-00.png",
+      name: "Digda",
+      isShiny: false,
+    },
+    {
+      id: 50,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/050-61.png",
+      name: "Digda",
+      isShiny: false,
     },
     {
       id: 51,
-      name: "Digdri",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/051-00.png",
+      name: "Digdri",
+      isShiny: false,
+    },
+    {
+      id: 51,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/051-61.png",
+      name: "Digdri",
+      isShiny: false,
     },
     {
       id: 52,
-      name: "Mauzi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/052-00.png",
+      name: "Mauzi",
+      isShiny: false,
+    },
+    {
+      id: 52,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/052-61.png",
+      name: "Mauzi",
+      isShiny: false,
     },
     {
       id: 53,
-      name: "Snobilikat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/053-00.png",
+      name: "Snobilikat",
+      isShiny: false,
+    },
+    {
+      id: 53,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/053-61.png",
+      name: "Snobilikat",
+      isShiny: false,
     },
     {
       id: 54,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/054-00.png",
       name: "Enton",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 55,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/055-00.png",
       name: "Entoron",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 56,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/056-00.png",
       name: "Menki",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 57,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/057-00.png",
       name: "Rasaff",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 58,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/058-00.png",
       name: "Fukano",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 59,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/059-00.png",
       name: "Arkani",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 60,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/060-00.png",
       name: "Quapsel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 61,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/061-00.png",
       name: "Quaputzi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 62,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/062-00.png",
       name: "Quappo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 63,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/063-00.png",
       name: "Abra",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 64,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/064-00.png",
       name: "Kadabra",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 65,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/065-00.png",
       name: "Simsala",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 66,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/066-00.png",
       name: "Machollo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 67,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/067-00.png",
       name: "Maschock",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 68,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/068-00.png",
       name: "Machomei",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 69,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/069-00.png",
       name: "Knofensa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 70,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/070-00.png",
       name: "Ultrigaria",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 71,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/071-00.png",
       name: "Sarzenia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 72,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/072-00.png",
       name: "Tentacha",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 73,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/073-00.png",
       name: "Tentoxa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 74,
-      name: "Kleinstein",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/074-00.png",
+      name: "Kleinstein",
+      isShiny: false,
+    },
+    {
+      id: 74,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/074-61.png",
+      name: "Kleinstein",
+      isShiny: false,
     },
     {
       id: 75,
-      name: "Georok",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/075-00.png",
+      name: "Georok",
+      isShiny: false,
+    },
+    {
+      id: 75,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/075-61.png",
+      name: "Georok",
+      isShiny: false,
     },
     {
       id: 76,
-      name: "Geowaz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/076-00.png",
+      name: "Geowaz",
+      isShiny: false,
+    },
+    {
+      id: 76,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/076-61.png",
+      name: "Geowaz",
+      isShiny: false,
     },
     {
       id: 77,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/077-00.png",
       name: "Ponita",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 78,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/078-00.png",
       name: "Gallopa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 79,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/079-00.png",
       name: "Flegmon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 80,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/080-00.png",
       name: "Lahmus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 81,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/081-00.png",
       name: "Magnetilo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 82,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/082-00.png",
       name: "Magneton",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 83,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/083-00.png",
       name: "Porenta",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 84,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/084-00.png",
       name: "Dodu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 85,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/085-00.png",
       name: "Dodri",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 86,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/086-00.png",
       name: "Jurob",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 87,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/087-00.png",
       name: "Jugong",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 88,
-      name: "Sleima",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/088-00.png",
+      name: "Sleima",
+      isShiny: false,
+    },
+    {
+      id: 88,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/088-61.png",
+      name: "Sleima",
+      isShiny: false,
     },
     {
       id: 89,
-      name: "Sleimok",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/089-00.png",
+      name: "Sleimok",
+      isShiny: false,
+    },
+    {
+      id: 89,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/089-61.png",
+      name: "Sleimok",
+      isShiny: false,
     },
     {
       id: 90,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/090-00.png",
       name: "Muschas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 91,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/091-00.png",
       name: "Austos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 92,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/092-00.png",
       name: "Nebulak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 93,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/093-00.png",
       name: "Alpollo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 94,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/094-00.png",
       name: "Gengar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 95,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/095-00.png",
       name: "Onix",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 96,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/096-00.png",
       name: "Traumato",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 97,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/097-00.png",
       name: "Hypno",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 98,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/098-00.png",
       name: "Krabby",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 99,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/099-00.png",
       name: "Kingler",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 100,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/100-00.png",
       name: "Voltobal",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 101,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/101-00.png",
       name: "Lektrobal",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 102,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/102-00.png",
       name: "Owei",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 103,
-      name: "Kokowei",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/103-00.png",
+      name: "Kokowei",
+      isShiny: false,
+    },
+    {
+      id: 103,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/103-61.png",
+      name: "Kokowei",
+      isShiny: false,
     },
     {
       id: 104,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/104-00.png",
       name: "Tragosso",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 105,
-      name: "Knogga",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/105-00.png",
+      name: "Knogga",
+      isShiny: false,
+    },
+    {
+      id: 105,
+      form: "Alola-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/105-61.png",
+      name: "Knogga",
+      isShiny: false,
     },
     {
       id: 106,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/106-00.png",
       name: "Kicklee",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 107,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/107-00.png",
       name: "Nockchan",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 108,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/108-00.png",
       name: "Schlurp",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 109,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/109-00.png",
       name: "Smogon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 110,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/110-00.png",
       name: "Smogmog",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 111,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/111-00.png",
       name: "Rihorn",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 112,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/112-00.png",
       name: "Rizeros",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 113,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/113-00.png",
       name: "Chaneira",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 114,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/114-00.png",
       name: "Tangela",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 115,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/115-00.png",
       name: "Kangama",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 116,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/116-00.png",
       name: "Seeper",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 117,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/117-00.png",
       name: "Seemon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 118,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/118-00.png",
       name: "Goldini",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 119,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/119-00.png",
       name: "Golking",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 120,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/120-00.png",
       name: "Sterndu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 121,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/121-00.png",
       name: "Starmie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 122,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/122-00.png",
       name: "Pantimos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 123,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/123-00.png",
       name: "Sichlor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 124,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/124-00.png",
       name: "Rossana",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 125,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/125-00.png",
       name: "Elektek",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 126,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/126-00.png",
       name: "Magmar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 127,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/127-00.png",
       name: "Pinsir",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 128,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/128-00.png",
       name: "Tauros",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 129,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/129-00.png",
       name: "Karpador",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 130,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/130-00.png",
       name: "Garados",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 131,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/131-00.png",
       name: "Lapras",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 132,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/132-00.png",
       name: "Ditto",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 133,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/133-00.png",
       name: "Evoli",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 134,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/134-00.png",
       name: "Aquana",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 135,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/135-00.png",
       name: "Blitza",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 136,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/136-00.png",
       name: "Flamara",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 137,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/137-00.png",
       name: "Porygon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 138,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/138-00.png",
       name: "Amonitas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 139,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/139-00.png",
       name: "Amoroso",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 140,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/140-00.png",
       name: "Kabuto",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 141,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/141-00.png",
       name: "Kabutops",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 142,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/142-00.png",
       name: "Aerodactyl",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 143,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/143-00.png",
       name: "Relaxo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 144,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/144-00.png",
       name: "Arktos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 145,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/145-00.png",
       name: "Zapdos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 146,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/146-00.png",
       name: "Lavados",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 147,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/147-00.png",
       name: "Dratini",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 148,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/148-00.png",
       name: "Dragonir",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 149,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/149-00.png",
       name: "Dragoran",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 150,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/150-00.png",
       name: "Mewtu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 151,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/151-00.png",
       name: "Mew",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 152,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/152-00.png",
       name: "Endivie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 153,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/153-00.png",
       name: "Lorblatt",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 154,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/154-00.png",
       name: "Meganie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 155,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/155-00.png",
       name: "Feurigel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 156,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/156-00.png",
       name: "Igelavar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 157,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/157-00.png",
       name: "Tornupto",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 158,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/158-00.png",
       name: "Karnimani",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 159,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/159-00.png",
       name: "Tyracroc",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 160,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/160-00.png",
       name: "Impergator",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 161,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/161-00.png",
       name: "Wiesor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 162,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/162-00.png",
       name: "Wiesenior",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 163,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/163-00.png",
       name: "Hoothoot",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 164,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/164-00.png",
       name: "Noctuh",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 165,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/165-00.png",
       name: "Ledyba",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 166,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/166-00.png",
       name: "Ledian",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 167,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/167-00.png",
       name: "Webarak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 168,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/168-00.png",
       name: "Ariados",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 169,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/169-00.png",
       name: "Iksbat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 170,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/170-00.png",
       name: "Lampi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 171,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/171-00.png",
       name: "Lanturn",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 172,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/172-00.png",
       name: "Pichu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 173,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/173-00.png",
       name: "Pii",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 174,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/174-00.png",
       name: "Fluffeluff",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 175,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/175-00.png",
       name: "Togepi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 176,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/176-00.png",
       name: "Togetic",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 177,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/177-00.png",
       name: "Natu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 178,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/178-00.png",
       name: "Xatu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 179,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/179-00.png",
       name: "Voltilamm",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 180,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/180-00.png",
       name: "Waaty",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 181,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/181-00.png",
       name: "Ampharos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 182,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/182-00.png",
       name: "Blubella",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 183,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/183-00.png",
       name: "Marill",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 184,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/184-00.png",
       name: "Azumarill",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 185,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/185-00.png",
       name: "Mogelbaum",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 186,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/186-00.png",
       name: "Quaxo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 187,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/187-00.png",
       name: "Hoppspross",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 188,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/188-00.png",
       name: "Hubelupf",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 189,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/189-00.png",
       name: "Papungha",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 190,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/190-00.png",
       name: "Griffel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 191,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/191-00.png",
       name: "Sonnkern",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 192,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/192-00.png",
       name: "Sonnflora",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 193,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/193-00.png",
       name: "Yanma",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 194,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/194-00.png",
       name: "Felino",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 195,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/195-00.png",
       name: "Morlord",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 196,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/196-00.png",
       name: "Psiana",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 197,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/197-00.png",
       name: "Nachtara",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 198,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/198-00.png",
       name: "Kramurx",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 199,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/199-00.png",
       name: "Laschoking",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 200,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/200-00.png",
       name: "Traunfugil",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 201,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/201-00.png",
       name: "Icognito",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 202,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/202-00.png",
       name: "Woingenau",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 203,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/203-00.png",
       name: "Girafarig",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 204,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/204-00.png",
       name: "Tannza",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 205,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/205-00.png",
       name: "Forstellka",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 206,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/206-00.png",
       name: "Dummisel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 207,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/207-00.png",
       name: "Skorgla",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 208,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/208-00.png",
       name: "Stahlos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 209,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/209-00.png",
       name: "Snubbull",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 210,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/210-00.png",
       name: "Granbull",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 211,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/211-00.png",
       name: "Baldorfish",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 212,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/212-00.png",
       name: "Scherox",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 213,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/213-00.png",
       name: "Pottrott",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 214,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/214-00.png",
       name: "Skaraborn",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 215,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/215-00.png",
       name: "Sniebel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 216,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/216-00.png",
       name: "Teddiursa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 217,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/217-00.png",
       name: "Ursaring",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 218,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/218-00.png",
       name: "Schneckmag",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 219,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/219-00.png",
       name: "Magcargo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 220,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/220-00.png",
       name: "Quiekel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 221,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/221-00.png",
       name: "Keifel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 222,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/222-00.png",
       name: "Corasonn",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 223,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/223-00.png",
       name: "Remoraid",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 224,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/224-00.png",
       name: "Octillery",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 225,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/225-00.png",
       name: "Botogel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 226,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/226-00.png",
       name: "Mantax",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 227,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/227-00.png",
       name: "Panzaeron",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 228,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/228-00.png",
       name: "Hunduster",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 229,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/229-00.png",
       name: "Hundemon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 230,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/230-00.png",
       name: "Seedraking",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 231,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/231-00.png",
       name: "Phanpy",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 232,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/232-00.png",
       name: "Donphan",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 233,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/233-00.png",
       name: "Porygon2",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 234,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/234-00.png",
       name: "Damhirplex",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 235,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/235-00.png",
       name: "Farbeagle",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 236,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/236-00.png",
       name: "Rabauz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 237,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/237-00.png",
       name: "Kapoera",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 238,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/238-00.png",
       name: "Kussilla",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 239,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/239-00.png",
       name: "Elekid",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 240,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/240-00.png",
       name: "Magby",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 241,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/241-00.png",
       name: "Miltank",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 242,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/242-00.png",
       name: "Heiteira",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 243,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/243-00.png",
       name: "Raikou",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 244,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/244-00.png",
       name: "Entei",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 245,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/245-00.png",
       name: "Suicune",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 246,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/246-00.png",
       name: "Larvitar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 247,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/247-00.png",
       name: "Pupitar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 248,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/248-00.png",
       name: "Despotar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 249,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/249-00.png",
       name: "Lugia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 250,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/250-00.png",
       name: "Ho-Oh",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 251,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/251-00.png",
       name: "Celebi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 252,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/252-00.png",
       name: "Geckarbor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 253,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/253-00.png",
       name: "Reptain",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 254,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/254-00.png",
       name: "Gewaldro",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 255,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/255-00.png",
       name: "Flemmli",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 256,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/256-00.png",
       name: "Jungglut",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 257,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/257-00.png",
       name: "Lohgock",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 258,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/258-00.png",
       name: "Hydropi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 259,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/259-00.png",
       name: "Moorabbel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 260,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/260-00.png",
       name: "Sumpex",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 261,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/261-00.png",
       name: "Fiffyen",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 262,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/262-00.png",
       name: "Magnayen",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 263,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/263-00.png",
       name: "Zigzachs",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 264,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/264-00.png",
       name: "Geradaks",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 265,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/265-00.png",
       name: "Waumpel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 266,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/266-00.png",
       name: "Schaloko",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 267,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/267-00.png",
       name: "Papinella",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 268,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/268-00.png",
       name: "Panekon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 269,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/269-00.png",
       name: "Pudox",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 270,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/270-00.png",
       name: "Loturzel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 271,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/271-00.png",
       name: "Lombrero",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 272,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/272-00.png",
       name: "Kappalores",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 273,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/273-00.png",
       name: "Samurzel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 274,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/274-00.png",
       name: "Blanas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 275,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/275-00.png",
       name: "Tengulist",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 276,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/276-00.png",
       name: "Schwalbini",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 277,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/277-00.png",
       name: "Schwalboss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 278,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/278-00.png",
       name: "Wingull",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 279,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/279-00.png",
       name: "Pelipper",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 280,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/280-00.png",
       name: "Trasla",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 281,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/281-00.png",
       name: "Kirlia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 282,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/282-00.png",
       name: "Guardevoir",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 283,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/283-00.png",
       name: "Gehweiher",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 284,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/284-00.png",
       name: "Maskeregen",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 285,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/285-00.png",
       name: "Knilz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 286,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/286-00.png",
       name: "Kapilz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 287,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/287-00.png",
       name: "Bummelz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 288,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/288-00.png",
       name: "Muntier",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 289,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/289-00.png",
       name: "Letarking",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 290,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/290-00.png",
       name: "Nincada",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 291,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/291-00.png",
       name: "Ninjask",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 292,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/292-00.png",
       name: "Ninjatom",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 293,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/293-00.png",
       name: "Flurmel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 294,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/294-00.png",
       name: "Krakeelo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 295,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/295-00.png",
       name: "Krawumms",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 296,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/296-00.png",
       name: "Makuhita",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 297,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/297-00.png",
       name: "Hariyama",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 298,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/298-00.png",
       name: "Azurill",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 299,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/299-00.png",
       name: "Nasgnet",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 300,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/300-00.png",
       name: "Eneco",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 301,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/301-00.png",
       name: "Enekoro",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 302,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/302-00.png",
       name: "Zobiris",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 303,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/303-00.png",
       name: "Flunkifer",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 304,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/304-00.png",
       name: "Stollunior",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 305,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/305-00.png",
       name: "Stollrak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 306,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/306-00.png",
       name: "Stolloss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 307,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/307-00.png",
       name: "Meditie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 308,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/308-00.png",
       name: "Meditalis",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 309,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/309-00.png",
       name: "Frizelbliz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 310,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/310-00.png",
       name: "Voltenso",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 311,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/311-00.png",
       name: "Plusle",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 312,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/312-00.png",
       name: "Minun",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 313,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/313-00.png",
       name: "Volbeat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 314,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/314-00.png",
       name: "Illumise",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 315,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/315-00.png",
       name: "Roselia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 316,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/316-00.png",
       name: "Schluppuck",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 317,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/317-00.png",
       name: "Schlukwech",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 318,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/318-00.png",
       name: "Kanivanha",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 319,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/319-00.png",
       name: "Tohaido",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 320,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/320-00.png",
       name: "Wailmer",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 321,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/321-00.png",
       name: "Wailord",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 322,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/322-00.png",
       name: "Camaub",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 323,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/323-00.png",
       name: "Camerupt",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 324,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/324-00.png",
       name: "Qurtel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 325,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/325-00.png",
       name: "Spoink",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 326,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/326-00.png",
       name: "Groink",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 327,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/327-00.png",
       name: "Pandir",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 328,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/328-00.png",
       name: "Knacklion",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 329,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/329-00.png",
       name: "Vibrava",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 330,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/330-00.png",
       name: "Libelldra",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 331,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/331-00.png",
       name: "Tuska",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 332,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/332-00.png",
       name: "Noktuska",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 333,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/333-00.png",
       name: "Wablu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 334,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/334-00.png",
       name: "Altaria",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 335,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/335-00.png",
       name: "Sengo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 336,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/336-00.png",
       name: "Vipitis",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 337,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/337-00.png",
       name: "Lunastein",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 338,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/338-00.png",
       name: "Sonnfel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 339,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/339-00.png",
       name: "Schmerbe",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 340,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/340-00.png",
       name: "Welsar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 341,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/341-00.png",
       name: "Krebscorps",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 342,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/342-00.png",
       name: "Krebutack",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 343,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/343-00.png",
       name: "Puppance",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 344,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/344-00.png",
       name: "Lepumentas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 345,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/345-00.png",
       name: "Liliep",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 346,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/346-00.png",
       name: "Wielie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 347,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/347-00.png",
       name: "Anorith",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 348,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/348-00.png",
       name: "Armaldo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 349,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/349-00.png",
       name: "Barschwa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 350,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/350-00.png",
       name: "Milotic",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 351,
-      name: "Formeo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/351-01.png",
+      name: "Formeo",
+      isShiny: false,
+    },
+    {
+      id: 351,
+      form: "Regenform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/351-03.png",
+      name: "Formeo",
+      isShiny: false,
+    },
+    {
+      id: 351,
+      form: "Schneeform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/351-04.png",
+      name: "Formeo",
+      isShiny: false,
+    },
+    {
+      id: 351,
+      form: "Sonnenform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/351-02.png",
+      name: "Formeo",
+      isShiny: false,
     },
     {
       id: 352,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/352-00.png",
       name: "Kecleon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 353,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/353-00.png",
       name: "Shuppet",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 354,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/354-00.png",
       name: "Banette",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 355,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/355-00.png",
       name: "Zwirrlicht",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 356,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/356-00.png",
       name: "Zwirrklop",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 357,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/357-00.png",
       name: "Tropius",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 358,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/358-00.png",
       name: "Palimpalim",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 359,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/359-00.png",
       name: "Absol",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 360,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/360-00.png",
       name: "Isso",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 361,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/361-00.png",
       name: "Schneppke",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 362,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/362-00.png",
       name: "Firnontor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 363,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/363-00.png",
       name: "Seemops",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 364,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/364-00.png",
       name: "Seejong",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 365,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/365-00.png",
       name: "Walraisa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 366,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/366-00.png",
       name: "Perlu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 367,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/367-00.png",
       name: "Aalabyss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 368,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/368-00.png",
       name: "Saganabyss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 369,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/369-00.png",
       name: "Relicanth",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 370,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/370-00.png",
       name: "Liebiskus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 371,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/371-00.png",
       name: "Kindwurm",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 372,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/372-00.png",
       name: "Draschel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 373,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/373-00.png",
       name: "Brutalanda",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 374,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/374-00.png",
       name: "Tanhel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 375,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/375-00.png",
       name: "Metang",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 376,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/376-00.png",
       name: "Metagross",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 377,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/377-00.png",
       name: "Regirock",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 378,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/378-00.png",
       name: "Regice",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 379,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/379-00.png",
       name: "Registeel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 380,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/380-00.png",
       name: "Latias",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 381,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/381-00.png",
       name: "Latios",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 382,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/382-00.png",
       name: "Kyogre",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 383,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/383-00.png",
       name: "Groudon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 384,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/384-00.png",
       name: "Rayquaza",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 385,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/385-00.png",
       name: "Jirachi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 386,
-      name: "Deoxys",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Normalform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/386-00.png",
+      name: "Deoxys",
+      isShiny: false,
+    },
+    {
+      id: 386,
+      form: "Angriffsform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/386-02.png",
+      name: "Deoxys",
+      isShiny: false,
+    },
+    {
+      id: 386,
+      form: "Verteidigungsform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/386-03.png",
+      name: "Deoxys",
+      isShiny: false,
+    },
+    {
+      id: 386,
+      form: "Initiativeform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/386-04.png",
+      name: "Deoxys",
+      isShiny: false,
     },
     {
       id: 387,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/387-00.png",
       name: "Chelast",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 388,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/388-00.png",
       name: "Chelcarain",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 389,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/389-00.png",
       name: "Chelterrar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 390,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/390-00.png",
       name: "Panflam",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 391,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/391-00.png",
       name: "Panpyro",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 392,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/392-00.png",
       name: "Panferno",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 393,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/393-00.png",
       name: "Plinfa",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 394,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/394-00.png",
       name: "Pliprin",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 395,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/395-00.png",
       name: "Impoleon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 396,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/396-00.png",
       name: "Staralili",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 397,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/397-00.png",
       name: "Staravia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 398,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/398-00.png",
       name: "Staraptor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 399,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/399-00.png",
       name: "Bidiza",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 400,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/400-00.png",
       name: "Bidifas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 401,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/401-00.png",
       name: "Zirpurze",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 402,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/402-00.png",
       name: "Zirpeise",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 403,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/403-00.png",
       name: "Sheinux",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 404,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/404-00.png",
       name: "Luxio",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 405,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/405-00.png",
       name: "Luxtra",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 406,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/406-00.png",
       name: "Knospi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 407,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/407-00.png",
       name: "Roserade",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 408,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/408-00.png",
       name: "Koknodon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 409,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/409-00.png",
       name: "Rameidon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 410,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/410-00.png",
       name: "Schilterus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 411,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/411-00.png",
       name: "Bollterus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 412,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/412-11.png",
       name: "Burmy",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 413,
-      name: "Burmadame",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Pflanzenumhang",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/413-11.png",
+      name: "Burmadame",
+      isShiny: false,
+    },
+    {
+      id: 413,
+      form: "Sandumhang",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/413-12.png",
+      name: "Burmadame",
+      isShiny: false,
+    },
+    {
+      id: 413,
+      form: "Lumpenumhang",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/413-13.png",
+      name: "Burmadame",
+      isShiny: false,
     },
     {
       id: 414,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/414-00.png",
       name: "Moterpel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 415,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/415-00.png",
       name: "Wadribie",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 416,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/416-00.png",
       name: "Honweisel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 417,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/417-00.png",
       name: "Pachirisu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 418,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/418-00.png",
       name: "Bamelin",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 419,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/419-00.png",
       name: "Bojelin",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 420,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/420-00.png",
       name: "Kikugi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 421,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/421-00.png",
       name: "Kinoso",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 422,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/422-00.png",
       name: "Schalellos",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 423,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/423-00.png",
       name: "Gastrodon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 424,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/424-00.png",
       name: "Ambidiffel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 425,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/425-00.png",
       name: "Driftlon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 426,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/426-00.png",
       name: "Drifzepeli",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 427,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/427-00.png",
       name: "Haspiror",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 428,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/428-00.png",
       name: "Schlapor",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 429,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/429-00.png",
       name: "Traunmagil",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 430,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/430-00.png",
       name: "Kramshef",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 431,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/431-00.png",
       name: "Charmian",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 432,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/432-00.png",
       name: "Shnurgarst",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 433,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/433-00.png",
       name: "Klingplim",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 434,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/434-00.png",
       name: "Skunkapuh",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 435,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/435-00.png",
       name: "Skuntank",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 436,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/436-00.png",
       name: "Bronzel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 437,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/437-00.png",
       name: "Bronzong",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 438,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/438-00.png",
       name: "Mobai",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 439,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/439-00.png",
       name: "Pantimimi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 440,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/440-00.png",
       name: "Wonneira",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 441,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/441-00.png",
       name: "Plaudagei",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 442,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/442-00.png",
       name: "Kryppuk",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 443,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/443-00.png",
       name: "Kaumalat",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 444,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/444-00.png",
       name: "Knarksel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 445,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/445-00.png",
       name: "Knakrack",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 446,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/446-00.png",
       name: "Mampfaxo",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 447,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/447-00.png",
       name: "Riolu",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 448,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/448-00.png",
       name: "Lucario",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 449,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/449-00.png",
       name: "Hippopotas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 450,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/450-00.png",
       name: "Hippoterus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 451,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/451-00.png",
       name: "Pionskora",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 452,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/452-00.png",
       name: "Piondragi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 453,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/453-00.png",
       name: "Glibunkel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 454,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/454-00.png",
       name: "Toxiquak",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 455,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/455-00.png",
       name: "Venuflibis",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 456,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/456-00.png",
       name: "Finneon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 457,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/457-00.png",
       name: "Lumineon",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 458,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/458-00.png",
       name: "Mantirps",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 459,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/459-00.png",
       name: "Shnebedeck",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 460,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/460-00.png",
       name: "Rexblisar",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 461,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/461-00.png",
       name: "Snibunna",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 462,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/462-00.png",
       name: "Magnezone",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 463,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/463-00.png",
       name: "Schlurplek",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 464,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/464-00.png",
       name: "Rihornior",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 465,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/465-00.png",
       name: "Tangoloss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 466,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/466-00.png",
       name: "Elevoltek",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 467,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/467-00.png",
       name: "Magbrant",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 468,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/468-00.png",
       name: "Togekiss",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 469,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/469-00.png",
       name: "Yanmega",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 470,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/470-00.png",
       name: "Folipurba",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 471,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/471-00.png",
       name: "Glaziola",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 472,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/472-00.png",
       name: "Skorgro",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 473,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/473-00.png",
       name: "Mamutel",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 474,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/474-00.png",
       name: "Porygon-Z",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 475,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/475-00.png",
       name: "Galagladi",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 476,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/476-00.png",
       name: "Voluminas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 477,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/477-00.png",
       name: "Zwirrfinst",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 478,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/478-00.png",
       name: "Frosdedje",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 479,
-      name: "Rotom",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Standardform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-00.png",
+      name: "Rotom",
+      isShiny: false,
+    },
+    {
+      id: 479,
+      form: "Hitze-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-12.png",
+      name: "Rotom",
+      isShiny: false,
+    },
+    {
+      id: 479,
+      form: "Wasch-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-13.png",
+      name: "Rotom",
+      isShiny: false,
+    },
+    {
+      id: 479,
+      form: "Frost-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-14.png",
+      name: "Rotom",
+      isShiny: false,
+    },
+    {
+      id: 479,
+      form: "Wirbel-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-15.png",
+      name: "Rotom",
+      isShiny: false,
+    },
+    {
+      id: 479,
+      form: "Schneid-Form",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/479-16.png",
+      name: "Rotom",
+      isShiny: false,
     },
     {
       id: 480,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/480-00.png",
       name: "Selfe",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 481,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/481-00.png",
       name: "Vesprit",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 482,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/482-00.png",
       name: "Tobutz",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 483,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/483-00.png",
       name: "Dialga",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 484,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/484-00.png",
       name: "Palkia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 485,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/485-00.png",
       name: "Heatran",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 486,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/486-00.png",
       name: "Regigigas",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 487,
-      name: "Giratina",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Wandelform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/487-11.png",
+      name: "Giratina",
+      isShiny: false,
+    },
+    {
+      id: 487,
+      form: "Urform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/487-12.png",
+      name: "Giratina",
+      isShiny: false,
     },
     {
       id: 488,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/488-00.png",
       name: "Cresselia",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 489,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/489-00.png",
       name: "Phione",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 490,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/490-00.png",
       name: "Manaphy",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 491,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/491-00.png",
       name: "Darkrai",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 492,
-      name: "Shaymin",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
       form: "Landform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/492-00.png",
+      name: "Shaymin",
+      isShiny: false,
+    },
+    {
+      id: 492,
+      form: "Zenitform",
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/492-12.png",
+      name: "Shaymin",
+      isShiny: false,
     },
     {
       id: 493,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/493-00.png",
       name: "Arceus",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 808,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/808-00.png",
       name: "Meltan",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
     {
       id: 809,
+      imageUrl:
+        "https://files.pokefans.net/images/pokemon-go/modelle/809-00.png",
       name: "Melmetal",
-      imageUrl: "https://static.thenounproject.com/png/18316-200.png",
+      isShiny: false,
     },
   ],
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
@@ -46,6 +46,7 @@ pokemon-raidboss-viewer {
     }
 
     .prbv__content__expires {
+      grid-area: prbv_expires;
       background-color: $won-lighter-gray;
       padding: 0.25rem;
       color: var(--won-subtitle-gray);
@@ -64,6 +65,7 @@ pokemon-raidboss-viewer {
       display: grid;
       grid-template-areas: "pkmv_image pkmv_name" "pkmv_image pkmv_id";
       grid-template-columns: minmax(3.5rem, min-content) 1fr;
+      grid-template-columns: minmax(3.5rem, 1fr) 1fr;
       grid-column-gap: 0.5rem;
       padding: 0.25rem;
       background: $won-light-gray;
@@ -73,6 +75,7 @@ pokemon-raidboss-viewer {
       &__image {
         grid-area: pkmv_image;
         align-self: center;
+        justify-self: end;
         @include fixed-square(3.5rem);
 
         &--unhatched {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_pokemon-raidboss-viewer.scss
@@ -65,7 +65,6 @@ pokemon-raidboss-viewer {
       display: grid;
       grid-template-areas: "pkmv_image pkmv_name" "pkmv_image pkmv_id";
       grid-template-columns: minmax(3.5rem, min-content) 1fr;
-      grid-template-columns: minmax(3.5rem, 1fr) 1fr;
       grid-column-gap: 0.5rem;
       padding: 0.25rem;
       background: $won-light-gray;
@@ -75,7 +74,6 @@ pokemon-raidboss-viewer {
       &__image {
         grid-area: pkmv_image;
         align-self: center;
-        justify-self: end;
         @include fixed-square(3.5rem);
 
         &--unhatched {


### PR DESCRIPTION
Known issues: 
* a few pictures ~~mostly~~ don't work, this is due to the links returned by the listservice
* ~~pokemon viewer currently can't display all pokemon, this is due to the viewer using the fallback list to retrieve information instead of its own fetch call - to fix this, we need to either update the fallback list (necessary anyway) or refactor pokemon viewing to also use the listservice~~ fixed
* ~~pokemon viewer uses placeholder icons until fixed pokemon picture links are available~~ fixed

ADDITION:
* ~~the fetching of pokemon raids has revealed that "level" is not necessarily an attribute that is present -> if a pokemon has already hatched(e.g. the raid Started) there might not be a level present, so please let us change the picker and viewer as well as the detail validation according to this requirement~~ fixed