### PR TITLE
Feat  publish preset persona #2958

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -418,6 +418,10 @@ function connectReactionAtom(
         connectMessage: "",
       });
 
+      const connectToSocketUri = connectToSocketType
+        ? atomUtils.getSocketUri(connectToAtom, connectToSocketType)
+        : atomUtils.getDefaultSocketUri(connectToAtom);
+
       won.wonMessageFromJsonLd(cnctMsg.message).then(optimisticEvent => {
         // connect action to be dispatched when the
         // ad hoc atom has been created:
@@ -428,6 +432,7 @@ function connectReactionAtom(
             eventUri: cnctMsg.eventUri,
             message: cnctMsg.message,
             optimisticEvent: optimisticEvent,
+            targetSocketUri: connectToSocketUri,
           },
         };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-holds.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-holds.js
@@ -26,8 +26,17 @@ function genComponentConf() {
           show-suggestions="self.isOwned"
           show-persona="::false"
       ></won-atom-card>
+      <div class="ach__createatom"
+          ng-if="self.isOwned"
+          ng-click="self.router__stateGo('create', {holderUri: self.atomUri})"
+        >
+          <svg class="ach__createatom__icon" title="Create a new post">
+            <use xlink:href="#ico36_plus" href="#ico36_plus" />
+          </svg>
+          <span class="ach__createatom__label">New</span>
+      </div>
       <div class="ach__empty"
-          ng-if="!self.hasHeldAtoms">
+          ng-if="!self.isOwned && !self.hasHeldAtoms">
           Not one single Atom present.
       </div>
     `;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-post.js
@@ -96,14 +96,15 @@ function genComponentConf() {
                 on-scroll="::self.scrollIntoView(element)">
             </won-create-isseeks>
         </div>
-        <div class="cp__footer" >
+        <div class="cp__footer" ng-if="self.initialLoadFinished">
             <won-labelled-hr label="::'done?'" class="cp__footer__labelledhr"></won-labelled-hr>
             <won-elm
               module="self.publishButton"
               props="{
                 buttonEnabled: self.isValid(),
                 showPersonas: self.isHoldable && self.loggedIn,
-                personas: self.personas
+                personas: self.personas,
+                presetHolderUri: self.isHolderAtomValid ? self.holderUri : undefined,
               }"
               on-publish="self.publish(personaId)"
               ng-if="self.showCreateInput && !self.isEditFromAtom">
@@ -222,8 +223,19 @@ function genComponentConf() {
           useCase = useCaseUtils.getUseCase(useCaseString);
         }
 
+        const holderUri = generalSelectors.getHolderUriFromRoute(state);
+        const isHolderOwned = accountUtils.isAtomOwned(
+          get(state, "account"),
+          holderUri
+        );
+        const holderAtom = isHolderOwned && getIn(state, ["atoms", holderUri]);
+        const isHolderAtomValid =
+          holderAtom && atomUtils.hasHolderSocket(holderAtom);
+
         return {
           loggedIn: accountUtils.isLoggedIn(get(state, "account")),
+          holderUri,
+          isHolderAtomValid,
           connectToAtomUri,
           processingPublish: state.getIn(["process", "processingPublish"]),
           connectionHasBeenLost: !generalSelectors.selectIsConnected(state),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/post-info.js
@@ -103,6 +103,9 @@ function genComponentConf() {
 
         const atomLoading =
           !atom || processSelectors.isAtomLoading(state, this.atomUri);
+
+        const holderUri = atomUtils.getHeldByUri(atom);
+
         return {
           loggedIn: accountUtils.isLoggedIn(get(state, "account")),
           isInactive: atomUtils.isInactive(atom),
@@ -121,6 +124,8 @@ function genComponentConf() {
             (showEnabledUseCases ||
               showReactionUseCases ||
               showAdHocRequestField),
+          addHolderUri: showEnabledUseCases && holderUri,
+          holderUri,
         };
       };
       connect2Redux(selectFromState, actionCreators, ["self.atomUri"], this);
@@ -136,6 +141,7 @@ function genComponentConf() {
         fromAtomUri: this.atomUri,
         viewConnUri: undefined,
         mode: "CONNECT",
+        holderUri: this.addHolderUri ? this.holderUri : undefined,
       });
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/configRouting.js
@@ -90,7 +90,7 @@ export const configRouting = [
         as: "map",
       },
       {
-        path: "/create?useCase?useCaseGroup?fromAtomUri?mode",
+        path: "/create?useCase?useCaseGroup?fromAtomUri?mode?holderUri",
         component: createComponent,
         as: "create",
       },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/atom-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/atom-reducer-main.js
@@ -4,7 +4,7 @@
 import { actionTypes } from "../../actions/actions.js";
 import Immutable from "immutable";
 import won from "../../won-es6.js";
-import { msStringToDate, getIn } from "../../utils.js";
+import { msStringToDate, getIn, get } from "../../utils.js";
 import {
   addAtomStubs,
   addAtom,
@@ -43,6 +43,7 @@ import {
   setShowPetriNetData,
   setMultiSelectType,
 } from "./reduce-connections.js";
+import * as atomUtils from "../../redux/utils/atom-utils.js";
 
 const initialState = Immutable.fromJS({});
 
@@ -432,9 +433,20 @@ export default function(allAtomsInState = initialState, action = {}) {
         // (see connectAdHoc)
         const atomUri = tmpAtom.get("uri");
 
+        //set socketUris to the default SocketUris if the socket Uris where not set yet
+        const socketUri = atomUtils.getDefaultSocketUri(tmpAtom);
+        const targetSocketUri = atomUtils.getDefaultSocketUri(
+          get(allAtomsInState, get(tmpConnection, "targetAtomUri"))
+        );
+
         const properConnection = tmpConnection
           .delete("usingTemporaryUri")
-          .set("uri", connUri);
+          .set("uri", connUri)
+          .set("socketUri", get(tmpConnection, "socketUri") || socketUri)
+          .set(
+            "targetSocketUri",
+            get(tmpConnection, "targetSocketUri") || targetSocketUri
+          );
 
         allAtomsInState = allAtomsInState
           .deleteIn([atomUri, "connections", tmpConnUri])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -274,6 +274,18 @@ export const getFromAtomUriFromRoute = createSelector(
   }
 );
 
+export const getHolderUriFromRoute = createSelector(
+  state => state,
+  state => {
+    const encodedHolderUri = getIn(state, [
+      "router",
+      "currentParams",
+      "holderUri",
+    ]);
+    return decodeUriComponentProperly(encodedHolderUri);
+  }
+);
+
 export const getModeFromRoute = createSelector(
   state => state,
   state => {
@@ -323,16 +335,18 @@ export function getOwnedCondensedPersonaList(state, includeArchived = false) {
     .toList()
     .filter(atom => atomUtils.isPersona(atom))
     .filter(atom => includeArchived || atomUtils.isActive(atom));
-  return personas.map(persona => {
-    return {
-      displayName: getIn(persona, ["content", "personaName"]),
-      website: getIn(persona, ["content", "website"]),
-      aboutMe: getIn(persona, ["content", "description"]),
-      url: get(persona, "uri"),
-      saved: !get(persona, "isBeingCreated"),
-      timestamp: get(persona, "creationDate").toISOString(),
-    };
-  });
+  return personas
+    .map(persona => {
+      return {
+        displayName: getIn(persona, ["content", "personaName"]),
+        website: getIn(persona, ["content", "website"]),
+        aboutMe: getIn(persona, ["content", "description"]),
+        url: get(persona, "uri"),
+        saved: !get(persona, "isBeingCreated"),
+        timestamp: get(persona, "creationDate").toISOString(),
+      };
+    })
+    .filter(persona => !!persona.displayName);
 }
 
 //TODO: move this method to a place that makes more sense, its not really a selector function

--- a/webofneeds/won-owner-webapp/src/main/webapp/elm/PublishButton.elm
+++ b/webofneeds/won-owner-webapp/src/main/webapp/elm/PublishButton.elm
@@ -37,6 +37,7 @@ type alias Props =
     , showPersonas : Bool
     , personas : Dict String Persona
     , label : String
+    , presetHolderUri: Maybe String
     }
 
 
@@ -54,7 +55,7 @@ propDecoder =
                         >> Dict.fromList
                     )
     in
-    Decode.map4 Props
+    Decode.map5 Props
         (Decode.field "buttonEnabled" Decode.bool)
         (Decode.field "showPersonas" Decode.bool)
         (Decode.field "personas" dictDecoder)
@@ -62,7 +63,9 @@ propDecoder =
             |> Decode.maybe
             |> Decode.map (Maybe.withDefault defaultLabel)
         )
-
+        (Decode.field "presetHolderUri" Decode.string
+                    |> Decode.maybe
+                )
 
 
 ---- MODEL ----
@@ -113,9 +116,9 @@ type SelectedPersona
 
 
 init : Props -> ( Model, Cmd Msg )
-init _ =
+init props =
     ( { state = Closed
-      , selectedPersona = Anonymous
+      , selectedPersona = props.presetHolderUri |> Maybe.map Persona |> Maybe.withDefault Anonymous
       , buttonPosition = NotQueried
       }
     , getRandomId

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-holds.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-holds.scss
@@ -17,4 +17,41 @@ won-atom-content-holds {
   & won-atom-card.ach__atom {
     border: $thinGrayBorder;
   }
+
+  & .ach__createatom {
+    border: $thinGrayBorder;
+    background: $won-light-gray;
+    padding: 0.5rem;
+    cursor: pointer;
+    display: grid;
+    grid-gap: 0.5rem;
+    grid-auto-flow: row;
+    justify-content: center;
+    align-content: center;
+    grid-template-rows: min-content min-content;
+    box-sizing: border-box;
+
+    &:hover {
+      border-color: $won-primary-color;
+
+      .ach__createatom__label {
+        color: $won-primary-color;
+      }
+
+      .ach__createatom__icon {
+        --local-primary: #{$won-primary-color};
+      }
+    }
+
+    .ach__createatom__label {
+      font-size: $mediumFontSize;
+      text-align: center;
+      color: $won-line-gray;
+    }
+
+    .ach__createatom__icon {
+      @include fixed-square($hugeiconSize);
+      --local-primary: #{$won-line-gray};
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2987 -> Reaction UseCasesreactionAtom connections did not show up after creation (reload was necessary)
Fixes #2958 -> Enabled UseCases of an atom with an attached persona preselect that persona as the "publish as"-persona in the creation of the enabled useCase

Adds "+ New" Button within each owned Personas Post Tab, and preselects the owned Persona within the atom creation