### PR TITLE
Reduce number of hint-emails

### DIFF
--- a/webofneeds/won-owner-webapp/pom.xml
+++ b/webofneeds/won-owner-webapp/pom.xml
@@ -53,6 +53,11 @@
 			<artifactId>won-utils-conversation</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>at.researchstudio.sat</groupId>
+			<artifactId>won-utils-batch</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!-- JSTL/Servlet -->
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -212,7 +212,7 @@ public class WonOwnerMailSender {
             atomTitles.put(localAtom, localAtomTitle);
         });
         velocityContext.put("atomTitle", atomTitles);
-        velocityContext.put("atomLink", atomTitles);
+        velocityContext.put("atomLink", atomLinks);
         return velocityContext;
     }
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -455,12 +455,6 @@ public class WonWebSocketHandler extends TextWebSocketHandler
                     }
                     return;
                 case ATOM_HINT_MESSAGE:
-                    if (userAtom.isMatches()) {
-                        String targetAtomUri = wonMessage.getHintTargetAtomURI().toString();
-                        emailSender.sendHintNotificationMessage(user.getEmail(), atomUri.toString(), targetAtomUri,
-                                        wonMessage.getRecipientURI().toString());
-                    }
-                    return;
                 case SOCKET_HINT_MESSAGE:
                     if (userAtom.isMatches()) {
                         Optional<URI> targetAtomUri = WonLinkedDataUtils
@@ -497,8 +491,6 @@ public class WonWebSocketHandler extends TextWebSocketHandler
                                     emailSender.sendMultipleHintsNotificationMessage(a[0], hintCounts);
                                 }
                             }, config);
