### PR TITLE
Do not add a joblocation to the jobposting

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
@@ -149,12 +149,12 @@ public class CreateAtomFromJobAction extends AbstractCreateAtomAction {
         hiringOrganisation.addProperty(SCHEMA.NAME, hokifyJob.getCompany());
         atom.addProperty(SCHEMA.ORGANIZATION, hiringOrganisation);
         // s:jobLocation
-        Resource jobLocation = atom.getModel().createResource();
-        jobLocation.addProperty(RDF.type, SCHEMA.PLACE);
-        // TODO look up lon/lat via nominatim
-        atom.addProperty(SCHEMA.JOBLOCATION, jobLocation);
         HashMap<String, String> location = hokifyBotsApi.fetchGeoLocation(hokifyJob.getCity(), hokifyJob.getCountry());
         if (location != null) {
+            Resource jobLocation = atom.getModel().createResource();
+            jobLocation.addProperty(RDF.type, SCHEMA.PLACE);
+            // TODO look up lon/lat via nominatim
+            atom.addProperty(SCHEMA.JOBLOCATION, jobLocation);
             DecimalFormat df = new DecimalFormat("##.######");
             df.setRoundingMode(RoundingMode.HALF_UP);
             df.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
@@ -186,9 +186,6 @@ public class CreateAtomFromJobAction extends AbstractCreateAtomAction {
             seCornerResource.addProperty(RDF.type, SCHEMA.GEOCOORDINATES);
             seCornerResource.addProperty(SCHEMA.LATITUDE, selat);
             seCornerResource.addProperty(SCHEMA.LONGITUDE, selng);
-        } else {
-            String alternateLocation = hokifyJob.getCity() + " " + hokifyJob.getCountry();
-            jobLocation.addProperty(SCHEMA.NAME, alternateLocation);
         }
         // s:description
         atom.addProperty(SCHEMA.DESCRIPTION, filterDescriptionString(hokifyJob.getDescription()));

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/util/HokifyBotsApi.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/util/HokifyBotsApi.java
@@ -78,7 +78,7 @@ public class HokifyBotsApi {
     }
 
     public HashMap<String, String> fetchGeoLocation(String city, String country) {
-        HashMap<String, String> loc = new HashMap<String, String>();
+        HashMap<String, String> loc = null;
         String cityString = city != null ? city.replace(" ", "+") : "";
         String countrySting = country != null ? country.replace(" ", "+") : "";
         String searchString = geoURL + "?city=" + cityString + "&country=" + countrySting + "&format=json";
@@ -98,6 +98,7 @@ public class HokifyBotsApi {
             }
             JSONArray jsonArray = new JSONArray(sb.toString());
             if (jsonArray.length() > 0) {
+                loc = new HashMap<String, String>();
                 JSONObject obj = jsonArray.getJSONObject(0);
                 JSONArray bBox = (JSONArray) obj.get("boundingbox");
                 loc.put("nwlat", (String) bBox.get(1));
@@ -107,14 +108,6 @@ public class HokifyBotsApi {
                 loc.put("lat", (String) obj.get("lat"));
                 loc.put("lng", (String) obj.get("lon"));
                 loc.put("name", (String) obj.get("display_name"));
-            } else {
-                loc.put("nwlat", "0");
-                loc.put("nwlng", "0");
-                loc.put("selat", "0");
-                loc.put("selng", "0");
-                loc.put("lat", "0");
-                loc.put("lng", "0");
-                loc.put("name", "no location");
             }
             httpClient.close();
             response.getEntity().getContent().close();


### PR DESCRIPTION
Instead of adding lat=lng=0.0 jobLocations in the jobposting we simply omit adding a location at all (that way we will reduce the parserErrors on the client side
fixes #2941