### PR TITLE
Rematch on derived data change

### DIFF
--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/DefaultSocketMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/DefaultSocketMessageProcessor.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface DefaultSocketMessageProcessor {
-    String direction();
+    String direction() default "ANY";
 
-    String messageType();
+    String messageType() default "ANY";
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageProcessor.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface FixedMessageProcessor {
-    String direction();
+    String direction() default "ANY";
 
-    String messageType();
+    String messageType() default "ANY";
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/FixedMessageReactionProcessor.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface FixedMessageReactionProcessor {
-    String direction();
+    String direction() default "ANY";
 
-    String messageType();
+    String messageType() default "ANY";
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/SocketMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/annotation/SocketMessageProcessor.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
 public @interface SocketMessageProcessor {
     String socketType();
 
-    String direction();
+    String direction() default "ANY";
 
-    String messageType();
+    String messageType() default "ANY";
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectionStateChangeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectionStateChangeReactionProcessor.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.util.Optional;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -25,6 +27,7 @@ import won.protocol.model.Connection;
 @Component
 @FixedMessageReactionProcessor()
 public class ConnectionStateChangeReactionProcessor extends AbstractCamelProcessor {
+    Logger logger = LoggerFactory.getLogger(getClass());
     public ConnectionStateChangeReactionProcessor() {
     }
 
@@ -34,6 +37,7 @@ public class ConnectionStateChangeReactionProcessor extends AbstractCamelProcess
         ConnectionStateChangeBuilder stateChangeBuilder = (ConnectionStateChangeBuilder) exchange.getIn()
                         .getHeader(WonCamelConstants.CONNECTION_STATE_CHANGE_BUILDER_HEADER);
         if (stateChangeBuilder == null) {
+            logger.info("no stateChangeBuilder found in exchange header, cannot check for state change");
             return;
         }
         // first, try to find the connection uri in the header:
@@ -65,7 +69,12 @@ public class ConnectionStateChangeReactionProcessor extends AbstractCamelProcess
             if (connectionStateChange.isConnect() || connectionStateChange.isDisconnect()) {
                 // trigger rematch
                 matcherProtocolMatcherClient.atomModified(atom.getAtomURI(), null);
+                logger.info("matchers notified of connection state change");
+            } else {
+                logger.debug("no relevant connection state change, not notifying matchers");
             }
+        } else {
+            logger.info("Could collect ConnectionStateChange information, not checking for state change");
         }
     }
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectionStateChangeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ConnectionStateChangeReactionProcessor.java
@@ -28,6 +28,7 @@ import won.protocol.model.Connection;
 @FixedMessageReactionProcessor()
 public class ConnectionStateChangeReactionProcessor extends AbstractCamelProcessor {
     Logger logger = LoggerFactory.getLogger(getClass());
+
     public ConnectionStateChangeReactionProcessor() {
     }
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ConnectionStateChangeBuilder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ConnectionStateChangeBuilder.java
@@ -41,7 +41,7 @@ public class ConnectionStateChangeBuilder {
     }
 
     public boolean canBuild() {
-        return newState.isPresent();
+        return oldState.isPresent() && newState.isPresent();
     }
 
     public ConnectionStateChange build() {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SocketDerivationProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SocketDerivationProcessor.java
@@ -7,15 +7,17 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import won.node.protocol.MatcherProtocolMatcherServiceClientSide;
+import won.node.protocol.impl.MatcherProtocolMatcherClientImpl;
 import won.node.socket.ConnectionStateChange;
 import won.node.socket.SocketService;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
 import won.protocol.message.processor.camel.WonCamelConstants;
-import won.protocol.model.Connection;
 import won.protocol.model.Atom;
-import won.protocol.repository.ConnectionRepository;
+import won.protocol.model.Connection;
 import won.protocol.repository.AtomRepository;
+import won.protocol.repository.ConnectionRepository;
 
 /**
  * Compares the connection state found in the header of the 'in' message with
@@ -28,6 +30,8 @@ public class SocketDerivationProcessor implements Processor {
     AtomRepository atomRepository;
     @Autowired
     SocketService derivationService;
+    @Autowired
+    protected MatcherProtocolMatcherServiceClientSide matcherProtocolMatcherClient;
 
     public SocketDerivationProcessor() {
     }
@@ -65,7 +69,11 @@ public class SocketDerivationProcessor implements Processor {
                 con = Optional.of(connectionRepository.findOneByConnectionURI(conUri));
             }
             Atom atom = atomRepository.findOneByAtomURI(con.get().getAtomURI());
-            derivationService.deriveDataForStateChange(connectionStateChange, atom, con.get());
+            boolean changed = derivationService.deriveDataForStateChange(connectionStateChange, atom, con.get());
+            if (changed) {
+                // trigger rematch
+                matcherProtocolMatcherClient.atomModified(atom.getAtomURI(), null);
+            }
         }
     }
 }

--- a/webofneeds/won-node/src/main/java/won/node/socket/SocketService.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/SocketService.java
@@ -62,7 +62,15 @@ public class SocketService {
         return false;
     }
 
-    public void deriveDataForStateChange(ConnectionStateChange stateChange, Atom atom, Connection con) {
+    /**
+     * Performs the data derivation in response to a connection state change.
+     * 
+     * @param stateChange
+     * @param atom
+     * @param con
+     * @return true if a the derived data was modified, false otherwise.
+     */
+    public boolean deriveDataForStateChange(ConnectionStateChange stateChange, Atom atom, Connection con) {
         if (stateChange.isConnect() || stateChange.isDisconnect()) {
             logger.info("performing data derivation for connection {}", con.getConnectionURI());
             Dataset atomDataset = atom.getDatatsetHolder().getDataset();
@@ -97,7 +105,9 @@ public class SocketService {
             atom.incrementVersion();
             atom.getDatatsetHolder().setDataset(atomDataset);
             atomRepository.save(atom);
+            return true;
         }
+        return false;
     }
 
     private Optional<SocketDefinition> getSocketConfig(URI socketType) {

--- a/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/package-info.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/package-info.java
@@ -1,0 +1,2 @@
+@java.lang.Deprecated
+package won.node.socket.businessactivity;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/package-info.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/package-info.java
@@ -1,0 +1,2 @@
+@java.lang.Deprecated
+package won.node.socket.impl;

--- a/webofneeds/won-node/src/main/java/won/node/socket/package-info.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/package-info.java
@@ -8,8 +8,4 @@
  * KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/**
- * Deprecated package, needs to be refactored.
- */
-@Deprecated
 package won.node.socket;


### PR DESCRIPTION
With this PR, a change to derived data (via establishing a connection or closing one) triggers a rematching for the atom in question. 

This became necessary as we started to require buddy relationships for matching. Behind the scenes, this is the course of events when Persona P1 creates atom A1:
1. A1 is created, 
2. matchers are notified
3. the connection to P1 is established. 

Consequently, matchers saw neither `A1 hold:heldBy P1` nor  `P1 hold:holds A1` and the embedded SPARQL query found nothing.

With the PR
* matchers are notified after a connection is established or closed
* matchers fetch fresh atom data for rematching
* New capabilities for message processors were added to the node:
    - allowing to specify a processor for all directions or types
    - allowing to specify multiple matching processors (which get executed sequentially)