-                            emailSender.sendHintNotificationMessage(user.getEmail(), atomUri.toString(),
-                                            targetAtomUri.get().toString(), wonMessage.getRecipientURI().toString());
                         } else {
                             logger.info("received socket hint to {} but could not identify corresponding atom - no mail sent.",
                                             wonMessage.getHintTargetSocketURI());

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -469,7 +470,7 @@ public class WonWebSocketHandler extends TextWebSocketHandler
                             // users emails in memory all the time
                             MessageDigest digest = MessageDigest.getInstance("SHA-256");
                             byte[] hash = digest.digest(user.getEmail().getBytes(StandardCharsets.UTF_8));
-                            String key = "HINT" + new String(hash);
+                            String key = "HINT" + Base64.getEncoder().encodeToString(hash);
                             String[] args = new String[] {
                                             user.getEmail(),
                                             atomUri.toString(),

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
@@ -1,8 +1,8 @@
 Hi there,
 
 The post '$targetAtomTitle' may be interesting for you. 
-To view it, go to 'Suggestions' for your post'$localAtomTitle': 
-$linkLocalAtom
+
+Go to your 'Suggestions' tab: $linkLocalAtom
 
 Best wishes, 
 

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
@@ -1,7 +1,7 @@
 Hi there,
 
 The post '$targetAtomTitle' may be interesting for you. 
-To view it, go to 'Suggestions' for your post here: 
+To view it, go to 'Suggestions' for your post'$localAtomTitle': 
 $linkLocalAtom
 
 Best wishes, 

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/hint-notification.vm
@@ -1,12 +1,8 @@
 Hi there,
 
-We have news regarding your post '$localAtomTitle' on $serviceName:
-
-We've received a hint that the post '$targetAtomTitle' may be a good match for you.
-    
-Contact the user: $linkConnection
-View your post: $linkLocalAtom  
-View their post: $linkTargetAtom
+The post '$targetAtomTitle' may be interesting for you. 
+To view it, go to 'Suggestions' for your post here: 
+$linkLocalAtom
 
 Best wishes, 
 

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
@@ -1,19 +1,19 @@
 Hi,
 
-
-#if [$atoms.size() > 1]
+#if ( $atoms.size() > 1 )
 Multple matches were found for you:
 #foreach ($atom in $atoms)
 * $hintCount[$atom] for '$atomTitle[$atom]'
-    View them: $atomLink[$atom]
+    Go to your 'Suggestions' tab: $atomLink[$atom]
+
 #end
 #else
 #foreach ($atom in $atoms)
 $hintCount[$atom] matches were found for your post '$atomTitle[$atom]'
 
-View them: $atomLink[$atom]
-#fi
-
+Go to your 'Suggestions' tab: $atomLink[$atom]
+#end
+#end
 Best wishes, 
 
 The team at $serviceName

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
@@ -1,11 +1,18 @@
 Hi,
 
-Multple matches were found for you:
 
+#if [$atoms.size() > 1]
+Multple matches were found for you:
 #foreach ($atom in $atoms)
-* $hintCount($atom) for '$atomTitle($atom)'
- 	 - see Suggestions: $atomLink($atom)
+* $hintCount[$atom] for '$atomTitle[$atom]'
+    View them: $atomLink[$atom]
 #end
+#else
+#foreach ($atom in $atoms)
+$hintCount[$atom] matches were found for your post '$atomTitle[$atom]'
+
+View them: $atomLink[$atom]
+#fi
 
 Best wishes, 
 

--- a/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
+++ b/webofneeds/won-owner-webapp/src/main/resources/mail-templates/multiple-hints-notification.vm
@@ -1,0 +1,12 @@
+Hi,
+
+Multple matches were found for you:
+
+#foreach ($atom in $atoms)
+* $hintCount($atom) for '$atomTitle($atom)'
+ 	 - see Suggestions: $atomLink($atom)
+#end
+
+Best wishes, 
+
+The team at $serviceName

--- a/webofneeds/won-utils/pom.xml
+++ b/webofneeds/won-utils/pom.xml
@@ -19,6 +19,7 @@
         <module>won-utils-goals</module>
         <module>won-utils-conversation</module>
         <module>won-utils-tls</module>
+        <module>won-utils-batch</module>
     </modules>
     <packaging>pom</packaging>
 </project>

--- a/webofneeds/won-utils/won-utils-batch/pom.xml
+++ b/webofneeds/won-utils/won-utils-batch/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>at.researchstudio.sat</groupId>
+		<artifactId>won-utils</artifactId>
+		<version>0.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>won-utils-batch</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+		<!-- LOGGING -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/webofneeds/won-utils/won-utils-batch/src/main/java/won/utils/batch/BatchingConsumer.java
+++ b/webofneeds/won-utils/won-utils-batch/src/main/java/won/utils/batch/BatchingConsumer.java
@@ -1,0 +1,304 @@
+package won.utils.batch;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Accepts items together with a key for grouping them, a
+ * Consumer<Collection<Object>> for consuming them. The consumer's purpose is to
+ * balance the following goals
+ * <ul>
+ * <li>the consumer should be called as soon as possible</li>
+ * <li>frequent invocations of the consumer should be avoided</li>
+ * </ul>
+ * The BatchingConsumer is being <code>accepted</code> <code>items</code>. It
+ * consumes them in 'chunks' of one or multiple items at a time. The following
+ * properties can be set for each key to govern this behaviour (higher up on
+ * this list is more imporant):
+ * <ul>
+ * <li><code>consumeFirst (boolean)</code>: if set, the filter consumes the
+ * accepted item immediately if there is not yet a batch for that key. However,
+ * the batch is created and subsequent items with the same key are collected in
+ * the batch.</li>
+ * <li><code>maxBatchAge (Duration)</code>: the whole batch cannot become older
+ * than this value. When it is reached, the whole batch is consumed.</li>
+ * <li><code>minChunkInterval (Duration)</code>: wait at least for this duration
+ * between chunks</li>
+ * <li><code>maxItemInterval (Duration)</code>: consume the current chunk when
+ * the instant the last item was accepted is longer ago than this value.</li>
+ * <li><code>maxBatchSize (integer)</code>: consume whole batch if its size has
+ * reached this value</li>
+ * </ul>
+ * 
+ * @author fkleedorfer
+ */
+public class BatchingConsumer<K, I> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Map<K, Batch<K, I>> batches = new HashMap<K, Batch<K, I>>(10);
+    ScheduledExecutorService executorSvc = Executors.newSingleThreadScheduledExecutor();
+    private Config defaultConfig = new ConfigBuilder()
+                    .maxBatchAge(Duration.ofHours(1))
+                    .maxItemInterval(Duration.ofMinutes(5))
+                    .consumeFirst(false)
+                    .maxBatchSize(200)
+                    .minChunkInterval(Duration.ofMinutes(15))
+                    .build();
+
+    public BatchingConsumer() {
+    }
+
+    public BatchingConsumer(Config config) {
+        this.defaultConfig = config;
+    }
+
+    public static class Config {
+        public Config(Optional<Duration> maxBatchAge, Optional<Duration> minChunkInterval,
+                        Optional<Duration> maxItemInterval, Optional<Boolean> consumeFirst,
+                        Optional<Integer> maxBatchSize) {
+            this.consumeFirst = consumeFirst;
+            this.maxBatchAge = maxBatchAge;
+            this.minChunkInterval = minChunkInterval;
+            this.maxItemInterval = maxItemInterval;
+            this.maxBatchSize = maxBatchSize;
+        }
+
+        public final Optional<Duration> maxBatchAge;
+        public final Optional<Duration> maxItemInterval;
+        public final Optional<Boolean> consumeFirst;
+        public final Optional<Duration> minChunkInterval;
+        public final Optional<Integer> maxBatchSize;
+    }
+
+    public static class ConfigBuilder {
+        public ConfigBuilder() {
+        }
+
+        private Optional<Duration> maxBatchAge = Optional.empty();
+        private Optional<Duration> maxItemInterval = Optional.empty();
+        private Optional<Boolean> consumeFirst = Optional.empty();
+        private Optional<Duration> minChunkInterval = Optional.empty();
+        private Optional<Integer> maxBatchSize = Optional.empty();
+
+        public ConfigBuilder maxBatchAge(Duration d) {
+            this.maxBatchAge = Optional.ofNullable(d);
+            return this;
+        }
+
+        public ConfigBuilder maxItemInterval(Duration d) {
+            this.maxItemInterval = Optional.ofNullable(d);
+            return this;
+        }
+
+        public ConfigBuilder consumeFirst(Boolean b) {
+            this.consumeFirst = Optional.ofNullable(b);
+            return this;
+        }
+
+        public ConfigBuilder minChunkInterval(Duration d) {
+            this.minChunkInterval = Optional.ofNullable(d);
+            return this;
+        }
+
+        public ConfigBuilder maxBatchSize(Integer s) {
+            this.maxBatchSize = Optional.ofNullable(s);
+            return this;
+        }
+
+        public Config build() {
+            return new Config(this.maxBatchAge, this.minChunkInterval, this.maxItemInterval, this.consumeFirst,
+                            this.maxBatchSize);
+        }
+    }
+
+    private class Batch<K, I> {
+        private final K key;
+        private final Queue<I> items = new LinkedList<>();
+        private final Config config;
+        private Optional<Instant> lastChunkInstant = Optional.empty();
+        private Consumer<Collection<I>> consumer;
+        private Optional<ScheduledFuture<?>> cleanupTask = Optional.empty();
+        private Optional<ScheduledFuture<?>> consumeChunkTask = Optional.empty();
+        private final AtomicBoolean firstAdd = new AtomicBoolean(true);
+        private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
+        private final Object monitor = new Object();
+
+        Batch(K key, Consumer<Collection<I>> consumer, Config config) {
+            this.key = key;
+            this.config = config;
+            this.consumer = consumer;
+        }
+
+        void add(I item) {
+            synchronized (monitor) {
+                this.lastChunkInstant = Optional.of(Instant.now());
+                if (this.config.consumeFirst.orElse(false) && this.firstAdd.compareAndSet(true, false)) {
+                    consume(Stream.of(item).collect(Collectors.toList()), false);
+                } else {
+                    items.add(item);
+                    if (config.maxBatchSize.isPresent() && items.size() >= config.maxBatchSize.get()) {
+                        consumeAll(false);
+                    }
+                }
+            }
+        }
+
+        boolean isShuttingDown() {
+            return shuttingDown.get();
+        }
+
+        void cleanupAndRemove() {
+            synchronized (monitor) {
+                this.shuttingDown.set(true);
+                consumeAll(false);
+                synchronized (batches) {
+                    batches.remove(this.key);
+                }
+                cancelTask(this.consumeChunkTask);
+                cancelTask(this.cleanupTask);
+            }
+        }
+
+        void cancelTask(Optional<ScheduledFuture<?>> task) {
+            synchronized (monitor) {
+                if (task.isPresent()) {
+                    task.get().cancel(false);
+                }
+            }
+        }
+
+        void consumeAll(boolean synchronous) {
+            consume(items, synchronous);
+        }
+
+        boolean consumeChunk() {
+            synchronized (monitor) {
+                if (isTooEarlyForChunk()) {
+                    return false;
+                }
+                consumeAll(false);
+            }
+            return true;
+        }
+
+        void consume(Collection<I> itemsToConsume, boolean synchronous) {
+            synchronized (monitor) {
+                this.lastChunkInstant = Optional.of(Instant.now());
+                final Collection<I> consumed = new ArrayList<I>(itemsToConsume.size());
+                consumed.addAll(itemsToConsume);
+                itemsToConsume.clear();
+                if (synchronous) {
+                    consumer.accept(consumed);
+                } else {
+                    executorSvc.execute(() -> {
+                        consumer.accept(consumed);
+                    });
+                }
+            }
+        }
+
+        boolean isTooEarlyForChunk() {
+            if (this.lastChunkInstant.isPresent() && config.minChunkInterval.isPresent()) {
+                return Duration.between(this.lastChunkInstant.get(), Instant.now())
+                                .compareTo(config.minChunkInterval.get()) < 0;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Schedules the consumption maxItemInterval in the future. If that does not
+         * lead to a chunk consumption because of other configuration settings, it is
+         * rescheduled then.
+         * 
+         * @param batch
+         */
+        void rescheduleChunkConsumption() {
+            if (!this.config.maxItemInterval.isPresent()) {
+                return;
+            }
+            synchronized (monitor) {
+                cancelTask(this.consumeChunkTask);
+                this.consumeChunkTask = Optional.of(executorSvc.schedule(() -> {
+                    boolean consumed = consumeChunk();
+                    if (!consumed) {
+                        rescheduleChunkConsumption();
+                    }
+                }, this.config.maxItemInterval.get().toNanos(), TimeUnit.NANOSECONDS));
+            }
+        }
+
+        /**
+         * Schedules the consumption of the batch and its removal from the batches map.
+         * 
+         * @param batch
+         */
+        private void scheduleCleanup() {
+            if (!this.config.maxBatchAge.isPresent()) {
+                return;
+            }
+            this.cleanupTask = Optional.of(executorSvc.schedule(() -> {
+                cleanupAndRemove();
+            }, this.config.maxBatchAge.get().toNanos(), TimeUnit.NANOSECONDS));
+        }
+    }
+
+    public void accept(K key, I item, Consumer<Collection<I>> consumer) {
+        accept(key, item, consumer, Optional.empty());
+    }
+
+    public void accept(K key, I item, Consumer<Collection<I>> consumer, Config config) {
+        accept(key, item, consumer, Optional.ofNullable(config));
+    }
+
+    /**
+     * Offer an item to the BatchingConsumer, providing a consumer and an optional
+     * config. The consumer must be specified just in case a new Batch is created in
+     * this invocation. If that happens, the consumer is used, otherwise it will not
+     * be. The config is optional because the BatchingConsumer has a defaultConfig
+     * that is used if no config is specified. Again, the config presented when a
+     * new Batch is instantiated will be used.
+     * 
+     * @param key
+     * @param item
+     * @param consumer
+     * @param config
+     */
+    public void accept(K key, I item, Consumer<Collection<I>> consumer, Optional<Config> config) {
+        Batch<K, I> batch = null;
+        synchronized (batches) {
+            batch = batches.get(key);
+            if (batch == null || batch.isShuttingDown()) {
+                batch = new Batch<K, I>(key, consumer, config.orElse(defaultConfig));
+                batch.scheduleCleanup();
+                batches.put(key, batch);
+            }
+        }
+        batch.add(item);
+        batch.rescheduleChunkConsumption();
+    }
+
+    public void consumeAllBatches() {
+        synchronized (batches) {
+            batches.values().forEach(batch -> batch.consumeAll(true));
+            batches.clear();
+        }
+    }
+}

--- a/webofneeds/won-utils/won-utils-batch/src/test/java/won/utils/batch/BatchingConsumerTests.java
+++ b/webofneeds/won-utils/won-utils-batch/src/test/java/won/utils/batch/BatchingConsumerTests.java
@@ -1,0 +1,239 @@
+package won.utils.batch;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import won.utils.batch.BatchingConsumer.Config;
+import won.utils.batch.BatchingConsumer.ConfigBuilder;
+
+public class BatchingConsumerTests {
+    @Test
+    public void testConsumeAllOneKey() {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter = new AtomicInteger(0);
+        c.accept("key1", "first item", items -> counter.addAndGet(items.size()));
+        Assert.assertEquals(0, counter.get());
+        c.accept("key1", "second item", items -> counter.set(-1));
+        Assert.assertEquals(0, counter.get());
+        c.accept("key1", "third item", items -> counter.set(-2));
+        Assert.assertEquals(0, counter.get());
+        c.accept("key1", "fourth item", items -> counter.set(-3));
+        Assert.assertEquals(0, counter.get());
+        c.consumeAllBatches();
+        Assert.assertEquals(4, counter.get());
+    }
+
+    @Test
+    public void testConsumeAllTwoKeys() {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        c.accept("key1", "first item", items -> counter1.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> counter2.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key1", "third item", items -> counter1.addAndGet(items.size()));
+        c.accept("key2", "fourth item", items -> counter2.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.consumeAllBatches();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    @Test
+    public void testConsumeConsumeFirstTwoKeys() throws Exception {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        CountDownLock countDown = new CountDownLock();
+        Config conf = new ConfigBuilder().consumeFirst(true).build();
+        countDown.newRound(1);
+        c.accept("key1", "first item", items -> countItems(counter1, countDown, items), conf);
+        countDown.await();
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        countDown.newRound(1);
+        c.accept("key2", "second item", items -> countItems(counter2, countDown, items), conf);
+        countDown.await();
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        c.accept("key1", "third item", items -> countItems(counter1, countDown, items));
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(2);
+        c.accept("key2", "fourth item", items -> countItems(counter2, countDown, items));
+        c.consumeAllBatches();
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    @Test
+    public void testMaxBatchSizeTwoKeys() throws Exception {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        CountDownLock countDown = new CountDownLock();
+        Config conf = new ConfigBuilder().maxBatchSize(2).build();
+        c.accept("key1", "first item", items -> countItems(counter1, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> countItems(counter2, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        countDown.newRound(1);
+        c.accept("key1", "third item", items -> countItems(counter1, countDown, items));
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        countDown.newRound(1);
+        c.accept("key2", "fourth item", items -> countItems(counter2, countDown, items));
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+        c.consumeAllBatches();
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    @Test
+    public void testMaxBatchAgeTwoKeys() throws Exception {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        CountDownLock countDown = new CountDownLock();
+        Config conf = new ConfigBuilder().maxBatchAge(Duration.ofMillis(100)).build();
+        countDown.newRound(2);
+        c.accept("key1", "first item", items -> countItems(counter1, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> countItems(counter2, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        Thread.sleep(200);
+        countDown.await();
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        c.accept("key1", "third item", items -> countItems(counter1, countDown, items));
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        c.accept("key2", "fourth item", items -> countItems(counter2, countDown, items));
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(2);
+        c.consumeAllBatches();
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    @Test
+    public void testMaxItemIntervalTwoKeys() throws Exception {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        CountDownLock countDown = new CountDownLock();
+        Config conf = new ConfigBuilder().maxItemInterval(Duration.ofMillis(50)).build();
+        countDown.newRound(2);
+        c.accept("key1", "first item", items -> countItems(counter1, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> countItems(counter2, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        Thread.sleep(200);
+        countDown.await();
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(1);
+        c.accept("key1", "third item", items -> countItems(counter1, countDown, items));
+        Thread.sleep(100);
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        c.accept("key2", "fourth item", items -> countItems(counter2, countDown, items));
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(1);
+        c.consumeAllBatches();
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    @Test
+    public void testMaxItemIntervalMinTimeBetweenChunksTwoKeys() throws Exception {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        CountDownLock countDown = new CountDownLock();
+        Config conf = new ConfigBuilder()
+                        .maxItemInterval(Duration.ofMillis(50))
+                        .minChunkInterval(Duration.ofMillis(200))
+                        .build();
+        countDown.newRound(2);
+        c.accept("key1", "first item", items -> countItems(counter1, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> countItems(counter2, countDown, items), conf);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        Thread.sleep(100);
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        Thread.sleep(150);
+        countDown.await();
+        Assert.assertEquals(1, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(1);
+        c.accept("key1", "third item", items -> countItems(counter1, countDown, items));
+        Thread.sleep(250);
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        c.accept("key2", "fourth item", items -> countItems(counter2, countDown, items));
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+        countDown.newRound(1);
+        c.consumeAllBatches();
+        countDown.await();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(2, counter2.get());
+    }
+
+    private void countItems(AtomicInteger counter1, CountDownLock countDown, Collection<String> items) {
+        counter1.addAndGet(items.size());
+        countDown.done();
+    }
+
+    private class CountDownLock {
+        private CountDownLatch latch;
+
+        public CountDownLock() {
+        }
+
+        public void newRound(int count) {
+            this.latch = new CountDownLatch(count);
+        }
+
+        public void done() {
+            this.latch.countDown();
+        }
+
+        public void await() throws InterruptedException {
+            this.latch.await(1, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/webofneeds/won-utils/won-utils-batch/src/test/java/won/utils/batch/BatchingConsumerTests.java
+++ b/webofneeds/won-utils/won-utils-batch/src/test/java/won/utils/batch/BatchingConsumerTests.java
@@ -50,6 +50,27 @@ public class BatchingConsumerTests {
         Assert.assertEquals(2, counter1.get());
         Assert.assertEquals(2, counter2.get());
     }
+    
+    @Test
+    public void testCancelOneConsumeAllTwoKeys() {
+        BatchingConsumer<String, String> c = new BatchingConsumer<>();
+        AtomicInteger counter1 = new AtomicInteger(0);
+        AtomicInteger counter2 = new AtomicInteger(0);
+        c.accept("key1", "first item", items -> counter1.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.accept("key2", "second item", items -> counter2.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.cancelBatch("key2");
+        c.accept("key1", "third item", items -> counter1.addAndGet(items.size()));
+        c.accept("key2", "fourth item", items -> counter2.addAndGet(items.size()));
+        Assert.assertEquals(0, counter1.get());
+        Assert.assertEquals(0, counter2.get());
+        c.consumeAllBatches();
+        Assert.assertEquals(2, counter1.get());
+        Assert.assertEquals(1, counter2.get());
+    }
 
     @Test
     public void testConsumeConsumeFirstTwoKeys() throws Exception {


### PR DESCRIPTION
Adds a batching feature for emails and applies it to HINT mails. 
The current settings for hint-mails are (see WonWebSocketHandler.java)
```
 BatchingConsumer.Config config = new BatchingConsumer.ConfigBuilder()
    .consumeFirst(true) // send the first mail immediately
    .maxBatchAge(Duration.ofHours(24)) // empty batch at least once a day
    .maxItemInterval(Duration.ofMinutes(10)) // wait 10 minutes after the last hint, then send mail
    .minChunkInterval(Duration.ofHours(6)) // send at most 1 mail every 6 hours (not counting the one for the first match)
    .maxBatchSize(50) // as soon as we reach 50 hints, send mail
.build();
```