### PR TITLE
Feat  autoopen group

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -302,13 +302,17 @@ export function connectionsOpen(connectionUri, textMessage) {
 export function connectionsConnectReactionAtom(
   connectToAtomUri,
   atomDraft,
-  persona
+  persona,
+  connectToSocketType,
+  atomDraftSocketType
 ) {
   return (dispatch, getState) =>
     connectReactionAtom(
       connectToAtomUri,
       atomDraft,
       persona,
+      connectToSocketType,
+      atomDraftSocketType,
       dispatch,
       getState
     ); // moved to separate function to make transpilation work properly
@@ -317,21 +321,16 @@ function connectReactionAtom(
   connectToAtomUri,
   atomDraft,
   personaUri,
+  connectToSocketType,
+  atomDraftSocketType,
   dispatch,
   getState
 ) {
   ensureLoggedIn(dispatch, getState).then(async () => {
-    //TODO: Determine the ownership of the connectToAtom and if it is owned by you then autoOpen the connection
     const state = getState();
-    const connectoToAtom = getIn(state, ["atoms", connectToAtomUri]);
+    const connectToAtom = getIn(state, ["atoms", connectToAtomUri]);
 
     const nodeUri = getIn(state, ["config", "defaultNodeUri"]);
-
-    // create new atom
-    const { message, eventUri, atomUri } = await buildCreateMessage(
-      atomDraft,
-      nodeUri
-    );
 
     // add persona
     if (personaUri) {
@@ -351,55 +350,121 @@ function connectReactionAtom(
         });
     }
 
-    // establish connection
-    const cnctMsg = buildConnectMessage({
-      ownedAtomUri: atomUri,
-      theirAtomUri: connectToAtomUri,
-      ownNodeUri: nodeUri,
-      theirNodeUri: connectoToAtom.get("nodeUri"),
-      connectMessage: "",
-    });
+    // create new atom
+    const { message, eventUri, atomUri } = await buildCreateMessage(
+      atomDraft,
+      nodeUri
+    );
 
-    won.wonMessageFromJsonLd(cnctMsg.message).then(optimisticEvent => {
-      // connect action to be dispatched when the
-      // ad hoc atom has been created:
-      //TODO: FIGURE OUT WHICH SOCKETS WILL BE CONNECTED
-      const connectAction = {
-        type: actionTypes.atoms.connect,
-        payload: {
-          eventUri: cnctMsg.eventUri,
-          message: cnctMsg.message,
-          optimisticEvent: optimisticEvent,
-        },
+    if (generalSelectors.isAtomOwned(state, connectToAtomUri)) {
+      const connectToSocketUri = connectToSocketType
+        ? atomUtils.getSocketUri(connectToAtom, connectToSocketType)
+        : atomUtils.getDefaultSocketUri(connectToAtom);
+
+      const getSocketFromDraft = atomDraft => {
+        const draftContent = atomDraft["content"];
+        const draftSockets = draftContent["sockets"];
+
+        if (draftSockets && atomDraftSocketType) {
+          for (let socketKey in draftSockets) {
+            if (draftSockets[socketKey] === atomDraftSocketType) {
+              return socketKey;
+            }
+          }
+        }
+
+        const defaultSocket = draftContent["defaultSocket"];
+        return defaultSocket && Object.keys(defaultSocket)[0];
       };
 
-      // register the connect action to be dispatched when
-      // atom creation is successful
-      dispatch({
-        type: actionTypes.messages.dispatchActionOn.registerSuccessOwn,
-        payload: {
-          eventUri: eventUri,
-          actionToDispatch: connectAction,
-        },
+      const atomDraftSocketUri = getSocketFromDraft(atomDraft);
+
+      if (atomDraftSocketUri && connectToSocketUri) {
+        ownerApi
+          .serverSideConnect(
+            connectToSocketUri,
+            `${atomUri}${atomDraftSocketUri}`,
+            false,
+            true
+          )
+          .then(async response => {
+            if (!response.ok) {
+              const errorMsg = await response.text();
+              throw new Error(`Could not connect owned atoms: ${errorMsg}`);
+            }
+          });
+        // create the new atom
+        dispatch({
+          type: actionTypes.atoms.create, // TODO custom action
+          payload: { eventUri, message, atomUri, atom: atomDraft },
+        });
+
+        dispatch(
+          actionCreators.router__stateGo("connections", {
+            useCase: undefined,
+            useCaseGroup: undefined,
+            fromAtomUri: undefined,
+            viewAtomUri: undefined,
+            viewConnUri: undefined,
+            mode: undefined,
+          })
+        );
+      } else {
+        throw new Error(
+          `Could not connect owned atoms did not find necessary sockets`
+        );
+      }
+    } else {
+      // establish connection
+      const cnctMsg = buildConnectMessage({
+        ownedAtomUri: atomUri,
+        theirAtomUri: connectToAtomUri,
+        ownNodeUri: nodeUri,
+        theirNodeUri: connectToAtom.get("nodeUri"),
+        connectMessage: "",
       });
 
-      // create the new atom
-      dispatch({
-        type: actionTypes.atoms.create, // TODO custom action
-        payload: { eventUri, message, atomUri, atom: atomDraft },
-      });
+      won.wonMessageFromJsonLd(cnctMsg.message).then(optimisticEvent => {
+        // connect action to be dispatched when the
+        // ad hoc atom has been created:
+        //TODO: FIGURE OUT WHICH SOCKETS WILL BE CONNECTED
+        const connectAction = {
+          type: actionTypes.atoms.connect,
+          payload: {
+            eventUri: cnctMsg.eventUri,
+            message: cnctMsg.message,
+            optimisticEvent: optimisticEvent,
+          },
+        };
 
-      dispatch(
-        actionCreators.router__stateGo("connections", {
-          useCase: undefined,
-          useCaseGroup: undefined,
-          fromAtomUri: undefined,
-          viewAtomUri: undefined,
-          viewConnUri: undefined,
-          mode: undefined,
-        })
-      );
-    });
+        // register the connect action to be dispatched when
+        // atom creation is successful
+        dispatch({
+          type: actionTypes.messages.dispatchActionOn.registerSuccessOwn,
+          payload: {
+            eventUri: eventUri,
+            actionToDispatch: connectAction,
+          },
+        });
+
+        // create the new atom
+        dispatch({
+          type: actionTypes.atoms.create, // TODO custom action
+          payload: { eventUri, message, atomUri, atom: atomDraft },
+        });
+
+        dispatch(
+          actionCreators.router__stateGo("connections", {
+            useCase: undefined,
+            useCaseGroup: undefined,
+            fromAtomUri: undefined,
+            viewAtomUri: undefined,
+            viewConnUri: undefined,
+            mode: undefined,
+          })
+        );
+      });
+    }
   });
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -338,21 +338,10 @@ function connectReactionAtom(
       const persona = getIn(state, ["atoms", personaUri]);
       ownerApi
         .serverSideConnect(
-          {
-            pending: false,
-            socket: atomUtils.getSocketUri(
-              persona,
-              won.HOLD.HolderSocketCompacted
-            ),
-          },
-          {
-            pending: true,
-            socket: `${atomUri}#holdableSocket`,
-            // FIXME: does not work as new atom is not in state yet
-            //socket: getIn(state, ["atoms", atomUri, "content", "sockets"]).keyOf(
-            //  "hold:HoldableSocket"
-            //),
-          }
+          atomUtils.getSocketUri(persona, won.HOLD.HolderSocketCompacted),
+          `${atomUri}#holdableSocket`,
+          false,
+          true
         )
         .then(async response => {
           if (!response.ok) {
@@ -418,7 +407,13 @@ export function connectionsConnectAdHoc(theirAtomUri, textMessage, persona) {
   return (dispatch, getState) =>
     connectAdHoc(theirAtomUri, textMessage, persona, dispatch, getState); // moved to separate function to make transpilation work properly
 }
-function connectAdHoc(theirAtomUri, textMessage, persona, dispatch, getState) {
+function connectAdHoc(
+  theirAtomUri,
+  textMessage,
+  personaUri,
+  dispatch,
+  getState
+) {
   ensureLoggedIn(dispatch, getState).then(async () => {
     const state = getState();
     const theirAtom = getIn(state, ["atoms", theirAtomUri]);
@@ -441,23 +436,13 @@ function connectAdHoc(theirAtomUri, textMessage, persona, dispatch, getState) {
     );
 
     // add persona
-    if (persona) {
+    if (personaUri) {
+      const persona = getIn(state, ["atoms", personaUri]);
       const response = await ownerApi.serverSideConnect(
-        {
-          pending: false,
-          //socket: `${persona}#holderSocket`,
-          socket: getIn(state, ["atoms", persona, "content", "sockets"]).keyOf(
-            "hold:HolderSocket"
-          ),
-        },
-        {
-          pending: true,
-          socket: `${atomUri}#holdableSocket`,
-          // FIXME: does not work as new atom is not in state yet
-          //socket: getIn(state, ["atoms", atomUri, "content", "sockets"]).keyOf(
-          //  "hold:HoldableSocket"
-          //),
-        }
+        atomUtils.getSocketUri(persona, won.HOLD.HolderSocketCompacted),
+        `${atomUri}#holdableSocket`,
+        false,
+        true
       );
       if (!response.ok) {
         const errorMsg = await response.text();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -336,27 +336,30 @@ function connectReactionAtom(
     // add persona
     if (personaUri) {
       const persona = getIn(state, ["atoms", personaUri]);
-      const response = await ownerApi.serverSideConnect(
-        {
-          pending: false,
-          socket: atomUtils.getSocketUri(
-            persona,
-            won.HOLD.HolderSocketCompacted
-          ),
-        },
-        {
-          pending: true,
-          socket: `${atomUri}#holdableSocket`,
-          // FIXME: does not work as new atom is not in state yet
-          //socket: getIn(state, ["atoms", atomUri, "content", "sockets"]).keyOf(
-          //  "hold:HoldableSocket"
-          //),
-        }
-      );
-      if (!response.ok) {
-        const errorMsg = await response.text();
-        throw new Error(`Could not connect identity: ${errorMsg}`);
-      }
+      ownerApi
+        .serverSideConnect(
+          {
+            pending: false,
+            socket: atomUtils.getSocketUri(
+              persona,
+              won.HOLD.HolderSocketCompacted
+            ),
+          },
+          {
+            pending: true,
+            socket: `${atomUri}#holdableSocket`,
+            // FIXME: does not work as new atom is not in state yet
+            //socket: getIn(state, ["atoms", atomUri, "content", "sockets"]).keyOf(
+            //  "hold:HoldableSocket"
+            //),
+          }
+        )
+        .then(async response => {
+          if (!response.ok) {
+            const errorMsg = await response.text();
+            throw new Error(`Could not connect identity: ${errorMsg}`);
+          }
+        });
     }
 
     // establish connection

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
@@ -82,25 +82,33 @@ export function atomCreate(draft, persona, nodeUri) {
         nodeUri
       );
       if (persona) {
-        const response = await ownerApi.serverSideConnect(
-          {
-            pending: false,
-            socket: `${persona}#holderSocket`,
-          },
-          {
-            pending: true,
-            socket: `${atomUri}#holdableSocket`,
-          }
-        );
-        if (!response.ok) {
-          const errorMsg = await response.text();
-          throw new Error(`Could not connect identity: ${errorMsg}`);
-        }
+        return ownerApi
+          .serverSideConnect(
+            {
+              pending: false,
+              socket: `${persona}#holderSocket`,
+            },
+            {
+              pending: true,
+              socket: `${atomUri}#holdableSocket`,
+            }
+          )
+          .then(async response => {
+            if (!response.ok) {
+              const errorMsg = await response.text();
+              throw new Error(`Could not connect identity: ${errorMsg}`);
+            }
+            dispatch({
+              type: actionTypes.atoms.create,
+              payload: { eventUri, message, atomUri, atom: draft },
+            });
+          });
+      } else {
+        dispatch({
+          type: actionTypes.atoms.create,
+          payload: { eventUri, message, atomUri, atom: draft },
+        });
       }
-      dispatch({
-        type: actionTypes.atoms.create,
-        payload: { eventUri, message, atomUri, atom: draft },
-      });
     });
   };
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
@@ -11,6 +11,7 @@ import { ensureLoggedIn } from "./account-actions.js";
 import { get, getIn } from "../utils.js";
 
 import * as accountUtils from "../account-utils.js";
+import * as ownerApi from "../owner-api";
 
 export function atomEdit(draft, oldAtom, nodeUri) {
   return (dispatch, getState) => {
@@ -81,23 +82,16 @@ export function atomCreate(draft, persona, nodeUri) {
         nodeUri
       );
       if (persona) {
-        const response = await fetch("rest/action/connect", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
+        const response = await ownerApi.serverSideConnect(
+          {
+            pending: false,
+            socket: `${persona}#holderSocket`,
           },
-          body: JSON.stringify([
-            {
-              pending: false,
-              socket: `${persona}#holderSocket`,
-            },
-            {
-              pending: true,
-              socket: `${atomUri}#holdableSocket`,
-            },
-          ]),
-          credentials: "include",
-        });
+          {
+            pending: true,
+            socket: `${atomUri}#holdableSocket`,
+          }
+        );
         if (!response.ok) {
           const errorMsg = await response.text();
           throw new Error(`Could not connect identity: ${errorMsg}`);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/create-atom-action.js
@@ -84,14 +84,10 @@ export function atomCreate(draft, persona, nodeUri) {
       if (persona) {
         return ownerApi
           .serverSideConnect(
-            {
-              pending: false,
-              socket: `${persona}#holderSocket`,
-            },
-            {
-              pending: true,
-              socket: `${atomUri}#holdableSocket`,
-            }
+            `${persona}#holderSocket`,
+            `${atomUri}#holdableSocket`,
+            false,
+            true
           )
           .then(async response => {
             if (!response.ok) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -125,15 +125,10 @@ async function connectReview(
 export function connectPersona(atomUri, personaUri) {
   return dispatch => {
     return ownerApi
+      .serverSideConnect()
       .serverSideConnect(
-        {
-          pending: false,
-          socket: `${personaUri}#holderSocket`,
-        },
-        {
-          pending: false,
-          socket: `${atomUri}#holdableSocket`,
-        }
+        `${personaUri}#holderSocket`,
+        `${atomUri}#holdableSocket`
       )
       .then(async response => {
         if (!response.ok) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -125,7 +125,6 @@ async function connectReview(
 export function connectPersona(atomUri, personaUri) {
   return dispatch => {
     return ownerApi
-      .serverSideConnect()
       .serverSideConnect(
         `${personaUri}#holderSocket`,
         `${atomUri}#holdableSocket`

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -6,6 +6,7 @@ import { getOwnedAtomByConnectionUri } from "../selectors/general-selectors";
 import { getOwnedConnectionByUri } from "../selectors/connection-selectors";
 import { buildConnectMessage, buildCloseMessage } from "../won-message-utils";
 import * as atomUtils from "../atom-utils.js";
+import * as ownerApi from "../owner-api";
 
 export function createPersona(persona, nodeUri) {
   return (dispatch, getState) => {
@@ -123,23 +124,16 @@ async function connectReview(
 
 export function connectPersona(atomUri, personaUri) {
   return async dispatch => {
-    const response = await fetch("rest/action/connect", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+    const response = await ownerApi.serverSideConnect(
+      {
+        pending: false,
+        socket: `${personaUri}#holderSocket`,
       },
-      body: JSON.stringify([
-        {
-          pending: false,
-          socket: `${personaUri}#holderSocket`,
-        },
-        {
-          pending: false,
-          socket: `${atomUri}#holdableSocket`,
-        },
-      ]),
-      credentials: "include",
-    });
+      {
+        pending: false,
+        socket: `${atomUri}#holdableSocket`,
+      }
+    );
     if (!response.ok) {
       const errorMsg = await response.text();
       throw new Error(`Could not connect identity: ${errorMsg}`);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/persona-actions.js
@@ -123,28 +123,31 @@ async function connectReview(
 }
 
 export function connectPersona(atomUri, personaUri) {
-  return async dispatch => {
-    const response = await ownerApi.serverSideConnect(
-      {
-        pending: false,
-        socket: `${personaUri}#holderSocket`,
-      },
-      {
-        pending: false,
-        socket: `${atomUri}#holdableSocket`,
-      }
-    );
-    if (!response.ok) {
-      const errorMsg = await response.text();
-      throw new Error(`Could not connect identity: ${errorMsg}`);
-    }
-    dispatch({
-      type: actionTypes.personas.connect,
-      payload: {
-        atomUri: atomUri,
-        personaUri: personaUri,
-      },
-    });
+  return dispatch => {
+    return ownerApi
+      .serverSideConnect(
+        {
+          pending: false,
+          socket: `${personaUri}#holderSocket`,
+        },
+        {
+          pending: false,
+          socket: `${atomUri}#holdableSocket`,
+        }
+      )
+      .then(async response => {
+        if (!response.ok) {
+          const errorMsg = await response.text();
+          throw new Error(`Could not connect identity: ${errorMsg}`);
+        }
+        dispatch({
+          type: actionTypes.personas.connect,
+          payload: {
+            atomUri: atomUri,
+            personaUri: personaUri,
+          },
+        });
+      });
   };
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/atom-utils.js
@@ -375,6 +375,16 @@ export function getSocketUri(atomImm, socketType) {
   );
 }
 
+export function getDefaultSocketUri(atomImm) {
+  return (
+    atomImm &&
+    atomImm
+      .getIn(["content", "defaultSocket"])
+      .keySeq()
+      .first()
+  );
+}
+
 export function getDefaultSocketWithKeyReset(atomImm) {
   const defaultSocket = getIn(atomImm, ["content", "defaultSocket"]);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -343,16 +343,23 @@ function genComponentConf() {
 
     save() {
       if (this.loggedIn && this.isFromAtomOwned) {
-        this.draftObject.useCase = get(this.useCase, "identifier");
-
-        if (!isBranchContentPresent(this.draftObject.content, true)) {
-          delete this.draftObject.content;
-        }
-        if (!isBranchContentPresent(this.draftObject.seeks, true)) {
-          delete this.draftObject.seeks;
-        }
+        this.sanitizeDraftObject();
 
         this.atoms__edit(this.draftObject, this.fromAtom);
+      }
+    }
+
+    /**
+     * Removes empty branches from the draft, and adds the proper useCase to the draft
+     */
+    sanitizeDraftObject() {
+      this.draftObject.useCase = get(this.useCase, "identifier");
+
+      if (!isBranchContentPresent(this.draftObject.content, true)) {
+        delete this.draftObject.content;
+      }
+      if (!isBranchContentPresent(this.draftObject.seeks, true)) {
+        delete this.draftObject.seeks;
       }
     }
 
@@ -361,6 +368,8 @@ function genComponentConf() {
         console.debug("publish in process, do not take any action");
         return;
       }
+
+      this.sanitizeDraftObject();
 
       if (this.connectToAtomUri) {
         const tempConnectToAtomUri = this.connectToAtomUri;
@@ -398,15 +407,6 @@ function genComponentConf() {
           );
         }
       } else {
-        this.draftObject.useCase = get(this.useCase, "identifier");
-
-        if (!isBranchContentPresent(this.draftObject.content, true)) {
-          delete this.draftObject.content;
-        }
-        if (!isBranchContentPresent(this.draftObject.seeks, true)) {
-          delete this.draftObject.seeks;
-        }
-
         const tempDraft = this.draftObject;
         const tempDefaultNodeUri = this.$ngRedux
           .getState()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/send-request.js
@@ -80,7 +80,10 @@ function genComponentConf() {
           isConnectible && !isOwned && hasReactionUseCases;
 
         const showAdHocRequestField =
-          isConnectible && !showEnabledUseCases && !showReactionUseCases;
+          !isOwned &&
+          isConnectible &&
+          !showEnabledUseCases &&
+          !showReactionUseCases;
 
         const viewState = get(state, "view");
         const visibleTab = viewUtils.getVisibleTabByAtomUri(viewState, atomUri);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/owner-api.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/owner-api.js
@@ -2,13 +2,27 @@
  * Created by quasarchimaere on 11.06.2019.
  */
 
-export function serverSideConnect(socket1, socket2) {
+export function serverSideConnect(
+  socketUri1,
+  socketUri2,
+  pending1 = false,
+  pending2 = false
+) {
   return fetch("rest/action/connect", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify([socket1, socket2]),
+    body: JSON.stringify([
+      {
+        pending: pending1,
+        socket: socketUri1,
+      },
+      {
+        pending: pending2,
+        socket: socketUri2,
+      },
+    ]),
     credentials: "include",
   });
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/owner-api.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/owner-api.js
@@ -1,0 +1,14 @@
+/**
+ * Created by quasarchimaere on 11.06.2019.
+ */
+
+export function serverSideConnect(socket1, socket2) {
+  return fetch("rest/action/connect", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify([socket1, socket2]),
+    credentials: "include",
+  });
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -66,6 +66,8 @@ export const cyclingPlan = {
         buddy: won.defaultContext["buddy"],
         hold: won.defaultContext["hold"],
         s: won.defaultContext["s"],
+        demo: won.defaultContext["demo"],
+        match: won.defaultContext["match"],
       },
       distinct: true,
       variables: [resultName, "?score"],
@@ -126,6 +128,7 @@ export const cyclingInterest = {
         s: won.defaultContext["s"],
         won: won.defaultContext["won"],
         con: won.defaultContext["con"],
+        demo: won.defaultContext["demo"],
       },
       geoCoordinates: getIn(draft, ["content", "location"]),
     });


### PR DESCRIPTION
Automatically open connect requests from an enabledUsecase to be accepted (both atoms belong to the current user).

- Creates the ability to "Plan a Ride" and make the interest join the groupchat automatically without having to accept the invite

- removes the ability to request adHocConnections of owned atoms (only enabledUseCases are possible)

- Fixes #2957 -> enabled UseCases did not produce a query, now they do