### PR TITLE
Adds simple collapsible invite participant/request as buddy handler

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.js
@@ -86,9 +86,9 @@ function genComponentConf() {
           ng-if="!self.buddies && !self.hasBuddyConnections">
           No Buddies present.
       </div>
-      <won-labelled-hr label="::'Request'" class="acb__labelledhr" ng-if="self.isOwned"></won-labelled-hr>
+      <won-labelled-hr label="::'Request'" class="acb__labelledhr" ng-if="self.isOwned" arrow="self.suggestAtomExpanded? 'up' : 'down'" ng-click="self.suggestAtomExpanded = !self.suggestAtomExpanded"></won-labelled-hr>
       <won-suggestpost-picker
-          ng-if="self.isOwned"
+          ng-if="self.isOwned && self.suggestAtomExpanded"
           initial-value="undefined"
           on-update="self.requestBuddy(value)"
           detail="::{placeholder: 'Insert AtomUri to invite'}"
@@ -104,6 +104,7 @@ function genComponentConf() {
     constructor() {
       attach(this, serviceDependencies, arguments);
       this.won = won;
+      this.suggestAtomExpanded = false;
       window.atomContentBuddies4dbg = this;
 
       const selectFromState = state => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.js
@@ -87,9 +87,9 @@ function genComponentConf() {
           ng-if="(!self.isOwned && !self.groupMembers) || (self.isOwned && !self.hasGroupChatConnections)">
           No Groupmembers present.
       </div>
-      <won-labelled-hr label="::'Invite'" class="acp__labelledhr" ng-if="self.isOwned"></won-labelled-hr>
+      <won-labelled-hr label="::'Invite'" class="acp__labelledhr" ng-if="self.isOwned" arrow="self.suggestAtomExpanded? 'up' : 'down'" ng-click="self.suggestAtomExpanded = !self.suggestAtomExpanded"></won-labelled-hr>
       <won-suggestpost-picker
-          ng-if="self.isOwned"
+          ng-if="self.isOwned && self.suggestAtomExpanded"
           initial-value="undefined"
           on-update="self.inviteParticipant(value)"
           detail="::{placeholder: 'Insert AtomUri to invite'}"
@@ -105,6 +105,7 @@ function genComponentConf() {
     constructor() {
       attach(this, serviceDependencies, arguments);
       this.won = won;
+      this.suggestAtomExpanded = false;
       window.postcontentparticipants4dbg = this;
 
       const selectFromState = state => {


### PR DESCRIPTION
We display every possible atom that can be used as a buddy/group participant directly in the group members and buddies tab. this resulted in a very overcrowded interface  as well as a performance drop (if many atoms are in the state, e.g. after viewing whats new).

This PR adds collapse/expand indicators on the labelled-hr to omit displaying and instantiating the suggest-post-picker component by default