### PR TITLE
Fix  useratom insert error

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestAtomController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestAtomController.java
@@ -15,7 +15,12 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
@@ -35,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
 import won.owner.model.Draft;
 import won.owner.model.User;
 import won.owner.model.UserAtom;
@@ -75,7 +81,7 @@ public class RestAtomController {
     @RequestMapping(value = { "/", "" }, produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
     public Map<URI, AtomPojo> getAllAtomsOfUser(@RequestParam(value = "state", required = false) AtomState state) {
         User user = getCurrentUser();
-        List<UserAtom> userAtoms = user.getUserAtoms();
+        Set<UserAtom> userAtoms = user.getUserAtoms();
         Map<URI, AtomPojo> atomMap = new HashMap<>();
         for (UserAtom userAtom : userAtoms) {
             if (state == null || state.equals(userAtom.getState())) {

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/ServerSideActionController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/ServerSideActionController.java
@@ -3,6 +3,7 @@ package won.owner.web.rest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class ServerSideActionController {
             return new ResponseEntity("Cannot process connect action: too many sockets specified to be connected.",
                             HttpStatus.CONFLICT);
         }
-        List<UserAtom> atoms = user.getUserAtoms();
+        Set<UserAtom> atoms = user.getUserAtoms();
         // keep sockets we can't process:
         Optional<SocketToConnect> problematicSocket = sockets.stream().filter(socket -> {
             // return false (not problematic) if the socket is pending (i.e., the atom it

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -293,7 +293,8 @@ public class WonWebSocketHandler extends TextWebSocketHandler
             if (!userOpt.isPresent()) {
                 userOpt = Optional.ofNullable(getUserForWonMessage(wonMessage));
             }
-            User user = userOpt.get();
+            User user = userOpt.orElse(null); // it's quite possible that we don't find the user object this way.
+                                              // Methods below can handle that.
             updateUserAtomAssociation(wonMessage, user);
             notifyPerPush(user, atomUri, wonMessage);
             webSocketSessions = findWebSocketSessionsForAtomAndUser(atomUri, user);

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -383,7 +383,7 @@ public class WonWebSocketHandler extends TextWebSocketHandler
                     if (wonMessage.getRecipientURI() != null) {
                         rootNode.put("connectionUri", wonMessage.getRecipientURI().toString());
                     } else {
-                        logger.info("received SocketHint for atom {} without recipientURI", userAtom.getUri());
+                        logger.warn("received SocketHint for atom {} without recipientURI", userAtom.getUri());
                     }
                     rootNode.put("icon", iconUrl);
                     String stringifiedJson;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -667,13 +667,16 @@ public class WonWebSocketHandler extends TextWebSocketHandler
     private void saveAtomUriWithUser(final WonMessage wonMessage, final WebSocketSession session) {
         User user = getUserForSession(session);
         URI atomUri = getOwnedAtomURI(wonMessage);
+        logger.debug("adding atom {} to atoms of user {}", atomUri, user.getId());
         UserAtom userAtom = new UserAtom(atomUri);
         // reload the user so we can save it
         // (the user object we get from getUserForSession is detached)
         user = userRepository.findOne(user.getId());
         userAtomRepository.save(userAtom);
+        logger.debug("saved user atom {}", userAtom.getId());
         user.addAtomUri(userAtom);
         userRepository.save(user);
+        logger.debug("atom {} added to atoms of user {}", userAtom.getId(), user.getId());
     }
 
     private void deactivateAtomUri(final WonMessage wonMessage, final WebSocketSession session) {

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -672,7 +672,7 @@ public class WonWebSocketHandler extends TextWebSocketHandler
         // reload the user so we can save it
         // (the user object we get from getUserForSession is detached)
         user = userRepository.findOne(user.getId());
-        userAtomRepository.save(userAtom);
+        userAtom = userAtomRepository.save(userAtom);
         logger.debug("saved user atom {}", userAtom.getId());
         user.addAtomUri(userAtom);
         userRepository.save(user);

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -647,7 +647,7 @@ public class WonWebSocketHandler extends TextWebSocketHandler
         } catch (Exception e) {
             logger.warn(MessageFormat.format(
                             "caught exception while trying to send on session {1} for atomUri {2}, " + "user {3}",
-                            session.getId(), atomUri, user), e);
+                            session.getId(), atomUri, user == null ? "(null)" : user.getId()), e);
             if (user != null) {
                 webSocketSessionService.removeMapping(user, session);
             }

--- a/webofneeds/won-owner/src/main/java/won/owner/model/User.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/User.java
@@ -214,11 +214,11 @@ public class User implements UserDetails, Persistable<Long> {
     /*
      * public List<Atom> getAtoms() { return atoms; }
      */
-    public void addAtomUri(UserAtom userAtom) {
+    public void addUserAtom(UserAtom userAtom) {
         this.userAtoms.add(userAtom);
     }
 
-    public void deleteAtomUri(UserAtom userAtom) {
+    public void removeUserAtom(UserAtom userAtom) {
         this.userAtoms.remove(userAtom);
     }
 

--- a/webofneeds/won-owner/src/main/java/won/owner/model/User.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/User.java
@@ -71,7 +71,7 @@ public class User implements UserDetails, Persistable<Long> {
     @OneToMany(fetch = FetchType.EAGER)
     @OrderBy("creationDate desc")
     @JoinTable(name = "wonuser_useratom", joinColumns = { @JoinColumn(name = "wonuser_id") })
-    private List<UserAtom> userAtoms;
+    private Set<UserAtom> userAtoms;
     @Column(name = "role")
     private String role;
     @Column(name = "email")
@@ -215,26 +215,18 @@ public class User implements UserDetails, Persistable<Long> {
      * public List<Atom> getAtoms() { return atoms; }
      */
     public void addAtomUri(UserAtom userAtom) {
-        synchronized (this) {
-            if (!this.userAtoms.contains(userAtom)) {
-                this.userAtoms.add(userAtom);
-            }
-        }
+        this.userAtoms.add(userAtom);
     }
 
     public void deleteAtomUri(UserAtom userAtom) {
-        for (int i = 0; i < this.userAtoms.size(); i++) {
-            if (this.userAtoms.get(i).getUri().equals(userAtom.getUri())) {
-                this.userAtoms.remove(i);
-            }
-        }
+        this.userAtoms.remove(userAtom);
     }
 
-    public List<UserAtom> getUserAtoms() {
+    public Set<UserAtom> getUserAtoms() {
         return userAtoms;
     }
 
-    public void setUserAtoms(final List<UserAtom> userAtoms) {
+    public void setUserAtoms(final Set<UserAtom> userAtoms) {
         this.userAtoms = userAtoms;
     }
 

--- a/webofneeds/won-owner/src/main/java/won/owner/model/UserAtom.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/UserAtom.java
@@ -121,4 +121,29 @@ public class UserAtom {
     public void setState(AtomState state) {
         this.state = state;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((uri == null) ? 0 : uri.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserAtom other = (UserAtom) obj;
+        if (uri == null) {
+            if (other.uri != null)
+                return false;
+        } else if (!uri.equals(other.uri))
+            return false;
+        return true;
+    }
 }


### PR DESCRIPTION
Fixes #2988 

WRT #2988, Changing the data structure from `List` to `Set` as suggested by @quasarchimaere ultimately did the trick.

This PR also contains minor refactoring of the `WonWebsocketHandler`, decoupling websocket/mail/push code from the logic that is responsible for updating the user's atoms.

The bug is hard to reproduce - it seems to depend on the user's data being in a specific configuration; I can reliably get there with one matchat user, but not with any other test user. 

*How to test*:
* check if creating with/without persona works
* go to the detail view of the new posting, check that it is not an external view (eg. the menu would not contain a `Remove` entry)
* Make sure you receive suggestions with that atom.