### PR TITLE
Fix  msgloading after edit

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -107,7 +107,7 @@ export function accountLogin(credentials, redirectToFeed = false) {
         })
       )
       .then(() => dispatch({ type: actionTypes.upgradeHttpSession }))
-      .then(() => stateStore.fetchOwnedData(dispatch))
+      .then(() => stateStore.fetchOwnedData(dispatch, getState))
       .then(() => dispatch({ type: actionTypes.account.loginFinished }))
       .catch(error =>
         error.response.json().then(loginError => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -158,7 +158,7 @@ const actionHierarchy = {
     storeWhatsAround: INJ_DEFAULT,
 
     storeOwnedMetaAtoms: INJ_DEFAULT,
-    storeTheirUrisInLoading: INJ_DEFAULT,
+    storeUriInLoading: INJ_DEFAULT,
 
     storeOwned: INJ_DEFAULT,
     storeTheirs: INJ_DEFAULT,
@@ -174,7 +174,7 @@ const actionHierarchy = {
     disconnect: disconnectPersona,
 
     storeTheirs: INJ_DEFAULT,
-    storeTheirUrisInLoading: INJ_DEFAULT,
+    storeUriInLoading: INJ_DEFAULT,
 
     storeUriFailed: INJ_DEFAULT,
     removeDeleted: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/atoms-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/atoms-actions.js
@@ -19,7 +19,8 @@ import * as stateStore from "../redux/state-store.js";
 import { get } from "../utils.js";
 
 export function fetchUnloadedAtom(atomUri) {
-  return dispatch => stateStore.fetchDataForNonOwnedAtomOnly(atomUri, dispatch);
+  return (dispatch, getState) =>
+    stateStore.fetchDataForNonOwnedAtomOnly(atomUri, dispatch, getState);
 }
 
 //ownConnectionUri is optional - set if known

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -33,18 +33,18 @@ export function connectionsChatMessageClaimOnSuccess(
   connectionUri
 ) {
   return (dispatch, getState) => {
-    const ownedAtom = getState()
-      .get("atoms")
-      .find(atom => atom.getIn(["connections", connectionUri]));
-    const theirAtomUri = getState().getIn([
+    const ownedAtom = get(getState(), "atoms").find(atom =>
+      getIn(atom, ["connections", connectionUri])
+    );
+    const theirAtomUri = getIn(getState(), [
       "atoms",
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       "connections",
       connectionUri,
       "targetAtomUri",
     ]);
-    const theirAtom = getState().getIn(["atoms", theirAtomUri]);
-    const theirConnectionUri = ownedAtom.getIn([
+    const theirAtom = getIn(getState(), ["atoms", theirAtomUri]);
+    const theirConnectionUri = getIn(ownedAtom, [
       "connections",
       connectionUri,
       "targetConnectionUri",
@@ -55,10 +55,10 @@ export function connectionsChatMessageClaimOnSuccess(
       additionalContent: additionalContent,
       referencedContentUris: undefined,
       connectionUri,
-      ownedAtomUri: ownedAtom.get("uri"),
+      ownedAtomUri: get(ownedAtom, "uri"),
       theirAtomUri: theirAtomUri,
-      ownNodeUri: ownedAtom.get("nodeUri"),
-      theirNodeUri: theirAtom.get("nodeUri"),
+      ownNodeUri: get(ownedAtom, "nodeUri"),
+      theirNodeUri: get(theirAtom, "nodeUri"),
       theirConnectionUri,
       isTTL: false,
     })
@@ -99,18 +99,18 @@ export function connectionsChatMessage(
   isTTL = false
 ) {
   return (dispatch, getState) => {
-    const ownedAtom = getState()
-      .get("atoms")
-      .find(atom => atom.getIn(["connections", connectionUri]));
-    const theirAtomUri = getState().getIn([
+    const ownedAtom = get(getState(), "atoms").find(atom =>
+      getIn(atom, ["connections", connectionUri])
+    );
+    const theirAtomUri = getIn(getState(), [
       "atoms",
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       "connections",
       connectionUri,
       "targetAtomUri",
     ]);
-    const theirAtom = getState().getIn(["atoms", theirAtomUri]);
-    const theirConnectionUri = ownedAtom.getIn([
+    const theirAtom = getIn(getState(), ["atoms", theirAtomUri]);
+    const theirConnectionUri = getIn(ownedAtom, [
       "connections",
       connectionUri,
       "targetConnectionUri",
@@ -126,7 +126,7 @@ export function connectionsChatMessage(
         let contentUris = [];
 
         referencedMessages.map(msg => {
-          const correctUri = msg.get("remoteUri") || msg.get("uri");
+          const correctUri = get(msg, "remoteUri") || get(msg, "uri");
           if (correctUri) contentUris.push({ "@id": correctUri });
           //THE PARTS BELOW SHOULD NOT BE CALLED WITHIN THIS DISPATCH
           switch (key) {
@@ -134,9 +134,9 @@ export function connectionsChatMessage(
               dispatch({
                 type: actionTypes.messages.messageStatus.markAsRetracted,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   retracted: true,
                 },
               });
@@ -145,9 +145,9 @@ export function connectionsChatMessage(
               dispatch({
                 type: actionTypes.messages.messageStatus.markAsRejected,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   rejected: true,
                 },
               });
@@ -157,9 +157,9 @@ export function connectionsChatMessage(
                 type:
                   actionTypes.messages.messageStatus.markAsCancellationPending,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   cancellationPending: true,
                 },
               });
@@ -168,9 +168,9 @@ export function connectionsChatMessage(
               dispatch({
                 type: actionTypes.messages.messageStatus.markAsAccepted,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   accepted: true,
                 },
               });
@@ -179,9 +179,9 @@ export function connectionsChatMessage(
               dispatch({
                 type: actionTypes.messages.messageStatus.markAsClaimed,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   claimed: true,
                 },
               });
@@ -190,9 +190,9 @@ export function connectionsChatMessage(
               dispatch({
                 type: actionTypes.messages.messageStatus.markAsProposed,
                 payload: {
-                  messageUri: msg.get("uri"),
+                  messageUri: get(msg, "uri"),
                   connectionUri: connectionUri,
-                  atomUri: ownedAtom.get("uri"),
+                  atomUri: get(ownedAtom, "uri"),
                   proposed: true,
                 },
               });
@@ -211,10 +211,10 @@ export function connectionsChatMessage(
       additionalContent: additionalContent,
       referencedContentUris: referencedContentUris,
       connectionUri,
-      ownedAtomUri: ownedAtom.get("uri"),
+      ownedAtomUri: get(ownedAtom, "uri"),
       theirAtomUri: theirAtomUri,
-      ownNodeUri: ownedAtom.get("nodeUri"),
-      theirNodeUri: theirAtom.get("nodeUri"),
+      ownNodeUri: get(ownedAtom, "nodeUri"),
+      theirNodeUri: get(theirAtom, "nodeUri"),
       theirConnectionUri,
       isTTL,
     })
@@ -251,18 +251,18 @@ export function connectionsChatMessage(
 
 export function connectionsOpen(connectionUri, textMessage) {
   return async (dispatch, getState) => {
-    const ownedAtom = getState()
-      .get("atoms")
-      .find(atom => atom.getIn(["connections", connectionUri]));
-    const theirAtomUri = getState().getIn([
+    const ownedAtom = get(getState(), "atoms").find(atom =>
+      getIn(atom, ["connections", connectionUri])
+    );
+    const theirAtomUri = getIn(getState(), [
       "atoms",
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       "connections",
       connectionUri,
       "targetAtomUri",
     ]);
-    const theirAtom = getState().getIn(["atoms", theirAtomUri]);
-    const theirConnectionUri = ownedAtom.getIn([
+    const theirAtom = getIn(getState(), ["atoms", theirAtomUri]);
+    const theirConnectionUri = getIn(ownedAtom, [
       "connections",
       connectionUri,
       "targetConnectionUri",
@@ -270,10 +270,10 @@ export function connectionsOpen(connectionUri, textMessage) {
 
     const openMsg = await buildOpenMessage(
       connectionUri,
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       theirAtomUri,
-      ownedAtom.get("nodeUri"),
-      theirAtom.get("nodeUri"),
+      get(ownedAtom, "nodeUri"),
+      get(theirAtom, "nodeUri"),
       theirConnectionUri,
       textMessage
     );
@@ -414,7 +414,7 @@ function connectReactionAtom(
         ownedAtomUri: atomUri,
         theirAtomUri: connectToAtomUri,
         ownNodeUri: nodeUri,
-        theirNodeUri: connectToAtom.get("nodeUri"),
+        theirNodeUri: get(connectToAtom, "nodeUri"),
         connectMessage: "",
       });
 
@@ -502,7 +502,7 @@ function connectAdHoc(
       ownedAtomUri: atomUri,
       theirAtomUri: theirAtomUri,
       ownNodeUri: nodeUri,
-      theirNodeUri: theirAtom.get("nodeUri"),
+      theirNodeUri: get(theirAtom, "nodeUri"),
       connectMessage: textMessage,
     });
 
@@ -553,18 +553,18 @@ function connectAdHoc(
 
 export function connectionsClose(connectionUri) {
   return (dispatch, getState) => {
-    const ownedAtom = getState()
-      .get("atoms")
-      .find(atom => atom.getIn(["connections", connectionUri]));
-    const theirAtomUri = getState().getIn([
+    const ownedAtom = get(getState(), "atoms").find(atom =>
+      getIn(atom, ["connections", connectionUri])
+    );
+    const theirAtomUri = getIn(getState(), [
       "atoms",
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       "connections",
       connectionUri,
       "targetAtomUri",
     ]);
-    const theirAtom = getState().getIn(["atoms", theirAtomUri]);
-    const theirConnectionUri = ownedAtom.getIn([
+    const theirAtom = getIn(getState(), ["atoms", theirAtomUri]);
+    const theirConnectionUri = getIn(ownedAtom, [
       "connections",
       connectionUri,
       "targetConnectionUri",
@@ -572,10 +572,10 @@ export function connectionsClose(connectionUri) {
 
     buildCloseMessage(
       connectionUri,
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       theirAtomUri,
-      ownedAtom.get("nodeUri"),
-      theirAtom.get("nodeUri"),
+      get(ownedAtom, "nodeUri"),
+      get(theirAtom, "nodeUri"),
       theirConnectionUri
     ).then(({ eventUri, message }) => {
       dispatch({
@@ -621,18 +621,18 @@ export function connectionsRate(connectionUri, rating) {
   return (dispatch, getState) => {
     const state = getState();
 
-    const ownedAtom = state
-      .get("atoms")
-      .find(atom => atom.getIn(["connections", connectionUri]));
-    const theirAtomUri = state.getIn([
+    const ownedAtom = get(state, "atoms").find(atom =>
+      getIn(atom, ["connections", connectionUri])
+    );
+    const theirAtomUri = getIn(state, [
       "atoms",
-      ownedAtom.get("uri"),
+      get(ownedAtom, "uri"),
       "connections",
       connectionUri,
       "targetAtomUri",
     ]);
-    const theirAtom = state.getIn(["atoms", theirAtomUri]);
-    const theirConnectionUri = ownedAtom.getIn([
+    const theirAtom = getIn(state, ["atoms", theirAtomUri]);
+    const theirConnectionUri = getIn(ownedAtom, [
       "connections",
       connectionUri,
       "targetConnectionUri",
@@ -640,17 +640,17 @@ export function connectionsRate(connectionUri, rating) {
 
     won
       .getConnectionWithEventUris(connectionUri, {
-        requesterWebId: ownedAtom.get("uri"),
+        requesterWebId: get(ownedAtom, "uri"),
       })
       .then(connection => {
         let msgToRateFor = { connection: connection };
 
         return buildRateMessage(
           msgToRateFor,
-          ownedAtom.get("uri"),
+          get(ownedAtom, "uri"),
           theirAtomUri,
-          ownedAtom.get("nodeUri"),
-          theirAtom.get("nodeUri"),
+          get(ownedAtom, "nodeUri"),
+          get(theirAtom, "nodeUri"),
           theirConnectionUri,
           rating
         );
@@ -688,7 +688,7 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
     const atom =
       connectionUri &&
       generalSelectors.getOwnedAtomByConnectionUri(state, connectionUri);
-    const atomUri = atom && atom.get("uri");
+    const atomUri = get(atom, "uri");
     const connection =
       connectionUri && getOwnedConnectionByUri(state, connectionUri);
     const processState = get(state, "process");
@@ -701,35 +701,19 @@ export function showLatestMessages(connectionUriParam, numberOfEvents) {
       return Promise.resolve(); //only load if not already started and connection itself not loading
     }
 
-    dispatch({
-      type: actionTypes.connections.fetchMessagesStart,
-      payload: Immutable.fromJS({ connectionUri: connectionUri }),
-    });
-
     const fetchParams = {
       requesterWebId: atomUri,
       pagingSize: numOfEvts2pageSize(numberOfEvents),
       deep: true,
     };
-    return won
-      .getConnectionWithEventUris(connectionUri, fetchParams)
-      .then(connection =>
-        getMessageUrisToLoad(
-          dispatch,
-          state,
-          connection,
-          connectionUri,
-          numberOfEvents
-        )
-      )
-      .then(eventUris => {
-        return urisToLookupSuccessAndFailedMap(
-          eventUris,
-          eventUri => won.getWonMessage(eventUri, { requesterWebId: atomUri }),
-          []
-        );
-      })
-      .then(events => storeMessages(dispatch, events, connectionUri));
+    return fetchMessages(
+      dispatch,
+      state,
+      connectionUri,
+      atomUri,
+      numberOfEvents,
+      fetchParams
+    );
   };
 }
 
@@ -742,7 +726,7 @@ export function loadLatestMessagesOfConnection({
   const atom =
     connectionUri &&
     generalSelectors.getOwnedAtomByConnectionUri(state, connectionUri);
-  const atomUri = atom && atom.get("uri");
+  const atomUri = get(atom, "uri");
   const connection =
     connectionUri && getOwnedConnectionByUri(state, connectionUri);
   const processState = get(state, "process");
@@ -755,36 +739,20 @@ export function loadLatestMessagesOfConnection({
     return Promise.resolve(); //only load if not already started and connection itself not loading
   }
 
-  dispatch({
-    type: actionTypes.connections.fetchMessagesStart,
-    payload: Immutable.fromJS({ connectionUri: connectionUri }),
-  });
-
   const fetchParams = {
     requesterWebId: atomUri,
     pagingSize: numOfEvts2pageSize(numberOfEvents),
     deep: true,
   };
 
-  return won
-    .getConnectionWithEventUris(connectionUri, fetchParams)
-    .then(connection =>
-      getMessageUrisToLoad(
-        dispatch,
-        state,
-        connection,
-        connectionUri,
-        numberOfEvents
-      )
-    )
-    .then(eventUris => {
-      return urisToLookupSuccessAndFailedMap(
-        eventUris,
-        eventUri => won.getWonMessage(eventUri, { requesterWebId: atomUri }),
-        []
-      );
-    })
-    .then(events => storeMessages(dispatch, events, connectionUri));
+  fetchMessages(
+    dispatch,
+    state,
+    connectionUri,
+    atomUri,
+    numberOfEvents,
+    fetchParams
+  );
 }
 
 /**
@@ -806,9 +774,9 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
     const atom =
       connectionUri &&
       generalSelectors.getOwnedAtomByConnectionUri(state, connectionUri);
-    const atomUri = atom && atom.get("uri");
-    const connection = atom && atom.getIn(["connections", connectionUri]);
-    const connectionMessages = connection && connection.get("messages");
+    const atomUri = get(atom, "uri");
+    const connection = getIn(atom, ["connections", connectionUri]);
+    const connectionMessages = get(connection, "messages");
     const processState = get(state, "process");
     if (
       !connection ||
@@ -821,16 +789,11 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
     // determine the oldest loaded event
     const sortedConnectionMessages = connectionMessages
       .valueSeq()
-      .sort((msg1, msg2) => msg1.get("date") - msg2.get("date"));
-    const oldestMessage = sortedConnectionMessages.first();
+      .sort((msg1, msg2) => get(msg1, "date") - get(msg2, "date"));
 
+    const oldestMessageUri = get(sortedConnectionMessages.first(), "uri");
     const messageHashValue =
-      oldestMessage &&
-      oldestMessage.get("uri").replace(/.*\/event\/(.*)/, "$1"); // everything following the `/event/`
-    dispatch({
-      type: actionTypes.connections.fetchMessagesStart,
-      payload: Immutable.fromJS({ connectionUri }),
-    });
+      oldestMessageUri && oldestMessageUri.replace(/.*\/event\/(.*)/, "$1"); // everything following the `/event/`
 
     const fetchParams = {
       requesterWebId: atomUri,
@@ -839,26 +802,49 @@ export function showMoreMessages(connectionUriParam, numberOfEvents) {
       resumebefore: messageHashValue,
     };
 
-    won
-      .getConnectionWithEventUris(connectionUri, fetchParams)
-      .then(connection =>
-        getMessageUrisToLoad(
-          dispatch,
-          state,
-          connection,
-          connectionUri,
-          numberOfEvents
-        )
-      )
-      .then(eventUris => {
-        return urisToLookupSuccessAndFailedMap(
-          eventUris,
-          eventUri => won.getWonMessage(eventUri, { requesterWebId: atomUri }),
-          []
-        );
-      })
-      .then(events => storeMessages(dispatch, events, connectionUri));
+    return fetchMessages(
+      dispatch,
+      state,
+      connectionUri,
+      atomUri,
+      numberOfEvents,
+      fetchParams
+    );
   };
+}
+
+async function fetchMessages(
+  dispatch,
+  state,
+  connectionUri,
+  atomUri,
+  numberOfEvents,
+  fetchParams
+) {
+  dispatch({
+    type: actionTypes.connections.fetchMessagesStart,
+    payload: Immutable.fromJS({ connectionUri: connectionUri }),
+  });
+
+  return won
+    .getConnectionWithEventUris(connectionUri, fetchParams)
+    .then(connection =>
+      getMessageUrisToLoad(
+        dispatch,
+        state,
+        connection,
+        connectionUri,
+        numberOfEvents
+      )
+    )
+    .then(eventUris => {
+      return urisToLookupSuccessAndFailedMap(
+        eventUris,
+        eventUri => won.getWonMessage(eventUri, { requesterWebId: atomUri }),
+        []
+      );
+    })
+    .then(events => storeMessages(dispatch, events, connectionUri));
 }
 
 async function getMessageUrisToLoad(
@@ -900,23 +886,25 @@ async function getMessageUrisToLoad(
 function storeMessages(dispatch, messages, connectionUri) {
   if (messages) {
     const messagesImm = Immutable.fromJS(messages);
+    const successMessages = get(messagesImm, "success");
+    const failedMessages = get(messagesImm, "failed");
 
-    if (messagesImm.get("success").size > 0) {
+    if (successMessages.size > 0) {
       dispatch({
         type: actionTypes.connections.fetchMessagesSuccess,
         payload: Immutable.fromJS({
           connectionUri: connectionUri,
-          events: messagesImm.get("success"),
+          events: successMessages,
         }),
       });
     }
 
-    if (messagesImm.get("failed").size > 0) {
+    if (failedMessages.size > 0) {
       dispatch({
         type: actionTypes.connections.fetchMessagesFailed,
         payload: Immutable.fromJS({
           connectionUri: connectionUri,
-          events: messagesImm.get("failed"),
+          events: failedMessages,
         }),
       });
     }
@@ -925,10 +913,7 @@ function storeMessages(dispatch, messages, connectionUri) {
     we can ensure that there is not going to be a lock on the connection because loadingMessages was complete but never
     reset its status
     */
-    if (
-      messagesImm.get("success").size == 0 &&
-      messagesImm.get("failed").size == 0
-    ) {
+    if (successMessages.size == 0 && failedMessages.size == 0) {
       dispatch({
         type: actionTypes.connections.fetchMessagesEnd,
         payload: Immutable.fromJS({ connectionUri: connectionUri }),
@@ -958,15 +943,18 @@ function limitNumberOfEventsToFetchInConnection(
 ) {
   const connectionImm = Immutable.fromJS(connection);
 
-  const allMessagesToLoad = state
-    .getIn(["process", "connections", connectionUri, "messages"])
-    .filter(msg => msg.get("toLoad") && !msg.get("failedToLoad"));
+  const allMessagesToLoad = getIn(state, [
+    "process",
+    "connections",
+    connectionUri,
+    "messages",
+  ]).filter(msg => get(msg, "toLoad") && !get(msg, "failedToLoad"));
   let messagesToFetch = [];
 
   const fetchedConnectionEvents =
     connectionImm &&
-    connectionImm.get("hasEvents") &&
-    connectionImm.get("hasEvents").filter(eventUri => !!eventUri); //Filter out undefined/null values
+    get(connectionImm, "hasEvents") &&
+    get(connectionImm, "hasEvents").filter(eventUri => !!eventUri); //Filter out undefined/null values
 
   if (fetchedConnectionEvents && fetchedConnectionEvents.size > 0) {
     fetchedConnectionEvents.map(eventUri => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -21,17 +21,17 @@ export const pageLoadAction = () => (dispatch, getState) => {
       })
     )
     .then(() => {
-      return loadingWhileSignedIn(dispatch);
+      return loadingWhileSignedIn(dispatch, getState);
     })
     .catch(() => handleNotLoggedIn()) //do not remove this line
     .then(() => checkAccessToCurrentRoute(dispatch, getState))
     .then(() => dispatch({ type: actionTypes.initialLoadFinished }));
 };
 
-function loadingWhileSignedIn(dispatch) {
+function loadingWhileSignedIn(dispatch, getState) {
   // reset websocket to make sure it's using the logged-in session
   dispatch(actionCreators.reconnect__start());
-  return stateStore.fetchOwnedData(dispatch);
+  return stateStore.fetchOwnedData(dispatch, getState);
 }
 
 export const fetchWhatsNew = modifiedAfterDate => (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -152,10 +152,7 @@ export function successfulEdit(event) {
 
     const processState = get(getState(), "process");
 
-    if (
-      processUtils.isAtomLoading(processState, atomURI) ||
-      processUtils.isAtomProcessingUpdate(processState, atomURI)
-    ) {
+    if (processUtils.isAtomLoading(processState, atomURI)) {
       console.debug(
         "successfulEdit: Atom is currently loading DO NOT FETCH AGAIN"
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -33,7 +33,7 @@ export function successfulCloseAtom(event) {
   };
 }
 export function failedCloseAtom(event) {
-  return dispatch => {
+  return (dispatch, getState) => {
     const atomUri = event.getRecipientAtom();
     /*
         * TODO not sure if it's necessary to invalidate
@@ -55,7 +55,7 @@ export function failedCloseAtom(event) {
       .then(() =>
         // as the atom and it's connections have been marked dirty
         // they will be reloaded on this action.
-        stateStore.fetchDataForOwnedAtoms([atomUri], dispatch)
+        stateStore.fetchDataForOwnedAtoms([atomUri], dispatch, getState)
       )
       .then(allThatData =>
         dispatch({
@@ -142,7 +142,7 @@ export function successfulCreate(event) {
 }
 
 export function successfulEdit(event) {
-  return dispatch => {
+  return (dispatch, getState) => {
     console.debug("Received success replace message:", event);
     //const state = getState();
     //load the edited data into the local rdf store and publish AtomEditEvent when done
@@ -151,7 +151,9 @@ export function successfulEdit(event) {
     won
       //.invalidateCacheForAtom(atomURI)
       .clearStoreWithPromise()
-      .then(() => stateStore.fetchDataForOwnedAtoms([atomURI], dispatch))
+      .then(() =>
+        stateStore.fetchDataForOwnedAtoms([atomURI], dispatch, getState)
+      )
       .then(() => {
         dispatch(
           actionCreators.atoms__editSuccessful({
@@ -194,7 +196,8 @@ export function processOpenMessage(event) {
     } else {
       senderAtomP = stateStore.fetchTheirAtomAndDispatch(
         senderAtomUri,
-        dispatch
+        dispatch,
+        getState
       );
     }
 
@@ -207,7 +210,8 @@ export function processOpenMessage(event) {
     } else {
       recipientAtomP = stateStore.fetchTheirAtomAndDispatch(
         recipientAtomUri,
-        dispatch
+        dispatch,
+        getState
       );
     }
 
@@ -305,7 +309,6 @@ export function processAgreementMessage(event) {
 
 export function processChangeNotificationMessage(event) {
   return (dispatch, getState) => {
-    console.debug("processChangeNotificationMessage for: ", event);
     const atomUriToLoad = event.getSenderAtom();
 
     won
@@ -313,9 +316,17 @@ export function processChangeNotificationMessage(event) {
       .clearStoreWithPromise()
       .then(() => {
         if (generalSelectors.isAtomOwned(getState(), atomUriToLoad)) {
-          stateStore.fetchDataForOwnedAtoms([atomUriToLoad], dispatch);
+          stateStore.fetchDataForOwnedAtoms(
+            [atomUriToLoad],
+            dispatch,
+            getState
+          );
         } else {
-          stateStore.fetchDataForNonOwnedAtomOnly(atomUriToLoad, dispatch);
+          stateStore.fetchDataForNonOwnedAtomOnly(
+            atomUriToLoad,
+            dispatch,
+            getState
+          );
         }
       });
 
@@ -591,7 +602,8 @@ export function processConnectMessage(event) {
     } else {
       senderAtomP = stateStore.fetchTheirAtomAndDispatch(
         senderAtomUri,
-        dispatch
+        dispatch,
+        getState
       );
     }
 
@@ -604,7 +616,8 @@ export function processConnectMessage(event) {
     } else {
       recipientAtomP = stateStore.fetchTheirAtomAndDispatch(
         recipientAtomUri,
-        dispatch
+        dispatch,
+        getState
       );
     }
 
@@ -975,7 +988,8 @@ export function processAtomHintMessage(event) {
           } else {
             return stateStore.fetchTheirAtomAndDispatch(
               targetAtomUri,
-              dispatch
+              dispatch,
+              getState
             );
           }
         })

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/atom-reducer-main.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/atom-reducer-main.js
@@ -6,7 +6,7 @@ import Immutable from "immutable";
 import won from "../../won-es6.js";
 import { msStringToDate, getIn, get } from "../../utils.js";
 import {
-  addAtomStubs,
+  addAtomStub,
   addAtom,
   addAtomInCreation,
   addMetaAtomStubs,
@@ -66,9 +66,9 @@ export default function(allAtomsInState = initialState, action = {}) {
       return addMetaAtomStubs(allAtomsInState, action.payload.get("metaAtoms"));
     }
 
-    case actionTypes.personas.storeTheirUrisInLoading:
-    case actionTypes.atoms.storeTheirUrisInLoading: {
-      return addAtomStubs(allAtomsInState, action.payload.get("uris"));
+    case actionTypes.personas.storeUriInLoading:
+    case actionTypes.atoms.storeUriInLoading: {
+      return addAtomStub(allAtomsInState, action.payload.get("uri"));
     }
 
     case actionTypes.atoms.storeOwned:

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -567,16 +567,16 @@ export default function(processState = initialState, action = {}) {
       return processState;
     }
 
-    case actionTypes.personas.storeTheirUrisInLoading:
-    case actionTypes.atoms.storeTheirUrisInLoading: {
-      const atomUris = get(action.payload, "uris");
-      atomUris &&
-        atomUris.forEach(atomUri => {
-          processState = updateAtomProcess(processState, atomUri, {
-            toLoad: false,
-            loading: true,
-          });
+    case actionTypes.personas.storeUriInLoading:
+    case actionTypes.atoms.storeUriInLoading: {
+      const atomUri = get(action.payload, "uri");
+
+      if (atomUri) {
+        processState = updateAtomProcess(processState, atomUri, {
+          toLoad: false,
+          loading: true,
         });
+      }
       return processState;
     }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -134,7 +134,7 @@ export default function(processState = initialState, action = {}) {
       return processState.set("processingWhatsNew", true);
 
     case actionTypes.atoms.storeWhatsNew: {
-      const metaAtoms = action.payload.get("metaAtoms");
+      const metaAtoms = get(action.payload, "metaAtoms");
       const atomUris = metaAtoms && [...metaAtoms.keys()];
       atomUris &&
         atomUris.forEach(atomUri => {
@@ -148,7 +148,7 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.atoms.storeWhatsAround: {
-      const metaAtoms = action.payload.get("metaAtoms");
+      const metaAtoms = get(action.payload, "metaAtoms");
       const atomUris = metaAtoms && [...metaAtoms.keys()];
       atomUris &&
         atomUris.forEach(atomUri => {
@@ -252,7 +252,7 @@ export default function(processState = initialState, action = {}) {
 
     case actionTypes.atoms.storeUriFailed:
     case actionTypes.personas.storeUriFailed: {
-      return updateAtomProcess(processState, action.payload.get("uri"), {
+      return updateAtomProcess(processState, get(action.payload, "uri"), {
         toLoad: false,
         loaded: false,
         failedToLoad: true,
@@ -263,13 +263,13 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.connections.storeUriFailed: {
       return updateConnectionProcess(
         processState,
-        action.payload.get("connUri"),
+        get(action.payload, "connUri"),
         { failedToStore: true, loading: false }
       );
     }
 
     case actionTypes.connections.fetchMessagesStart: {
-      const connUri = action.payload.get("connectionUri");
+      const connUri = get(action.payload, "connectionUri");
 
       return updateConnectionProcess(processState, connUri, {
         loadingMessages: true,
@@ -278,7 +278,7 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.fetchMessagesEnd: {
-      const connUri = action.payload.get("connectionUri");
+      const connUri = get(action.payload, "connectionUri");
 
       return updateConnectionProcess(processState, connUri, {
         loadingMessages: false,
@@ -287,8 +287,8 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.messageUrisInLoading: {
-      const connUri = action.payload.get("connectionUri");
-      const messageUris = action.payload.get("uris");
+      const connUri = get(action.payload, "connectionUri");
+      const messageUris = get(action.payload, "uris");
 
       if (messageUris) {
         messageUris.map(messageUri => {
@@ -305,9 +305,9 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.fetchMessagesSuccess: {
-      const connUri = action.payload.get("connectionUri");
+      const connUri = get(action.payload, "connectionUri");
 
-      const loadedMessages = action.payload.get("events");
+      const loadedMessages = get(action.payload, "events");
       if (loadedMessages) {
         processState = updateConnectionProcess(processState, connUri, {
           loadingMessages: false,
@@ -328,8 +328,8 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.fetchMessagesFailed: {
-      const connUri = action.payload.get("connectionUri");
-      const failedMessages = action.payload.get("events");
+      const connUri = get(action.payload, "connectionUri");
+      const failedMessages = get(action.payload, "events");
 
       if (failedMessages) {
         processState = updateConnectionProcess(processState, connUri, {
@@ -404,13 +404,13 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.storeMetaConnections: {
-      const connections = action.payload.get("connections");
+      const connections = get(action.payload, "connections");
 
       connections &&
         connections.map(conn => {
           processState = updateConnectionProcess(
             processState,
-            conn.get("connectionUri"),
+            get(conn, "connectionUri"),
             {
               toLoad: true,
             }
@@ -426,7 +426,7 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.storeActiveUrisInLoading: {
-      const connUris = action.payload.get("connUris");
+      const connUris = get(action.payload, "connUris");
 
       connUris &&
         connUris.forEach(connUri => {
@@ -452,7 +452,7 @@ export default function(processState = initialState, action = {}) {
     }
 
     case actionTypes.connections.storeActive: {
-      let connections = action.payload.get("connections");
+      let connections = get(action.payload, "connections");
 
       connections &&
         connections.map((conn, connUri) => {
@@ -481,7 +481,7 @@ export default function(processState = initialState, action = {}) {
               toLoad: true,
             });
           }
-          const eventsOfConnection = conn.get("hasEvents");
+          const eventsOfConnection = get(conn, "hasEvents");
           eventsOfConnection &&
             eventsOfConnection.map(eventUri => {
               processState = updateMessageProcess(
@@ -499,54 +499,56 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.atoms.storeTheirs:
     case actionTypes.personas.storeTheirs:
     case actionTypes.atoms.storeOwned: {
-      let atoms = action.payload.get("atoms");
+      let atoms = get(action.payload, "atoms");
 
       atoms &&
         atoms.map(atom => {
           const parsedAtom = parseAtom(atom);
-          processState = updateAtomProcess(
-            processState,
-            parsedAtom.get("uri"),
-            {
-              toLoad: false,
-              failedToLoad: false,
-              loading: false,
-              loaded: true,
-            }
-          );
+          if (parsedAtom) {
+            processState = updateAtomProcess(
+              processState,
+              get(parsedAtom, "uri"),
+              {
+                toLoad: false,
+                failedToLoad: false,
+                loading: false,
+                loaded: true,
+              }
+            );
 
-          const heldAtomUris = parsedAtom.get("holds");
-          heldAtomUris.map(heldAtomUri => {
-            if (!processUtils.isAtomLoaded(processState, heldAtomUri)) {
-              processState = updateAtomProcess(processState, heldAtomUri, {
-                toLoad: true,
-              });
-            }
-          });
+            const heldAtomUris = get(parsedAtom, "holds");
+            heldAtomUris.map(heldAtomUri => {
+              if (!processUtils.isAtomLoaded(processState, heldAtomUri)) {
+                processState = updateAtomProcess(processState, heldAtomUri, {
+                  toLoad: true,
+                });
+              }
+            });
 
-          const groupMemberUris = parsedAtom.get("groupMembers");
-          groupMemberUris.map(groupMemberUri => {
-            if (!processUtils.isAtomLoaded(processState, groupMemberUri)) {
-              processState = updateAtomProcess(processState, groupMemberUri, {
-                toLoad: true,
-              });
-            }
-          });
+            const groupMemberUris = get(parsedAtom, "groupMembers");
+            groupMemberUris.map(groupMemberUri => {
+              if (!processUtils.isAtomLoaded(processState, groupMemberUri)) {
+                processState = updateAtomProcess(processState, groupMemberUri, {
+                  toLoad: true,
+                });
+              }
+            });
 
-          const buddyUris = parsedAtom.get("buddies");
-          buddyUris.map(buddyUri => {
-            if (!processUtils.isAtomLoaded(processState, buddyUri)) {
-              processState = updateAtomProcess(processState, buddyUri, {
-                toLoad: true,
-              });
-            }
-          });
+            const buddyUris = get(parsedAtom, "buddies");
+            buddyUris.map(buddyUri => {
+              if (!processUtils.isAtomLoaded(processState, buddyUri)) {
+                processState = updateAtomProcess(processState, buddyUri, {
+                  toLoad: true,
+                });
+              }
+            });
+          }
         });
       return processState;
     }
 
     case actionTypes.atoms.storeOwnedMetaAtoms: {
-      const metaAtoms = action.payload.get("metaAtoms");
+      const metaAtoms = get(action.payload, "metaAtoms");
 
       metaAtoms &&
         metaAtoms.map((metaAtom, metaAtomUri) => {
@@ -567,7 +569,7 @@ export default function(processState = initialState, action = {}) {
 
     case actionTypes.personas.storeTheirUrisInLoading:
     case actionTypes.atoms.storeTheirUrisInLoading: {
-      const atomUris = action.payload.get("uris");
+      const atomUris = get(action.payload, "uris");
       atomUris &&
         atomUris.forEach(atomUri => {
           processState = updateAtomProcess(processState, atomUri, {
@@ -585,7 +587,7 @@ export default function(processState = initialState, action = {}) {
     case actionTypes.atoms.delete:
     case actionTypes.atoms.removeDeleted:
     case actionTypes.personas.removeDeleted: {
-      const atomUri = action.payload.get("uri");
+      const atomUri = get(action.payload, "uri");
       return processState.deleteIn(["atoms", atomUri]);
     }
 
@@ -628,10 +630,10 @@ export function addOriginatorAtomToLoad(
     );
     if (parsedMessage) {
       const connectionUri =
-        insertIntoConnUri || parsedMessage.get("belongsToUri");
+        insertIntoConnUri || get(parsedMessage, "belongsToUri");
 
       let atomUri = insertIntoAtomUri;
-      if (!atomUri && parsedMessage.getIn(["data", "outgoingMessage"])) {
+      if (!atomUri && getIn(parsedMessage, ["data", "outgoingMessage"])) {
         // atomUri is the message's senderAtom
         atomUri = wonMessage.getSenderAtom();
       } else if (!atomUri) {
@@ -639,7 +641,7 @@ export function addOriginatorAtomToLoad(
         atomUri = wonMessage.getRecipientAtom();
       }
 
-      const originatorUri = parsedMessage.getIn(["data", "originatorUri"]);
+      const originatorUri = getIn(parsedMessage, ["data", "originatorUri"]);
 
       if (originatorUri) {
         //Message is originally from another atom, we might need to add the atom as well

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -3,7 +3,7 @@ import Immutable from "immutable";
 import { actionTypes } from "../actions/actions.js";
 import * as atomUtils from "./utils/atom-utils.js";
 import { parseMetaAtom } from "../reducers/atom-reducer/parse-atom.js";
-import { is } from "../utils.js";
+import { is, get, getIn, numOfEvts2pageSize } from "../utils.js";
 import won from "../won-es6";
 
 export function fetchOwnedData(dispatch) {
@@ -190,6 +190,115 @@ export function fetchWhatsAround(
     });
 }
 
+export function fetchMessages(
+  dispatch,
+  state,
+  connectionUri,
+  atomUri,
+  numberOfEvents,
+  fetchParams
+) {
+  dispatch({
+    type: actionTypes.connections.fetchMessagesStart,
+    payload: Immutable.fromJS({ connectionUri: connectionUri }),
+  });
+
+  return won
+    .getConnectionWithEventUris(connectionUri, fetchParams)
+    .then(connection =>
+      getMessageUrisToLoad(
+        dispatch,
+        state,
+        connection,
+        connectionUri,
+        numberOfEvents
+      )
+    )
+    .then(eventUris => {
+      return urisToLookupSuccessAndFailedMap(
+        eventUris,
+        eventUri => won.getWonMessage(eventUri, { requesterWebId: atomUri }),
+        []
+      );
+    })
+    .then(events => storeMessages(dispatch, events, connectionUri));
+}
+
+async function getMessageUrisToLoad(
+  dispatch,
+  state,
+  connection,
+  connectionUri,
+  numberOfEvents
+) {
+  console.debug(
+    "getMessageUrisToLoad of connection(uri:",
+    connectionUri,
+    "): ",
+    connection
+  );
+  const messagesToFetch = limitNumberOfEventsToFetchInConnection(
+    state,
+    connection,
+    connectionUri,
+    numberOfEvents
+  );
+
+  dispatch({
+    type: actionTypes.connections.messageUrisInLoading,
+    payload: Immutable.fromJS({
+      connectionUri: connectionUri,
+      uris: messagesToFetch,
+    }),
+  });
+
+  return messagesToFetch;
+}
+
+/**
+ * Helper function that stores dispatches the success and failed actions for a given set of messages
+ * @param messages
+ * @param connectionUri
+ */
+function storeMessages(dispatch, messages, connectionUri) {
+  if (messages) {
+    const messagesImm = Immutable.fromJS(messages);
+    const successMessages = get(messagesImm, "success");
+    const failedMessages = get(messagesImm, "failed");
+
+    if (successMessages.size > 0) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesSuccess,
+        payload: Immutable.fromJS({
+          connectionUri: connectionUri,
+          events: successMessages,
+        }),
+      });
+    }
+
+    if (failedMessages.size > 0) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesFailed,
+        payload: Immutable.fromJS({
+          connectionUri: connectionUri,
+          events: failedMessages,
+        }),
+      });
+    }
+
+    /*If neither succes nor failed has any elements we simply say that fetching Ended, that way
+    we can ensure that there is not going to be a lock on the connection because loadingMessages was complete but never
+    reset its status
+    */
+    if (successMessages.size == 0 && failedMessages.size == 0) {
+      dispatch({
+        type: actionTypes.connections.fetchMessagesEnd,
+        payload: Immutable.fromJS({ connectionUri: connectionUri }),
+      });
+    }
+  }
+}
+
 function fetchConnectionsOfAtomAndDispatch(atomUri, dispatch) {
   return won
     .getConnectionUrisWithStateByAtomUri(atomUri, atomUri)
@@ -254,6 +363,54 @@ function fetchOwnedAtomAndDispatch(atomUri, dispatch) {
 }
 
 /**
+ * Helper Method to make sure we only load numberOfEvents messages into the store, seems that the cache is not doing what its supposed to do otherwise
+ * FIXME: remove this once the fetchpaging works again (or at all)
+ * @param state
+ * @param connection
+ * @param connectionUri
+ * @param numberOfEvents
+ * @returns {Array}
+ */
+function limitNumberOfEventsToFetchInConnection(
+  state,
+  connection,
+  connectionUri,
+  numberOfEvents
+) {
+  const connectionImm = Immutable.fromJS(connection);
+
+  const allMessagesToLoad = getIn(state, [
+    "process",
+    "connections",
+    connectionUri,
+    "messages",
+  ]).filter(msg => get(msg, "toLoad") && !get(msg, "failedToLoad"));
+  let messagesToFetch = [];
+
+  const fetchedConnectionEvents =
+    connectionImm &&
+    get(connectionImm, "hasEvents") &&
+    get(connectionImm, "hasEvents").filter(eventUri => !!eventUri); //Filter out undefined/null values
+
+  if (fetchedConnectionEvents && fetchedConnectionEvents.size > 0) {
+    fetchedConnectionEvents.map(eventUri => {
+      if (
+        allMessagesToLoad.has(eventUri) &&
+        messagesToFetch.length < numOfEvts2pageSize(numberOfEvents)
+      ) {
+        messagesToFetch.push(eventUri);
+      }
+    });
+  } else {
+    allMessagesToLoad.map((messageStatus, messageUri) => {
+      messagesToFetch.push(messageUri);
+    });
+  }
+
+  return messagesToFetch;
+}
+
+/**
  * Takes a single uri or an array of uris, performs the lookup function on each
  * of them seperately, collects the results and builds an map/object
  * with the uris as keys and the results as values.
@@ -308,6 +465,51 @@ function urisToLookupMap(
     uris.forEach((uri, i) => {
       if (dataObjects[i]) {
         lookupMap[uri] = dataObjects[i];
+      }
+    });
+    return lookupMap;
+  });
+}
+
+/**
+ * Takes a single uri or an array of uris, performs the lookup function on each
+ * of them seperately, collects the results and builds an map/object
+ * with the uris as keys and the results as values.
+ * If any call to the asyncLookupFunction fails, the corresponding
+ * key-value-pair will not be contained in the success-result but rather in the failed-results.
+ * @param uris
+ * @param asyncLookupFunction
+ * @param excludeUris uris to exclude from lookup
+ * @return {*}
+ */
+function urisToLookupSuccessAndFailedMap(
+  uris,
+  asyncLookupFunction,
+  excludeUris = []
+) {
+  //make sure we have an array and not a single uri.
+  const urisAsArray = is("Array", uris) ? uris : [uris];
+  const excludeUrisAsArray = is("Array", excludeUris)
+    ? excludeUris
+    : [excludeUris];
+
+  const urisAsArrayWithoutExcludes = urisAsArray.filter(
+    uri => excludeUrisAsArray.indexOf(uri) < 0
+  );
+
+  const asyncLookups = urisAsArrayWithoutExcludes.map(uri =>
+    asyncLookupFunction(uri).catch(error => {
+      return error;
+    })
+  );
+  return Promise.all(asyncLookups).then(dataObjects => {
+    const lookupMap = { success: {}, failed: {} };
+    //make sure there's the same
+    uris.forEach((uri, i) => {
+      if (dataObjects[i] instanceof Error) {
+        lookupMap["failed"][uri] = dataObjects[i];
+      } else if (dataObjects[i]) {
+        lookupMap["success"][uri] = dataObjects[i];
       }
     });
     return lookupMap;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -89,8 +89,8 @@ export function fetchTheirAtomAndDispatch(atomUri, dispatch, getState) {
   const processState = get(getState(), "process");
 
   if (processUtils.isAtomLoading(processState, atomUri)) {
-    //TODO: OMIT FETCH AGAIN
-    console.debug("Atom is currently loading TODO: OMIT NEW FETCH");
+    console.debug("fetchTheirAtomAndDispatch: Atom is already loading...");
+    //TODO: IMPL OMIT FETCH
   }
 
   dispatch({
@@ -103,7 +103,11 @@ export function fetchTheirAtomAndDispatch(atomUri, dispatch, getState) {
     .then(atom => {
       if (atom["hold:heldBy"] && atom["hold:heldBy"]["@id"]) {
         const personaUri = atom["hold:heldBy"]["@id"];
-        //TODO: CHECK IF FETCH IS ALREADY RUNNING FOR PERSONA OR PERSONA ALREADY PRESENT
+        if (processUtils.isAtomLoading(processState, personaUri)) {
+          console.debug("Persona attached to Atom is currently loading...");
+          //TODO: IMPL OMIT FETCH
+        }
+
         dispatch({
           type: actionTypes.personas.storeUriInLoading,
           payload: Immutable.fromJS({ uri: personaUri }),
@@ -243,12 +247,6 @@ async function getMessageUrisToLoad(
   connectionUri,
   numberOfEvents
 ) {
-  console.debug(
-    "getMessageUrisToLoad of connection(uri:",
-    connectionUri,
-    "): ",
-    connection
-  );
   const messagesToFetch = limitNumberOfEventsToFetchInConnection(
     state,
     connection,
@@ -327,12 +325,6 @@ function fetchConnectionsOfAtomAndDispatch(atomUri, dispatch) {
         .filter(conn => conn.connectionState !== won.WON.Suggested)
         .map(conn => conn.connectionUri);
 
-      const targetAtomUris = connectionsWithStateAndSocket.map(
-        conn => conn.targetAtomUri
-      );
-
-      console.debug("targetAtomUris: ", targetAtomUris);
-
       dispatch({
         type: actionTypes.connections.storeActiveUrisInLoading,
         payload: Immutable.fromJS({
@@ -351,7 +343,6 @@ function fetchConnectionsOfAtomAndDispatch(atomUri, dispatch) {
 }
 
 function fetchOwnedAtomAndDispatch(atomUri, dispatch, getState) {
-  //TODO: CHECK IF FETCH IS CURRENTLY RUNNING OR SOMETHING
   return won
     .getAtom(atomUri)
     .then(atom => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -277,14 +277,9 @@ function urisToLookupMap(
     ? excludeUris
     : [excludeUris];
 
-  const urisAsArrayWithoutExcludes = urisAsArray.filter(uri => {
-    const exclude = excludeUrisAsArray.indexOf(uri) < 0;
-    if (exclude) {
-      return true;
-    } else {
-      return false;
-    }
-  });
+  const urisAsArrayWithoutExcludes = urisAsArray.filter(
+    uri => excludeUrisAsArray.indexOf(uri) < 0
+  );
 
   const asyncLookups = urisAsArrayWithoutExcludes.map(uri =>
     asyncLookupFunction(uri).catch(error => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/linkeddata-service-won.js
@@ -137,6 +137,7 @@ import won from "./won.js";
   };
 
   won.clearStoreWithPromise = async function() {
+    //TODO: CHECK IF THERE ARE CURRENTLY LOCKS IN PLACE
     won.clearStore();
   };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -575,3 +575,8 @@ export function compareArrayBuffers(left, right) {
 
   return true;
 }
+
+export function numOfEvts2pageSize(numberOfEvents) {
+  // `*3*` to compensate for the *roughly* 2 additional success events per chat message
+  return numberOfEvents * 3;
+}


### PR DESCRIPTION
Fixes #2867 -> if an atom with an active connection is edited, there was a racecondition breaking the atom in our redux state and showing it as failedToLoad (only happened sometimes), this is now fixed

Fixes #2871 -> loading atoms that have changed or trying to reload them after an edit won't result in atomLoading failed any longer

Fixes #2892 -> showMoreMessages did not work after an edit of the need with the connection that we try to load more Messages of -> this is "fixed" now, due to an edit messing with our rdfstore we lose the eventUris as rdf and can't sort them anymore, so instead of trying to get the next x-messages we simply load all messageUris we know are still to be loaded within this connection (fork applies only after an edit of an atom)