### PR TITLE
Refac  logger

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/BaseBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/BaseBot.java
@@ -28,7 +28,7 @@ import won.protocol.model.Connection;
  * Basic Bot implementation intended to be extended. Does nothing.
  */
 public abstract class BaseBot implements Bot {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private BotLifecyclePhase lifecyclePhase = BotLifecyclePhase.DOWN;
     private boolean workDone = false;
     @Autowired
@@ -53,7 +53,7 @@ public abstract class BaseBot implements Bot {
         try {
             botContextWrapper.getBotContext().saveToObjectMap("temp", "temp", "temp");
             Object o = botContextWrapper.getBotContext().loadFromObjectMap("temp", "temp");
-            Assert.isTrue(o.equals("temp"));
+            Assert.isTrue("temp".equals(o), "does not equal 'temp'");
         } catch (Exception e) {
             logger.error("Bot cannot establish connection with bot context");
             throw e;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/BaseBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/BaseBot.java
@@ -10,25 +10,25 @@
  */
 package won.bot.framework.bot.base;
 
-import java.net.URI;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
-
 import won.bot.framework.bot.Bot;
 import won.bot.framework.bot.BotLifecyclePhase;
 import won.bot.framework.bot.context.BotContextWrapper;
 import won.protocol.message.WonMessage;
 import won.protocol.model.Connection;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Basic Bot implementation intended to be extended. Does nothing.
  */
 public abstract class BaseBot implements Bot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private BotLifecyclePhase lifecyclePhase = BotLifecyclePhase.DOWN;
     private boolean workDone = false;
     @Autowired

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
@@ -14,6 +14,8 @@ import java.net.URI;
 import java.util.concurrent.Executor;
 
 import org.apache.jena.query.Dataset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
 
 import won.bot.framework.bot.BotLifecyclePhase;
@@ -90,6 +92,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * on the internal event bus) if it is in lifecycle phase ACTIVE.
  */
 public abstract class EventBot extends TriggeredBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus eventBus;
     private EventListenerContext eventListenerContext = new MyEventListenerContext();
     private EventGeneratingWonMessageSenderWrapper wonMessageSenderWrapper;
@@ -391,6 +394,8 @@ public abstract class EventBot extends TriggeredBot {
      * ErrorEvents and will not react to a WorkDoneEvent.
      */
     private class ErrorEventListener extends BaseEventListener {
+        private final Logger logger = LoggerFactory.getLogger(getClass());
+
         public ErrorEventListener(EventListenerContext context) {
             super(context);
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/EventBot.java
@@ -10,14 +10,10 @@
  */
 package won.bot.framework.bot.base;
 
-import java.net.URI;
-import java.util.concurrent.Executor;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
-
 import won.bot.framework.bot.BotLifecyclePhase;
 import won.bot.framework.bot.context.BotContext;
 import won.bot.framework.bot.context.BotContextWrapper;
@@ -32,21 +28,8 @@ import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
 import won.bot.framework.eventbot.event.impl.lifecycle.ErrorEvent;
 import won.bot.framework.eventbot.event.impl.lifecycle.InitializeEvent;
 import won.bot.framework.eventbot.event.impl.lifecycle.ShutdownEvent;
-import won.bot.framework.eventbot.event.impl.matcher.AtomActivatedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.matcher.AtomDeactivatedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.matcher.AtomModifiedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.matcher.MatcherRegisteredEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.CloseFromOtherAtomEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.OpenFromOtherAtomEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.SuccessResponseEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.WonMessageSentEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.WonMessageSentOnConnectionEvent;
+import won.bot.framework.eventbot.event.impl.matcher.*;
+import won.bot.framework.eventbot.event.impl.wonmessage.*;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.matcher.component.MatcherNodeURISource;
 import won.matcher.protocol.impl.MatcherProtocolMatcherServiceImplJMSBased;
@@ -59,6 +42,10 @@ import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.linkeddata.LinkedDataSource;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.Executor;
 
 /**
  * Base class for bots that define their behaviour through event listeners. Once
@@ -92,7 +79,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * on the internal event bus) if it is in lifecycle phase ACTIVE.
  */
 public abstract class EventBot extends TriggeredBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private EventBus eventBus;
     private EventListenerContext eventListenerContext = new MyEventListenerContext();
     private EventGeneratingWonMessageSenderWrapper wonMessageSenderWrapper;
@@ -394,8 +381,6 @@ public abstract class EventBot extends TriggeredBot {
      * ErrorEvents and will not react to a WorkDoneEvent.
      */
     private class ErrorEventListener extends BaseEventListener {
-        private final Logger logger = LoggerFactory.getLogger(getClass());
-
         public ErrorEventListener(EventListenerContext context) {
             super(context);
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/FactoryBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/FactoryBot.java
@@ -1,7 +1,5 @@
 package won.bot.framework.bot.base;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
@@ -11,8 +9,11 @@ import won.bot.framework.eventbot.behaviour.ExecuteWonMessageCommandBehaviour;
 import won.bot.framework.eventbot.behaviour.FactoryBotHintBehaviour;
 import won.bot.framework.eventbot.behaviour.FactoryBotInitBehaviour;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
 public abstract class FactoryBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     protected final void initializeEventListeners() {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/FactoryBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/FactoryBot.java
@@ -2,6 +2,8 @@ package won.bot.framework.bot.base;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.behaviour.BotBehaviour;
@@ -10,6 +12,8 @@ import won.bot.framework.eventbot.behaviour.FactoryBotHintBehaviour;
 import won.bot.framework.eventbot.behaviour.FactoryBotInitBehaviour;
 
 public abstract class FactoryBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     protected final void initializeEventListeners() {
         if (!(super.getBotContextWrapper() instanceof FactoryBotContextWrapper)) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/TriggeredBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/TriggeredBot.java
@@ -12,6 +12,8 @@ package won.bot.framework.bot.base;
 
 import java.util.concurrent.ScheduledFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.Trigger;
 
 /**
@@ -19,6 +21,7 @@ import org.springframework.scheduling.Trigger;
  * act() method to be called according to the trigger's specification.
  */
 public abstract class TriggeredBot extends ScheduledActionBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Trigger trigger;
     private ScheduledFuture scheduledExecution;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/TriggeredBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/bot/base/TriggeredBot.java
@@ -10,18 +10,19 @@
  */
 package won.bot.framework.bot.base;
 
-import java.util.concurrent.ScheduledFuture;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.Trigger;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ScheduledFuture;
 
 /**
  * Bot base class that expects a trigger to be injected that will cause the
  * act() method to be called according to the trigger's specification.
  */
 public abstract class TriggeredBot extends ScheduledActionBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Trigger trigger;
     private ScheduledFuture scheduledExecution;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/AbstractCompositeAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/AbstractCompositeAtomProducer.java
@@ -25,7 +25,7 @@ import won.bot.framework.component.atomproducer.AtomProducer;
  */
 public abstract class AbstractCompositeAtomProducer implements AtomProducer {
     private Set<AtomProducer> atomFactories = new HashSet<AtomProducer>();
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(AbstractCompositeAtomProducer.class);
 
     @Override
     public synchronized Dataset create() {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/AbstractCompositeAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/AbstractCompositeAtomProducer.java
@@ -10,6 +10,7 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -24,8 +25,8 @@ import won.bot.framework.component.atomproducer.AtomProducer;
  * delegate request is not guaranteed. Not thread safe.
  */
 public abstract class AbstractCompositeAtomProducer implements AtomProducer {
-    private Set<AtomProducer> atomFactories = new HashSet<AtomProducer>();
-    private static final Logger logger = LoggerFactory.getLogger(AbstractCompositeAtomProducer.class);
+    private Set<AtomProducer> atomFactories = new HashSet<>();
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized Dataset create() {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/DirectoryBasedAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/DirectoryBasedAtomProducer.java
@@ -10,27 +10,27 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import won.bot.framework.component.atomproducer.FileBasedAtomProducer;
 import won.bot.framework.component.atomproducer.AtomProducer;
+import won.bot.framework.component.atomproducer.FileBasedAtomProducer;
 import won.protocol.exception.DataIntegrityException;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * AtomProducer that is configured to read atoms from a directory.
  */
 public class DirectoryBasedAtomProducer implements AtomProducer {
     private static final int NOT_INITIALIZED = -1;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private File directory;
     // true if the factory should keep creating atoms after having used each file,
     // false if the factory should use each file only once.

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/MailFileAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/MailFileAtomProducer.java
@@ -10,12 +10,6 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-
-import javax.mail.internet.MimeMessage;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.mail.util.MimeMessageParser;
 import org.apache.jena.query.Dataset;
@@ -23,15 +17,20 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.component.atomproducer.FileBasedAtomProducer;
 import won.protocol.util.DefaultAtomModelWrapper;
+
+import javax.mail.internet.MimeMessage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: fkleedorfer Date: 17.12.13
  */
 public class MailFileAtomProducer implements FileBasedAtomProducer {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized Dataset readAtomFromFile(final File file) throws IOException {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TemplateBasedAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TemplateBasedAtomProducer.java
@@ -10,8 +10,6 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
-import java.io.IOException;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
@@ -19,17 +17,19 @@ import org.apache.jena.riot.RDFLanguages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
-
 import won.protocol.model.AtomGraphType;
 import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * AtomProducer that reads an atom model at startup time and overlays it with
  * the data retrieved from the atom factory it wraps.
  */
 public class TemplateBasedAtomProducer extends AbstractAtomProducerWrapper {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Model templateModel;
     private Resource template;
     private boolean initialized = false;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TrigFileAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TrigFileAtomProducer.java
@@ -10,25 +10,25 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.component.atomproducer.FileBasedAtomProducer;
 import won.protocol.util.AtomModelWrapper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: fkleedorfer Date: 17.12.13
  */
 public class TrigFileAtomProducer implements FileBasedAtomProducer {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized Dataset readAtomFromFile(final File file) throws IOException {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TurtleFileAtomProducer.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/atomproducer/impl/TurtleFileAtomProducer.java
@@ -10,10 +10,6 @@
  */
 package won.bot.framework.component.atomproducer.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -21,15 +17,19 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.component.atomproducer.FileBasedAtomProducer;
 import won.protocol.util.AtomModelWrapper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: fkleedorfer Date: 17.12.13
  */
 public class TurtleFileAtomProducer implements FileBasedAtomProducer {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized Dataset readAtomFromFile(final File file) throws IOException {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/nodeurisource/impl/RandomMultiNodeUriSource.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/nodeurisource/impl/RandomMultiNodeUriSource.java
@@ -10,22 +10,22 @@
  */
 package won.bot.framework.component.nodeurisource.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.bot.framework.component.nodeurisource.NodeURISource;
+
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.bot.framework.component.nodeurisource.NodeURISource;
-
 /**
  * User: fkleedorfer Date: 19.12.13
  */
 public class RandomMultiNodeUriSource implements NodeURISource {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<URI> nodeURIs = null;
     private long seed = System.currentTimeMillis();
     private Random random = new Random(seed);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/component/nodeurisource/impl/RoundRobinMultiNodeUriSource.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/component/nodeurisource/impl/RoundRobinMultiNodeUriSource.java
@@ -10,22 +10,22 @@
  */
 package won.bot.framework.component.nodeurisource.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.bot.framework.component.nodeurisource.NodeURISource;
+
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.bot.framework.component.nodeurisource.NodeURISource;
 
 /**
  * NodeUriSource that is given a list of URIs and returns each element in a
  * round robin fashion.
  */
 public class RoundRobinMultiNodeUriSource implements NodeURISource {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<URI> nodeURIs = null;
     private int lastIndex = -1;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/BaseEventBotAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/BaseEventBotAction.java
@@ -10,6 +10,7 @@
  */
 package won.bot.framework.eventbot.action;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
 import org.javasimon.SimonManager;
@@ -27,7 +28,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  *
  */
 public abstract class BaseEventBotAction implements won.bot.framework.eventbot.action.EventBotAction {
-    private static final Logger logger = LoggerFactory.getLogger(BaseEventBotAction.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private EventListenerContext eventListenerContext;
     private static final String EXCEPTION_TAG = "failed";
     private final String stopwatchName = getClass().getName();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/BaseEventBotAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/BaseEventBotAction.java
@@ -27,7 +27,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  *
  */
 public abstract class BaseEventBotAction implements won.bot.framework.eventbot.action.EventBotAction {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(BaseEventBotAction.class);
     private EventListenerContext eventListenerContext;
     private static final String EXCEPTION_TAG = "failed";
     private final String stopwatchName = getClass().getName();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -10,6 +10,7 @@
  */
 package won.bot.framework.eventbot.action;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -29,7 +30,7 @@ import won.protocol.message.WonMessage;
  * User: fkleedorfer Date: 02.02.14
  */
 public class EventBotActionUtils {
-    private static final Logger logger = LoggerFactory.getLogger(EventBotActionUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static void rememberInList(EventListenerContext ctx, URI uri, String uriListName) {
         if (uriListName != null && uriListName.trim().length() > 0) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogAction.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -19,6 +21,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Outputs a message via the configured logging system.
  */
 public class LogAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected String message;
 
     public LogAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogAction.java
@@ -17,11 +17,13 @@ import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Outputs a message via the configured logging system.
  */
 public class LogAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected String message;
 
     public LogAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogErrorAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogErrorAction.java
@@ -16,11 +16,13 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Outputs a message via the configured logging system.
  */
 public class LogErrorAction extends LogAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public LogErrorAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogErrorAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/LogErrorAction.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
@@ -18,6 +20,8 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Outputs a message via the configured logging system.
  */
 public class LogErrorAction extends LogAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public LogErrorAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateAtomWithSocketsAction.java
@@ -10,18 +10,15 @@
  */
 package won.bot.framework.eventbot.action.impl.atomlifecycle;
 
-import java.net.URI;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
-import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
+import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomProducerExhaustedEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
@@ -32,12 +29,15 @@ import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Creates an atom with the specified sockets. If no socket is specified, the
  * chatSocket will be used.
  */
 public class CreateAtomWithSocketsAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public CreateAtomWithSocketsAction(EventListenerContext eventListenerContext, String uriListName, URI... sockets) {
         this(eventListenerContext, uriListName, true, false, sockets);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateAtomWithSocketsAction.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
 import won.bot.framework.eventbot.event.Event;
@@ -35,6 +37,8 @@ import won.protocol.util.WonRdfUtils;
  * chatSocket will be used.
  */
 public class CreateAtomWithSocketsAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public CreateAtomWithSocketsAction(EventListenerContext eventListenerContext, String uriListName, URI... sockets) {
         this(eventListenerContext, uriListName, true, false, sockets);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateEchoAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateEchoAtomWithSocketsAction.java
@@ -10,19 +10,16 @@
  */
 package won.bot.framework.eventbot.action.impl.atomlifecycle;
 
-import java.net.URI;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
-import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
-import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
+import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
+import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.message.WonMessage;
@@ -31,12 +28,15 @@ import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Creates an atom with the specified sockets. If no socket is specified, the
  * chatSocket will be used.
  */
 public class CreateEchoAtomWithSocketsAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public CreateEchoAtomWithSocketsAction(EventListenerContext eventListenerContext, URI... sockets) {
         super(eventListenerContext, sockets);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateEchoAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/atomlifecycle/CreateEchoAtomWithSocketsAction.java
@@ -15,6 +15,8 @@ import java.net.URI;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
 import won.bot.framework.eventbot.event.Event;
@@ -34,6 +36,8 @@ import won.protocol.util.WonRdfUtils;
  * chatSocket will be used.
  */
 public class CreateEchoAtomWithSocketsAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public CreateEchoAtomWithSocketsAction(EventListenerContext eventListenerContext, URI... sockets) {
         super(eventListenerContext, sockets);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/crawl/CrawlAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/crawl/CrawlAction.java
@@ -14,7 +14,6 @@ import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StopWatch;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -23,13 +22,15 @@ import won.bot.framework.eventbot.event.impl.crawl.CrawlCommandFailureEvent;
 import won.bot.framework.eventbot.event.impl.crawl.CrawlCommandSuccessEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Expects a CrawlCommandEvent to contain the required crawl information. Crawls
  * the data using the LinkedDataSource and publishes a CrawlSuccessEvent when
  * done.
  */
 public class CrawlAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public CrawlAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
@@ -15,6 +15,8 @@ import java.net.URI;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
 import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
@@ -45,6 +47,7 @@ import won.protocol.vocabulary.WONMATCH;
  * chatSocket will be used.
  */
 public class CreateDebugAtomWithSocketsAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Counter counter = new CounterImpl("DebugAtomsCounter");
     private boolean isInitialForHint;
     private boolean isInitialForConnect;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
@@ -10,11 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl.debugbot;
 
-import java.net.URI;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -27,11 +24,7 @@ import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
 import won.bot.framework.eventbot.event.AtomSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.AtomCreatedEventForDebugConnect;
-import won.bot.framework.eventbot.event.impl.debugbot.AtomCreatedEventForDebugHint;
-import won.bot.framework.eventbot.event.impl.debugbot.ConnectDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintType;
+import won.bot.framework.eventbot.event.impl.debugbot.*;
 import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
 import won.bot.framework.eventbot.listener.EventListener;
@@ -42,12 +35,15 @@ import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WONMATCH;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Creates an atom with the specified sockets. If no socket is specified, the
  * chatSocket will be used.
  */
 public class CreateDebugAtomWithSocketsAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Counter counter = new CounterImpl("DebugAtomsCounter");
     private boolean isInitialForHint;
     private boolean isInitialForConnect;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
@@ -10,25 +10,12 @@
  */
 package won.bot.framework.eventbot.action.impl.debugbot;
 
-import java.net.URI;
-import java.text.DecimalFormat;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StopWatch;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.behaviour.CrawlConnectionDataBehaviour;
@@ -42,15 +29,7 @@ import won.bot.framework.eventbot.event.impl.command.connectionmessage.Connectio
 import won.bot.framework.eventbot.event.impl.command.deactivate.DeactivateAtomCommandEvent;
 import won.bot.framework.eventbot.event.impl.crawlconnection.CrawlConnectionCommandEvent;
 import won.bot.framework.eventbot.event.impl.crawlconnection.CrawlConnectionCommandSuccessEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.ConnectDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintType;
-import won.bot.framework.eventbot.event.impl.debugbot.MessageToElizaEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.ReplaceDebugAtomContentCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.SendNDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.SetCacheEagernessCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.SetChattinessDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.UsageDebugCommandEvent;
+import won.bot.framework.eventbot.event.impl.debugbot.*;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.agreement.AgreementProtocolState;
 import won.protocol.message.WonMessage;
@@ -61,12 +40,21 @@ import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.validation.WonConnectionValidator;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.text.DecimalFormat;
+import java.time.Duration;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 /**
  * Listener that reacts to incoming messages, creating internal bot events for
  * them
  */
 public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     Pattern PATTERN_USAGE = Pattern.compile("^usage|\\?|help|debug$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_HINT = Pattern.compile("^hint(\\s+((random|incompatible)\\s+)?socket)?$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_CLOSE = Pattern.compile("^close$", Pattern.CASE_INSENSITIVE);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/DebugBotIncomingMessageToEventMappingAction.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StopWatch;
 
 import won.bot.framework.eventbot.EventListenerContext;
@@ -64,6 +66,7 @@ import won.protocol.validation.WonConnectionValidator;
  * them
  */
 public class DebugBotIncomingMessageToEventMappingAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     Pattern PATTERN_USAGE = Pattern.compile("^usage|\\?|help|debug$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_HINT = Pattern.compile("^hint(\\s+((random|incompatible)\\s+)?socket)?$", Pattern.CASE_INSENSITIVE);
     Pattern PATTERN_CLOSE = Pattern.compile("^close$", Pattern.CASE_INSENSITIVE);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/OpenConnectionDebugAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/OpenConnectionDebugAction.java
@@ -10,13 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.debugbot;
 
-import java.net.URI;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -32,11 +26,17 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * User: fkleedorfer Date: 30.01.14
  */
 public class OpenConnectionDebugAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String welcomeMessage;
     private Pattern PATTERN_WAIT = Pattern.compile("wait(\\s+([0-9]{1,2}))?");
     private Pattern PATTERN_DENY = Pattern.compile("deny");

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/OpenConnectionDebugAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/OpenConnectionDebugAction.java
@@ -17,6 +17,8 @@ import java.util.regex.Pattern;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
@@ -34,6 +36,7 @@ import won.protocol.util.WonRdfUtils;
  * User: fkleedorfer Date: 30.01.14
  */
 public class OpenConnectionDebugAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String welcomeMessage;
     private Pattern PATTERN_WAIT = Pattern.compile("wait(\\s+([0-9]{1,2}))?");
     private Pattern PATTERN_DENY = Pattern.compile("deny");

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/ReplaceDebugAtomContentAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/ReplaceDebugAtomContentAction.java
@@ -10,48 +10,32 @@
  */
 package won.bot.framework.eventbot.action.impl.debugbot;
 
-import java.net.URI;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
-import won.bot.framework.eventbot.action.EventBotActionUtils;
 import won.bot.framework.eventbot.action.impl.counter.Counter;
 import won.bot.framework.eventbot.action.impl.counter.CounterImpl;
-import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
-import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
-import won.bot.framework.eventbot.event.AtomSpecificEvent;
 import won.bot.framework.eventbot.event.impl.command.replace.ReplaceCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.ConnectDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.HintDebugCommandEvent;
-import won.bot.framework.eventbot.event.impl.debugbot.AtomCreatedEventForDebugConnect;
-import won.bot.framework.eventbot.event.impl.debugbot.AtomCreatedEventForDebugHint;
 import won.bot.framework.eventbot.event.impl.debugbot.ReplaceDebugAtomContentCommandEvent;
-import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
-import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
 import won.bot.framework.eventbot.listener.EventListener;
-import won.protocol.message.WonMessage;
-import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.DefaultAtomModelWrapper;
-import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
-import won.protocol.util.WonRdfUtils;
-import won.protocol.vocabulary.WON;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Creates an atom with the specified sockets. If no socket is specified, the
  * chatSocket will be used.
  */
 public class ReplaceDebugAtomContentAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Counter counter = new CounterImpl("DebugAtomsReplaceCounter");
 
     public ReplaceDebugAtomContentAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/ReplaceDebugAtomContentAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/ReplaceDebugAtomContentAction.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -49,6 +51,7 @@ import won.protocol.vocabulary.WON;
  * chatSocket will be used.
  */
 public class ReplaceDebugAtomContentAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Counter counter = new CounterImpl("DebugAtomsReplaceCounter");
 
     public ReplaceDebugAtomContentAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/SendChattyMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/SendChattyMessageAction.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -34,6 +36,7 @@ import won.protocol.util.WonRdfUtils;
  * messages via its connections spontaneously.
  */
 public class SendChattyMessageAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private double probabilityOfSendingMessage = 0.1;
     private String[] messagesForShortInactivity;
     public static final String KEY_CHATTY_CONNECTIONS = "chattyConnections";

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/SendChattyMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/SendChattyMessageAction.java
@@ -10,15 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl.debugbot;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -31,12 +24,19 @@ import won.protocol.model.ConnectionModelMapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
 /**
  * Action to perform when the debug bot is set to be 'chatty' - that is, sends
  * messages via its connections spontaneously.
  */
 public class SendChattyMessageAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private double probabilityOfSendingMessage = 0.1;
     private String[] messagesForShortInactivity;
     public static final String KEY_CHATTY_CONNECTIONS = "chattyConnections";

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/FactoryHintCheckAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/FactoryHintCheckAction.java
@@ -10,9 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.factory;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
@@ -26,11 +23,15 @@ import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent
 import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * Checks if the received hint is for a factoryURI
  */
 public class FactoryHintCheckAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public FactoryHintCheckAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/FactoryHintCheckAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/FactoryHintCheckAction.java
@@ -13,6 +13,8 @@ package won.bot.framework.eventbot.action.impl.factory;
 import java.net.URI;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -28,6 +30,8 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Checks if the received hint is for a factoryURI
  */
 public class FactoryHintCheckAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public FactoryHintCheckAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/InitFactoryAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/InitFactoryAction.java
@@ -6,6 +6,8 @@ import java.time.Duration;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
 import won.bot.framework.component.atomproducer.AtomProducer;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -50,6 +52,7 @@ import won.protocol.util.WonRdfUtils;
  * InitFactoryFinishedEvent once it is completed
  */
 public class InitFactoryAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private static int FACTORYATOMCREATION_DURATION_INMILLIS = 250;
     private int targetInFlightCount;
     private int maxInFlightCount;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/InitFactoryAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/factory/InitFactoryAction.java
@@ -1,11 +1,7 @@
 package won.bot.framework.eventbot.action.impl.factory;
 
-import java.net.URI;
-import java.time.Duration;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.FactoryBotContextWrapper;
@@ -14,22 +10,14 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.impl.MultipleActions;
 import won.bot.framework.eventbot.action.impl.PublishEventAction;
-import won.bot.framework.eventbot.action.impl.counter.Counter;
-import won.bot.framework.eventbot.action.impl.counter.CounterImpl;
-import won.bot.framework.eventbot.action.impl.counter.DecrementCounterAction;
-import won.bot.framework.eventbot.action.impl.counter.IncrementCounterAction;
-import won.bot.framework.eventbot.action.impl.counter.TargetCountReachedEvent;
-import won.bot.framework.eventbot.action.impl.counter.TargetCounterDecorator;
 import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
-import won.bot.framework.eventbot.action.impl.trigger.ActionOnTriggerEventListener;
-import won.bot.framework.eventbot.action.impl.trigger.BotTrigger;
-import won.bot.framework.eventbot.action.impl.trigger.BotTriggerEvent;
-import won.bot.framework.eventbot.action.impl.trigger.StartBotTriggerCommandEvent;
-import won.bot.framework.eventbot.action.impl.trigger.StopBotTriggerCommandEvent;
+import won.bot.framework.eventbot.action.impl.counter.*;
+import won.bot.framework.eventbot.action.impl.trigger.*;
 import won.bot.framework.eventbot.action.impl.wonmessage.execCommand.ExecuteCreateAtomCommandAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.execCommand.LogMessageCommandFailureAction;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
+import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomProducerExhaustedEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandFailureEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandResultEvent;
@@ -40,19 +28,22 @@ import won.bot.framework.eventbot.event.impl.factory.FactoryAtomCreationSkippedE
 import won.bot.framework.eventbot.event.impl.factory.InitFactoryFinishedEvent;
 import won.bot.framework.eventbot.event.impl.factory.StartFactoryAtomCreationEvent;
 import won.bot.framework.eventbot.event.impl.lifecycle.InitializeEvent;
-import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomProducerExhaustedEvent;
 import won.bot.framework.eventbot.filter.impl.TargetCounterFilter;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.time.Duration;
+
 /**
  * Action that creates all atoms from the atomproducer and publishes the
  * InitFactoryFinishedEvent once it is completed
  */
 public class InitFactoryAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static int FACTORYATOMCREATION_DURATION_INMILLIS = 250;
     private int targetInFlightCount;
     private int maxInFlightCount;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
@@ -1,21 +1,11 @@
 package won.bot.framework.eventbot.action.impl.hokify.receive;
 
-import java.math.RoundingMode;
-import java.net.URI;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Random;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.datatypes.BaseDatatype;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
@@ -40,11 +30,21 @@ import won.protocol.vocabulary.WONCON;
 import won.protocol.vocabulary.WONMATCH;
 import won.protocol.vocabulary.WXCHAT;
 
+import java.lang.invoke.MethodHandles;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Random;
+
 /**
  * Created by MS on 18.09.2018.
  */
 public class CreateAtomFromJobAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private HokifyBotsApi hokifyBotsApi;
     private boolean createAllInOne;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/receive/CreateAtomFromJobAction.java
@@ -16,6 +16,8 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -42,6 +44,7 @@ import won.protocol.vocabulary.WXCHAT;
  * Created by MS on 18.09.2018.
  */
 public class CreateAtomFromJobAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private HokifyBotsApi hokifyBotsApi;
     private boolean createAllInOne;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Connect2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Connect2HokifyAction.java
@@ -1,9 +1,6 @@
 package won.bot.framework.eventbot.action.impl.hokify.send;
 
-import java.net.URI;
-
 import org.apache.jena.rdf.model.Model;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
@@ -20,11 +17,14 @@ import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
 import won.protocol.model.Connection;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by ms on 24.09.2018.
  */
 public class Connect2HokifyAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public Connect2HokifyAction(EventListenerContext ctx) {
         super(ctx);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Connect2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Connect2HokifyAction.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.jena.rdf.model.Model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -22,6 +24,8 @@ import won.protocol.util.WonRdfUtils;
  * Created by ms on 24.09.2018.
  */
 public class Connect2HokifyAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public Connect2HokifyAction(EventListenerContext ctx) {
         super(ctx);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Hint2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Hint2HokifyAction.java
@@ -3,6 +3,8 @@ package won.bot.framework.eventbot.action.impl.hokify.send;
 import java.net.URI;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -19,6 +21,7 @@ import won.protocol.message.WonMessage;
  * Created by MS on 24.09.2018.
  */
 public class Hint2HokifyAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     WonHokifyJobBotHandler wonHokifyJobBotHandler;
 
     public Hint2HokifyAction(EventListenerContext ctx) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Hint2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Hint2HokifyAction.java
@@ -1,8 +1,5 @@
 package won.bot.framework.eventbot.action.impl.hokify.send;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
@@ -17,11 +14,15 @@ import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEve
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.message.WonMessage;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * Created by MS on 24.09.2018.
  */
 public class Hint2HokifyAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonHokifyJobBotHandler wonHokifyJobBotHandler;
 
     public Hint2HokifyAction(EventListenerContext ctx) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/HokifyHelpAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/HokifyHelpAction.java
@@ -9,11 +9,13 @@ import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.telegram.SendHelpEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Created by MS on 24.09.2018.
  */
 public class HokifyHelpAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private WonHokifyJobBotHandler wonHokifyJobBotHandler;
 
     public HokifyHelpAction(EventListenerContext eventListenerContext, WonHokifyJobBotHandler wonHokifyJobBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/HokifyHelpAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/HokifyHelpAction.java
@@ -1,5 +1,7 @@
 package won.bot.framework.eventbot.action.impl.hokify.send;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.impl.hokify.WonHokifyJobBotHandler;
@@ -11,6 +13,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Created by MS on 24.09.2018.
  */
 public class HokifyHelpAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private WonHokifyJobBotHandler wonHokifyJobBotHandler;
 
     public HokifyHelpAction(EventListenerContext eventListenerContext, WonHokifyJobBotHandler wonHokifyJobBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Message2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Message2HokifyAction.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.jena.rdf.model.Model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -19,6 +21,7 @@ import won.protocol.util.WonRdfUtils;
  * Created by MS on 24.09.2018.
  */
 public class Message2HokifyAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     WonHokifyJobBotHandler wonHokifyBotHandler;
 
     public Message2HokifyAction(EventListenerContext ctx) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Message2HokifyAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/send/Message2HokifyAction.java
@@ -1,9 +1,6 @@
 package won.bot.framework.eventbot.action.impl.hokify.send;
 
-import java.net.URI;
-
 import org.apache.jena.rdf.model.Model;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.HokifyJobBotContextWrapper;
@@ -17,11 +14,14 @@ import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.model.Connection;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by MS on 24.09.2018.
  */
 public class Message2HokifyAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonHokifyJobBotHandler wonHokifyBotHandler;
 
     public Message2HokifyAction(EventListenerContext ctx) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/util/HokifyMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/hokify/util/HokifyMessageGenerator.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.methods.send.SendMessage;
 import org.telegram.telegrambots.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.api.objects.replykeyboard.buttons.InlineKeyboardButton;
@@ -21,7 +19,6 @@ import won.protocol.util.WonRdfUtils;
  * Created by MS on 17.09.2018.
  */
 public class HokifyMessageGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(HokifyMessageGenerator.class);
     private EventListenerContext eventListenerContext;
 
     public SendMessage getHintMessage(URI targetAtomUri, URI yourAtomUri) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/lifecycle/SignalWorkDoneAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/lifecycle/SignalWorkDoneAction.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl.lifecycle;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.Bot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -21,6 +23,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * BaseEventBotAction telling the framework that the bot's work is done.
  */
 public class SignalWorkDoneAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Bot bot;
 
     public SignalWorkDoneAction(EventListenerContext eventListenerContext, Bot bot) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/lifecycle/SignalWorkDoneAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/lifecycle/SignalWorkDoneAction.java
@@ -19,11 +19,13 @@ import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.lifecycle.WorkDoneEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * BaseEventBotAction telling the framework that the bot's work is done.
  */
 public class SignalWorkDoneAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Bot bot;
 
     public SignalWorkDoneAction(EventListenerContext eventListenerContext, Bot bot) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateAtomFromMailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateAtomFromMailAction.java
@@ -10,6 +10,8 @@ import javax.mail.internet.MimeMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -32,6 +34,7 @@ import won.protocol.util.WonRdfUtils;
  * Created by fsuda on 30.09.2016.
  */
 public class CreateAtomFromMailAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MailContentExtractor mailContentExtractor;
 
     public CreateAtomFromMailAction(EventListenerContext eventListenerContext,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateAtomFromMailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/CreateAtomFromMailAction.java
@@ -1,24 +1,16 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
+import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
 import won.bot.framework.eventbot.action.impl.mail.model.MailPropertyType;
 import won.bot.framework.eventbot.action.impl.mail.model.UriType;
 import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
-import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.mail.CreateAtomFromMailEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
@@ -30,11 +22,18 @@ import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+
 /**
  * Created by fsuda on 30.09.2016.
  */
 public class CreateAtomFromMailAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MailContentExtractor mailContentExtractor;
 
     public CreateAtomFromMailAction(EventListenerContext eventListenerContext,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -1,18 +1,8 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
-import java.io.IOException;
-import java.net.URI;
-import java.security.AccessControlException;
-import java.util.List;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
@@ -30,18 +20,27 @@ import won.bot.framework.eventbot.event.impl.command.deactivate.DeactivateAtomCo
 import won.bot.framework.eventbot.event.impl.mail.MailCommandEvent;
 import won.bot.framework.eventbot.event.impl.mail.SubscribeUnsubscribeEvent;
 import won.bot.framework.eventbot.listener.EventListener;
+import won.protocol.model.AtomState;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionModelMapper;
-import won.protocol.model.AtomState;
 import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.security.AccessControlException;
+import java.util.List;
 
 /**
  * Created by fsuda on 18.10.2016.
  */
 public class MailCommandAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MailContentExtractor mailContentExtractor;
 
     public MailCommandAction(EventListenerContext eventListenerContext, MailContentExtractor mailContentExtractor) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailCommandAction.java
@@ -13,6 +13,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -39,6 +41,7 @@ import won.protocol.util.WonRdfUtils;
  * Created by fsuda on 18.10.2016.
  */
 public class MailCommandAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MailContentExtractor mailContentExtractor;
 
     public MailCommandAction(EventListenerContext eventListenerContext, MailContentExtractor mailContentExtractor) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
@@ -1,10 +1,5 @@
 package won.bot.framework.eventbot.action.impl.mail.receive;
 
-import java.io.IOException;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
@@ -19,11 +14,16 @@ import won.bot.framework.eventbot.event.impl.mail.MailReceivedEvent;
 import won.bot.framework.eventbot.event.impl.mail.WelcomeMailEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
 /**
  * Created by fsuda on 30.09.2016.
  */
 public class MailParserAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MailContentExtractor mailContentExtractor;
 
     public MailParserAction(EventListenerContext eventListenerContext, MailContentExtractor mailContentExtractor) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/receive/MailParserAction.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -21,6 +23,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Created by fsuda on 30.09.2016.
  */
 public class MailParserAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MailContentExtractor mailContentExtractor;
 
     public MailParserAction(EventListenerContext eventListenerContext, MailContentExtractor mailContentExtractor) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import javax.mail.internet.MimeMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -22,6 +24,7 @@ import won.protocol.model.Connection;
  * Created by fsuda on 03.10.2016.
  */
 public class Connect2MailParserAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Connect2MailParserAction.java
@@ -1,14 +1,9 @@
 package won.bot.framework.eventbot.action.impl.mail.send;
 
-import java.net.URI;
-
-import javax.mail.internet.MimeMessage;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -20,11 +15,15 @@ import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEven
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.model.Connection;
 
+import javax.mail.internet.MimeMessage;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by fsuda on 03.10.2016.
  */
 public class Connect2MailParserAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import javax.mail.internet.MimeMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -25,6 +27,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Created by fsuda on 03.10.2016.
  */
 public class Hint2MailParserAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Hint2MailParserAction.java
@@ -1,15 +1,9 @@
 package won.bot.framework.eventbot.action.impl.mail.send;
 
-import java.net.URI;
-import java.util.Optional;
-
-import javax.mail.internet.MimeMessage;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -23,11 +17,16 @@ import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent
 import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import javax.mail.internet.MimeMessage;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * Created by fsuda on 03.10.2016.
  */
 public class Hint2MailParserAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import javax.mail.internet.MimeMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -22,6 +24,7 @@ import won.protocol.model.Connection;
  * Created by fsuda on 18.10.2016.
  */
 public class Message2MailAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/Message2MailAction.java
@@ -1,14 +1,9 @@
 package won.bot.framework.eventbot.action.impl.mail.send;
 
-import java.net.URI;
-
-import javax.mail.internet.MimeMessage;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-
 import won.bot.framework.bot.context.MailBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -20,11 +15,15 @@ import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEven
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.model.Connection;
 
+import javax.mail.internet.MimeMessage;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by fsuda on 18.10.2016.
  */
 public class Message2MailAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MessageChannel sendChannel;
     private WonMimeMessageGenerator mailGenerator;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/mail/send/WonMimeMessageGenerator.java
@@ -3,6 +3,7 @@ package won.bot.framework.eventbot.action.impl.mail.send;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ import won.protocol.vocabulary.sparql.WonQueries;
  * Mail2WonBot
  */
 public class WonMimeMessageGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(WonMimeMessageGenerator.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private VelocityEngine velocityEngine;
     private int MAX_CONVERSATION_DEPTH = 3;
@@ -251,7 +252,7 @@ public class WonMimeMessageGenerator {
                 velocityContext.put("messages", messages);
             }
         } catch (QueryParseException e) {
-            logger.error("query parse exception {}", e);
+            logger.error("query parse exception", e);
         }
     }
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/maintenance/StatisticsLoggingAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/maintenance/StatisticsLoggingAction.java
@@ -12,7 +12,6 @@ package won.bot.framework.eventbot.action.impl.maintenance;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.bus.EventBus;
@@ -20,11 +19,13 @@ import won.bot.framework.eventbot.bus.impl.EventBusStatistics;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /*
  * Collects the EventBusStatistics and logs them.
  */
 public class StatisticsLoggingAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public StatisticsLoggingAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/MatchAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/MatchAtomsAction.java
@@ -15,6 +15,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -30,6 +32,8 @@ import won.protocol.util.WonRdfUtils;
  * to the second.
  */
 public class MatchAtomsAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public MatchAtomsAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/MatchAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/MatchAtomsAction.java
@@ -10,11 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.matcher;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -27,12 +22,17 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Iterator;
+
 /**
  * BaseEventBotAction that sends a hint message to the first atom in the context
  * to the second.
  */
 public class MatchAtomsAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public MatchAtomsAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/RegisterMatcherAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/RegisterMatcherAction.java
@@ -15,6 +15,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -26,6 +28,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * User: fkleedorfer Date: 28.03.14
  */
 public class RegisterMatcherAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private List<URI> registeredNodes = new LinkedList<>();
 
     public RegisterMatcherAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/RegisterMatcherAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/matcher/RegisterMatcherAction.java
@@ -10,11 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.matcher;
 
-import java.net.URI;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -24,11 +19,17 @@ import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.matcher.MatcherRegisterFailedEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * User: fkleedorfer Date: 28.03.14
  */
 public class RegisterMatcherAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<URI> registeredNodes = new LinkedList<>();
 
     public RegisterMatcherAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MatchingLoadTestMonitorAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MatchingLoadTestMonitorAction.java
@@ -10,16 +10,9 @@
  */
 package won.bot.framework.eventbot.action.impl.monitor;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -30,11 +23,14 @@ import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent
 import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+
 /**
  * Created by hfriedrich on 02.10.2015.
  */
 public class MatchingLoadTestMonitorAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     Map<String, Long> atomEventStartTime = Collections.synchronizedMap(new HashMap<>());
     Map<String, List<Long>> hintEventReceivedTime = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> atomSplits = Collections.synchronizedMap(new HashMap<>());

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MatchingLoadTestMonitorAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MatchingLoadTestMonitorAction.java
@@ -20,6 +20,8 @@ import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -32,6 +34,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Created by hfriedrich on 02.10.2015.
  */
 public class MatchingLoadTestMonitorAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     Map<String, Long> atomEventStartTime = Collections.synchronizedMap(new HashMap<>());
     Map<String, List<Long>> hintEventReceivedTime = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> atomSplits = Collections.synchronizedMap(new HashMap<>());

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MessageLifecycleMonitoringAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MessageLifecycleMonitoringAction.java
@@ -25,6 +25,8 @@ import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -42,6 +44,7 @@ import won.protocol.message.WonMessage;
 import won.protocol.util.RdfUtils;
 
 public class MessageLifecycleMonitoringAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     Map<String, Split> msgSplitsB = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> msgSplitsBC = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> msgSplitsBCD = Collections.synchronizedMap(new HashMap<>());

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MessageLifecycleMonitoringAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/monitor/MessageLifecycleMonitoringAction.java
@@ -10,13 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.monitor;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.commons.io.Charsets;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.riot.Lang;
@@ -24,7 +17,6 @@ import org.apache.jena.sparql.core.Quad;
 import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -34,17 +26,17 @@ import won.bot.framework.eventbot.event.impl.monitor.CrawlDoneEvent;
 import won.bot.framework.eventbot.event.impl.monitor.CrawlReadyEvent;
 import won.bot.framework.eventbot.event.impl.monitor.MessageDispatchStartedEvent;
 import won.bot.framework.eventbot.event.impl.monitor.MessageDispatchedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.DeliveryResponseEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.MessageSpecificEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.SuccessResponseEvent;
+import won.bot.framework.eventbot.event.impl.wonmessage.*;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.message.WonMessage;
 import won.protocol.util.RdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
+
 public class MessageLifecycleMonitoringAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     Map<String, Split> msgSplitsB = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> msgSplitsBC = Collections.synchronizedMap(new HashMap<>());
     Map<String, Split> msgSplitsBCD = Collections.synchronizedMap(new HashMap<>());

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/socket/TwoPhaseCommitNoVoteDeactivateAllAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/socket/TwoPhaseCommitNoVoteDeactivateAllAtomsAction.java
@@ -10,13 +10,9 @@
  */
 package won.bot.framework.eventbot.action.impl.socket;
 
-import java.net.URI;
-import java.util.Collection;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -33,11 +29,15 @@ import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collection;
+
 /**
  * User: Danijel Date: 21.5.14.
  */
 public class TwoPhaseCommitNoVoteDeactivateAllAtomsAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public TwoPhaseCommitNoVoteDeactivateAllAtomsAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/socket/TwoPhaseCommitNoVoteDeactivateAllAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/socket/TwoPhaseCommitNoVoteDeactivateAllAtomsAction.java
@@ -17,6 +17,8 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -35,6 +37,8 @@ import won.protocol.util.WonRdfUtils;
  * User: Danijel Date: 21.5.14.
  */
 public class TwoPhaseCommitNoVoteDeactivateAllAtomsAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public TwoPhaseCommitNoVoteDeactivateAllAtomsAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/CritiqueBotCommand.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/CritiqueBotCommand.java
@@ -15,7 +15,6 @@ import won.bot.framework.eventbot.event.impl.telegram.TelegramCreateAtomEvent;
  * Created by fsuda on 15.12.2016.
  */
 public class CritiqueBotCommand extends BotCommand {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus bus;
 
     public CritiqueBotCommand(String commandIdentifier, String description, EventBus bus) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/DemandBotCommand.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/DemandBotCommand.java
@@ -15,7 +15,6 @@ import won.bot.framework.eventbot.event.impl.telegram.TelegramCreateAtomEvent;
  * Created by fsuda on 15.12.2016.
  */
 public class DemandBotCommand extends BotCommand {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus bus;
 
     public DemandBotCommand(String commandIdentifier, String description, EventBus bus) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/HelpBotCommand.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/HelpBotCommand.java
@@ -1,7 +1,5 @@
 package won.bot.framework.eventbot.action.impl.telegram.Commands;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Chat;
 import org.telegram.telegrambots.api.objects.User;
 import org.telegram.telegrambots.bots.AbsSender;
@@ -14,7 +12,6 @@ import won.bot.framework.eventbot.event.impl.telegram.SendHelpEvent;
  * Created by fsuda on 15.12.2016.
  */
 public class HelpBotCommand extends BotCommand {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus bus;
 
     public HelpBotCommand(String commandIdentifier, String description, EventBus bus) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/OfferBotCommand.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/OfferBotCommand.java
@@ -15,7 +15,6 @@ import won.bot.framework.eventbot.event.impl.telegram.TelegramCreateAtomEvent;
  * Created by fsuda on 15.12.2016.
  */
 public class OfferBotCommand extends BotCommand {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus bus;
 
     public OfferBotCommand(String commandIdentifier, String description, EventBus bus) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/TogetherBotCommand.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/Commands/TogetherBotCommand.java
@@ -15,7 +15,6 @@ import won.bot.framework.eventbot.event.impl.telegram.TelegramCreateAtomEvent;
  * Created by fsuda on 15.12.2016.
  */
 public class TogetherBotCommand extends BotCommand {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBus bus;
 
     public TogetherBotCommand(String commandIdentifier, String description, EventBus bus) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Connect2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Connect2TelegramAction.java
@@ -2,6 +2,8 @@ package won.bot.framework.eventbot.action.impl.telegram.send;
 
 import java.net.URI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
 
@@ -20,6 +22,7 @@ import won.protocol.model.Connection;
  * Created by fsuda on 03.10.2016.
  */
 public class Connect2TelegramAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Connect2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Connect2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Connect2TelegramAction.java
@@ -1,12 +1,9 @@
 package won.bot.framework.eventbot.action.impl.telegram.send;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
-
 import won.bot.framework.bot.context.TelegramBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -18,11 +15,14 @@ import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEven
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.model.Connection;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by fsuda on 03.10.2016.
  */
 public class Connect2TelegramAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Connect2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Hint2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Hint2TelegramAction.java
@@ -1,13 +1,9 @@
 package won.bot.framework.eventbot.action.impl.telegram.send;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
-
 import won.bot.framework.bot.context.TelegramBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -22,11 +18,15 @@ import won.bot.framework.eventbot.event.impl.wonmessage.SocketHintFromMatcherEve
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.message.WonMessage;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * Created by fsuda on 03.10.2016.
  */
 public class Hint2TelegramAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Hint2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Hint2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Hint2TelegramAction.java
@@ -3,6 +3,8 @@ package won.bot.framework.eventbot.action.impl.telegram.send;
 import java.net.URI;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
 
@@ -24,6 +26,7 @@ import won.protocol.message.WonMessage;
  * Created by fsuda on 03.10.2016.
  */
 public class Hint2TelegramAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Hint2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Message2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Message2TelegramAction.java
@@ -1,12 +1,9 @@
 package won.bot.framework.eventbot.action.impl.telegram.send;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
-
 import won.bot.framework.bot.context.TelegramBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -19,11 +16,14 @@ import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.message.WonMessage;
 import won.protocol.model.Connection;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by fsuda on 18.10.2016.
  */
 public class Message2TelegramAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Message2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Message2TelegramAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/Message2TelegramAction.java
@@ -2,6 +2,8 @@ package won.bot.framework.eventbot.action.impl.telegram.send;
 
 import java.net.URI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
 
@@ -21,6 +23,7 @@ import won.protocol.model.Connection;
  * Created by fsuda on 18.10.2016.
  */
 public class Message2TelegramAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     WonTelegramBotHandler wonTelegramBotHandler;
 
     public Message2TelegramAction(EventListenerContext ctx, WonTelegramBotHandler wonTelegramBotHandler) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/TelegramCreateAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/TelegramCreateAction.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
 
@@ -33,6 +35,7 @@ import won.protocol.util.WonRdfUtils;
  * Created by fsuda on 15.12.2016.
  */
 public class TelegramCreateAction extends AbstractCreateAtomAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private WonTelegramBotHandler wonTelegramBotHandler;
     private TelegramContentExtractor telegramContentExtractor;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/TelegramCreateAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/send/TelegramCreateAction.java
@@ -1,23 +1,17 @@
 package won.bot.framework.eventbot.action.impl.telegram.send;
 
-import java.net.URI;
-import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.objects.Message;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
-
 import won.bot.framework.bot.context.TelegramBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
+import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
 import won.bot.framework.eventbot.action.impl.mail.model.UriType;
 import won.bot.framework.eventbot.action.impl.mail.model.WonURI;
-import won.bot.framework.eventbot.action.impl.atomlifecycle.AbstractCreateAtomAction;
 import won.bot.framework.eventbot.action.impl.telegram.WonTelegramBotHandler;
 import won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor;
 import won.bot.framework.eventbot.event.Event;
@@ -31,11 +25,17 @@ import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
 /**
  * Created by fsuda on 15.12.2016.
  */
 public class TelegramCreateAction extends AbstractCreateAtomAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private WonTelegramBotHandler wonTelegramBotHandler;
     private TelegramContentExtractor telegramContentExtractor;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/util/TelegramMessageGenerator.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/telegram/util/TelegramMessageGenerator.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.jena.query.Dataset;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.api.methods.send.SendMessage;
 import org.telegram.telegrambots.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.api.objects.replykeyboard.buttons.InlineKeyboardButton;
@@ -21,7 +19,6 @@ import won.protocol.util.WonRdfUtils;
  * Created by fsuda on 16.12.2016.
  */
 public class TelegramMessageGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(TelegramMessageGenerator.class);
     private EventListenerContext eventListenerContext;
 
     public SendMessage getHintMessage(Long chatId, URI targetAtomUri, URI yourAtomUri) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/CloseConnectionAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/CloseConnectionAction.java
@@ -10,10 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -27,12 +24,15 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Listener that will try to obtain a connectionURI from any event passed to it
  * and close that connection.
  */
 public class CloseConnectionAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String farewellMessage;
 
     public CloseConnectionAction(final EventListenerContext context, String farewellMessage) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/CloseConnectionAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/CloseConnectionAction.java
@@ -14,6 +14,8 @@ import java.net.URI;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
@@ -30,6 +32,7 @@ import won.protocol.util.WonRdfUtils;
  * and close that connection.
  */
 public class CloseConnectionAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String farewellMessage;
 
     public CloseConnectionAction(final EventListenerContext context, String farewellMessage) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectFromListToListAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectFromListToListAction.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -35,6 +37,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * used.
  */
 public class ConnectFromListToListAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String fromListName;
     private String toListName;
     private Optional<URI> fromSocketType = Optional.empty();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectFromListToListAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectFromListToListAction.java
@@ -10,14 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -31,13 +24,20 @@ import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * BaseEventBotAction connecting two atoms on the specified sockets. The atom's
  * URIs are obtained from the bot context. The first two URIs found there are
  * used.
  */
 public class ConnectFromListToListAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String fromListName;
     private String toListName;
     private Optional<URI> fromSocketType = Optional.empty();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectTwoAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectTwoAtomsAction.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -34,6 +36,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * used.
  */
 public class ConnectTwoAtomsAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private String welcomeMessage;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectTwoAtomsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectTwoAtomsAction.java
@@ -10,13 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Optional;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -30,13 +24,19 @@ import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Optional;
+
 /**
  * BaseEventBotAction connecting two atoms on the specified sockets. The atom's
  * URIs are obtained from the bot context. The first two URIs found there are
  * used.
  */
 public class ConnectTwoAtomsAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private String welcomeMessage;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectWithAssociatedAtomAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectWithAssociatedAtomAction.java
@@ -10,33 +10,26 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
-
-import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer.Tag;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
-import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.AtomSpecificEvent;
+import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.protocol.exception.WonMessageBuilderException;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
-import won.protocol.util.WonRdfUtils;
 import won.protocol.util.RdfUtils.Pair;
+import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
 
 /**
  * BaseEventBotAction connecting two atoms on the specified sockets or on two
@@ -45,7 +38,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * botContext.saveToObjectMap method.
  */
 public class ConnectWithAssociatedAtomAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private String welcomeMessage;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectWithAssociatedAtomAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/ConnectWithAssociatedAtomAction.java
@@ -22,6 +22,8 @@ import org.apache.jena.query.Dataset;
 
 import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer.Tag;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -43,6 +45,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * botContext.saveToObjectMap method.
  */
 public class ConnectWithAssociatedAtomAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private String welcomeMessage;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/HintAssociatedAtomAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/HintAssociatedAtomAction.java
@@ -10,15 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.jena.rdf.model.Model;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -38,6 +30,10 @@ import won.protocol.util.RdfUtils.Pair;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
 
 /**
  * BaseEventBotAction connecting two atoms on the specified sockets, or on other
@@ -63,7 +59,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * </ul>
  */
 public class HintAssociatedAtomAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private URI matcherURI;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/HintAssociatedAtomAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/HintAssociatedAtomAction.java
@@ -19,6 +19,8 @@ import java.util.Set;
 
 import org.apache.jena.rdf.model.Model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.AtomSpecificEvent;
@@ -61,6 +63,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * </ul>
  */
 public class HintAssociatedAtomAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Optional<URI> targetSocketType = Optional.empty();
     private Optional<URI> localSocketType = Optional.empty();
     private URI matcherURI;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.BotActionUtils;
@@ -37,6 +39,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * User: fkleedorfer Date: 30.01.14
  */
 public class OpenConnectionAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String welcomeMessage;
 
     public OpenConnectionAction(final EventListenerContext context, final String welcomeMessage) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/OpenConnectionAction.java
@@ -10,11 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -35,11 +31,15 @@ import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * User: fkleedorfer Date: 30.01.14
  */
 public class OpenConnectionAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String welcomeMessage;
 
     public OpenConnectionAction(final EventListenerContext context, final String welcomeMessage) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondToMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondToMessageAction.java
@@ -10,9 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Date;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -22,12 +19,16 @@ import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+
 /**
  * Listener that responds to a message with automatic messages. Can be
  * configured to apply a timeout (non-blocking) before sending messages.
  */
 public class RespondToMessageAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private long millisTimeoutBeforeReply = 0;
     private String message = null;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondToMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondToMessageAction.java
@@ -13,6 +13,8 @@ package won.bot.framework.eventbot.action.impl.wonmessage;
 import java.net.URI;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.BotActionUtils;
@@ -25,6 +27,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * configured to apply a timeout (non-blocking) before sending messages.
  */
 public class RespondToMessageAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private long millisTimeoutBeforeReply = 0;
     private String message = null;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondWithEchoToMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondWithEchoToMessageAction.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
@@ -32,6 +34,7 @@ import won.protocol.util.WonRdfUtils;
  * Can be configured to apply a timeout (non-blocking) before sending messages.
  */
 public class RespondWithEchoToMessageAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private long millisTimeoutBeforeReply = 0;
 
     public RespondWithEchoToMessageAction(EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondWithEchoToMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/RespondWithEchoToMessageAction.java
@@ -10,11 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Date;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -29,12 +25,16 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+
 /**
  * Listener that responds to open and message events with automatic messages.
  * Can be configured to apply a timeout (non-blocking) before sending messages.
  */
 public class RespondWithEchoToMessageAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private long millisTimeoutBeforeReply = 0;
 
     public RespondWithEchoToMessageAction(EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendFeedbackForHintAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendFeedbackForHintAction.java
@@ -10,11 +10,7 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-import java.util.Random;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -28,11 +24,15 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Random;
+
 /**
  * User: fkleedorfer Date: 30.01.14
  */
 public class SendFeedbackForHintAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // random number generator needed for random feedback value
     Random random = new Random(System.currentTimeMillis());
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendFeedbackForHintAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendFeedbackForHintAction.java
@@ -15,6 +15,8 @@ import java.util.Random;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -30,6 +32,7 @@ import won.protocol.util.WonRdfUtils;
  * User: fkleedorfer Date: 30.01.14
  */
 public class SendFeedbackForHintAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     // random number generator needed for random feedback value
     Random random = new Random(System.currentTimeMillis());
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendMessageAction.java
@@ -12,6 +12,8 @@ package won.bot.framework.eventbot.action.impl.wonmessage;
 
 import java.net.URI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.BotActionUtils;
@@ -23,6 +25,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * Action that sends a generic message.
  */
 public class SendMessageAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String message = "Hello World";
 
     public SendMessageAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendMessageAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/SendMessageAction.java
@@ -10,8 +10,6 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -21,11 +19,14 @@ import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Action that sends a generic message.
  */
 public class SendMessageAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String message = "Hello World";
 
     public SendMessageAction(final EventListenerContext eventListenerContext) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateAtomCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateAtomCommandAction.java
@@ -10,13 +10,9 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
-import java.net.URI;
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -38,11 +34,15 @@ import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WONMATCH;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+
 /**
  * Action executing a CreateAtomCommandEvent, creating the specified atom.
  */
 public class ExecuteCreateAtomCommandAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public ExecuteCreateAtomCommandAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateAtomCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteCreateAtomCommandAction.java
@@ -17,6 +17,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -40,6 +42,8 @@ import won.protocol.vocabulary.WONMATCH;
  * Action executing a CreateAtomCommandEvent, creating the specified atom.
  */
 public class ExecuteCreateAtomCommandAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public ExecuteCreateAtomCommandAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteDeactivateAtomCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteDeactivateAtomCommandAction.java
@@ -1,9 +1,6 @@
 package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
-import java.net.URI;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -22,11 +19,14 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created by fsuda on 17.05.2017.
  */
 public class ExecuteDeactivateAtomCommandAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public ExecuteDeactivateAtomCommandAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteDeactivateAtomCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteDeactivateAtomCommandAction.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -24,6 +26,8 @@ import won.protocol.util.WonRdfUtils;
  * Created by fsuda on 17.05.2017.
  */
 public class ExecuteDeactivateAtomCommandAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public ExecuteDeactivateAtomCommandAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteReplaceCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteReplaceCommandAction.java
@@ -10,12 +10,9 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
-import java.net.URI;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -35,13 +32,15 @@ import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
-import won.protocol.vocabulary.WON;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Action executing a CreateAtomCommandEvent, creating the specified atom.
  */
 public class ExecuteReplaceCommandAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public ExecuteReplaceCommandAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteReplaceCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteReplaceCommandAction.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -39,6 +41,8 @@ import won.protocol.vocabulary.WON;
  * Action executing a CreateAtomCommandEvent, creating the specified atom.
  */
 public class ExecuteReplaceCommandAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public ExecuteReplaceCommandAction(final EventListenerContext eventListenerContext) {
         super(eventListenerContext);
     }

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteSendMessageCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteSendMessageCommandAction.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
@@ -38,6 +40,7 @@ import won.protocol.util.WonRdfUtils;
  * registered
  */
 public abstract class ExecuteSendMessageCommandAction<T extends MessageCommandEvent> extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private boolean messageIsSentToRemoteNode = true;
 
     protected ExecuteSendMessageCommandAction(EventListenerContext eventListenerContext,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteSendMessageCommandAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/ExecuteSendMessageCommandAction.java
@@ -15,9 +15,9 @@ import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotActionUtils;
+import won.bot.framework.eventbot.event.AtomSpecificEvent;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
-import won.bot.framework.eventbot.event.AtomSpecificEvent;
 import won.bot.framework.eventbot.event.TargetAtomSpecificEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandEvent;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandFailureEvent;
@@ -31,6 +31,8 @@ import won.protocol.message.WonMessage;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Action executing a MessageCommandEvent and publishing MessageCommandSuccess
  * and MessageCommandFailure events indicating how well sending that message
@@ -40,7 +42,7 @@ import won.protocol.util.WonRdfUtils;
  * registered
  */
 public abstract class ExecuteSendMessageCommandAction<T extends MessageCommandEvent> extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private boolean messageIsSentToRemoteNode = true;
 
     protected ExecuteSendMessageCommandAction(EventListenerContext eventListenerContext,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/LogMessageCommandFailureAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/wonmessage/execCommand/LogMessageCommandFailureAction.java
@@ -12,18 +12,19 @@ package won.bot.framework.eventbot.action.impl.wonmessage.execCommand;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.command.MessageCommandFailureEvent;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Logs type and optional message of a MessageCommandFailureEvent.
  */
 public class LogMessageCommandFailureAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public LogMessageCommandFailureAction(EventListenerContext eventListenerContext) {
         super(eventListenerContext);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/AnalyzeBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/AnalyzeBehaviour.java
@@ -1,23 +1,10 @@
 package won.bot.framework.eventbot.behaviour;
 
-import java.io.StringWriter;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.BotContext;
@@ -27,11 +14,7 @@ import won.bot.framework.eventbot.action.impl.factory.model.Precondition;
 import won.bot.framework.eventbot.action.impl.factory.model.Proposal;
 import won.bot.framework.eventbot.action.impl.factory.model.ProposalState;
 import won.bot.framework.eventbot.bus.EventBus;
-import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
-import won.bot.framework.eventbot.event.Event;
-import won.bot.framework.eventbot.event.MessageEvent;
-import won.bot.framework.eventbot.event.AtomSpecificEvent;
-import won.bot.framework.eventbot.event.TargetAtomSpecificEvent;
+import won.bot.framework.eventbot.event.*;
 import won.bot.framework.eventbot.event.impl.analyzation.agreement.AgreementCancellationAcceptedEvent;
 import won.bot.framework.eventbot.event.impl.analyzation.agreement.ProposalAcceptedEvent;
 import won.bot.framework.eventbot.event.impl.analyzation.precondition.PreconditionMetEvent;
@@ -54,8 +37,16 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.utils.goals.GoalInstantiationProducer;
 import won.utils.goals.GoalInstantiationResult;
 
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+
 public class AnalyzeBehaviour extends BotBehaviour {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final BotContext botContext;
     private final String preconditionToProposalListMapName;
     private final String proposalToPreconditionListMapName;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/AnalyzeBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/AnalyzeBehaviour.java
@@ -18,6 +18,8 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.context.BotContext;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -53,6 +55,7 @@ import won.utils.goals.GoalInstantiationProducer;
 import won.utils.goals.GoalInstantiationResult;
 
 public class AnalyzeBehaviour extends BotBehaviour {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final BotContext botContext;
     private final String preconditionToProposalListMapName;
     private final String proposalToPreconditionListMapName;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/BotBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/BotBehaviour.java
@@ -10,22 +10,18 @@
  */
 package won.bot.framework.eventbot.behaviour;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public abstract class BotBehaviour {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private AtomicBoolean active = new AtomicBoolean(false);
     protected final String name;
     protected final EventListenerContext context;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/BotBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/BotBehaviour.java
@@ -25,7 +25,7 @@ import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
 public abstract class BotBehaviour {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private AtomicBoolean active = new AtomicBoolean(false);
     protected final String name;
     protected final EventListenerContext context;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/CrawlConnectionDataBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/CrawlConnectionDataBehaviour.java
@@ -10,13 +10,6 @@
  */
 package won.bot.framework.eventbot.behaviour;
 
-import java.net.URI;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.shared.PrefixMapping;
@@ -25,7 +18,6 @@ import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.EventBotAction;
@@ -51,12 +43,20 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
 /**
  * Crawls the complete connection data. This behaviour is transient, it is only
  * active once for a specific activity and then deactivates itself.
  */
 public class CrawlConnectionDataBehaviour extends BotBehaviour {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private CrawlConnectionCommandEvent command;
     private Duration abortTimeout;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/EagerlyPopulateCacheBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/behaviour/EagerlyPopulateCacheBehaviour.java
@@ -1,14 +1,7 @@
 package won.bot.framework.eventbot.behaviour;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -22,8 +15,15 @@ import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.CachingLinkedDataSource;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 public class EagerlyPopulateCacheBehaviour extends BotBehaviour {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public EagerlyPopulateCacheBehaviour(EventListenerContext context) {
         super(context);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/bus/impl/AsyncEventBusImpl.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/bus/impl/AsyncEventBusImpl.java
@@ -10,31 +10,24 @@
  */
 package won.bot.framework.eventbot.bus.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.SubscriptionAware;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
 /**
  *
  */
 public class AsyncEventBusImpl implements EventBus {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Map<Class<? extends Event>, List<EventListener>> listenerMap = new ConcurrentHashMap<>();
     private Executor executor;
     private Object monitor = new Object();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/filter/impl/AbstractNamedUriListFilter.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/filter/impl/AbstractNamedUriListFilter.java
@@ -10,21 +10,21 @@
  */
 package won.bot.framework.eventbot.filter.impl;
 
-import java.net.URI;
-import java.util.Collection;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collection;
 
 /**
  * Event filter that accepts atom specific events the URI of which is found in
  * the specified named URI list.
  */
 public abstract class AbstractNamedUriListFilter extends EventListenerContextAwareFilter {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String listname;
 
     public AbstractNamedUriListFilter(final EventListenerContext context, final String listname) {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractDoOnceAfterNEventsListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractDoOnceAfterNEventsListener.java
@@ -16,13 +16,15 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Counts how often it is called, offers to call a callback when a certain
  * number is reached. After the target count of events is reached, a
  * FinishedEvent is published. This allows for chaining listeners.
  */
 public abstract class AbstractDoOnceAfterNEventsListener extends BaseEventListener implements CountingListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private int targetCount;
     private int count = 0;
     private Object monitor = new Object();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractDoOnceAfterNEventsListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractDoOnceAfterNEventsListener.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.listener;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
@@ -20,6 +22,7 @@ import won.bot.framework.eventbot.filter.EventFilter;
  * FinishedEvent is published. This allows for chaining listeners.
  */
 public abstract class AbstractDoOnceAfterNEventsListener extends BaseEventListener implements CountingListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private int targetCount;
     private int count = 0;
     private Object monitor = new Object();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractFinishingListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractFinishingListener.java
@@ -16,13 +16,15 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Base class for listeners that eventually stop listening. When the decision is
  * made to finish, a FinishedEvent is published and the listener is unsubscribed
  * from all further events.
  */
 public abstract class AbstractFinishingListener extends BaseEventListener implements FinishingListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Object monitor = new Object();
     private boolean finished = false;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractFinishingListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractFinishingListener.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.listener;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
@@ -20,6 +22,7 @@ import won.bot.framework.eventbot.filter.EventFilter;
  * from all further events.
  */
 public abstract class AbstractFinishingListener extends BaseEventListener implements FinishingListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Object monitor = new Object();
     private boolean finished = false;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractHandleFirstNEventsListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractHandleFirstNEventsListener.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.listener;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
@@ -19,6 +21,7 @@ import won.bot.framework.eventbot.filter.EventFilter;
  * number is reached.
  */
 public abstract class AbstractHandleFirstNEventsListener extends BaseEventListener implements CountingListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private int targetCount;
     private int count = 0;
     private Object monitor = new Object();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractHandleFirstNEventsListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/AbstractHandleFirstNEventsListener.java
@@ -16,12 +16,14 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Counts how often it is called, offers to call a callback when a certain
  * number is reached.
  */
 public abstract class AbstractHandleFirstNEventsListener extends BaseEventListener implements CountingListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private int targetCount;
     private int count = 0;
     private Object monitor = new Object();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/BaseEventListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/BaseEventListener.java
@@ -23,7 +23,7 @@ import won.bot.framework.eventbot.filter.EventFilter;
  * Base class for event listeners
  */
 public abstract class BaseEventListener implements EventListener {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private EventListenerContext context;
     private int eventCount = 0;
     private int exceptionCount = 0;
@@ -64,9 +64,7 @@ public abstract class BaseEventListener implements EventListener {
             // allow for ignoring events. Such event are not counted.
             return;
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("handling event {} with listener {}", event, this);
-        }
+        logger.debug("handling event {} with listener {}", event, this);
         countEvent(event);
         long startTime = System.currentTimeMillis();
         try {

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/BaseEventListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/BaseEventListener.java
@@ -12,18 +12,19 @@ package won.bot.framework.eventbot.listener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.lifecycle.ErrorEvent;
 import won.bot.framework.eventbot.event.impl.listener.FinishedEvent;
 import won.bot.framework.eventbot.filter.EventFilter;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Base class for event listeners
  */
 public abstract class BaseEventListener implements EventListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private EventListenerContext context;
     private int eventCount = 0;
     private int exceptionCount = 0;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/ActionOnEventListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/ActionOnEventListener.java
@@ -18,12 +18,14 @@ import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Executes a task when an event is seen. If the property timesToRun > 0, will
  * unregister after that number of events.
  */
 public class ActionOnEventListener extends BaseEventListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private EventBotAction task;
     private int timesRun = 0;
     private int timesToRun = -1;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/ActionOnEventListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/ActionOnEventListener.java
@@ -10,6 +10,8 @@
  */
 package won.bot.framework.eventbot.listener.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.EventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -21,6 +23,7 @@ import won.bot.framework.eventbot.listener.BaseEventListener;
  * unregister after that number of events.
  */
 public class ActionOnEventListener extends BaseEventListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private EventBotAction task;
     private int timesRun = 0;
     private int timesToRun = -1;

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMessageResponderListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMessageResponderListener.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
@@ -34,6 +36,7 @@ import won.protocol.util.WonRdfUtils;
  * from events.
  */
 public class AutomaticMessageResponderListener extends AbstractHandleFirstNEventsListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private long millisTimeoutBeforeReply = 1000;
 
     public AutomaticMessageResponderListener(final EventListenerContext context, final int targetNumberOfMessages,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMessageResponderListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMessageResponderListener.java
@@ -10,11 +10,7 @@
  */
 package won.bot.framework.eventbot.listener.impl;
 
-import java.net.URI;
-import java.util.Date;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -29,6 +25,10 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+
 /**
  * Listener that responds to open and message events with automatic messages.
  * Can be configured to apply a timeout (non-blocking) before sending messages.
@@ -36,7 +36,7 @@ import won.protocol.util.WonRdfUtils;
  * from events.
  */
 public class AutomaticMessageResponderListener extends AbstractHandleFirstNEventsListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private long millisTimeoutBeforeReply = 1000;
 
     public AutomaticMessageResponderListener(final EventListenerContext context, final int targetNumberOfMessages,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMonitoredMessageResponderListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMonitoredMessageResponderListener.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.ConnectionSpecificEvent;
 import won.bot.framework.eventbot.event.Event;
@@ -35,6 +37,7 @@ import won.protocol.util.WonRdfUtils;
  * from events.
  */
 public class AutomaticMonitoredMessageResponderListener extends AbstractHandleFirstNEventsListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private long millisTimeoutBeforeReply = 1000;
 
     public AutomaticMonitoredMessageResponderListener(final EventListenerContext context,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMonitoredMessageResponderListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/AutomaticMonitoredMessageResponderListener.java
@@ -10,11 +10,7 @@
  */
 package won.bot.framework.eventbot.listener.impl;
 
-import java.net.URI;
-import java.util.Date;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -30,6 +26,10 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+
 /**
  * Listener that responds to open and message events with automatic messages.
  * Can be configured to apply a timeout (non-blocking) before sending messages.
@@ -37,7 +37,7 @@ import won.protocol.util.WonRdfUtils;
  * from events.
  */
 public class AutomaticMonitoredMessageResponderListener extends AbstractHandleFirstNEventsListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private long millisTimeoutBeforeReply = 1000;
 
     public AutomaticMonitoredMessageResponderListener(final EventListenerContext context,

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/WaitForNEventsListener.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/listener/impl/WaitForNEventsListener.java
@@ -12,17 +12,18 @@ package won.bot.framework.eventbot.listener.impl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.filter.EventFilter;
 import won.bot.framework.eventbot.listener.AbstractDoOnceAfterNEventsListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Listener that waits for N events, then publishes a FinishedEvent.
  */
 public class WaitForNEventsListener extends AbstractDoOnceAfterNEventsListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public WaitForNEventsListener(final EventListenerContext context, final int targetCount) {
         super(context, targetCount);

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/BotManagerImpl.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/BotManagerImpl.java
@@ -18,7 +18,7 @@ import won.bot.framework.manager.BotManager;
  * BotManager, simple in-memory implementation.
  */
 public class BotManagerImpl implements BotManager {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private List<Bot> bots = new LinkedList<Bot>();
     private Map<URI, Bot> botByUri = new HashMap<URI, Bot>();
     private Map<URI, List<Bot>> botListByUri = new HashMap<URI, List<Bot>>();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/BotManagerImpl.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/BotManagerImpl.java
@@ -1,24 +1,19 @@
 package won.bot.framework.manager.impl;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.bot.Bot;
 import won.bot.framework.manager.BotManager;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
 
 /**
  * BotManager, simple in-memory implementation.
  */
 public class BotManagerImpl implements BotManager {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<Bot> bots = new LinkedList<Bot>();
     private Map<URI, Bot> botByUri = new HashMap<URI, Bot>();
     private Map<URI, List<Bot>> botListByUri = new HashMap<URI, List<Bot>>();

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/SpringAwareBotManagerImpl.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/SpringAwareBotManagerImpl.java
@@ -1,9 +1,5 @@
 package won.bot.framework.manager.impl;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -18,8 +14,12 @@ import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
-
 import won.bot.framework.bot.Bot;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Spring context aware bot registry that adds all beans of type Bot defined in
@@ -29,7 +29,7 @@ import won.bot.framework.bot.Bot;
  */
 public class SpringAwareBotManagerImpl extends BotManagerImpl
                 implements ApplicationContextAware, DisposableBean, ApplicationListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private ApplicationContext applicationContext;
     private Trigger checkWorkDoneTrigger = null;
     @Autowired

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/SpringAwareBotManagerImpl.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/manager/impl/SpringAwareBotManagerImpl.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +29,7 @@ import won.bot.framework.bot.Bot;
  */
 public class SpringAwareBotManagerImpl extends BotManagerImpl
                 implements ApplicationContextAware, DisposableBean, ApplicationListener {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private ApplicationContext applicationContext;
     private Trigger checkWorkDoneTrigger = null;
     @Autowired

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/AtomCreatorBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/AtomCreatorBot.java
@@ -16,30 +16,28 @@ import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.impl.MultipleActions;
-import won.bot.framework.eventbot.action.impl.counter.Counter;
-import won.bot.framework.eventbot.action.impl.counter.CounterImpl;
-import won.bot.framework.eventbot.action.impl.counter.DecrementCounterAction;
-import won.bot.framework.eventbot.action.impl.counter.IncrementCounterAction;
-import won.bot.framework.eventbot.action.impl.counter.TargetCounterDecorator;
+import won.bot.framework.eventbot.action.impl.atomlifecycle.CreateAtomWithSocketsAction;
+import won.bot.framework.eventbot.action.impl.counter.*;
 import won.bot.framework.eventbot.action.impl.listener.UnsubscribeListenerAction;
 import won.bot.framework.eventbot.action.impl.monitor.MatchingLoadTestMonitorAction;
-import won.bot.framework.eventbot.action.impl.atomlifecycle.CreateAtomWithSocketsAction;
 import won.bot.framework.eventbot.bus.EventBus;
-import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
-import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
+import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomProducerExhaustedEvent;
+import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  *
  */
 public class AtomCreatorBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected BaseEventListener groupMemberCreator;
     protected BaseEventListener workDoneSignaller;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/AtomCreatorBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/AtomCreatorBot.java
@@ -10,6 +10,8 @@
  */
 package won.bot.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -37,6 +39,7 @@ import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
  *
  */
 public class AtomCreatorBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected BaseEventListener groupMemberCreator;
     protected BaseEventListener workDoneSignaller;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/GroupCycleBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/GroupCycleBot.java
@@ -18,6 +18,8 @@ import java.util.Set;
 
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.bot.context.GroupBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -64,6 +66,7 @@ import won.protocol.util.WonRdfUtils;
  * that the group socket suppresses echos.
  */
 public class GroupCycleBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final int NUMBER_OF_GROUPMEMBERS = 3;
     private final int NUMBER_OF_GROUPS = 10;
     private final ConnectionHolder connectionForFirstMessage = new ConnectionHolder();
@@ -327,6 +330,8 @@ public class GroupCycleBot extends EventBot {
     }
 
     private class ConnectGroupsBehaviour extends BotBehaviour {
+        private final Logger logger = LoggerFactory.getLogger(getClass());
+
         public ConnectGroupsBehaviour(EventListenerContext context) {
             super(context);
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/GroupCycleBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/GroupCycleBot.java
@@ -10,31 +10,19 @@
  */
 package won.bot.impl;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.bot.context.GroupBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
-import won.bot.framework.eventbot.action.impl.counter.CountEvent;
-import won.bot.framework.eventbot.action.impl.counter.CounterImpl;
-import won.bot.framework.eventbot.action.impl.counter.EventPublishingCounter;
-import won.bot.framework.eventbot.action.impl.counter.IncrementCounterAction;
-import won.bot.framework.eventbot.action.impl.counter.TargetCountReachedEvent;
-import won.bot.framework.eventbot.action.impl.counter.TargetCounterDecorator;
+import won.bot.framework.eventbot.action.impl.counter.*;
 import won.bot.framework.eventbot.behaviour.BehaviourBarrier;
 import won.bot.framework.eventbot.behaviour.BotBehaviour;
 import won.bot.framework.eventbot.behaviour.ExecuteWonMessageCommandBehaviour;
-import won.bot.framework.eventbot.event.BaseEvent;
 import won.bot.framework.eventbot.event.BaseAtomSpecificEvent;
+import won.bot.framework.eventbot.event.BaseEvent;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.cmd.CommandEvent;
 import won.bot.framework.eventbot.event.impl.command.connect.ConnectCommandEvent;
@@ -48,8 +36,8 @@ import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEven
 import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.OpenFromOtherAtomEvent;
 import won.bot.framework.eventbot.filter.EventFilter;
-import won.bot.framework.eventbot.filter.impl.CommandResultFilter;
 import won.bot.framework.eventbot.filter.impl.AtomUriEventFilter;
+import won.bot.framework.eventbot.filter.impl.CommandResultFilter;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
@@ -59,6 +47,13 @@ import won.protocol.model.SocketType;
 import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 /**
  * Bot that creates NUMBER_OF_GROUPS groupchats, adds NUMBER_OF_GROUPMEMBERS
  * members to each, links them to each other and sends a message on behalf of
@@ -66,7 +61,7 @@ import won.protocol.util.WonRdfUtils;
  * that the group socket suppresses echos.
  */
 public class GroupCycleBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final int NUMBER_OF_GROUPMEMBERS = 3;
     private final int NUMBER_OF_GROUPS = 10;
     private final ConnectionHolder connectionForFirstMessage = new ConnectionHolder();
@@ -330,8 +325,6 @@ public class GroupCycleBot extends EventBot {
     }
 
     private class ConnectGroupsBehaviour extends BotBehaviour {
-        private final Logger logger = LoggerFactory.getLogger(getClass());
-
         public ConnectGroupsBehaviour(EventListenerContext context) {
             super(context);
         }

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/GroupingBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/GroupingBot.java
@@ -10,35 +10,28 @@
  */
 package won.bot.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.bot.context.GroupBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
-import won.bot.framework.eventbot.action.impl.lifecycle.SignalWorkDoneAction;
 import won.bot.framework.eventbot.action.impl.atomlifecycle.CreateAtomWithSocketsAction;
 import won.bot.framework.eventbot.action.impl.atomlifecycle.DeactivateAllAtomsOfListAction;
+import won.bot.framework.eventbot.action.impl.lifecycle.SignalWorkDoneAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.ConnectFromListToListAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.OpenConnectionAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.RespondToMessageAction;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
+import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
 import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
 import won.bot.framework.eventbot.event.impl.listener.FinishedEvent;
-import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.CloseFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.OpenFromOtherAtomEvent;
-import won.bot.framework.eventbot.filter.impl.AcceptOnceFilter;
-import won.bot.framework.eventbot.filter.impl.FinishedEventFilter;
-import won.bot.framework.eventbot.filter.impl.AtomUriEventFilter;
-import won.bot.framework.eventbot.filter.impl.AtomUriInNamedListFilter;
-import won.bot.framework.eventbot.filter.impl.OrFilter;
+import won.bot.framework.eventbot.filter.impl.*;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
@@ -48,11 +41,15 @@ import won.bot.framework.eventbot.listener.impl.WaitForNEventsListener;
 import won.protocol.model.SocketType;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *
  */
 public class GroupingBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected static final int NO_OF_GROUPMEMBERS = 5;
     protected static final int NO_OF_MESSAGES = 5;
     protected static final long MILLIS_BETWEEN_MESSAGES = 1;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/GroupingBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/GroupingBot.java
@@ -13,6 +13,8 @@ package won.bot.impl;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.bot.context.GroupBotContextWrapper;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -50,6 +52,7 @@ import won.protocol.util.WonRdfUtils;
  *
  */
 public class GroupingBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected static final int NO_OF_GROUPMEMBERS = 5;
     protected static final int NO_OF_MESSAGES = 5;
     protected static final long MILLIS_BETWEEN_MESSAGES = 1;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/HokifyJobBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/HokifyJobBot.java
@@ -3,6 +3,8 @@ package won.bot.impl;
 import java.time.Duration;
 import java.util.ArrayList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -35,6 +37,7 @@ import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
  * created by MS on 17.09.2018
  */
 public class HokifyJobBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String botName;
     private int updateTime;
     private String jsonURL;
@@ -102,7 +105,7 @@ public class HokifyJobBot extends EventBot {
             bus.publish(new StartHokifyFetchEvent());
             bus.publish(new FetchHokifyJobDataEvent());
         } catch (Exception e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
     }
 

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/HokifyJobBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/HokifyJobBot.java
@@ -1,8 +1,5 @@
 package won.bot.impl;
 
-import java.time.Duration;
-import java.util.ArrayList;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
@@ -32,12 +29,16 @@ import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.util.ArrayList;
+
 /**
  * This Bot checks the Hokify jobs and creates and publishes them as atoms
  * created by MS on 17.09.2018
  */
 public class HokifyJobBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String botName;
     private int updateTime;
     private String jsonURL;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/LastSeenAtomsMatcherBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/LastSeenAtomsMatcherBot.java
@@ -10,10 +10,6 @@
  */
 package won.bot.impl;
 
-import java.net.URI;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
@@ -24,8 +20,8 @@ import won.bot.framework.eventbot.action.impl.matcher.RegisterMatcherAction;
 import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
-import won.bot.framework.eventbot.event.impl.matcher.MatcherRegisterFailedEvent;
 import won.bot.framework.eventbot.event.impl.matcher.AtomCreatedEventForMatcher;
+import won.bot.framework.eventbot.event.impl.matcher.MatcherRegisterFailedEvent;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
@@ -35,11 +31,15 @@ import won.protocol.message.WonMessageBuilder;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Bot that connects the two last seen atoms using a hint.
  */
 public class LastSeenAtomsMatcherBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private BaseEventListener matcherRegistrator;
     private BaseEventListener matcherIndexer;
     private int registrationMatcherRetryInterval;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/LastSeenAtomsMatcherBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/LastSeenAtomsMatcherBot.java
@@ -14,6 +14,8 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -37,6 +39,7 @@ import won.protocol.util.WonRdfUtils;
  * Bot that connects the two last seen atoms using a hint.
  */
 public class LastSeenAtomsMatcherBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private BaseEventListener matcherRegistrator;
     private BaseEventListener matcherIndexer;
     private int registrationMatcherRetryInterval;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/RandomSimulatorBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/RandomSimulatorBot.java
@@ -18,24 +18,24 @@ import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.action.impl.MultipleActions;
 import won.bot.framework.eventbot.action.impl.ProbabilisticSelectionAction;
 import won.bot.framework.eventbot.action.impl.RandomDelayedAction;
+import won.bot.framework.eventbot.action.impl.atomlifecycle.CreateAtomWithSocketsAction;
 import won.bot.framework.eventbot.action.impl.counter.Counter;
 import won.bot.framework.eventbot.action.impl.counter.CounterImpl;
 import won.bot.framework.eventbot.action.impl.counter.DecrementCounterAction;
 import won.bot.framework.eventbot.action.impl.counter.IncrementCounterAction;
 import won.bot.framework.eventbot.action.impl.lifecycle.SignalWorkDoneAction;
-import won.bot.framework.eventbot.action.impl.atomlifecycle.CreateAtomWithSocketsAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.CloseConnectionAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.OpenConnectionAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendFeedbackForHintAction;
 import won.bot.framework.eventbot.action.impl.wonmessage.SendMessageAction;
 import won.bot.framework.eventbot.bus.EventBus;
-import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.AtomCreationFailedEvent;
-import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
+import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomCreatedEvent;
 import won.bot.framework.eventbot.event.impl.atomlifecycle.AtomProducerExhaustedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
+import won.bot.framework.eventbot.event.impl.lifecycle.ActEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent;
+import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.OpenFromOtherAtomEvent;
 import won.bot.framework.eventbot.listener.BaseEventListener;
@@ -43,11 +43,13 @@ import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnceAfterNEventsListener;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  *
  */
 public class RandomSimulatorBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final double PROB_OPEN_ON_HINT = 0.3;
     private static final double PROB_MESSAGE_ON_OPEN = 0.5;
     private static final double PROB_MESSAGE_ON_MESSAGE = 0.5;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/RandomSimulatorBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/RandomSimulatorBot.java
@@ -10,6 +10,8 @@
  */
 package won.bot.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
@@ -45,6 +47,7 @@ import won.bot.framework.eventbot.listener.impl.ActionOnceAfterNEventsListener;
  *
  */
 public class RandomSimulatorBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final double PROB_OPEN_ON_HINT = 0.3;
     private static final double PROB_MESSAGE_ON_OPEN = 0.5;
     private static final double PROB_MESSAGE_ON_MESSAGE = 0.5;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Telegram2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Telegram2WonBot.java
@@ -6,16 +6,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.TelegramBotsApi;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
-
 import won.bot.framework.bot.base.EventBot;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.impl.telegram.WonTelegramBotHandler;
 import won.bot.framework.eventbot.action.impl.telegram.receive.TelegramMessageReceivedAction;
-import won.bot.framework.eventbot.action.impl.telegram.send.Connect2TelegramAction;
-import won.bot.framework.eventbot.action.impl.telegram.send.Hint2TelegramAction;
-import won.bot.framework.eventbot.action.impl.telegram.send.Message2TelegramAction;
-import won.bot.framework.eventbot.action.impl.telegram.send.TelegramCreateAction;
-import won.bot.framework.eventbot.action.impl.telegram.send.TelegramHelpAction;
+import won.bot.framework.eventbot.action.impl.telegram.send.*;
 import won.bot.framework.eventbot.action.impl.telegram.util.TelegramContentExtractor;
 import won.bot.framework.eventbot.action.impl.telegram.util.TelegramMessageGenerator;
 import won.bot.framework.eventbot.behaviour.BotBehaviour;
@@ -26,10 +21,12 @@ import won.bot.framework.eventbot.bus.EventBus;
 import won.bot.framework.eventbot.event.impl.telegram.SendHelpEvent;
 import won.bot.framework.eventbot.event.impl.telegram.TelegramCreateAtomEvent;
 import won.bot.framework.eventbot.event.impl.telegram.TelegramMessageReceivedEvent;
-import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.AtomHintFromMatcherEvent;
+import won.bot.framework.eventbot.event.impl.wonmessage.ConnectFromOtherAtomEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.MessageFromOtherAtomEvent;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * This Bot checks the Telegram-Messages sent to a given telegram-bot and
@@ -37,7 +34,7 @@ import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
  * 14.12.2016.
  */
 public class Telegram2WonBot extends EventBot {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String botName;
     private String token;
     private EventBus bus;

--- a/webofneeds/won-bot/src/main/java/won/bot/impl/Telegram2WonBot.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/impl/Telegram2WonBot.java
@@ -1,5 +1,7 @@
 package won.bot.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.TelegramBotsApi;
@@ -35,6 +37,7 @@ import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
  * 14.12.2016.
  */
 public class Telegram2WonBot extends EventBot {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String botName;
     private String token;
     private EventBus bus;

--- a/webofneeds/won-bot/src/main/java/won/bot/integration/BotMatcherProtocolMatcherServiceCallback.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/integration/BotMatcherProtocolMatcherServiceCallback.java
@@ -10,24 +10,24 @@
  */
 package won.bot.integration;
 
-import java.net.URI;
-import java.util.Date;
-import java.util.List;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
-
 import won.bot.framework.bot.Bot;
 import won.bot.framework.manager.BotManager;
 import won.matcher.protocol.MatcherProtocolMatcherServiceCallback;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
 
 /**
  * OwnerProtocolOwnerServiceCallback that dispatches the calls to the bots.
  */
 public class BotMatcherProtocolMatcherServiceCallback implements MatcherProtocolMatcherServiceCallback {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     BotManager botManager;
     TaskScheduler taskScheduler;
 

--- a/webofneeds/won-bot/src/main/java/won/bot/integration/BotOwnerCallback.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/integration/BotOwnerCallback.java
@@ -1,13 +1,9 @@
 package won.bot.integration;
 
-import java.net.URI;
-import java.util.Date;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
-
 import won.bot.exception.NoBotResponsibleException;
 import won.bot.framework.bot.Bot;
 import won.bot.framework.manager.BotManager;
@@ -16,12 +12,16 @@ import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
 import won.protocol.model.Connection;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Date;
+
 /**
  * OwnerProtocolOwnerServiceCallback that dispatches the calls to the bots.
  */
 @Qualifier("default")
 public class BotOwnerCallback implements OwnerCallback {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     BotManager botManager;
     TaskScheduler taskScheduler;
 

--- a/webofneeds/won-bot/src/test/java/won/bot/framework/events/EventBusTests.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/framework/events/EventBusTests.java
@@ -10,24 +10,24 @@
  */
 package won.bot.framework.events;
 
-import java.util.concurrent.CountDownLatch;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
 import won.bot.framework.eventbot.bus.impl.AsyncEventBusImpl;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * User: fkleedorfer Date: 30.01.14
  */
 public class EventBusTests {
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 
     @Before

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
@@ -10,9 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -125,6 +122,7 @@ public class CommentBotTest {
      * information during the run that we later check with asserts.
      */
     public static class MyBot extends CommentBot {
+        private final Logger logger = LoggerFactory.getLogger(getClass());
         /**
          * Used for synchronization with the @TestD method: it should wait at the
          * barrier until our bot is done, then execute the asserts.
@@ -232,7 +230,7 @@ public class CommentBotTest {
                 actualList.add(soln.toString());
                 RDFNode node = soln.get("?connection");
             }
-            assertEquals("wrong number of results", 1, actualList.size());
+            Assert.assertEquals("wrong number of results", 1, actualList.size());
             qExec.close();
         }
 
@@ -250,7 +248,7 @@ public class CommentBotTest {
                 QuerySolution soln = results.nextSolution();
                 actualList.add(soln.toString());
             }
-            assertTrue("wrong number of results", actualList.size() >= 1);
+            Assert.assertTrue("wrong number of results", actualList.size() >= 1);
             // String expected1 = "( ?event = <" + EXAMPLE_ONTOLOGY_URI + "Open_01_1> ) (
             // ?eventType = <" + WON_ONTOLOGY_URI + "Open> )";
             // assertThat(actualList, hasItems(expected1));
@@ -275,7 +273,7 @@ public class CommentBotTest {
             } finally {
                 qExec.close();
             }
-            assertTrue("wrong number of results", actualList.size() >= 1);
+            Assert.assertTrue("wrong number of results", actualList.size() >= 1);
             return commentModel;
         }
 
@@ -307,7 +305,7 @@ public class CommentBotTest {
                 atomConnectionCollectionURI = URI.create(nodeStr);
             }
             qExec.close();
-            assertTrue("wrong number of results", actualList.size() >= 1);
+            Assert.assertTrue("wrong number of results", actualList.size() >= 1);
             Dataset atomConnections = getEventListenerContext().getLinkedDataSource()
                             .getDataForResource(atomConnectionCollectionURI);
             String queryString2 = sparqlPrefix + "SELECT ?connection WHERE {" + "?connections rdfs:member ?connection"
@@ -326,7 +324,7 @@ public class CommentBotTest {
                 atomConnectionURI = URI.create(nodeStr);
             }
             qExec2.close();
-            assertTrue("wrong number of results", actualList2.size() >= 1);
+            Assert.assertTrue("wrong number of results", actualList2.size() >= 1);
             Dataset atomConnection = getEventListenerContext().getLinkedDataSource()
                             .getDataForResource(atomConnectionURI);
             String queryString3 = sparqlPrefix + "SELECT ?targetConnection WHERE {"
@@ -343,7 +341,7 @@ public class CommentBotTest {
                 String nodeStr = node.toString();
                 commentConnectionsURI = URI.create(nodeStr);
             }
-            assertTrue("wrong number of results", actualList3.size() >= 1);
+            Assert.assertTrue("wrong number of results", actualList3.size() >= 1);
             Dataset targetConnections = getEventListenerContext().getLinkedDataSource()
                             .getDataForResource(commentConnectionsURI);
             String queryString4 = sparqlPrefix + "SELECT ?targetConnection WHERE {"
@@ -362,8 +360,8 @@ public class CommentBotTest {
                 atomConnectionURICheck = URI.create(nodeStr);
             }
             qExec4.close();
-            assertTrue("wrong number of results", actualList4.size() >= 1);
-            assertEquals(atomConnectionURI, atomConnectionURICheck);
+            Assert.assertTrue("wrong number of results", actualList4.size() >= 1);
+            Assert.assertEquals(atomConnectionURI, atomConnectionURICheck);
         }
 
         public ResultSet executeQuery(String queryString, Model model) {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/CommentBotTest.java
@@ -10,20 +10,7 @@
  */
 package won.bot.integrationtest;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.vocabulary.RDFS;
@@ -39,7 +26,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import won.bot.PropertyPathConfigurator;
 import won.bot.framework.bot.context.CommentBotContextWrapper;
 import won.bot.framework.eventbot.event.impl.lifecycle.WorkDoneEvent;
@@ -51,13 +37,21 @@ import won.protocol.util.linkeddata.CachingLinkedDataSource;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.vocabulary.WON;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:/spring/app/simpleCommentTest.xml" })
 public class CommentBotTest {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int RUN_ONCE = 1;
     private static final long ACT_LOOP_TIMEOUT_MILLIS = 100;
     private static final long ACT_LOOP_INITIAL_DELAY_MILLIS = 100;
@@ -122,7 +116,6 @@ public class CommentBotTest {
      * information during the run that we later check with asserts.
      */
     public static class MyBot extends CommentBot {
-        private final Logger logger = LoggerFactory.getLogger(getClass());
         /**
          * Used for synchronization with the @TestD method: it should wait at the
          * barrier until our bot is done, then execute the asserts.

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/ConversationBotTest.java
@@ -10,9 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,11 +22,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import won.bot.framework.eventbot.event.impl.lifecycle.WorkDoneEvent;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.manager.impl.SpringAwareBotManagerImpl;
 import won.bot.impl.ConversationBot;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Integration test.
@@ -37,7 +37,7 @@ import won.bot.impl.ConversationBot;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:/spring/app/simple2AtomConversationTest.xml" })
 public class ConversationBotTest {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int RUN_ONCE = 1;
     private static final long ACT_LOOP_TIMEOUT_MILLIS = 100;
     private static final long ACT_LOOP_INITIAL_DELAY_MILLIS = 100;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/GroupingBotTest.java
@@ -10,10 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +22,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import won.bot.framework.eventbot.event.impl.lifecycle.WorkDoneEvent;
 import won.bot.framework.eventbot.listener.BaseEventListener;
 import won.bot.framework.eventbot.listener.CountingListener;
@@ -34,13 +29,18 @@ import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.manager.impl.SpringAwareBotManagerImpl;
 import won.bot.impl.GroupingBot;
 
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Integration test.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:/spring/app/simple2AtomGroupingTest.xml" })
 public class GroupingBotTest {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int RUN_ONCE = 1;
     private static final long ACT_LOOP_TIMEOUT_MILLIS = 100;
     private static final long ACT_LOOP_INITIAL_DELAY_MILLIS = 100;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/MatcherBotTest.java
@@ -10,9 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,11 +22,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import won.bot.framework.eventbot.event.impl.lifecycle.WorkDoneEvent;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.manager.impl.SpringAwareBotManagerImpl;
 import won.bot.impl.MatcherProtocolTestBot;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Integration test.
@@ -37,7 +37,7 @@ import won.bot.impl.MatcherProtocolTestBot;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:/spring/app/simpleMatcherTest.xml" })
 public class MatcherBotTest {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int RUN_ONCE = 1;
     private static final long ACT_LOOP_TIMEOUT_MILLIS = 1000;
     private static final long ACT_LOOP_INITIAL_DELAY_MILLIS = 2000;

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/SecurityBotTests.java
@@ -10,9 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +22,6 @@ import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.concurrent.SettableListenableFuture;
-
 import won.bot.IntegrationtestBot;
 import won.bot.framework.bot.base.TriggeredBot;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -40,9 +36,13 @@ import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnEventListener;
 import won.bot.framework.manager.BotManager;
 import won.bot.integrationtest.security.DelayedDuplicateMessageSendingConversationBot;
+import won.bot.integrationtest.security.DuplicateAtomURIFailureBot;
 import won.bot.integrationtest.security.DuplicateMessageSendingConversationBot;
 import won.bot.integrationtest.security.DuplicateMessageURIFailureBot;
-import won.bot.integrationtest.security.DuplicateAtomURIFailureBot;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Integration test.
@@ -50,7 +50,7 @@ import won.bot.integrationtest.security.DuplicateAtomURIFailureBot;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:/spring/app/securityBotTest.xml" })
 public class SecurityBotTests {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private BotManager botManager;
     @Autowired

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/TripBarrierAction.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/TripBarrierAction.java
@@ -12,6 +12,8 @@ package won.bot.integrationtest;
 
 import java.util.concurrent.CyclicBarrier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
@@ -22,6 +24,7 @@ import won.bot.framework.eventbot.listener.EventListener;
  * with bot execution.
  */
 public class TripBarrierAction extends BaseEventBotAction {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private CyclicBarrier barrier;
 
     public TripBarrierAction(final EventListenerContext eventListenerContext, final CyclicBarrier barrier) {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/TripBarrierAction.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/TripBarrierAction.java
@@ -10,8 +10,6 @@
  */
 package won.bot.integrationtest;
 
-import java.util.concurrent.CyclicBarrier;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.bot.framework.eventbot.EventListenerContext;
@@ -19,12 +17,15 @@ import won.bot.framework.eventbot.action.BaseEventBotAction;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.listener.EventListener;
 
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CyclicBarrier;
+
 /**
  * Action that trips the specified barrier. Used to synchronize test execution
  * with bot execution.
  */
 public class TripBarrierAction extends BaseEventBotAction {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private CyclicBarrier barrier;
 
     public TripBarrierAction(final EventListenerContext eventListenerContext, final CyclicBarrier barrier) {

--- a/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DelayedDuplicateMessageSenderDecorator.java
+++ b/webofneeds/won-bot/src/test/java/won/bot/integrationtest/failsim/DelayedDuplicateMessageSenderDecorator.java
@@ -12,18 +12,19 @@ package won.bot.integrationtest.failsim;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.bot.framework.eventbot.EventListenerContext;
 import won.protocol.message.WonMessage;
 import won.protocol.message.sender.WonMessageSender;
 import won.protocol.message.sender.exception.WonMessageSenderException;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * Decorates the EventListenerContext such that the bot sends each message
  * twice.
  */
 public class DelayedDuplicateMessageSenderDecorator extends BaseEventListenerContextDecorator {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private long delay = 100;
 
     public DelayedDuplicateMessageSenderDecorator(EventListenerContext delegate) {

--- a/webofneeds/won-core/src/main/java/won/cryptography/key/KeyInformationExtractorBouncyCastle.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/key/KeyInformationExtractorBouncyCastle.java
@@ -7,8 +7,6 @@ import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
 
 import org.bouncycastle.jce.spec.ECNamedCurveSpec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import won.cryptography.exception.KeyNotSupportedException;
 
@@ -16,8 +14,6 @@ import won.cryptography.exception.KeyNotSupportedException;
  * User: fsalcher Date: 24.07.2014
  */
 public class KeyInformationExtractorBouncyCastle implements KeyInformationExtractor {
-    private static final Logger logger = LoggerFactory.getLogger(KeyInformationExtractorBouncyCastle.class);
-
     public String getAlgorithm(Key key) {
         return key.getAlgorithm();
     }

--- a/webofneeds/won-core/src/main/java/won/cryptography/keymanagement/KeyPairAliasDerivationStrategyFactory.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/keymanagement/KeyPairAliasDerivationStrategyFactory.java
@@ -13,11 +13,13 @@ package won.cryptography.keymanagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Created by fkleedorfer on 22.03.2017.
  */
 public class KeyPairAliasDerivationStrategyFactory {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String predefinedAlias = null;
 
     public KeyPairAliasDerivationStrategy create() {

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/CertificateOnStartupCreator.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/CertificateOnStartupCreator.java
@@ -1,10 +1,11 @@
 package won.cryptography.service;
 
-import java.io.IOException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * Checks if the node certificate is already present in the specified keystore
@@ -14,7 +15,7 @@ import org.springframework.beans.factory.InitializingBean;
  */
 @Deprecated
 public class CertificateOnStartupCreator implements InitializingBean {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private CryptographyService cryptographyService;
 
     @Override

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/CertificateService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/CertificateService.java
@@ -1,20 +1,5 @@
 package won.cryptography.service;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.KeyPair;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -27,15 +12,22 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.*;
 
 /**
  * User: fsalcher Date: 13.06.2014
  */
 public class CertificateService {
     private static final String PROVIDER_BC = org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public CertificateService() {
     }

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/CryptographyService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/CryptographyService.java
@@ -1,7 +1,15 @@
 package won.cryptography.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import won.cryptography.service.keystore.FileBasedKeyStoreService;
+import won.cryptography.service.keystore.KeyStoreService;
+
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyStoreException;
@@ -12,20 +20,11 @@ import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import won.cryptography.service.keystore.FileBasedKeyStoreService;
-import won.cryptography.service.keystore.KeyStoreService;
-
 /**
  * User: fsalcher Date: 12.06.2014
  */
 public class CryptographyService {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private KeyPairService keyPairService;
     private CertificateService certificateService;
     private KeyStoreService keyStoreService;

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/KeyPairService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/KeyPairService.java
@@ -1,16 +1,16 @@
 package won.cryptography.service;
 
+import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.cryptography.key.KeyInformationExtractor;
+
+import java.lang.invoke.MethodHandles;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.spec.ECGenParameterSpec;
-
-import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.cryptography.key.KeyInformationExtractor;
 
 /**
  * Service responsible for generating key pairs.
@@ -19,7 +19,7 @@ import won.cryptography.key.KeyInformationExtractor;
  * @version 2014-07
  */
 public class KeyPairService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private KeyPairGenerator keyPairGeneratorBrainpoolp384r1 = new KeyPairGeneratorSpi.ECDSA();
     private org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi keyPairGeneratorSecp384r1 = new org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi.ECDSA();
 

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/RegistrationRestClientHttps.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/RegistrationRestClientHttps.java
@@ -1,28 +1,23 @@
 package won.cryptography.service;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-import javax.annotation.PostConstruct;
-
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
-
 import won.cryptography.service.keystore.KeyStoreService;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
 
 /**
  * User: ypanchenko Date: 08.10.2015
  */
 public class RegistrationRestClientHttps implements RegistrationClient {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String registrationQuery;
     private PrivateKeyStrategy privateKeyStrategy;
     private KeyStoreService keyStoreService;

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/TrustStoreService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/TrustStoreService.java
@@ -1,20 +1,20 @@
 package won.cryptography.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.security.KeyStore;
-import java.security.cert.Certificate;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.service.keystore.FileBasedKeyStoreService;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
 
 /**
  * User: ypanchenko Date: 05.08.2015
  */
 public class TrustStoreService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private FileBasedKeyStoreService serviceImpl;
 
     public TrustStoreService(String filePath, String storePW) {

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/keystore/AbstractKeyStoreService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/keystore/AbstractKeyStoreService.java
@@ -1,17 +1,18 @@
 package won.cryptography.service.keystore;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public abstract class AbstractKeyStoreService implements KeyStoreService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String PROVIDER_BC = org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
     private static final String KEY_STORE_TYPE = "UBER";
     // 'UBER' is more secure, 'PKCS12' is supported by all tools, easier for

--- a/webofneeds/won-core/src/main/java/won/cryptography/service/keystore/FileBasedKeyStoreService.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/service/keystore/FileBasedKeyStoreService.java
@@ -1,28 +1,24 @@
 package won.cryptography.service.keystore;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.Element;
-
 /**
  * User: fsalcher Date: 12.06.2014
  */
 public class FileBasedKeyStoreService extends AbstractKeyStoreService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String PROVIDER_BC = org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
     private static final String KEY_STORE_TYPE = "UBER";
     // 'UBER' is more secure, 'PKCS12' is supported by all tools, easier for

--- a/webofneeds/won-core/src/main/java/won/cryptography/ssl/KeyManagerWrapperWithKeyServiceAndStrategy.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/ssl/KeyManagerWrapperWithKeyServiceAndStrategy.java
@@ -1,22 +1,21 @@
 package won.cryptography.ssl;
 
+import org.apache.http.ssl.PrivateKeyDetails;
+import org.apache.http.ssl.PrivateKeyStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.cryptography.service.keystore.KeyStoreService;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import java.lang.invoke.MethodHandles;
 import java.net.Socket;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.X509KeyManager;
-
-import org.apache.http.ssl.PrivateKeyDetails;
-import org.apache.http.ssl.PrivateKeyStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.cryptography.service.keystore.KeyStoreService;
 
 /**
  * User: ypanchenko Date: 12.08.2015 This class is similar to the implementation
@@ -28,7 +27,7 @@ import won.cryptography.service.keystore.KeyStoreService;
  * https://hc.apache.org/httpcomponents-client-4.4.x/httpclient/xref/org/apache/http/conn/ssl/SSLContextBuilder.html
  */
 public class KeyManagerWrapperWithKeyServiceAndStrategy implements X509KeyManager {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final X509KeyManager keyManager;
     private final PrivateKeyStrategy aliasStrategy;
 

--- a/webofneeds/won-core/src/main/java/won/cryptography/ssl/PredefinedAliasPrivateKeyStrategy.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/ssl/PredefinedAliasPrivateKeyStrategy.java
@@ -1,12 +1,13 @@
 package won.cryptography.ssl;
 
-import java.net.Socket;
-import java.util.Map;
-
 import org.apache.http.ssl.PrivateKeyDetails;
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.net.Socket;
+import java.util.Map;
 
 /**
  * When the server requests a certificate, and if it does not specify which one
@@ -20,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * 27.07.2015
  */
 public class PredefinedAliasPrivateKeyStrategy implements PrivateKeyStrategy {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String alias;
 
     public PredefinedAliasPrivateKeyStrategy(String alias) {

--- a/webofneeds/won-core/src/main/java/won/cryptography/ssl/TOFUStrategy.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/ssl/TOFUStrategy.java
@@ -1,13 +1,13 @@
 package won.cryptography.ssl;
 
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.service.TrustStoreService;
+
+import java.lang.invoke.MethodHandles;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 /**
  * Trust on first use strategy: if certificate is already known and trusted
@@ -22,7 +22,7 @@ import won.cryptography.service.TrustStoreService;
 public class TOFUStrategy implements TrustStrategy {
     private TrustStoreService trustStoreService;
     private AliasGenerator aliasGenerator = new AliasFromFingerprintGenerator();
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void setTrustStoreService(TrustStoreService trustStoreService) {
         this.trustStoreService = trustStoreService;

--- a/webofneeds/won-core/src/main/java/won/cryptography/ssl/TOLUStrategy.java
+++ b/webofneeds/won-core/src/main/java/won/cryptography/ssl/TOLUStrategy.java
@@ -1,13 +1,13 @@
 package won.cryptography.ssl;
 
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.service.TrustStoreService;
+
+import java.lang.invoke.MethodHandles;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 /**
  * Can be useful for development: a certificate will become trusted after
@@ -18,7 +18,7 @@ import won.cryptography.service.TrustStoreService;
 public class TOLUStrategy implements TrustStrategy {
     private TrustStoreService trustStoreService;
     private AliasGenerator aliasGenerator;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void setTrustStoreService(TrustStoreService trustStoreService) {
         this.trustStoreService = trustStoreService;

--- a/webofneeds/won-core/src/main/java/won/db/FlywayWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/db/FlywayWrapper.java
@@ -1,18 +1,19 @@
 package won.db;
 
-import javax.sql.DataSource;
-
 import org.flywaydb.core.Flyway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+
+import javax.sql.DataSource;
+import java.lang.invoke.MethodHandles;
 
 /**
  * This Bean is used to determine whether or not an update/validation of the ddl
  * is done via flywaydb.
  */
 public class FlywayWrapper implements InitializingBean {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String ddlStrategy = "";
     private DataSource dataSource;
 

--- a/webofneeds/won-core/src/main/java/won/db/FlywayWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/db/FlywayWrapper.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.InitializingBean;
  * is done via flywaydb.
  */
 public class FlywayWrapper implements InitializingBean {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String ddlStrategy = "";
     private DataSource dataSource;
 

--- a/webofneeds/won-core/src/main/java/won/monitoring/AbstractFileOutputRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/AbstractFileOutputRecorder.java
@@ -12,6 +12,7 @@ package won.monitoring;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -26,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractFileOutputRecorder extends AbstractRecorder {
     private static final String TEMPDIR_PREFIX = "monitoringStatsCSV";
-    private static final Logger logger = LoggerFactory.getLogger(AbstractFileOutputRecorder.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private File outputDirectory;
     /**
      * DateFormat pattern for creating the filename for the date it is written.

--- a/webofneeds/won-core/src/main/java/won/monitoring/AbstractFileOutputRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/AbstractFileOutputRecorder.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractFileOutputRecorder extends AbstractRecorder {
     private static final String TEMPDIR_PREFIX = "monitoringStatsCSV";
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(AbstractFileOutputRecorder.class);
     private File outputDirectory;
     /**
      * DateFormat pattern for creating the filename for the date it is written.

--- a/webofneeds/won-core/src/main/java/won/monitoring/AbstractRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/AbstractRecorder.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * Simple base class for recorders.
  */
 public abstract class AbstractRecorder implements MonitoringStatisticsRecorder {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private String recorderName;
 
     protected AbstractRecorder() {

--- a/webofneeds/won-core/src/main/java/won/monitoring/MonitoringStatisticsRecorderTask.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/MonitoringStatisticsRecorderTask.java
@@ -10,17 +10,18 @@
  */
 package won.monitoring;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
 
 /**
  * Task intended to be scheduled regularly. In each execution it triggers all
  * MonitoringStatisticsRecorders it has been provided.
  */
 public class MonitoringStatisticsRecorderTask implements Runnable {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<MonitoringStatisticsRecorder> monitoringStatisticsRecorders;
     private boolean resetMonitorAfterRecording;
     private MonitoringResetter monitoringResetter;

--- a/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonCsvStatisticsRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonCsvStatisticsRecorder.java
@@ -19,6 +19,8 @@ import org.javasimon.Sample;
 import org.javasimon.Simon;
 import org.javasimon.SimonManager;
 import org.javasimon.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.supercsv.cellprocessor.Optional;
 import org.supercsv.cellprocessor.constraint.NotNull;
 import org.supercsv.cellprocessor.ift.CellProcessor;
@@ -32,6 +34,8 @@ import won.monitoring.AbstractFileOutputRecorder;
  * Recorder that writes the Simon stats to a csv file.
  */
 public class SimonCsvStatisticsRecorder extends AbstractFileOutputRecorder {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     /**
      * Sets up the processors used.
      * 

--- a/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonCsvStatisticsRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonCsvStatisticsRecorder.java
@@ -10,11 +10,6 @@
  */
 package won.monitoring.simon;
 
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.javasimon.Sample;
 import org.javasimon.Simon;
 import org.javasimon.SimonManager;
@@ -27,14 +22,19 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.CsvMapWriter;
 import org.supercsv.io.ICsvMapWriter;
 import org.supercsv.prefs.CsvPreference;
-
 import won.monitoring.AbstractFileOutputRecorder;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Recorder that writes the Simon stats to a csv file.
  */
 public class SimonCsvStatisticsRecorder extends AbstractFileOutputRecorder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Sets up the processors used.

--- a/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonResetter.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonResetter.java
@@ -14,14 +14,15 @@ import org.javasimon.SimonManager;
 import org.javasimon.utils.SimonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.monitoring.MonitoringResetter;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * Resetter for the Simon monitoring framework.
  */
 public class SimonResetter implements MonitoringResetter {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void resetMonitoringStatistics() {

--- a/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonSysoutStatisticsRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonSysoutStatisticsRecorder.java
@@ -13,17 +13,18 @@ package won.monitoring.simon;
 import org.javasimon.Simon;
 import org.javasimon.SimonManager;
 import org.javasimon.utils.SimonUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.monitoring.AbstractRecorder;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * MonitoringStatisticsRecorder that prints the statistics via the logger with
  * loglevel 'debug'.
  */
 public class SimonSysoutStatisticsRecorder extends AbstractRecorder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void recordMonitoringStatistics() {

--- a/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonSysoutStatisticsRecorder.java
+++ b/webofneeds/won-core/src/main/java/won/monitoring/simon/SimonSysoutStatisticsRecorder.java
@@ -14,6 +14,8 @@ import org.javasimon.Simon;
 import org.javasimon.SimonManager;
 import org.javasimon.utils.SimonUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.monitoring.AbstractRecorder;
 
 /**
@@ -21,10 +23,12 @@ import won.monitoring.AbstractRecorder;
  * loglevel 'debug'.
  */
 public class SimonSysoutStatisticsRecorder extends AbstractRecorder {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void recordMonitoringStatistics() {
-        Simon rootSimon = SimonManager.getRootSimon();
         if (logger.isDebugEnabled()) {
+            Simon rootSimon = SimonManager.getRootSimon();
             logger.debug("Monitoring statistics: \n" + SimonUtils.simonTreeString(rootSimon));
         }
     }

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/ActiveMQServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/ActiveMQServiceImpl.java
@@ -10,11 +10,6 @@
  */
 package won.protocol.jms;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.path.Path;
@@ -25,18 +20,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
-
 import won.protocol.model.ProtocolType;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WON;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * User: sbyim Date: 28.11.13
  */
 public class ActiveMQServiceImpl implements ActiveMQService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String PATH_OWNER_PROTOCOL_QUEUE_NAME = "<" + WON.supportsWonProtocolImpl + ">/<"
                     + WON.ownerQueue + ">";
     private static final String PATH_ATOM_PROTOCOL_QUEUE_NAME = "<" + WON.supportsWonProtocolImpl + ">/<"

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/AtomBasedCamelConfiguratorImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/AtomBasedCamelConfiguratorImpl.java
@@ -10,21 +10,20 @@
  */
 package won.protocol.jms;
 
-import java.net.URI;
-
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-
 import won.cryptography.ssl.MessagingContext;
 import won.protocol.exception.CamelConfigurationFailedException;
 import won.protocol.model.MessagingType;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 // import won.node.camel.routes.AtomProtocolDynamicRoutes;
 /**
@@ -42,7 +41,7 @@ public abstract class AtomBasedCamelConfiguratorImpl implements AtomProtocolCame
     private MessagingContext messagingContext;
     @Autowired
     protected BrokerComponentFactory brokerComponentFactory;
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized String configureCamelEndpointForAtomUri(URI wonNodeURI, URI brokerUri,

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/MatcherActiveMQServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/MatcherActiveMQServiceImpl.java
@@ -10,29 +10,25 @@
  */
 package won.protocol.jms;
 
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathParser;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import won.protocol.model.ProtocolType;
+import won.protocol.util.RdfUtils;
+import won.protocol.vocabulary.WON;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jena.shared.PrefixMapping;
-import org.apache.jena.sparql.path.Path;
-import org.apache.jena.sparql.path.PathParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
-
-import won.protocol.model.ProtocolType;
-import won.protocol.util.RdfUtils;
-import won.protocol.vocabulary.WON;
-
 /**
  * User: sbyim Date: 28.11.13
  */
 public class MatcherActiveMQServiceImpl extends ActiveMQServiceImpl implements MatcherActiveMQService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private List<String> matcherProtocolTopicList;
     private String pathInformation;
     private static final String PATH_MATCHER_PROTOCOL_OUT_ATOM_CREATED = "<" + WON.supportsWonProtocolImpl + ">/<"

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/MessagingServiceImpl.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/MessagingServiceImpl.java
@@ -1,14 +1,8 @@
 package won.protocol.jms;
 
-import java.util.Iterator;
-import java.util.Map;
-
-import org.apache.camel.CamelContext;
-import org.apache.camel.CamelContextAware;
-import org.apache.camel.Endpoint;
-import org.apache.camel.Exchange;
-import org.apache.camel.ExchangePattern;
-import org.apache.camel.ProducerTemplate;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.camel.*;
 import org.apache.camel.impl.DefaultExchange;
 import org.apache.camel.spi.Synchronization;
 import org.slf4j.Logger;
@@ -17,8 +11,9 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
+import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * User: LEIH-NB Date: 04.11.13
@@ -27,7 +22,7 @@ public class MessagingServiceImpl<T> implements ApplicationContextAware, Messagi
     private static final long DEFAULT_JMS_EXPIRATION_TIME = 0;
     private CamelContext camelContext;
     private ProducerTemplate producerTemplate;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private ApplicationContext applicationContext;
 
     /**

--- a/webofneeds/won-core/src/main/java/won/protocol/jms/WonJmsConfiguration.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/WonJmsConfiguration.java
@@ -1,16 +1,17 @@
 package won.protocol.jms;
 
-import javax.jms.ConnectionFactory;
-
 import org.apache.camel.component.jms.JmsConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jms.ConnectionFactory;
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: LEIH-NB Date: 28.04.14
  */
 public class WonJmsConfiguration extends JmsConfiguration {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public WonJmsConfiguration(ConnectionFactory connectionFactory) {
         super(connectionFactory);

--- a/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageDecoder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/WonMessageDecoder.java
@@ -1,6 +1,7 @@
 package won.protocol.message;
 
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
@@ -13,7 +14,7 @@ import org.slf4j.LoggerFactory;
  * User: ypanchenko Date: 04.08.2014
  */
 public class WonMessageDecoder {
-    private static final Logger logger = LoggerFactory.getLogger(WonMessageDecoder.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static WonMessage decodeFromJsonLd(String message) {
         return decode(Lang.JSONLD, message);

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/camel/WonMessageProcessorCamelAdapter.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/camel/WonMessageProcessorCamelAdapter.java
@@ -14,9 +14,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * Adapts a WonMessageProcessor to act as a camel processor. The WonMessage
@@ -25,7 +26,7 @@ import won.protocol.message.processor.WonMessageProcessor;
  * object replaces the original one.
  */
 public class WonMessageProcessorCamelAdapter implements Processor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static String WON_MESSAGE_HEADER = "wonMessage";
     private WonMessageProcessor adaptee;
 

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/UriConsistencyCheckingWonMessageProcessor.java
@@ -1,11 +1,6 @@
 package won.protocol.message.processor.impl;
 
-import java.net.URI;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
 import won.protocol.message.WonMessageType;
@@ -16,6 +11,8 @@ import won.protocol.service.WonNodeInfo;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.WonRdfUtils;
 
+import java.net.URI;
+
 /**
  * Checks if the event, graph or atom uri is well-formed according the node's
  * domain and its path conventions. Used on incoming messages. User: ypanchenko
@@ -24,7 +21,6 @@ import won.protocol.util.WonRdfUtils;
 public class UriConsistencyCheckingWonMessageProcessor implements WonMessageProcessor {
     @Autowired
     protected WonNodeInformationService wonNodeInformationService;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public WonMessage process(final WonMessage message) throws UriAlreadyInUseException {

--- a/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/WellformednessCheckingWonMessageProcessor.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/message/processor/impl/WellformednessCheckingWonMessageProcessor.java
@@ -14,13 +14,14 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageNotWellFormedException;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.util.RdfUtils;
 import won.protocol.validation.WonMessageValidator;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * Checks WonMessages for integrity. The following steps are performed:
@@ -34,7 +35,7 @@ import won.protocol.validation.WonMessageValidator;
  * </pre>
  */
 public class WellformednessCheckingWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     WonMessageValidator validator = new WonMessageValidator();
 
     @Override

--- a/webofneeds/won-core/src/main/java/won/protocol/model/AtomState.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/AtomState.java
@@ -10,6 +10,7 @@
  */
 package won.protocol.model;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -22,7 +23,7 @@ import won.protocol.vocabulary.WON;
  */
 public enum AtomState {
     INACTIVE("Inactive"), ACTIVE("Active"), DELETED("Deleted");
-    private static final Logger logger = LoggerFactory.getLogger(AtomState.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String name;
 
     private AtomState(String name) {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionState.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/ConnectionState.java
@@ -10,6 +10,7 @@
  */
 package won.protocol.model;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ import won.protocol.vocabulary.WON;
 public enum ConnectionState {
     SUGGESTED("Suggested"), REQUEST_SENT("RequestSent"), REQUEST_RECEIVED("RequestReceived"), CONNECTED("Connected"),
     CLOSED("Closed"), DELETED("Deleted");
-    private static final Logger logger = LoggerFactory.getLogger(ConnectionState.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String name;
 
     private ConnectionState(String name) {

--- a/webofneeds/won-core/src/main/java/won/protocol/model/DatasetHolder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/DatasetHolder.java
@@ -10,22 +10,6 @@
  */
 package won.protocol.model;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.net.URI;
-
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.PrePersist;
-import javax.persistence.PreUpdate;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.riot.Lang;
@@ -33,6 +17,13 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RiotException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.persistence.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Encapsulates a jena dataset for storing it in a relational db.
@@ -49,7 +40,7 @@ public class DatasetHolder {
     @Column(name = "version", columnDefinition = "integer DEFAULT 0", nullable = false)
     private int version = 0;
     @Transient
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Column(name = "datasetURI", unique = true)
     @Convert(converter = URIConverter.class)
     private URI uri;

--- a/webofneeds/won-core/src/main/java/won/protocol/model/DatasetHolderAggregator.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/DatasetHolderAggregator.java
@@ -10,13 +10,6 @@
  */
 package won.protocol.model;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.SequenceInputStream;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.riot.Lang;
@@ -25,6 +18,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StopWatch;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * Aggregates the datasets wrapped by a number of dataset holders. As soon as
  * the aggregate() function is called, all datasetHolders added so far are read
@@ -32,7 +33,7 @@ import org.springframework.util.StopWatch;
  * All subsequent calls to aggregate just yield the already aggregated dataset.
  */
 public class DatasetHolderAggregator {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<InputStream> inputStreams = null;
     private Lang rdfLanguage = null;
     private static final Lang DEFAULT_RDF_LANGUAGE = Lang.NQUADS;

--- a/webofneeds/won-core/src/main/java/won/protocol/model/ModelHolder.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/ModelHolder.java
@@ -10,25 +10,19 @@
  */
 package won.protocol.model;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.net.URI;
-
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.persistence.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Encapsulates a jena model for storing it in a relational db.
@@ -38,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class ModelHolder {
     private static final int DEFAULT_BYTE_ARRAY_SIZE = 500;
     @Transient
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // the URI of the model
     @Id
     @Column(name = "modelURI", unique = true)

--- a/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwareEventListenerIntegrator.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwareEventListenerIntegrator.java
@@ -19,13 +19,15 @@ import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Integrator for hibernate to allow listening to entity changes and update
  * parent entity versions. Modeled after this example:
  * https://vladmihalcea.com/2016/08/30/how-to-increment-the-parent-entity-version-whenever-a-child-entity-gets-modified-with-jpa-and-hibernate/
  */
 public class ParentAwareEventListenerIntegrator implements Integrator {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public ParentAwareEventListenerIntegrator() {
     }

--- a/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwareFlushEventListener.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwareFlushEventListener.java
@@ -22,8 +22,10 @@ import org.hibernate.proxy.HibernateProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
 public class ParentAwareFlushEventListener implements FlushEntityEventListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final ParentAwareFlushEventListener INSTANCE = new ParentAwareFlushEventListener();
 
     @Override

--- a/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwarePersistEventListener.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/model/parentaware/ParentAwarePersistEventListener.java
@@ -10,8 +10,6 @@
  */
 package won.protocol.model.parentaware;
 
-import java.util.Map;
-
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.PersistEvent;
@@ -20,8 +18,11 @@ import org.hibernate.proxy.HibernateProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+
 public class ParentAwarePersistEventListener implements PersistEventListener {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final ParentAwarePersistEventListener INSTANCE = new ParentAwarePersistEventListener();
 
     @Override

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestBridge.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestBridge.java
@@ -1,26 +1,26 @@
 package won.protocol.rest;
 
-import javax.annotation.PostConstruct;
-
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
-
-import won.cryptography.keymanagement.KeyPairAliasDerivationStrategy;
 import won.cryptography.keymanagement.AtomUriAsAliasStrategy;
+import won.cryptography.keymanagement.KeyPairAliasDerivationStrategy;
 import won.cryptography.service.CryptographyUtils;
 import won.cryptography.service.TrustStoreService;
 import won.cryptography.service.keystore.KeyStoreService;
 import won.cryptography.ssl.PredefinedAliasPrivateKeyStrategy;
 
+import javax.annotation.PostConstruct;
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: ypanchenko Date: 02.02.2016
  */
 public class LinkedDataRestBridge {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private RestTemplate restTemplateWithDefaultWebId;
     private Integer readTimeout;
     private Integer connectionTimeout;

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -10,9 +10,6 @@
  */
 package won.protocol.rest;
 
-import java.net.URI;
-import java.text.MessageFormat;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +22,12 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.text.MessageFormat;
+
 public abstract class LinkedDataRestClient {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Retrieves RDF for the specified resource URI. Expects that the resource URI

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClientHttps.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClientHttps.java
@@ -10,10 +10,6 @@
  */
 package won.protocol.rest;
 
-import java.net.URI;
-
-import javax.annotation.PostConstruct;
-
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,19 +17,22 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
-
-import won.cryptography.keymanagement.KeyPairAliasDerivationStrategy;
 import won.cryptography.keymanagement.AtomUriAsAliasStrategy;
+import won.cryptography.keymanagement.KeyPairAliasDerivationStrategy;
 import won.cryptography.service.CryptographyUtils;
 import won.cryptography.service.TrustStoreService;
 import won.cryptography.service.keystore.KeyStoreService;
 import won.cryptography.ssl.PredefinedAliasPrivateKeyStrategy;
 
+import javax.annotation.PostConstruct;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: ypanchenko Date: 07.10.15
  */
 public class LinkedDataRestClientHttps extends LinkedDataRestClient {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private HttpMessageConverter datasetConverter;
     String acceptHeaderValue = null;
     private Integer readTimeout;

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/RdfDatasetAttachmentConverter.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/RdfDatasetAttachmentConverter.java
@@ -10,8 +10,6 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.Property;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -28,7 +26,6 @@ import won.protocol.vocabulary.WONMSG;
  * User: fsalcher Date: 15.09.2014
  */
 public class RdfDatasetAttachmentConverter extends AbstractHttpMessageConverter<Dataset> {
-    private static final Logger logger = LoggerFactory.getLogger(RdfDatasetAttachmentConverter.class);
     private static final MediaType[] supportedMediaTypes = { MediaType.ALL // we can do this because we have placed a
                                                                            // hack
                                                                            // in the LinkedDataWebController that

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/RdfDatasetConverter.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/RdfDatasetConverter.java
@@ -1,6 +1,7 @@
 package won.protocol.rest;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.List;
 
@@ -11,7 +12,6 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.RDFLanguages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -32,7 +32,7 @@ import won.protocol.util.RdfUtils;
  * </p>
  */
 public class RdfDatasetConverter extends AbstractHttpMessageConverter<Dataset> {
-    private static final Logger logger = LoggerFactory.getLogger(RdfDatasetConverter.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final MediaType[] supportedMediaTypes = {
                     RDFMediaType.APPLICATION_TRIG,
                     RDFMediaType.APPLICATION_NQUADS,

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/RdfModelConverter.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/RdfModelConverter.java
@@ -11,6 +11,7 @@
 package won.protocol.rest;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -38,7 +39,7 @@ import org.springframework.http.converter.HttpMessageNotWritableException;
  * formats jena supports, plus JSON-LD
  */
 public class RdfModelConverter extends AbstractHttpMessageConverter<Model> {
-    private static final Logger logger = LoggerFactory.getLogger(RdfModelConverter.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public RdfModelConverter() {
         this(buildMediaTypeArray());
@@ -84,7 +85,7 @@ public class RdfModelConverter extends AbstractHttpMessageConverter<Model> {
     private static MediaType[] buildMediaTypeArray() {
         // now register the media types this converter can handle
         Collection<Lang> languages = RDFLanguages.getRegisteredLanguages();
-        Set<MediaType> mediaTypeSet = new HashSet<MediaType>();
+        Set<MediaType> mediaTypeSet = new HashSet<>();
         for (Lang lang : languages) {
             if (datasetWriterExistsForLang(lang)) {
                 ContentType ct = lang.getContentType();
@@ -93,7 +94,7 @@ public class RdfModelConverter extends AbstractHttpMessageConverter<Model> {
                 mediaTypeSet.add(mt);
             }
         }
-        return mediaTypeSet.toArray(new MediaType[mediaTypeSet.size()]);
+        return mediaTypeSet.toArray(new MediaType[0]);
     }
 
     private static boolean datasetWriterExistsForLang(Lang lang) {

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/WonEtagHelper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/WonEtagHelper.java
@@ -10,6 +10,7 @@
  */
 package won.protocol.rest;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ import org.springframework.http.MediaType;
  * Utils for our very specific way of creating/parsing etags.
  */
 public class WonEtagHelper {
-    private static final Logger logger = LoggerFactory.getLogger(WonEtagHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final char VERSION_MEDIATYPE_DELIMITER = ' ';
     private String version = null;
     private MediaType mediaType = null;

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/WonEtagHelper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/WonEtagHelper.java
@@ -12,8 +12,8 @@ package won.protocol.rest;
 
 import java.util.List;
 
-import org.hibernate.annotations.common.util.impl.LoggerFactory;
-import org.jboss.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -21,7 +21,7 @@ import org.springframework.http.MediaType;
  * Utils for our very specific way of creating/parsing etags.
  */
 public class WonEtagHelper {
-    private static final Logger logger = LoggerFactory.logger(WonEtagHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(WonEtagHelper.class);
     private static final char VERSION_MEDIATYPE_DELIMITER = ' ';
     private String version = null;
     private MediaType mediaType = null;

--- a/webofneeds/won-core/src/main/java/won/protocol/util/DateTimeUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/DateTimeUtils.java
@@ -9,14 +9,11 @@ import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * User: atus Date: 23.04.13
  */
 public class DateTimeUtils {
-    private static final Logger logger = LoggerFactory.getLogger(DateTimeUtils.class);
     private static SimpleDateFormat sdf;
     private static final String DATE_FORMAT_XSD_DATE_TIME_STAMP = "yyyy-MM-DD'T'hh:mm:ss.sssZ";
 

--- a/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -23,8 +24,6 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -74,7 +73,7 @@ import won.protocol.exception.IncorrectPropertyCountException;
 public class RdfUtils {
     public static final RDFNode EMPTY_RDF_NODE = null;
     private static final CheapInsecureRandomString randomString = new CheapInsecureRandomString();
-    private static final Logger logger = LoggerFactory.getLogger(RdfUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static String toString(Model model) {
         String ret = "";
@@ -224,10 +223,7 @@ public class RdfUtils {
             if (!dataset.containsNamedModel(name)) {
                 // treat empty named graphs same as non-existent ones: check if the named graph
                 // in the otherDataset is empty
-                if (otherDataset.getNamedModel(name).isEmpty()) {
-                    return true;
-                }
-                return false;
+                return otherDataset.getNamedModel(name).isEmpty();
             }
         }
         return true;
@@ -260,7 +256,7 @@ public class RdfUtils {
             cloneSecond = cloneModel(secondModel);
         }
         if (firstModel == null || secondModel == null) {
-            return new Pair<Model>(cloneFirst, cloneSecond);
+            return new Pair<>(cloneFirst, cloneSecond);
         }
         // both models are non-null:
         // remove all statements from clones that exist in the other one, too (excluding
@@ -313,7 +309,7 @@ public class RdfUtils {
                 cloneFirst.remove(stmt);
             }
         }
-        return new Pair<Model>(cloneFirst, cloneSecond);
+        return new Pair<>(cloneFirst, cloneSecond);
     }
 
     public static Pair<Dataset> diff(Dataset firstDataset, Dataset secondDataset) {
@@ -346,7 +342,7 @@ public class RdfUtils {
                 secondResultDataset.addNamedModel(name, cloneModel(secondDataset.getNamedModel(name)));
             }
         }
-        return new Pair<Dataset>(firstResultDataset, secondResultDataset);
+        return new Pair<>(firstResultDataset, secondResultDataset);
     }
 
     public static class Pair<E> {
@@ -688,7 +684,7 @@ public class RdfUtils {
 
     public static Set<URI> getGraphUris(Dataset dataset) {
         Iterator<String> urisIterator = dataset.listNames();
-        Set<URI> uris = new HashSet<URI>();
+        Set<URI> uris = new HashSet<>();
         while (urisIterator.hasNext()) {
             uris.add(URI.create(urisIterator.next()));
         }
@@ -770,7 +766,7 @@ public class RdfUtils {
      */
     public static Map<String, String> mergeNsPrefixes(final Map<String, String> prioritaryPrefixes,
                     final Map<String, String> additionalPrefixes) {
-        Map<String, String> mergedPrefixes = new HashMap<String, String>();
+        Map<String, String> mergedPrefixes = new HashMap<>();
         mergedPrefixes.putAll(additionalPrefixes);
         mergedPrefixes.putAll(prioritaryPrefixes); // overwrites the additional prefixes when clashing
         return mergedPrefixes;
@@ -1141,9 +1137,8 @@ public class RdfUtils {
      * @return
      */
     public static Iterator<Node> getNodesForPropertyPath(final Model model, URI resourceURI, Path propertyPath) {
-        Iterator<Node> result = PathEval.eval(model.getGraph(), model.getResource(resourceURI.toString()).asNode(),
+        return PathEval.eval(model.getGraph(), model.getResource(resourceURI.toString()).asNode(),
                         propertyPath, Context.emptyContext);
-        return result;
     }
 
     /**
@@ -1233,7 +1228,7 @@ public class RdfUtils {
                     return Collections.emptyList();
                 }
                 NodeIterator it = model.listObjectsOfProperty(res, model.createProperty(property.toString()));
-                List<T> ret = new ArrayList<T>();
+                List<T> ret = new ArrayList<>();
                 while (it.hasNext()) {
                     RDFNode node = it.next();
                     ret.add(resultMapper.apply(node));
@@ -1351,7 +1346,7 @@ public class RdfUtils {
     }
 
     public static Stream<Statement> toStatementStream(final Dataset dataset, final ModelSelector modelSelector) {
-        List<Statement> results = new LinkedList<Statement>();
+        List<Statement> results = new LinkedList<>();
         for (Iterator<Model> modelIterator = modelSelector.select(dataset); modelIterator.hasNext();) {
             Model m = modelIterator.next();
             for (StmtIterator stmtIt = m.listStatements(); stmtIt.hasNext();) {
@@ -1362,7 +1357,7 @@ public class RdfUtils {
     }
 
     public static Stream<Statement> toStatementStream(final Model model) {
-        List<Statement> results = new LinkedList<Statement>();
+        List<Statement> results = new LinkedList<>();
         for (StmtIterator stmtIt = model.listStatements(); stmtIt.hasNext();) {
             results.add(stmtIt.next());
         }
@@ -1370,7 +1365,7 @@ public class RdfUtils {
     }
 
     public static Stream<Model> toModelStream(final Dataset dataset) {
-        List<Model> ret = new LinkedList<Model>();
+        List<Model> ret = new LinkedList<>();
         Model model = dataset.getDefaultModel();
         if (model != null) {
             ret.add(model);
@@ -1382,7 +1377,7 @@ public class RdfUtils {
     }
 
     public static Stream<NamedModel> toNamedModelStream(final Dataset dataset, boolean includeDefaultModel) {
-        List<NamedModel> ret = new LinkedList<NamedModel>();
+        List<NamedModel> ret = new LinkedList<>();
         if (includeDefaultModel) {
             Model model = dataset.getDefaultModel();
             if (model != null) {
@@ -1438,7 +1433,7 @@ public class RdfUtils {
      * @return
      */
     public static <T> Iterator<T> visit(Dataset dataset, ModelVisitor<T> visitor, ModelSelector modelSelector) {
-        List<T> results = new LinkedList<T>();
+        List<T> results = new LinkedList<>();
         for (Iterator<Model> modelIterator = modelSelector.select(dataset); modelIterator.hasNext();) {
             results.add(visitor.visit(modelIterator.next()));
         }
@@ -1461,7 +1456,7 @@ public class RdfUtils {
      */
     public static <E, T extends Collection<E>> List<E> visitFlattenedToList(Dataset dataset, ModelVisitor<T> visitor,
                     ModelSelector modelSelector) {
-        List<E> results = new ArrayList<E>();
+        List<E> results = new ArrayList<>();
         for (Iterator<Model> modelIterator = modelSelector.select(dataset); modelIterator.hasNext();) {
             results.addAll(visitor.visit(modelIterator.next()));
         }
@@ -1511,7 +1506,7 @@ public class RdfUtils {
      * @return
      */
     public static <T> T findFirst(Dataset dataset, ModelVisitor<T> visitor, ModelSelector modelSelector) {
-        List<T> results = new LinkedList<T>();
+        List<T> results = new LinkedList<>();
         for (Iterator<Model> modelIterator = modelSelector.select(dataset); modelIterator.hasNext();) {
             T result = visitor.visit(modelIterator.next());
             if (result != null)
@@ -1699,7 +1694,7 @@ public class RdfUtils {
 
     public static RDFNode findOnePropertyFromResource(final Model model, final Resource resource,
                     final Property property) {
-        List<RDFNode> foundNodes = new ArrayList<RDFNode>();
+        List<RDFNode> foundNodes = new ArrayList<>();
         NodeIterator iterator = model.listObjectsOfProperty(resource, property);
         while (iterator.hasNext()) {
             foundNodes.add(iterator.next());
@@ -1887,22 +1882,22 @@ public class RdfUtils {
             if (uri == null) { // if no such prefix-uri yet, add it
                 toModel.setNsPrefix(prefix, fromModel.getNsPrefixURI(prefix));
             } else {
-                if (uri.equals(fromModel.getNsPrefixURI(prefix))) {
-                    // prefix-uri is already there, do nothing
-                } else {
+                if (!uri.equals(fromModel.getNsPrefixURI(prefix))) {
                     // prefix-uri collision, redefine prefix
                     int counter = 2;
                     while (!toModel.getNsPrefixMap().containsKey(prefix + counter)) {
                         counter++;
                     }
                     toModel.setNsPrefix(prefix + counter, fromModel.getNsPrefixURI(prefix));
-                }
+                } /*else {
+                    // prefix-uri is already there, do nothing
+                }*/
             }
         }
     }
 
     public static List<String> getModelNames(Dataset dataset) {
-        List<String> modelNames = new ArrayList<String>();
+        List<String> modelNames = new ArrayList<>();
         Iterator<String> names = dataset.listNames();
         while (names.hasNext()) {
             modelNames.add(names.next());

--- a/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/RdfUtils.java
@@ -1,54 +1,10 @@
 package won.protocol.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.lang.invoke.MethodHandles;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
+import com.google.common.collect.Iterators;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.QuerySolutionMap;
-import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.ResIterator;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdf.model.impl.StatementImpl;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
@@ -62,10 +18,17 @@ import org.apache.jena.util.FileUtils;
 import org.apache.jena.util.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Iterators;
-
 import won.protocol.exception.IncorrectPropertyCountException;
+
+import java.io.*;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Utilities for RDF manipulation with Jena.
@@ -1889,9 +1852,9 @@ public class RdfUtils {
                         counter++;
                     }
                     toModel.setNsPrefix(prefix + counter, fromModel.getNsPrefixURI(prefix));
-                } /*else {
-                    // prefix-uri is already there, do nothing
-                }*/
+                } /*
+                   * else { // prefix-uri is already there, do nothing }
+                   */
             }
         }
     }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingAllButListsLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingAllButListsLinkedDataSource.java
@@ -1,12 +1,13 @@
 package won.protocol.util.linkeddata;
 
-import java.net.URI;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * User: ypanchenko Date: 06.11.2015
@@ -17,7 +18,7 @@ public class CachingAllButListsLinkedDataSource extends CachingLinkedDataSource 
     // TODO actually the connection itself should also not be cached - i.e. status
     // can be updated
     private Pattern pattern_connections_list_uri = Pattern.compile("(.+)/connections(/)?");
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public Dataset getDataForResource(URI resource) {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
@@ -10,10 +10,26 @@
  */
 package won.protocol.util.linkeddata;
 
-import static java.util.EnumSet.noneOf;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import won.protocol.rest.DatasetResponseWithStatusCodeAndHeaders;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.text.ParseException;
@@ -28,23 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.ehcache.EhCacheCacheManager;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-
-import net.sf.ehcache.CacheException;
-import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.Element;
-import won.protocol.rest.DatasetResponseWithStatusCodeAndHeaders;
+import static java.util.EnumSet.noneOf;
 
 /**
  * LinkedDataSource implementation that uses an ehcache for caching.
@@ -55,7 +55,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
     private static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
     private static final int DEFAULT_EXPIRY_PERIOD = 600;
     private static final int DEFAULT_BYTE_ARRAY_SIZE = 500;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired(required = true)
     private EhCacheCacheManager cacheManager;
     private Ehcache cache;

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSourceBase.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSourceBase.java
@@ -10,20 +10,6 @@
  */
 package won.protocol.util.linkeddata;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.function.BiFunction;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
@@ -41,19 +27,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-
 import won.protocol.rest.DatasetResponseWithStatusCodeAndHeaders;
 import won.protocol.rest.LinkedDataFetchingException;
 import won.protocol.rest.LinkedDataRestClient;
 import won.protocol.util.AuthenticationThreadLocal;
 import won.protocol.util.RdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 /**
  * LinkedDataSource implementation that delegates fetching linked data resources
  * to the provided LinedDataRestClient.
  */
 public class LinkedDataSourceBase implements LinkedDataSource {
-    private final Logger logger = LoggerFactory.getLogger(LinkedDataSourceBase.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected LinkedDataRestClient linkedDataRestClient;
     @Autowired
     private ThreadPoolExecutor parallelRequestsThreadpool;

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/WonLinkedDataUtils.java
@@ -10,6 +10,7 @@
  */
 package won.protocol.util.linkeddata;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
@@ -33,7 +34,6 @@ import org.apache.jena.shared.impl.PrefixMappingImpl;
 import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathParser;
 import org.apache.jena.vocabulary.RDFS;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +51,7 @@ import won.protocol.vocabulary.WONMSG;
  * Utilitiy functions for common linked data lookups.
  */
 public class WonLinkedDataUtils {
-    private static final Logger logger = LoggerFactory.getLogger(WonLinkedDataUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static URI getConnectionStateforConnectionURI(URI connectionURI, LinkedDataSource linkedDataSource) {
         assert linkedDataSource != null : "linkedDataSource must not be null";

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/impl/SparqlUpdateCrawlerCallback.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/impl/SparqlUpdateCrawlerCallback.java
@@ -10,10 +10,6 @@
  */
 package won.protocol.util.linkeddata.impl;
 
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.Iterator;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
@@ -24,15 +20,19 @@ import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.util.linkeddata.CrawlerCallback;
+
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Iterator;
 
 /**
  * Crawler callback implementation that writes crawled data to a predefined
  * sparql endpoint.
  */
 public class SparqlUpdateCrawlerCallback implements CrawlerCallback {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     String sparqlEndpoint = null;
 
     public void setSparqlEndpoint(final String sparqlEndpoint) {

--- a/webofneeds/won-core/src/main/java/won/protocol/validation/WonSparqlValidator.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/validation/WonSparqlValidator.java
@@ -11,25 +11,20 @@
 package won.protocol.validation;
 
 import org.apache.jena.graph.Node;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.query.ResultSetFormatter;
-import org.apache.jena.query.Syntax;
+import org.apache.jena.query.*;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.tdb.TDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: ypanchenko Date: 02.06.2015
  */
 public class WonSparqlValidator {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final Var SELECT_VALIDATION_VARIABLE = Var.alloc("check");
     public static final String SELECT_VALIDATION_PASSED_VALUE = "OK";
     private Query constraint;

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/GRDeliveryMethod.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/GRDeliveryMethod.java
@@ -1,5 +1,6 @@
 package won.protocol.vocabulary;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -12,7 +13,7 @@ public enum GRDeliveryMethod {
     DELIVERY_MODE_DIRECT_DOWNLOAD("DeliveryModeDirectDownload"), DELIVERY_MODE_FREIGHT("DeliveryModeFreight"),
     DELIVERY_MODE_MAIL("DeliveryModeMail"), DELIVERY_MODE_OWN_FLEET("DeliveryModeOwnFleet"),
     DELIVERY_MODE_PICK_UP("DeliveryModePickUp");
-    private static final Logger logger = LoggerFactory.getLogger(GRDeliveryMethod.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String name;
 
     private GRDeliveryMethod(String name) {

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/activemq/CertificateCheckingBrokerFilter.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/activemq/CertificateCheckingBrokerFilter.java
@@ -10,8 +10,6 @@
  */
 package won.cryptography.activemq;
 
-import java.security.cert.X509Certificate;
-
 import org.apache.activemq.broker.Broker;
 import org.apache.activemq.broker.BrokerFilter;
 import org.apache.activemq.broker.ConnectionContext;
@@ -19,9 +17,11 @@ import org.apache.activemq.broker.region.Subscription;
 import org.apache.activemq.command.ConsumerInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.ssl.AliasFromFingerprintGenerator;
 import won.cryptography.ssl.AliasGenerator;
+
+import java.lang.invoke.MethodHandles;
+import java.security.cert.X509Certificate;
 
 /**
  * BrokerFilter implementation that authorizes consumers if their TLS
@@ -31,7 +31,7 @@ import won.cryptography.ssl.AliasGenerator;
 public class CertificateCheckingBrokerFilter extends BrokerFilter {
     private String queueNamePrefixToCheck;
     private AliasGenerator aliasGenerator = new AliasFromFingerprintGenerator();
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public CertificateCheckingBrokerFilter(final Broker next, String queueNamePrefixToCheck) {
         super(next);

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/SignatureVerificationState.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/SignatureVerificationState.java
@@ -1,16 +1,8 @@
 package won.cryptography.rdfsign;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import won.protocol.message.WonSignatureData;
+
+import java.util.*;
 
 /**
  * User: ypanchenko Date: 24.03.2015
@@ -23,7 +15,6 @@ public class SignatureVerificationState {
     private Map<String, String> signatureGraphNameToSignedGraphName = new HashMap<>();
     private Map<String, String> signatureGraphNameToSignatureValue = new HashMap<>();
     private List<WonSignatureData> signatures = new ArrayList<>();
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public void addSignedGraphName(String signedGraphName) {
         if (!signedGraphNameToSignatureGraphName.containsKey(signedGraphName)) {

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonKeysReaderWriter.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonKeysReaderWriter.java
@@ -28,8 +28,6 @@ import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import won.cryptography.exception.KeyNotSupportedException;
 import won.cryptography.key.KeyInformationExtractor;
@@ -45,8 +43,6 @@ import won.protocol.vocabulary.WON;
  * 27.03.2015
  */
 public class WonKeysReaderWriter {
-    private static final Logger logger = LoggerFactory.getLogger(WonKeysReaderWriter.class);
-
     public WonKeysReaderWriter() {
     }
 
@@ -165,8 +161,7 @@ public class WonKeysReaderWriter {
                 return ret;
             }
         });
-        Set<String> ret = new HashSet<>();
-        ret.addAll(keyRefs);
+        Set<String> ret = new HashSet<>(keyRefs);
         return ret;
     }
 

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonSigner.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonSigner.java
@@ -1,16 +1,9 @@
 package won.cryptography.rdfsign;
 
-import java.io.StringWriter;
-import java.security.MessageDigest;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
-
+import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.SignatureAlgorithmInterface;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm.SignatureAlgorithmFisteus2010;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -21,19 +14,22 @@ import org.apache.jena.vocabulary.RDF;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.SignatureAlgorithmInterface;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm.SignatureAlgorithmFisteus2010;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
 import won.protocol.message.WonSignatureData;
 import won.protocol.vocabulary.SFSIG;
+
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.security.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Created by ypanchenko on 12.06.2014.
  */
 public class WonSigner {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // TODO make it configurable which algorithm is used RSA or ECDSA
     public static final String SIGNING_ALGORITHM_NAME = "NONEwithECDSA";
     public static final String SIGNING_ALGORITHM_PROVIDER = "BC";

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
@@ -1,17 +1,8 @@
 package won.cryptography.rdfsign;
 
-import static won.cryptography.rdfsign.WonSigner.ENV_HASH_ALGORITHM;
-import static won.cryptography.rdfsign.WonSigner.SIGNING_ALGORITHM_PROVIDER;
-
-import java.io.StringWriter;
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.Provider;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.util.Base64;
-import java.util.Map;
-
+import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.SignatureAlgorithmInterface;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm.SignatureAlgorithmFisteus2010;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -21,20 +12,29 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.SignatureAlgorithmInterface;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm.SignatureAlgorithmFisteus2010;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
 import won.protocol.message.WonSignatureData;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.Map;
+
+import static won.cryptography.rdfsign.WonSigner.ENV_HASH_ALGORITHM;
+import static won.cryptography.rdfsign.WonSigner.SIGNING_ALGORITHM_PROVIDER;
+
 /**
  * User: ypanchenko Date: 15.07.2014
  */
 public class WonVerifier {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Dataset dataset;
     private SignatureVerificationState verificationState = new SignatureVerificationState();
 

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/webid/TrustWebIdStrategy.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/webid/TrustWebIdStrategy.java
@@ -1,18 +1,18 @@
 package won.cryptography.webid;
 
+import org.apache.http.ssl.TrustStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.cryptography.service.CertificateService;
+import won.protocol.util.linkeddata.LinkedDataSource;
+
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
-
-import org.apache.http.ssl.TrustStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.cryptography.service.CertificateService;
-import won.protocol.util.linkeddata.LinkedDataSource;
 
 /**
  * Trust all the certificates that contains at least one verified webID in
@@ -21,7 +21,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * public key of the presented certificate. User: ypanchenko Date: 23.10.2015
  */
 public class TrustWebIdStrategy implements TrustStrategy {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private WebIDVerificationAgent verificationAgent;
 
     public TrustWebIdStrategy(LinkedDataSource linkedDataSource) {

--- a/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/KeyForNewAtomAddingProcessor.java
+++ b/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/KeyForNewAtomAddingProcessor.java
@@ -1,5 +1,6 @@
 package won.protocol.message.processor.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.security.PublicKey;
 
 import org.apache.jena.query.Dataset;
@@ -28,7 +29,7 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
  * (browser). User: ypanchenko Date: 10.04.2015
  */
 public class KeyForNewAtomAddingProcessor implements WonMessageProcessor {
-    private static final Logger logger = LoggerFactory.getLogger(KeyForNewAtomAddingProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private CryptographyService cryptographyService;
     private KeyPairAliasDerivationStrategy keyPairAliasDerivationStrategy;
 

--- a/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/SignatureAddingWonMessageProcessor.java
+++ b/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/SignatureAddingWonMessageProcessor.java
@@ -1,12 +1,8 @@
 package won.protocol.message.processor.impl;
 
-import java.security.PrivateKey;
-import java.security.PublicKey;
-
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.keymanagement.KeyPairAliasDerivationStrategy;
 import won.cryptography.service.CryptographyService;
 import won.protocol.message.WonMessage;
@@ -14,11 +10,15 @@ import won.protocol.message.WonMessageEncoder;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
 
+import java.lang.invoke.MethodHandles;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
 /**
  * User: ypanchenko Date: 03.04.2015
  */
 public class SignatureAddingWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private CryptographyService cryptographyService;
     private KeyPairAliasDerivationStrategy keyPairAliasDerivationStrategy;
 

--- a/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/SignatureCheckingWonMessageProcessor.java
+++ b/webofneeds/won-cryptography/src/main/java/won/protocol/message/processor/impl/SignatureCheckingWonMessageProcessor.java
@@ -10,22 +10,11 @@
  */
 package won.protocol.message.processor.impl;
 
-import java.net.URI;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PublicKey;
-import java.security.SignatureException;
-import java.security.spec.InvalidKeySpecException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import won.cryptography.rdfsign.SignatureVerificationState;
@@ -38,12 +27,23 @@ import won.protocol.rest.LinkedDataFetchingException;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Checks all signatures found in a WonMessage. It is assumed that the message
  * is well-formed.
  */
 public class SignatureCheckingWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public SignatureCheckingWonMessageProcessor() {
     }

--- a/webofneeds/won-cryptography/src/test/java/won/cryptography/utils/TestSigningUtils.java
+++ b/webofneeds/won-cryptography/src/test/java/won/cryptography/utils/TestSigningUtils.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.Security;
@@ -42,7 +43,7 @@ import won.cryptography.service.keystore.KeyStoreService;
  * User: ypanchenko Date: 24.03.2015
  */
 public class TestSigningUtils {
-    private final static Logger LOGGER = LoggerFactory.getLogger(TestSigningUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final String KEYS_FILE = "/won-signed-messages/test-keys.jks";
     // theoretically can be a public key WebID...
     public static String atomCertUri = "http://localhost:8080/won/resource/atom/3144709509622353000";
@@ -92,7 +93,7 @@ public class TestSigningUtils {
     }
 
     public static Set<String> getSubjects(Model model) {
-        Set<String> subjs = new HashSet<String>();
+        Set<String> subjs = new HashSet<>();
         StmtIterator sti = model.listStatements();
         while (sti.hasNext()) {
             Statement st = sti.next();
@@ -103,7 +104,7 @@ public class TestSigningUtils {
     }
 
     public static Set<String> getUriResourceObjects(Model model) {
-        Set<String> objs = new HashSet<String>();
+        Set<String> objs = new HashSet<>();
         StmtIterator sti = model.listStatements();
         while (sti.hasNext()) {
             Statement st = sti.next();
@@ -196,7 +197,7 @@ public class TestSigningUtils {
         BigInteger serialNumber = BigInteger.valueOf(1);
         Certificate cert = certificateService.createSelfSignedCertificate(serialNumber, keyPair, certUri, certUri);
         storeService.putKey(certUri, keyPair.getPrivate(), new Certificate[] { cert }, false);
-        LOGGER.debug("Adding for uri {} certificate {}", certUri, cert);
+        logger.debug("Adding for uri {} certificate {}", certUri, cert);
         // KeyInformationExtractorBouncyCastle extractor = new
         // KeyInformationExtractorBouncyCastle();
     }
@@ -215,7 +216,7 @@ public class TestSigningUtils {
 
     public static void writeToTempFile(final Dataset testDataset) throws IOException {
         File outFile = File.createTempFile("won", ".trig");
-        LOGGER.debug("Check output in temp file: " + outFile);
+        logger.debug("Check output in temp file: " + outFile);
         OutputStream os = new FileOutputStream(outFile);
         RDFDataMgr.write(os, testDataset, RDFFormat.TRIG.getLang());
         os.close();

--- a/webofneeds/won-cryptography/src/test/java/won/cryptogrpahy/service/CryptographyServiceTest.java
+++ b/webofneeds/won-cryptography/src/test/java/won/cryptogrpahy/service/CryptographyServiceTest.java
@@ -1,5 +1,6 @@
 package won.cryptogrpahy.service;
 
+import java.lang.invoke.MethodHandles;
 import java.security.KeyPair;
 
 import org.junit.Assert;
@@ -18,7 +19,7 @@ import won.cryptography.service.KeyPairService;
  * User: fsalcher Date: 17.07.2014
  */
 public class CryptographyServiceTest {
-    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private ApplicationContext context;
 
     @Before
@@ -49,13 +50,13 @@ public class CryptographyServiceTest {
         KeyInformationExtractorBouncyCastle extractor = new KeyInformationExtractorBouncyCastle();
         try {
             Assert.assertEquals("ECDSA", extractor.getAlgorithm(keypair.getPublic()));
-            LOGGER.debug("algorithm: " + extractor.getAlgorithm(keypair.getPublic()));
+            logger.debug("algorithm: " + extractor.getAlgorithm(keypair.getPublic()));
             Assert.assertEquals("brainpoolp384r1", extractor.getCurveID(keypair.getPublic()));
-            LOGGER.debug("curveID: " + extractor.getCurveID(keypair.getPublic()));
+            logger.debug("curveID: " + extractor.getCurveID(keypair.getPublic()));
             Assert.assertNotNull(extractor.getQX(keypair.getPublic()));
-            LOGGER.debug("qx: " + extractor.getQX(keypair.getPublic()));
+            logger.debug("qx: " + extractor.getQX(keypair.getPublic()));
             Assert.assertNotNull(extractor.getQY(keypair.getPublic()));
-            LOGGER.debug("qy: " + extractor.getQY(keypair.getPublic()));
+            logger.debug("qy: " + extractor.getQY(keypair.getPublic()));
         } catch (KeyNotSupportedException ex) {
             Assert.fail(ex.getMessage());
         }
@@ -68,13 +69,13 @@ public class CryptographyServiceTest {
         KeyInformationExtractorBouncyCastle extractor = new KeyInformationExtractorBouncyCastle();
         try {
             Assert.assertEquals("ECDSA", extractor.getAlgorithm(keypair.getPublic()));
-            LOGGER.debug("algorithm: " + extractor.getAlgorithm(keypair.getPublic()));
+            logger.debug("algorithm: " + extractor.getAlgorithm(keypair.getPublic()));
             Assert.assertEquals("secp384r1", extractor.getCurveID(keypair.getPublic()));
-            LOGGER.debug("curveID: " + extractor.getCurveID(keypair.getPublic()));
+            logger.debug("curveID: " + extractor.getCurveID(keypair.getPublic()));
             Assert.assertNotNull(extractor.getQX(keypair.getPublic()));
-            LOGGER.debug("qx: " + extractor.getQX(keypair.getPublic()));
+            logger.debug("qx: " + extractor.getQX(keypair.getPublic()));
             Assert.assertNotNull(extractor.getQY(keypair.getPublic()));
-            LOGGER.debug("qy: " + extractor.getQY(keypair.getPublic()));
+            logger.debug("qy: " + extractor.getQY(keypair.getPublic()));
         } catch (KeyNotSupportedException ex) {
             Assert.fail(ex.getMessage());
         }

--- a/webofneeds/won-matcher-rescal/src/main/java/won/matcher/rescal/service/HintReader.java
+++ b/webofneeds/won-matcher-rescal/src/main/java/won/matcher/rescal/service/HintReader.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ import won.matcher.utils.tensor.TensorMatchingData;
  */
 @Component
 public class HintReader {
-    private static final Logger log = LoggerFactory.getLogger(HintReader.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private RescalMatcherConfig config;
 
@@ -50,7 +51,7 @@ public class HintReader {
         // connection entries)
         fis = new FileInputStream(config.getExecutionDirectory() + "/output/hints.mtx");
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fis, "UTF-8"));
-        StringBuffer stringBuffer = new StringBuffer();
+        StringBuilder stringBuffer = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {
             if (line.startsWith("%%MatrixMarket")) {
                 if (!line.contains("row-major") || !line.contains("column-major")) {
@@ -70,8 +71,8 @@ public class HintReader {
             // IllegalArgumentException can occur here if we have no atoms and thus now
             // hints, catch this case and return
             // null to indicate no hints were found
-            log.warn("Cannot load hint matrix file. This can happen if no hints were created");
-            log.debug("Exception was: ", e);
+            logger.warn("Cannot load hint matrix file. This can happen if no hints were created");
+            logger.debug("Exception was: ", e);
             return null;
         }
         // create the hint events and return them in one bulk hint object

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/http/HttpService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/http/HttpService.java
@@ -1,21 +1,18 @@
 package won.matcher.service.common.service.http;
 
-import java.nio.charset.Charset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.Charset;
 
 /**
  * Service to use HTTP to request resources
@@ -25,7 +22,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 @Scope("prototype")
 public class HttpService {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private RestTemplate restTemplate;
     private HttpHeaders jsonHeaders;
 
@@ -51,11 +48,11 @@ public class HttpService {
 
     public void postJsonRequest(String uri, String body) {
         ResponseEntity<String> response = null;
-        log.debug("POST URI: {}", uri);
+        logger.debug("POST URI: {}", uri);
         HttpEntity<String> jsonEntity = new HttpEntity(body, jsonHeaders);
         response = restTemplate.exchange(uri, HttpMethod.POST, jsonEntity, String.class);
         if (response.getStatusCode() != HttpStatus.OK) {
-            log.warn("HTTP POST request returned status code: {}", response.getStatusCode());
+            logger.warn("HTTP POST request returned status code: {}", response.getStatusCode());
             throw new HttpClientErrorException(response.getStatusCode());
         }
     }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/monitoring/MonitoringService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/monitoring/MonitoringService.java
@@ -1,8 +1,5 @@
 package won.matcher.service.common.service.monitoring;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
@@ -12,13 +9,17 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by hfriedrich on 09.10.2015.
  */
 @Component
 @Scope("singleton")
 public class MonitoringService {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final String ATOM_HINT_STOPWATCH = "AtomReceivedUntilFirstHintSent";
     private Map<String, Map<String, Split>> stopWatchSplits = new HashMap<>();
     @Value("${matcher.service.monitoring}")
@@ -36,7 +37,8 @@ public class MonitoringService {
                 stopWatchSplits.put(stopWatchName, splits);
             }
             if (splits.get(splitName) != null) {
-                log.warn("Split '{}' in stopwatch {} already set for monitoring start event", splitName, stopWatchName);
+                logger.warn("Split '{}' in stopwatch {} already set for monitoring start event", splitName,
+                                stopWatchName);
                 return;
             }
             Stopwatch stopwatch = SimonManager.getStopwatch(stopWatchName);
@@ -49,12 +51,12 @@ public class MonitoringService {
         if (isMonitoringEnabled()) {
             Map<String, Split> splits = stopWatchSplits.get(stopWatchName);
             if (splits == null) {
-                log.warn("No stopwatch '{}' found for monitoring end event", stopWatchName);
+                logger.warn("No stopwatch '{}' found for monitoring end event", stopWatchName);
                 return;
             }
             Split split = splits.get(splitName);
             if (split == null) {
-                log.warn("No split '{}' in stopwatch '{}' found for monitoring end event", splitName, stopWatchName);
+                logger.warn("No split '{}' in stopwatch '{}' found for monitoring end event", splitName, stopWatchName);
                 return;
             }
             split.stop();

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
@@ -1,22 +1,6 @@
 package won.matcher.service.common.service.sparql;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QueryParseException;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
@@ -34,8 +18,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import won.protocol.util.RdfUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 
 /**
  * Service to access of Sparql enpoint database to save or query linked data.
@@ -43,7 +34,7 @@ import won.protocol.util.RdfUtils;
  */
 @Component
 public class SparqlService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected String sparqlEndpoint;
     // protected DatasetAccessor accessor;
 

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
@@ -43,7 +43,7 @@ import won.protocol.util.RdfUtils;
  */
 @Component
 public class SparqlService {
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected String sparqlEndpoint;
     // protected DatasetAccessor accessor;
 
@@ -91,7 +91,7 @@ public class SparqlService {
         String query = "";
         Iterator<String> graphNames = ds.listNames();
         while (graphNames.hasNext()) {
-            log.debug("Save dataset");
+            logger.debug("Save dataset");
             String graphName = graphNames.next();
             Model model = ds.getNamedModel(graphName);
             query += createUpdateNamedGraphQuery(graphName, model);
@@ -151,14 +151,14 @@ public class SparqlService {
      */
     public void executeUpdateQuery(String updateQuery) {
         try {
-            log.debug("Update SPARQL Endpoint: {}", sparqlEndpoint);
-            log.debug("Execute query: {}", updateQuery);
+            logger.debug("Update SPARQL Endpoint: {}", sparqlEndpoint);
+            logger.debug("Execute query: {}", updateQuery);
             UpdateRequest query = UpdateFactory.create(updateQuery);
             UpdateProcessRemote riStore = (UpdateProcessRemote) UpdateExecutionFactory.createRemote(query,
                             sparqlEndpoint);
             riStore.execute();
         } catch (QueryParseException e) {
-            log.warn("Error parsing update query: " + updateQuery, e);
+            logger.warn("Error parsing update query: " + updateQuery, e);
         }
     }
 }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -1,18 +1,6 @@
 package won.matcher.service.crawler.service;
 
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.slf4j.Logger;
@@ -21,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
 import won.matcher.service.common.event.AtomEvent;
 import won.matcher.service.common.event.BulkAtomEvent;
 import won.matcher.service.common.event.Cause;
@@ -30,6 +17,10 @@ import won.matcher.service.crawler.config.CrawlConfig;
 import won.matcher.service.crawler.msg.CrawlUriMessage;
 import won.protocol.util.AtomModelWrapper;
 
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+
 /**
  * Sparql service extended with methods for crawling
  * <p>
@@ -37,7 +28,7 @@ import won.protocol.util.AtomModelWrapper;
  */
 @Component
 public class CrawlSparqlService extends SparqlService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String HTTP_HEADER_SEPARATOR = ", ";
 
     @Autowired

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/service/CrawlSparqlService.java
@@ -15,6 +15,8 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -35,6 +37,7 @@ import won.protocol.util.AtomModelWrapper;
  */
 @Component
 public class CrawlSparqlService extends SparqlService {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final String HTTP_HEADER_SEPARATOR = ", ";
 
     @Autowired
@@ -137,8 +140,8 @@ public class CrawlSparqlService extends SparqlService {
         pps.setNsPrefix("won", "https://w3id.org/won/core#");
         pps.setCommandText(queryString);
         pps.setLiteral("status", status.toString());
-        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-        log.debug("Execute query: {}", pps.toString());
+        logger.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        logger.debug("Execute query: {}", pps.toString());
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             while (results.hasNext()) {
@@ -157,7 +160,7 @@ public class CrawlSparqlService extends SparqlService {
                 }
                 msg = new CrawlUriMessage(uri, baseUri, wonNode, CrawlUriMessage.STATUS.PROCESS,
                                 System.currentTimeMillis(), etags);
-                log.debug("Created message: {}", msg);
+                logger.debug("Created message: {}", msg);
                 msgs.add(msg);
             }
             return msgs;
@@ -258,8 +261,8 @@ public class CrawlSparqlService extends SparqlService {
         }
         pps.setIri("baseUriWithoutTrailingSlash", baseUri);
         pps.setIri("baseUriWithTrailingSlash", baseUri + "/");
-        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-        log.debug("Execute query: {}", pps.toString());
+        logger.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        logger.debug("Execute query: {}", pps.toString());
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             while (results.hasNext()) {
@@ -271,7 +274,7 @@ public class CrawlSparqlService extends SparqlService {
                     etags = commaConcatenatedStringToSet(etagsString);
                 }
                 CrawlUriMessage newUriMsg = null;
-                log.debug("Extracted URI: {}", extractedUri);
+                logger.debug("Extracted URI: {}", extractedUri);
                 if (baseProperty) {
                     newUriMsg = new CrawlUriMessage(extractedUri, extractedUri, wonNodeUri,
                                     CrawlUriMessage.STATUS.PROCESS, crawlDate, etags);
@@ -349,7 +352,7 @@ public class CrawlSparqlService extends SparqlService {
         // query template to retrieve all alctive cralwed/saved atoms in a certain date
         // range
         String orderClause = sortAscending ? "ORDER BY ?date\n" : "ORDER BY DESC(?date)\n";
-        log.debug("bulk load atom data from sparql endpoint in date range: [{},{}]", fromDate, toDate);
+        logger.debug("bulk load atom data from sparql endpoint in date range: [{},{}]", fromDate, toDate);
         String queryTemplate = "SELECT ?atomUri ?wonNodeUri ?date WHERE {  \n" + "  ?atomUri a won:Atom. \n"
                         + "  ?atomUri won:crawlDate ?date.  \n" + "  ?atomUri won:atomState won:Active. \n"
                         + "  ?atomUri won:wonNode ?wonNodeUri. \n"
@@ -363,8 +366,8 @@ public class CrawlSparqlService extends SparqlService {
         pps.setLiteral("toDate", toDate);
         pps.setLiteral("offset", offset);
         pps.setLiteral("limit", limit);
-        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-        log.debug("Execute query: {}", pps.toString());
+        logger.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        logger.debug("Execute query: {}", pps.toString());
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             // load all the atoms into one bulk atom event
@@ -383,7 +386,7 @@ public class CrawlSparqlService extends SparqlService {
                     bulkAtomEvent.addAtomEvent(atomEvent);
                 }
             }
-            log.debug("number of atom events created: " + bulkAtomEvent.getAtomEvents().size());
+            logger.debug("number of atom events created: " + bulkAtomEvent.getAtomEvents().size());
             return bulkAtomEvent;
         }
     }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/service/WonNodeSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/service/WonNodeSparqlService.java
@@ -1,15 +1,6 @@
 package won.matcher.service.nodemanager.service;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.slf4j.Logger;
@@ -17,12 +8,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import won.matcher.service.common.service.sparql.SparqlService;
 import won.protocol.exception.DataIntegrityException;
 import won.protocol.service.WonNodeInfo;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WON;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Sparql service extended with methods for won node controller User: hfriedrich
@@ -30,7 +25,7 @@ import won.protocol.vocabulary.WON;
  */
 @Component
 public class WonNodeSparqlService extends SparqlService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Autowired
     public WonNodeSparqlService(@Value("${uri.sparql.endpoint}") final String sparqlEndpoint) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/service/WonNodeSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/nodemanager/service/WonNodeSparqlService.java
@@ -12,6 +12,8 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,8 @@ import won.protocol.vocabulary.WON;
  */
 @Component
 public class WonNodeSparqlService extends SparqlService {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Autowired
     public WonNodeSparqlService(@Value("${uri.sparql.endpoint}") final String sparqlEndpoint) {
         super(sparqlEndpoint);
@@ -45,8 +49,8 @@ public class WonNodeSparqlService extends SparqlService {
         ParameterizedSparqlString pps = new ParameterizedSparqlString();
         pps.setCommandText(queryString);
         pps.setNsPrefix("won", "https://w3id.org/won/core#");
-        log.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
-        log.debug("Execute query: {}", pps.toString());
+        logger.debug("Query SPARQL Endpoint: {}", sparqlEndpoint);
+        logger.debug("Execute query: {}", pps.toString());
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             while (results.hasNext()) {

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
@@ -1,18 +1,6 @@
 package won.matcher.service.rematch.service;
 
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.slf4j.Logger;
@@ -21,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
 import won.matcher.service.common.event.AtomEvent;
 import won.matcher.service.common.event.AtomEvent.TYPE;
 import won.matcher.service.common.event.BulkAtomEvent;
@@ -31,6 +18,14 @@ import won.matcher.service.crawler.config.CrawlConfig;
 import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
 /**
  * Sparql service extended with methods for rematching
  * <p>
@@ -38,7 +33,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  */
 @Component
 public class RematchSparqlService extends SparqlService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String HTTP_HEADER_SEPARATOR = ", ";
     @Autowired
     LinkedDataSource linkedDataSource;

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
@@ -15,6 +15,8 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +38,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  */
 @Component
 public class RematchSparqlService extends SparqlService {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final String HTTP_HEADER_SEPARATOR = ", ";
     @Autowired
     LinkedDataSource linkedDataSource;
@@ -150,7 +153,7 @@ public class RematchSparqlService extends SparqlService {
     }
 
     public BulkAtomEvent findAtomsForRematching() {
-        log.debug("searching atoms for rematching");
+        logger.debug("searching atoms for rematching");
         StringBuilder builder = new StringBuilder();
         // Selects atomUris using a back-off strategy, each time doubling
         // the time difference to the reference date
@@ -188,7 +191,7 @@ public class RematchSparqlService extends SparqlService {
                 }
             }
         }
-        log.debug("atomEvents for rematching: " + bulkAtomEvent.getAtomEvents().size());
+        logger.debug("atomEvents for rematching: " + bulkAtomEvent.getAtomEvents().size());
         return bulkAtomEvent;
     }
 

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/index/AtomIndexer.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/index/AtomIndexer.java
@@ -1,14 +1,10 @@
 package won.matcher.solr.index;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Map;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
+import com.github.jsonldjava.core.JsonLdError;
+import com.github.jsonldjava.core.JsonLdOptions;
+import com.github.jsonldjava.core.JsonLdProcessor;
+import com.github.jsonldjava.utils.JsonUtils;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
@@ -19,19 +15,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
-
-import com.github.jsonldjava.core.JsonLdError;
-import com.github.jsonldjava.core.JsonLdOptions;
-import com.github.jsonldjava.core.JsonLdProcessor;
-import com.github.jsonldjava.utils.JsonUtils;
-
 import won.matcher.service.common.service.http.HttpService;
 import won.matcher.solr.config.SolrMatcherConfig;
 import won.protocol.model.Coordinate;
-import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.AtomModelWrapper;
+import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMATCH;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
 
 /**
  * Created by hfriedrich on 03.08.2016.
@@ -39,7 +34,7 @@ import won.protocol.vocabulary.WONMATCH;
 @Component
 @Scope("prototype")
 public class AtomIndexer {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final String SOLR_IS_LOCATION_COORDINATES_FIELD = "is_atom_location";
     public static final String SOLR_SEEKS_LOCATION_COORDINATES_FIELD = "seeks_atom_location";
     public static final String SOLR_SEEKS_SEEKS_LOCATION_COORDINATES_FIELD = "seeksSeeks_atom_location";
@@ -111,11 +106,11 @@ public class AtomIndexer {
         if (config.isCommitIndexedAtomImmediately()) {
             indexUri += "?commit=" + config.isCommitIndexedAtomImmediately();
         }
-        log.debug("Post atom to solr index. \n Solr URI: {} \n Atom (JSON): {}", indexUri, atomJson);
+        logger.debug("Post atom to solr index. \n Solr URI: {} \n Atom (JSON): {}", indexUri, atomJson);
         try {
             httpService.postJsonRequest(indexUri, atomJson);
         } catch (HttpClientErrorException e) {
-            log.info("Error indexing atom with solr. \n Solr URI: {} \n Atom (JSON): {}", indexUri, atomJson);
+            logger.info("Error indexing atom with solr. \n Solr URI: {} \n Atom (JSON): {}", indexUri, atomJson);
         }
     }
 }

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/DefaultMatcherQueryExecuter.java
@@ -1,9 +1,5 @@
 package won.matcher.solr.query;
 
-import java.io.IOException;
-
-import javax.annotation.PostConstruct;
-
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -16,17 +12,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import won.matcher.solr.config.SolrMatcherConfig;
 import won.matcher.solr.hints.HintBuilder;
 import won.matcher.solr.query.factory.MatchingContextQueryFactory;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * Created by hfriedrich on 12.08.2016.
  */
 @Component
 public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     SolrMatcherConfig config;
     SolrClient solrClient;
@@ -40,11 +39,11 @@ public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor {
     public SolrDocumentList executeAtomQuery(String queryString, int maxHints, SolrParams params,
                     String... filterQueries) throws IOException, SolrServerException {
         if (queryString == null) {
-            log.debug("query string is null, do execute any query!");
+            logger.debug("query string is null, do execute any query!");
             return null;
         }
         SolrQuery query = new SolrQuery();
-        log.debug("use query: {} with filters {}", queryString, filterQueries);
+        logger.debug("use query: {} with filters {}", queryString, filterQueries);
         query.setQuery(queryString);
         query.setFields("id", "score", HintBuilder.WON_NODE_SOLR_FIELD, HintBuilder.HAS_FLAG_SOLR_FIELD,
                         MatchingContextQueryFactory.MATCHING_CONTEXT_SOLR_FIELD);
@@ -73,7 +72,7 @@ public class DefaultMatcherQueryExecuter implements SolrMatcherQueryExecutor {
             }
             return results;
         } catch (SolrException e) {
-            log.warn("Exception {} thrown for query: {}", e, queryString);
+            logger.warn("Exception {} thrown for query: {}", e, queryString);
         }
         return null;
     }

--- a/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicAtomQueryFactory.java
+++ b/webofneeds/won-matcher-solr/src/main/java/won/matcher/solr/query/factory/BasicAtomQueryFactory.java
@@ -1,17 +1,14 @@
 package won.matcher.solr.query.factory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import won.matcher.solr.utils.MatcherAtomContentPropertyType;
 import won.protocol.model.Coordinate;
 import won.protocol.util.DefaultAtomModelWrapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by hfriedrich on 01.08.2016.
@@ -52,7 +49,6 @@ public class BasicAtomQueryFactory extends AtomDatasetQueryFactory {
         locationFieldMap.put(MatcherAtomContentPropertyType.SEEKS, "seeks_atom_location");
         locationFieldMap.put(MatcherAtomContentPropertyType.SEEKS_SEEKS, "seeksSeeks_atom_location");
     }
-    private final Logger log = LoggerFactory.getLogger(getClass());
     protected ArrayList<SolrQueryFactory> contentFactories;
     protected ArrayList<SolrQueryFactory> locationFactories;
     protected DefaultAtomModelWrapper atomModelWrapper;

--- a/webofneeds/won-matcher-utils/src/main/java/won/matcher/utils/tensor/TensorMatchingData.java
+++ b/webofneeds/won-matcher-utils/src/main/java/won/matcher/utils/tensor/TensorMatchingData.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -19,7 +20,7 @@ import org.slf4j.LoggerFactory;
  * User: hfriedrich Date: 17.07.2014
  */
 public class TensorMatchingData {
-    private static final Logger logger = LoggerFactory.getLogger(TensorMatchingData.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int MAX_DIMENSION = 1000000;
     public static final String HEADERS_FILE = "headers.txt";
     public static final String ATOM_INDICES_FILE = "atomIndices.txt";
@@ -225,7 +226,7 @@ public class TensorMatchingData {
     }
 
     public List<String> getAtoms() {
-        ArrayList<String> continuousList = new ArrayList<String>();
+        ArrayList<String> continuousList = new ArrayList<>();
         for (String atom : atoms) {
             if (atom != null) {
                 continuousList.add(atom);
@@ -235,7 +236,7 @@ public class TensorMatchingData {
     }
 
     public List<String> getAttributes() {
-        ArrayList<String> continuousList = new ArrayList<String>();
+        ArrayList<String> continuousList = new ArrayList<>();
         for (String attr : attributes) {
             if (attr != null) {
                 continuousList.add(attr);
@@ -245,8 +246,7 @@ public class TensorMatchingData {
     }
 
     public List<String> getSlices() {
-        ArrayList<String> continuousList = new ArrayList<String>();
-        continuousList.addAll(slices);
+        ArrayList<String> continuousList = new ArrayList<>(slices);
         return continuousList;
     }
 
@@ -313,7 +313,7 @@ public class TensorMatchingData {
         OutputStreamWriter os = new OutputStreamWriter(fos, "UTF-8");
         for (int i = 0; i < nextIndex; i++) {
             String entity = (atoms.get(i) != null) ? atoms.get(i) : attributes.get(i);
-            os.append(entity + "\n");
+            os.append(entity).append("\n");
         }
         os.close();
         // write the atom indices file
@@ -321,7 +321,7 @@ public class TensorMatchingData {
         os = new OutputStreamWriter(fos, "UTF-8");
         for (int i = 0; i < nextIndex; i++) {
             if (atoms.get(i) != null) {
-                os.append(i + "\n");
+                os.append(String.valueOf(i)).append("\n");
             }
         }
         os.close();

--- a/webofneeds/won-matcher/src/main/java/won/matcher/cli/MatcherCLI.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/cli/MatcherCLI.java
@@ -1,14 +1,9 @@
 package won.matcher.cli;
 
-import java.lang.invoke.MethodHandles;
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
-
 import won.matcher.protocol.impl.MatcherProtocolAtomServiceClient;
 import won.protocol.exception.IllegalMessageForAtomStateException;
 import won.protocol.exception.NoSuchAtomException;
@@ -19,6 +14,10 @@ import won.protocol.message.WonMessageDirection;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * User: gabriel Date: 14.02.13 Time: 15:00
@@ -41,7 +40,8 @@ public class MatcherCLI implements CommandLineRunner {
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "-h":
-                    System.out.println("USAGE: java MatcherCLI [-n1 atom1] [-n2 atom2] [-o originator] [-s score] [-h]");
+                    System.out.println(
+                                    "USAGE: java MatcherCLI [-n1 atom1] [-n2 atom2] [-o originator] [-s score] [-h]");
                     System.exit(0);
                 case "-n1":
                     atom1 = args[++i];

--- a/webofneeds/won-matcher/src/main/java/won/matcher/cli/MatcherCLI.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/cli/MatcherCLI.java
@@ -1,8 +1,8 @@
 package won.matcher.cli;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +24,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
  * User: gabriel Date: 14.02.13 Time: 15:00
  */
 public class MatcherCLI implements CommandLineRunner {
-    private static final Logger logger = LoggerFactory.getLogger(MatcherCLI.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private MatcherProtocolAtomServiceClient client;
     @Autowired
@@ -39,17 +39,22 @@ public class MatcherCLI implements CommandLineRunner {
         String org = "http://localhost:8080/matcher";
         double score = 1;
         for (int i = 0; i < args.length; i++) {
-            if (args[i].equals("-h")) {
-                System.out.println("USAGE: java MatcherCLI [-n1 atom1] [-n2 atom2] [-o originator] [-s score] [-h]");
-                System.exit(0);
-            } else if (args[i].equals("-n1")) {
-                atom1 = args[++i];
-            } else if (args[i].equals("-n2")) {
-                atom2 = args[++i];
-            } else if (args[i].equals("-o")) {
-                org = args[++i];
-            } else if (args[i].equals("-s")) {
-                score = Double.parseDouble(args[++i]);
+            switch (args[i]) {
+                case "-h":
+                    System.out.println("USAGE: java MatcherCLI [-n1 atom1] [-n2 atom2] [-o originator] [-s score] [-h]");
+                    System.exit(0);
+                case "-n1":
+                    atom1 = args[++i];
+                    break;
+                case "-n2":
+                    atom2 = args[++i];
+                    break;
+                case "-o":
+                    org = args[++i];
+                    break;
+                case "-s":
+                    score = Double.parseDouble(args[++i]);
+                    break;
             }
         }
         try {

--- a/webofneeds/won-matcher/src/main/java/won/matcher/component/MatcherNodeURISourceImpl.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/component/MatcherNodeURISourceImpl.java
@@ -14,14 +14,10 @@ import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * User: LEIH-NB Date: 11.04.14
  */
 public class MatcherNodeURISourceImpl implements MatcherNodeURISource {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private List<URI> nodeURIs = null;
 
     @Override

--- a/webofneeds/won-matcher/src/main/java/won/matcher/messaging/MatcherProtocolCamelConfiguratorImpl.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/messaging/MatcherProtocolCamelConfiguratorImpl.java
@@ -10,20 +10,20 @@
  */
 package won.matcher.messaging;
 
-import java.net.URI;
-import java.util.Set;
-
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.apache.camel.RoutesBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.matcher.camel.routes.Matcher2NodeDynamicRoutes;
 import won.matcher.camel.routes.MatcherApplicationListenerRouteBuilder;
 import won.protocol.exception.CamelConfigurationFailedException;
-import won.protocol.jms.MatcherProtocolCamelConfigurator;
 import won.protocol.jms.AtomBasedCamelConfiguratorImpl;
+import won.protocol.jms.MatcherProtocolCamelConfigurator;
 import won.protocol.model.MessagingType;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Set;
 
 // import won.node.camel.routes.AtomProtocolDynamicRoutes;
 /**
@@ -31,7 +31,7 @@ import won.protocol.model.MessagingType;
  */
 public class MatcherProtocolCamelConfiguratorImpl extends AtomBasedCamelConfiguratorImpl
                 implements MatcherProtocolCamelConfigurator {
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public synchronized void addRemoteTopicListeners(final Set<String> endpoints, final URI remoteEndpoint)

--- a/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolAtomServiceClient.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolAtomServiceClient.java
@@ -1,20 +1,20 @@
 package won.matcher.protocol.impl;
 
-import java.net.URI;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.matcher.MatcherProtocolAtomServiceClientSide;
 import won.protocol.message.WonMessage;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * User: gabriel Date: 12.02.13 Time: 17:26
  */
 public class MatcherProtocolAtomServiceClient implements MatcherProtocolAtomServiceClientSide {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     MatcherProtocolAtomServiceClientSide delegate;
 
     public void hint(URI atomURI, URI otherAtom, double score, URI originator, Model content, WonMessage wonMessage)

--- a/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolAtomServiceClientJMSBased.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolAtomServiceClientJMSBased.java
@@ -10,15 +10,10 @@
  */
 package won.matcher.protocol.impl;
 
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.jms.CamelConfiguration;
 import won.protocol.jms.MatcherProtocolCommunicationService;
 import won.protocol.jms.MessagingService;
@@ -27,11 +22,16 @@ import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageEncoder;
 import won.protocol.util.RdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * User: gabriel Date: 12.02.13 Time: 17:26
  */
 public class MatcherProtocolAtomServiceClientJMSBased implements MatcherProtocolAtomServiceClientSide {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MessagingService messagingService;
     private MatcherProtocolCommunicationService matcherProtocolCommunicationService;
     private String startingEndpoint;

--- a/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-matcher/src/main/java/won/matcher/protocol/impl/MatcherProtocolCommunicationServiceImpl.java
@@ -1,22 +1,16 @@
 package won.matcher.protocol.impl;
 
-import java.net.URI;
-import java.util.Set;
-
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.cryptography.service.RegistrationRestClientHttps;
 import won.protocol.exception.CamelConfigurationFailedException;
 import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.jms.ActiveMQService;
-import won.protocol.jms.CamelConfiguration;
-import won.protocol.jms.CamelConfigurator;
-import won.protocol.jms.MatcherActiveMQService;
-import won.protocol.jms.MatcherProtocolCamelConfigurator;
-import won.protocol.jms.MatcherProtocolCommunicationService;
-import won.protocol.jms.AtomProtocolCamelConfigurator;
+import won.protocol.jms.*;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Set;
 
 /**
  * User: ypanchenko Date: 02.09.2015
@@ -25,7 +19,7 @@ public class MatcherProtocolCommunicationServiceImpl implements MatcherProtocolC
     private RegistrationRestClientHttps registrationClient;
     private MatcherProtocolCamelConfigurator matcherProtocolCamelConfigurator;
     private MatcherActiveMQService activeMQService;
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void setRegistrationClient(final RegistrationRestClientHttps registrationClient) {
         this.registrationClient = registrationClient;

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -37,16 +37,16 @@ import org.springframework.web.servlet.HandlerMapping;
 import won.cryptography.service.RegistrationServer;
 import won.node.service.impl.URIService;
 import won.protocol.exception.IncorrectPropertyCountException;
-import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchAtomException;
+import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.WonProtocolException;
 import won.protocol.message.WonMessageType;
+import won.protocol.model.AtomState;
 import won.protocol.model.Connection;
 import won.protocol.model.DataWithEtag;
-import won.protocol.model.AtomState;
 import won.protocol.rest.WonEtagHelper;
-import won.protocol.service.LinkedDataService;
 import won.protocol.service.AtomInformationService;
+import won.protocol.service.LinkedDataService;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.CNT;
 import won.protocol.vocabulary.HTTP;
@@ -56,6 +56,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -108,7 +109,7 @@ import java.util.regex.Pattern;
 @Controller
 @RequestMapping("/")
 public class LinkedDataWebController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // full prefix of an atom resource
     private String atomResourceURIPrefix;
     // path of an atom resource

--- a/webofneeds/won-node/src/main/java/won/node/camel/AtomProtocolCommunicationServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/AtomProtocolCommunicationServiceImpl.java
@@ -10,21 +10,17 @@
  */
 package won.node.camel;
 
-import java.net.URI;
-
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.cryptography.service.RegistrationClient;
 import won.cryptography.service.RegistrationRestClientHttps;
 import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.jms.ActiveMQService;
-import won.protocol.jms.CamelConfiguration;
-import won.protocol.jms.CamelConfigurator;
-import won.protocol.jms.AtomProtocolCamelConfigurator;
-import won.protocol.jms.AtomProtocolCommunicationService;
+import won.protocol.jms.*;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * User: syim Date: 27.01.14
@@ -40,12 +36,12 @@ public class AtomProtocolCommunicationServiceImpl implements AtomProtocolCommuni
         this.registrationClient = registrationClient;
     }
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public synchronized CamelConfiguration configureCamelEndpoint(URI wonNodeUri) throws Exception {
         String atomProtocolQueueName;
         CamelConfiguration camelConfiguration = new CamelConfiguration();
-        logger.debug("ensuring camel is configured for remote wonNodeUri", new Object[] { wonNodeUri });
+        logger.debug("ensuring camel is configured for remote wonNodeUri {}", wonNodeUri);
         URI remoteNodeBrokerUri = activeMQService.getBrokerEndpoint(wonNodeUri);
         if (atomProtocolCamelConfigurator.getBrokerComponentNameWithBrokerUri(remoteNodeBrokerUri) != null) {
             logger.debug("broker component name is already known");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractCamelProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractCamelProcessor.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.camel.Processor;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import won.cryptography.service.RandomNumberService;
@@ -54,7 +55,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * User: syim Date: 02.03.2015
  */
 public abstract class AbstractCamelProcessor implements Processor {
-    protected Logger logger = org.slf4j.LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(AbstractCamelProcessor.class);
     @Autowired
     protected MessagingService messagingService;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractCamelProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/AbstractCamelProcessor.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.camel.Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import won.cryptography.service.RandomNumberService;
@@ -55,7 +53,6 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * User: syim Date: 02.03.2015
  */
 public abstract class AbstractCamelProcessor implements Processor {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractCamelProcessor.class);
     @Autowired
     protected MessagingService messagingService;
     @Autowired
@@ -175,7 +172,7 @@ public abstract class AbstractCamelProcessor implements Processor {
     }
 
     protected List<String> toStringIds(final List<OwnerApplication> ownerApplications) {
-        List<String> ownerApplicationIds = new ArrayList<String>(ownerApplications.size());
+        List<String> ownerApplicationIds = new ArrayList<>(ownerApplications.size());
         for (OwnerApplication app : ownerApplications) {
             ownerApplicationIds.add(app.getOwnerApplicationId());
         }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateAtomMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateAtomMessageProcessor.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -21,6 +23,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ActivateMessageString)
 public class ActivateAtomMessageProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateAtomMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/ActivateAtomMessageProcessor.java
@@ -1,13 +1,10 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
@@ -17,13 +14,16 @@ import won.protocol.model.AtomState;
 import won.protocol.util.DataAccessUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ActivateMessageString)
 public class ActivateAtomMessageProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/AtomHintMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/AtomHintMessageProcessor.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,6 +33,7 @@ import won.protocol.vocabulary.WONMSG;
  */
 @Component
 public class AtomHintMessageProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Value("${ignore.hints.suggested.connection.count.max}")
     private Long maxAtomHintsCount = 100L;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/AtomHintMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/AtomHintMessageProcessor.java
@@ -1,39 +1,27 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
-import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.MissingMessagePropertyException;
-import won.protocol.model.Atom;
-import won.protocol.model.Connection;
-import won.protocol.model.ConnectionEventType;
-import won.protocol.model.ConnectionState;
-import won.protocol.model.Socket;
-import won.protocol.repository.ConnectionRepository;
-import won.protocol.util.RdfUtils;
-import won.protocol.util.WonRdfUtils;
-import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 public class AtomHintMessageProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Value("${ignore.hints.suggested.connection.count.max}")
     private Long maxAtomHintsCount = 100L;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromOwnerProcessor.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -23,6 +25,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 public class CloseMessageFromOwnerProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromOwnerProcessor.java
@@ -1,7 +1,5 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
@@ -19,13 +17,16 @@ import won.protocol.model.ConnectionEventType;
 import won.protocol.model.ConnectionState;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 public class CloseMessageFromOwnerProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromSystemProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromSystemProcessor.java
@@ -14,6 +14,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -41,6 +43,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromSystemString, messageType = WONMSG.CloseMessageString)
 public class CloseMessageFromSystemProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromSystemProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CloseMessageFromSystemProcessor.java
@@ -10,14 +10,11 @@
  */
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.node.camel.processor.general.OutboundMessageFactoryProcessor;
@@ -29,6 +26,9 @@ import won.protocol.model.Connection;
 import won.protocol.model.ConnectionEventType;
 import won.protocol.model.ConnectionState;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Processes a CLOSE message coming from the FROM_SYSTEM direction. The effects
@@ -43,7 +43,7 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromSystemString, messageType = WONMSG.CloseMessageString)
 public class CloseMessageFromSystemProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageProcessor.java
@@ -1,14 +1,5 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.query.Dataset;
@@ -18,23 +9,21 @@ import org.javasimon.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.UriAlreadyInUseException;
-import won.protocol.model.ConnectionContainer;
-import won.protocol.model.DatasetHolder;
-import won.protocol.model.Socket;
-import won.protocol.model.Atom;
-import won.protocol.model.AtomMessageContainer;
-import won.protocol.model.AtomState;
-import won.protocol.model.OwnerApplication;
+import won.protocol.model.*;
 import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * User: syim Date: 02.03.2015
@@ -42,7 +31,7 @@ import won.protocol.vocabulary.WONMSG;
 @Service
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CreateMessageString)
 public class CreateAtomMessageProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageProcessor.java
@@ -15,6 +15,8 @@ import org.apache.jena.query.Dataset;
 import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.javasimon.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -40,6 +42,8 @@ import won.protocol.vocabulary.WONMSG;
 @Service
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CreateMessageString)
 public class CreateAtomMessageProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageReactionProcessor.java
@@ -16,6 +16,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,6 +39,7 @@ import won.protocol.vocabulary.WONMSG;
 @Service
 @FixedMessageReactionProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CreateMessageString)
 public class CreateAtomMessageReactionProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     AtomRepository atomRepository;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/CreateAtomMessageReactionProcessor.java
@@ -10,8 +10,6 @@
  */
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.query.Dataset;
@@ -20,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
 import won.protocol.exception.NoSuchAtomException;
@@ -33,13 +30,16 @@ import won.protocol.repository.AtomRepository;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Reacts to a CREATE message, informing matchers of the newly created atom.
  */
 @Service
 @FixedMessageReactionProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CreateMessageString)
 public class CreateAtomMessageReactionProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     AtomRepository atomRepository;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateMessageFromSystemProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateMessageFromSystemProcessor.java
@@ -10,13 +10,10 @@
  */
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
@@ -27,10 +24,13 @@ import won.protocol.model.AtomState;
 import won.protocol.util.DataAccessUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromSystemString, messageType = WONMSG.DeactivateMessageString)
 public class DeactivateMessageFromSystemProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateMessageFromSystemProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/DeactivateMessageFromSystemProcessor.java
@@ -13,6 +13,8 @@ package won.node.camel.processor.fixed;
 import java.net.URI;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -28,6 +30,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromSystemString, messageType = WONMSG.DeactivateMessageString)
 public class DeactivateMessageFromSystemProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(Exchange exchange) throws Exception {
         WonMessage wonMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromExternalProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromExternalProcessor.java
@@ -11,13 +11,15 @@ import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: quasarchimaere Date: 03.04.2019
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.FailureResponseString)
 public class FailureResponseFromExternalProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         WonMessage responseMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromExternalProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/FailureResponseFromExternalProcessor.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.fixed;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -15,6 +17,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.FailureResponseString)
 public class FailureResponseFromExternalProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         WonMessage responseMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);
         assert responseMessage != null : "wonMessage header must not be null";

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
@@ -10,8 +10,6 @@
  */
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.rdf.model.RDFNode;
@@ -19,7 +17,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.message.WonMessage;
@@ -29,13 +26,16 @@ import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.WONCON;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 public class HintFeedbackMessageFromOwnerProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/HintFeedbackMessageFromOwnerProcessor.java
@@ -16,6 +16,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -33,6 +35,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 public class HintFeedbackMessageFromOwnerProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeReactionProcessor.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -22,6 +24,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageReactionProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 public class OpenMessageFromNodeReactionProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(Exchange exchange) throws Exception {
         // if the connection's socket isAutoOpen and the connection state is
@@ -50,7 +54,7 @@ public class OpenMessageFromNodeReactionProcessor extends AbstractCamelProcessor
                         .setMessagePropertiesForOpen(messageURI, connectMessageToReactTo,
                                         "This is an automatic OPEN message sent by the WoN node")
                         .setWonMessageDirection(WonMessageDirection.FROM_SYSTEM).build();
-        logger.info("sending auto-open for connection {}, reacting to open", msg.getSenderURI());
+        logger.debug("sending auto-open for connection {}, reacting to open", msg.getSenderURI());
         super.sendSystemMessage(msg);
     }
 }

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromNodeReactionProcessor.java
@@ -1,14 +1,10 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
 import won.protocol.message.WonMessage;
@@ -21,10 +17,14 @@ import won.protocol.model.Socket;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
+
 @Component
 @FixedMessageReactionProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 public class OpenMessageFromNodeReactionProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -28,6 +30,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 public class OpenMessageFromOwnerProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromOwnerProcessor.java
@@ -1,15 +1,10 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.Objects;
-import java.util.Optional;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.node.camel.processor.general.OutboundMessageFactoryProcessor;
@@ -24,13 +19,18 @@ import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 public class OpenMessageFromOwnerProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromSystemProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/OpenMessageFromSystemProcessor.java
@@ -11,6 +11,8 @@ import won.protocol.message.WonMessage;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Required for auto-open sockets. Delegates the processing method to the
  * OpenMessageFromOwnerProcessor.
@@ -18,7 +20,7 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromSystemString, messageType = WONMSG.OpenMessageString)
 public class OpenMessageFromSystemProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private OpenMessageFromOwnerProcessor openFromOwnerProcessor;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendChangeNotificationMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendChangeNotificationMessageFromNodeProcessor.java
@@ -16,6 +16,7 @@ import won.protocol.model.ConnectionState;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 /**
@@ -24,7 +25,7 @@ import java.net.URI;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 public class SendChangeNotificationMessageFromNodeProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendChangeNotificationMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendChangeNotificationMessageFromNodeProcessor.java
@@ -2,6 +2,8 @@ package won.node.camel.processor.fixed;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
@@ -22,6 +24,8 @@ import java.net.URI;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 public class SendChangeNotificationMessageFromNodeProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
@@ -1,13 +1,10 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.exception.IllegalMessageForConnectionStateException;
@@ -19,13 +16,16 @@ import won.protocol.model.ConnectionState;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromNodeProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeProcessor.java
@@ -4,6 +4,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -23,6 +25,8 @@ import won.protocol.vocabulary.WONMSG;
 @Component
 @FixedMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromNodeProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     public void process(final Exchange exchange) throws Exception {
         Message message = exchange.getIn();
         WonMessage wonMessage = (WonMessage) message.getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SendMessageFromNodeReactionProcessor.java
@@ -1,15 +1,10 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Objects;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.FixedMessageReactionProcessor;
 import won.protocol.message.WonMessage;
@@ -22,13 +17,18 @@ import won.protocol.util.RdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
 @Component
 @FixedMessageReactionProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 /**
  * If the message has a msg:injectIntoConnection property, try to forward it.
  */
 public class SendMessageFromNodeReactionProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SocketHintMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SocketHintMessageProcessor.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,6 +33,7 @@ import won.protocol.vocabulary.WONMSG;
  */
 @Component
 public class SocketHintMessageProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     @Value("${ignore.hints.suggested.connection.count.max}")

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SocketHintMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/fixed/SocketHintMessageProcessor.java
@@ -1,8 +1,5 @@
 package won.node.camel.processor.fixed;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
@@ -10,9 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
-import won.node.camel.processor.annotation.FixedMessageProcessor;
 import won.protocol.exception.IncompatibleSocketsException;
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.camel.WonCamelConstants;
@@ -22,18 +17,19 @@ import won.protocol.model.ConnectionEventType;
 import won.protocol.model.ConnectionState;
 import won.protocol.model.Socket;
 import won.protocol.repository.ConnectionRepository;
-import won.protocol.util.RdfUtils;
-import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
-import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
 
 /**
  * User: syim Date: 02.03.2015
  */
 @Component
 public class SocketHintMessageProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     @Value("${ignore.hints.suggested.connection.count.max}")

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
@@ -10,14 +10,10 @@
  */
 package won.node.camel.processor.general;
 
-import java.io.StringWriter;
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -29,13 +25,17 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
 
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Sends a error response message back to the sender of the original message, if
  * that message was sent on behalf of a specified atom (i.e. its senderAtomURI
  * is set).
  */
 public class FailResponder extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/FailResponder.java
@@ -18,6 +18,8 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
@@ -33,6 +35,8 @@ import won.protocol.util.WonRdfUtils;
  * is set).
  */
 public class FailResponder extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) throws Exception {
         Exception exception = null;

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/LockMessageParentWonMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/LockMessageParentWonMessageProcessor.java
@@ -10,28 +10,28 @@
  */
 package won.node.camel.processor.general;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageUtils;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.model.Connection;
-import won.protocol.repository.ConnectionMessageContainerRepository;
-import won.protocol.repository.ConnectionRepository;
 import won.protocol.repository.AtomMessageContainerRepository;
 import won.protocol.repository.AtomRepository;
+import won.protocol.repository.ConnectionMessageContainerRepository;
+import won.protocol.repository.ConnectionRepository;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Optional;
 
 /**
  * Acquires a pessimistic read lock on the message's parent.
  */
 public class LockMessageParentWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     ConnectionRepository connectionRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/MessageReferencer.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/MessageReferencer.java
@@ -10,17 +10,10 @@
  */
 package won.node.camel.processor.general;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.cryptography.rdfsign.SigningStage;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageType;
@@ -30,20 +23,22 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.message.processor.impl.WonMessageSignerVerifier;
 import won.protocol.model.DatasetHolder;
 import won.protocol.model.MessageEventPlaceholder;
-import won.protocol.repository.ConnectionMessageContainerRepository;
-import won.protocol.repository.ConnectionRepository;
-import won.protocol.repository.DatasetHolderRepository;
-import won.protocol.repository.MessageEventRepository;
-import won.protocol.repository.AtomMessageContainerRepository;
-import won.protocol.repository.AtomRepository;
+import won.protocol.repository.*;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Utility class containing code needed at multiple points for adding references
  * to previous messages to a message.
  */
 public class MessageReferencer {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private MessageEventRepository messageEventRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/OutboundMessageCreatingProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/OutboundMessageCreatingProcessor.java
@@ -14,9 +14,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.camel.WonCamelConstants;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * Processor that expects an outgoingMessageFactory in the respecitve in header,
@@ -24,7 +25,7 @@ import won.protocol.message.processor.camel.WonCamelConstants;
  * WonOutgoingMessage header
  */
 public class OutboundMessageCreatingProcessor implements Processor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/PersistingWonMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/PersistingWonMessageProcessor.java
@@ -10,12 +10,9 @@
  */
 package won.node.camel.processor.general;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.service.DataAccessService;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageEncoder;
@@ -23,21 +20,20 @@ import won.protocol.message.WonMessageType;
 import won.protocol.message.WonMessageUtils;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
-import won.protocol.model.ConnectionMessageContainer;
-import won.protocol.model.DatasetHolder;
-import won.protocol.model.MessageContainer;
-import won.protocol.model.MessageEventPlaceholder;
-import won.protocol.model.AtomMessageContainer;
+import won.protocol.model.*;
+import won.protocol.repository.AtomMessageContainerRepository;
 import won.protocol.repository.ConnectionMessageContainerRepository;
 import won.protocol.repository.DatasetHolderRepository;
 import won.protocol.repository.MessageEventRepository;
-import won.protocol.repository.AtomMessageContainerRepository;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Persists the specified WonMessage.
  */
 public class PersistingWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     protected MessageEventRepository messageEventRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ReferenceToUnreferencedMessageAddingProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ReferenceToUnreferencedMessageAddingProcessor.java
@@ -10,10 +10,7 @@
  */
 package won.node.camel.processor.general;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
@@ -22,7 +19,6 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
  * Created by fkleedorfer on 22.07.2016.
  */
 public class ReferenceToUnreferencedMessageAddingProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private MessageReferencer messageReferencer;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import org.apache.camel.Exchange;
 import org.apache.jena.query.Dataset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageDirection;
@@ -15,6 +17,8 @@ import won.protocol.model.MessageEventPlaceholder;
  * User: ypanchenko Date: 27.04.2015
  */
 public class ResponseResenderProcessor extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) throws Exception {
         WonMessage originalMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.ORIGINAL_MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/ResponseResenderProcessor.java
@@ -1,10 +1,7 @@
 package won.node.camel.processor.general;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.jena.query.Dataset;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -13,11 +10,14 @@ import won.protocol.message.WonMessageDirection;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.model.MessageEventPlaceholder;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * User: ypanchenko Date: 27.04.2015
  */
 public class ResponseResenderProcessor extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SocketTypeSlipComputer.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SocketTypeSlipComputer.java
@@ -10,6 +10,18 @@
  */
 package won.node.camel.processor.general;
 
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
+import won.node.camel.processor.annotation.SocketMessageProcessor;
+import won.protocol.message.WonMessage;
+import won.protocol.message.processor.camel.WonCamelConstants;
+import won.protocol.message.processor.exception.WonMessageProcessingException;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -17,30 +29,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Expression;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-
-import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
-import won.node.camel.processor.annotation.SocketMessageProcessor;
-import won.protocol.message.WonMessage;
-import won.protocol.message.WonMessageDirection;
-import won.protocol.message.WonMessageType;
-import won.protocol.message.processor.camel.WonCamelConstants;
-import won.protocol.message.processor.exception.MissingMessagePropertyException;
-import won.protocol.message.processor.exception.WonMessageProcessingException;
-import won.protocol.vocabulary.WONMSG;
-
 /**
  * User: syim Date: 11.03.2015
  */
 public class SocketTypeSlipComputer implements InitializingBean, ApplicationContextAware, Expression {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private HashMap<String, Object> socketMessageProcessorsMap;
     private ApplicationContext applicationContext;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
@@ -10,19 +10,18 @@
  */
 package won.node.camel.processor.general;
 
-import java.net.URI;
-
 import org.apache.camel.Exchange;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
 import won.protocol.message.WonMessageDirection;
-import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Sends a success response message back to the sender of the original message,
@@ -30,7 +29,7 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
  * senderAtomURI is set).
  */
 public class SuccessResponder extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) throws Exception {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/SuccessResponder.java
@@ -14,6 +14,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
@@ -28,6 +30,8 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
  * senderAtomURI is set).
  */
 public class SuccessResponder extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) throws Exception {
         WonMessage originalMessage = (WonMessage) exchange.getIn().getHeader(WonCamelConstants.MESSAGE_HEADER);

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/UriAlreadyUsedCheckingWonMessageProcessor.java
@@ -10,26 +10,23 @@
  */
 package won.node.camel.processor.general;
 
-import java.net.URI;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.util.IsoMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.EventAlreadyProcessedException;
 import won.protocol.message.processor.exception.UriAlreadyInUseException;
-import won.protocol.model.MessageEventPlaceholder;
 import won.protocol.model.Atom;
-import won.protocol.repository.MessageEventRepository;
+import won.protocol.model.MessageEventPlaceholder;
 import won.protocol.repository.AtomRepository;
+import won.protocol.repository.MessageEventRepository;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.WonRdfUtils;
+
+import java.net.URI;
 
 /**
  * Checks whether the event or atom URI is already used. It is possible that
@@ -42,7 +39,6 @@ import won.protocol.util.WonRdfUtils;
  * User: ypanchenko Date: 23.04.2015
  */
 public class UriAlreadyUsedCheckingWonMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private MessageEventRepository messageEventRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.CloseMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.CloseMessageString)
 public class CloseFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.CloseMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.CloseMessageString)
 public class CloseFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromOwnerChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 public class CloseFromOwnerChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/CloseFromOwnerChatSocketImpl.java
@@ -7,9 +7,10 @@ import org.springframework.stereotype.Component;
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
-import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.CloseMessageString)
 public class CloseFromOwnerChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromOwnerChatSocketImpl.java
@@ -4,7 +4,6 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
@@ -13,6 +12,8 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: syim Date: 05.03.2015
  */
@@ -20,7 +21,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromOwnerChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/ConnectFromOwnerChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -18,6 +20,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromOwnerChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/FailureResponseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/FailureResponseFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.FailureResponseString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.FailureResponseString)
 public class FailureResponseFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/FailureResponseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/FailureResponseFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: quasarchimaere Date: 04.04.2019
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.FailureResponseString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.FailureResponseString)
 public class FailureResponseFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/HintFeedbackMessageFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/HintFeedbackMessageFromOwnerChatSocketImpl.java
@@ -11,6 +11,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -26,6 +28,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 public class HintFeedbackMessageFromOwnerChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/HintFeedbackMessageFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/HintFeedbackMessageFromOwnerChatSocketImpl.java
@@ -14,12 +14,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -28,7 +29,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.HintFeedbackMessageString)
 public class HintFeedbackMessageFromOwnerChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 public class OpenFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.OpenMessageString)
 public class OpenFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromOwnerChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 public class OpenFromOwnerChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/OpenFromOwnerChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.OpenMessageString)
 public class OpenFromOwnerChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendChangeNotificationMessageFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendChangeNotificationMessageFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: quasarchimaere Date: 04.04.2019
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 public class SendChangeNotificationMessageFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendChangeNotificationMessageFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendChangeNotificationMessageFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ChangeNotificationMessageString)
 public class SendChangeNotificationMessageFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: syim Date: 05.03.2015
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromOwnerChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -18,6 +20,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectionMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromOwnerChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromOwnerChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SendMessageFromOwnerChatSocketImpl.java
@@ -4,7 +4,6 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
@@ -13,6 +12,8 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: syim Date: 05.03.2015
  */
@@ -20,7 +21,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectionMessageString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromOwnerChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SuccessResponseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SuccessResponseFromNodeChatSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.chatSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -16,6 +18,8 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.SuccessResponseString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.SuccessResponseString)
 public class SuccessResponseFromNodeChatSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SuccessResponseFromNodeChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/chatSocket/SuccessResponseFromNodeChatSocketImpl.java
@@ -4,12 +4,13 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.DefaultSocketMessageProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXCHAT;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: quasarchimaere Date: 04.04.2019
@@ -18,7 +19,7 @@ import won.protocol.vocabulary.WXCHAT;
 @DefaultSocketMessageProcessor(direction = WONMSG.FromExternalString, messageType = WONMSG.SuccessResponseString)
 @SocketMessageProcessor(socketType = WXCHAT.ChatSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.SuccessResponseString)
 public class SuccessResponseFromNodeChatSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/groupSocket/SendMessageFromNodeGroupSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/groupSocket/SendMessageFromNodeGroupSocketImpl.java
@@ -1,14 +1,10 @@
 package won.node.camel.processor.socket.groupSocket;
 
-import java.net.URI;
-import java.util.List;
-
 import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.message.WonMessage;
@@ -22,6 +18,10 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXGROUP;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+
 /**
  * Created with IntelliJ IDEA. User: gabriel Date: 16.09.13 Time: 18:42 To
  * change this template use File | Settings | File Templates.
@@ -29,7 +29,7 @@ import won.protocol.vocabulary.WXGROUP;
 @Component
 @SocketMessageProcessor(socketType = WXGROUP.GroupSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectionMessageString)
 public class SendMessageFromNodeGroupSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
 

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromNodeReviewSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromNodeReviewSocketImpl.java
@@ -1,8 +1,5 @@
 package won.node.camel.processor.socket.reviewSocket;
 
-import java.net.URI;
-import java.util.Map;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.query.Dataset;
@@ -13,7 +10,6 @@ import org.apache.jena.rdf.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.message.WonMessage;
@@ -21,9 +17,12 @@ import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.model.Atom;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.SCHEMA;
-import won.protocol.vocabulary.WON;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXREVIEW;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Map;
 
 /**
  * User: MS Date: 12.12.2018
@@ -31,7 +30,7 @@ import won.protocol.vocabulary.WXREVIEW;
 @Component
 @SocketMessageProcessor(socketType = WXREVIEW.ReviewSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromNodeReviewSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromNodeReviewSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromNodeReviewSocketImpl.java
@@ -10,6 +10,8 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -29,6 +31,8 @@ import won.protocol.vocabulary.WXREVIEW;
 @Component
 @SocketMessageProcessor(socketType = WXREVIEW.ReviewSocketString, direction = WONMSG.FromExternalString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromNodeReviewSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         Message message = exchange.getIn();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromOwnerReviewSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromOwnerReviewSocketImpl.java
@@ -1,6 +1,8 @@
 package won.node.camel.processor.socket.reviewSocket;
 
 import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import won.node.camel.processor.AbstractCamelProcessor;
@@ -14,6 +16,8 @@ import won.protocol.vocabulary.WXREVIEW;
 @Component
 @SocketMessageProcessor(socketType = WXREVIEW.ReviewSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromOwnerReviewSocketImpl extends AbstractCamelProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     @Override
     public void process(final Exchange exchange) {
         logger.debug("default socket implementation, not doing anything");

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromOwnerReviewSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/socket/reviewSocket/ConnectFromOwnerReviewSocketImpl.java
@@ -4,11 +4,12 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import won.node.camel.processor.AbstractCamelProcessor;
 import won.node.camel.processor.annotation.SocketMessageProcessor;
 import won.protocol.vocabulary.WONMSG;
 import won.protocol.vocabulary.WXREVIEW;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: MS Date: 12.12.2018
@@ -16,7 +17,7 @@ import won.protocol.vocabulary.WXREVIEW;
 @Component
 @SocketMessageProcessor(socketType = WXREVIEW.ReviewSocketString, direction = WONMSG.FromOwnerString, messageType = WONMSG.ConnectMessageString)
 public class ConnectFromOwnerReviewSocketImpl extends AbstractCamelProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(final Exchange exchange) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/route/AtomProtocolDynamicRoutes.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/route/AtomProtocolDynamicRoutes.java
@@ -15,11 +15,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: LEIH-NB Date: 25.11.13
  */
 public class AtomProtocolDynamicRoutes extends RouteBuilder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String from;
 
     public AtomProtocolDynamicRoutes(CamelContext camelContext, String from) {

--- a/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/route/fixed/WonMessageRoutes.java
@@ -1,10 +1,5 @@
 package won.node.camel.route.fixed;
 
-import static org.apache.camel.builder.PredicateBuilder.isNotEqualTo;
-import static org.apache.camel.builder.PredicateBuilder.not;
-
-import java.net.URI;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Expression;
 import org.apache.camel.LoggingLevel;
@@ -15,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.orm.jpa.JpaSystemException;
-
 import won.node.camel.predicate.IsResponseMessagePredicate;
 import won.node.camel.predicate.ShouldCallSocketImplForMessagePredicate;
 import won.node.camel.predicate.ShouldEchoToOwnerPredicate;
@@ -23,11 +17,17 @@ import won.protocol.message.WonMessage;
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
+import static org.apache.camel.builder.PredicateBuilder.isNotEqualTo;
+import static org.apache.camel.builder.PredicateBuilder.not;
+
 /**
  * User: syim Date: 02.03.2015
  */
 public class WonMessageRoutes extends RouteBuilder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private void logRouteStart(Exchange exchange) {
         // UnitOfWork -> getRouteContext -> Route -> Id.

--- a/webofneeds/won-node/src/main/java/won/node/maintenance/AtomInactivityChecker.java
+++ b/webofneeds/won-node/src/main/java/won/node/maintenance/AtomInactivityChecker.java
@@ -10,14 +10,6 @@
  */
 package won.node.maintenance;
 
-import java.text.SimpleDateFormat;
-import java.time.Duration;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -30,10 +22,18 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.stereotype.Component;
-
 import won.node.service.impl.AtomManagementService;
 import won.protocol.model.Atom;
 import won.protocol.repository.AtomRepository;
+
+import java.lang.invoke.MethodHandles;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Uses a timer to check atoms for inactivity and send them warnings or
@@ -41,7 +41,7 @@ import won.protocol.repository.AtomRepository;
  */
 @Component
 public class AtomInactivityChecker implements InitializingBean, DisposableBean {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Trigger trigger;
     private TaskScheduler taskScheduler;
     private int inactivityCheckInterval = -1;

--- a/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolAtomServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolAtomServiceImpl.java
@@ -10,25 +10,24 @@
  */
 package won.node.protocol.impl;
 
-import java.net.URI;
-
-import javax.jws.WebMethod;
-
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
 import won.protocol.matcher.MatcherProtocolAtomService;
 import won.protocol.message.WonMessage;
 import won.protocol.service.MatcherFacingAtomCommunicationService;
+
+import javax.jws.WebMethod;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * User: fkleedorfer Date: 02.11.12
  */
 @Service
 public class MatcherProtocolAtomServiceImpl implements MatcherProtocolAtomService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private MatcherFacingAtomCommunicationService matcherFacingAtomCommunicationService;
 
     @Override

--- a/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolAtomServiceImplJMSBased.java
+++ b/webofneeds/won-node/src/main/java/won/node/protocol/impl/MatcherProtocolAtomServiceImplJMSBased.java
@@ -10,17 +10,14 @@
  */
 package won.node.protocol.impl;
 
-import java.net.URI;
-
 import org.apache.camel.Header;
 import org.apache.jena.riot.Lang;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
 import won.protocol.matcher.MatcherProtocolAtomService;
 import won.protocol.message.WonMessageDecoder;
 import won.protocol.util.RdfUtils;
+
+import java.net.URI;
 
 /**
  * User: fkleedorfer Date: 02.11.12
@@ -28,7 +25,6 @@ import won.protocol.util.RdfUtils;
 @Service
 public class MatcherProtocolAtomServiceImplJMSBased// implements MatcherProtocolAtomService
 {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
     private MatcherProtocolAtomService delegate;
 
     public void hint(@Header("atomURI") final String atomURI, @Header("otherAtomURI") final String otherAtomURI,

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/AtomManagementService.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/AtomManagementService.java
@@ -10,15 +10,10 @@
  */
 package won.node.service.impl;
 
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import won.protocol.jms.MessagingService;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
@@ -27,12 +22,17 @@ import won.protocol.model.Atom;
 import won.protocol.repository.AtomRepository;
 import won.protocol.service.WonNodeInformationService;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Manipulates atoms from the system side by generating msg:FromSystem messages.
  */
 @Component
 public class AtomManagementService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private MessagingService messagingService;
     @Autowired
@@ -46,7 +46,8 @@ public class AtomManagementService {
             return;
         }
         if (message == null || message.trim().length() == 0) {
-            logger.warn("sendTextMessageToOwner called for atom {}, but message is null or empty - doing nothing");
+            logger.warn("sendTextMessageToOwner called for atom {}, but message is null or empty - doing nothing",
+                            atomURI);
             return;
         }
         logger.debug("Sending FromSystem text message to atom {}", atomURI);
@@ -54,12 +55,14 @@ public class AtomManagementService {
         // does not exist at all)
         Atom atom = atomRepository.findOneByAtomURI(atomURI);
         if (atom == null) {
-            logger.debug("deactivateAtom called for atom {} but that atom was not found in the repository - doing nothing");
+            logger.debug("deactivateAtom called for atom {} but that atom was not found in the repository - doing nothing",
+                            atomURI);
             return;
         }
         URI wonNodeURI = wonNodeInformationService.getWonNodeUri(atomURI);
         if (wonNodeURI == null) {
-            logger.debug("deactivateAtom called for atom {} but we could not find a WonNodeURI for that atom - doing nothing");
+            logger.debug("deactivateAtom called for atom {} but we could not find a WonNodeURI for that atom - doing nothing",
+                            atomURI);
             return;
         }
         URI messageURI = wonNodeInformationService.generateEventURI(wonNodeURI);

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/DataAccessServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/DataAccessServiceImpl.java
@@ -1,9 +1,5 @@
 package won.node.service.impl;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.jena.graph.TripleBoundary;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
@@ -14,36 +10,23 @@ import org.apache.jena.rdf.model.StatementTripleBoundary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import won.protocol.exception.ConnectionAlreadyExistsException;
-import won.protocol.exception.IllegalMessageForAtomStateException;
-import won.protocol.exception.IllegalMessageForConnectionStateException;
-import won.protocol.exception.NoSuchAtomException;
-import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.model.Atom;
-import won.protocol.model.AtomState;
-import won.protocol.model.Connection;
-import won.protocol.model.ConnectionEventType;
-import won.protocol.model.ConnectionMessageContainer;
-import won.protocol.model.ConnectionState;
-import won.protocol.model.DatasetHolder;
-import won.protocol.model.Socket;
-import won.protocol.repository.AtomMessageContainerRepository;
-import won.protocol.repository.AtomRepository;
-import won.protocol.repository.ConnectionContainerRepository;
-import won.protocol.repository.ConnectionMessageContainerRepository;
-import won.protocol.repository.ConnectionRepository;
-import won.protocol.repository.DatasetHolderRepository;
-import won.protocol.repository.SocketRepository;
+import won.protocol.exception.*;
+import won.protocol.model.*;
+import won.protocol.repository.*;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.DataAccessUtils;
 import won.protocol.vocabulary.WONCON;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * T User: gabriel Date: 06/11/13
  */
 public class DataAccessServiceImpl implements won.node.service.DataAccessService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private URIService URIService;
     @Autowired
     private AtomRepository atomRepository;

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/LinkedDataServiceImpl.java
@@ -29,24 +29,24 @@ import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 import won.cryptography.rdfsign.WonKeysReaderWriter;
 import won.cryptography.service.CryptographyService;
-import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.exception.NoSuchAtomException;
+import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.message.WonMessageType;
 import won.protocol.model.*;
 import won.protocol.model.unread.UnreadMessageInfo;
 import won.protocol.model.unread.UnreadMessageInfoForAtom;
+import won.protocol.repository.AtomRepository;
 import won.protocol.repository.DatasetHolderRepository;
 import won.protocol.repository.MessageEventRepository;
-import won.protocol.repository.AtomRepository;
-import won.protocol.service.LinkedDataService;
 import won.protocol.service.AtomInformationService;
+import won.protocol.service.LinkedDataService;
 import won.protocol.service.impl.UnreadInformationService;
 import won.protocol.util.DefaultPrefixUtils;
 import won.protocol.util.RdfUtils;
-import won.protocol.vocabulary.LDP;
 import won.protocol.vocabulary.RDFG;
 import won.protocol.vocabulary.WON;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  * sorting
  */
 public class LinkedDataServiceImpl implements LinkedDataService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // prefix of an atom resource
     private String atomResourceURIPrefix;
     // prefix of a connection resource

--- a/webofneeds/won-node/src/main/java/won/node/service/impl/OwnerManagementServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/impl/OwnerManagementServiceImpl.java
@@ -1,20 +1,20 @@
 package won.node.service.impl;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.model.OwnerApplication;
 import won.protocol.repository.OwnerApplicationRepository;
 import won.protocol.service.ApplicationManagementService;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
 
 /**
  * User: sbyim Date: 11.11.13
  */
 public class OwnerManagementServiceImpl implements ApplicationManagementService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private OwnerApplicationRepository ownerApplicatonRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/coordinatorcompletion/BACCState.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/coordinatorcompletion/BACCState.java
@@ -2,9 +2,6 @@ package won.node.socket.businessactivity.coordinatorcompletion;
 
 import java.net.URI;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import won.node.socket.impl.WON_TX;
 
 /**
@@ -286,7 +283,6 @@ public enum BACCState {
             return null;
         }
     };
-    private static final Logger logger = LoggerFactory.getLogger(BACCState.class);
     private String name;
     private Phase phase;
     private static BACCEventType resendEvent = null;

--- a/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/participantcompletion/BAPCState.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/businessactivity/participantcompletion/BAPCState.java
@@ -1,5 +1,6 @@
 package won.node.socket.businessactivity.participantcompletion;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -223,7 +224,7 @@ public enum BAPCState {
             return null;
         }
     };
-    private static final Logger logger = LoggerFactory.getLogger(BAPCState.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String name;
     private Phase phase;
     private static BAPCEventType resendEvent = null;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/AbstractBASocket.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/AbstractBASocket.java
@@ -1,9 +1,5 @@
 package won.node.socket.impl;
 
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.concurrent.ExecutorService;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -13,26 +9,26 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.service.DataAccessService;
-import won.protocol.exception.ConnectionAlreadyExistsException;
-import won.protocol.exception.IllegalMessageForConnectionStateException;
-import won.protocol.exception.IllegalMessageForAtomStateException;
-import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.exception.NoSuchAtomException;
+import won.protocol.exception.*;
 import won.protocol.message.WonMessage;
-import won.protocol.model.Connection;
 import won.protocol.model.Atom;
 import won.protocol.model.AtomState;
+import won.protocol.model.Connection;
 import won.protocol.repository.DatasetHolderRepository;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.WON;
+
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
 
 /**
  * User: Danijel Date: 4.6.14.
  */
 public abstract class AbstractBASocket implements SocketLogic {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     protected won.node.service.impl.URIService URIService;
     protected ExecutorService executorService;
     protected DataAccessService dataService;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/AbstractSocket.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/AbstractSocket.java
@@ -1,9 +1,5 @@
 package won.node.socket.impl;
 
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.concurrent.ExecutorService;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -14,23 +10,22 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.service.DataAccessService;
-import won.protocol.exception.ConnectionAlreadyExistsException;
-import won.protocol.exception.IllegalMessageForConnectionStateException;
-import won.protocol.exception.IllegalMessageForAtomStateException;
-import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.exception.NoSuchAtomException;
-import won.protocol.exception.WonMessageBuilderException;
+import won.protocol.exception.*;
 import won.protocol.message.WonMessage;
-import won.protocol.model.Connection;
 import won.protocol.model.Atom;
 import won.protocol.model.AtomState;
-import won.protocol.repository.DatasetHolderRepository;
+import won.protocol.model.Connection;
 import won.protocol.repository.AtomRepository;
+import won.protocol.repository.DatasetHolderRepository;
 import won.protocol.service.WonNodeInformationService;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.vocabulary.WON;
+
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Created with IntelliJ IDEA. User: gabriel Date: 16.09.13 Time: 17:09 To
@@ -42,7 +37,7 @@ public abstract class AbstractSocket implements SocketLogic {
     // so as to form a unique graph name used for storing data that is managed by
     // the socket
     private static final String SOCKET_GRAPH_PATH = "socketgraph";
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     protected WonNodeInformationService wonNodeInformationService;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BAAtomicCCCoordinatorSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BAAtomicCCCoordinatorSocketImpl.java
@@ -1,17 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-import java.util.List;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.coordinatorcompletion.BACCEventType;
 import won.node.socket.businessactivity.coordinatorcompletion.BACCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -24,11 +16,15 @@ import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+
 /**
  * User: Danijel Date: 26.3.14.
  */
 public class BAAtomicCCCoordinatorSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     private BAStateManager stateManager;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BAAtomicPCCoordinatorSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BAAtomicPCCoordinatorSocketImpl.java
@@ -1,17 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-import java.util.List;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.participantcompletion.BAPCEventType;
 import won.node.socket.businessactivity.participantcompletion.BAPCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -24,11 +16,15 @@ import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
+
 /**
  * User: Danijel Date: 19.3.14.
  */
 public class BAAtomicPCCoordinatorSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BACCCoordinatorSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BACCCoordinatorSocketImpl.java
@@ -1,16 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.coordinatorcompletion.BACCEventType;
 import won.node.socket.businessactivity.coordinatorcompletion.BACCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -22,12 +15,15 @@ import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 6.2.14. Time: 15.36 To change
  * this template use File | Settings | File Templates.
  */
 public class BACCCoordinatorSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     private BAStateManager stateManager;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BACCParticipantSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BACCParticipantSocketImpl.java
@@ -1,16 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.coordinatorcompletion.BACCEventType;
 import won.node.socket.businessactivity.coordinatorcompletion.BACCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -22,12 +15,15 @@ import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 6.2.14. Time: 15.32 To change
  * this template use File | Settings | File Templates.
  */
 public class BACCParticipantSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BAPCCoordinatorSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BAPCCoordinatorSocketImpl.java
@@ -1,16 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.participantcompletion.BAPCEventType;
 import won.node.socket.businessactivity.participantcompletion.BAPCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -21,12 +14,15 @@ import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 16.1.14. Time: 16.39 To
  * change this template use File | Settings | File Templates.
  */
 public class BAPCCoordinatorSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private BAStateManager stateManager;
 

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/BAPCParticipantSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/BAPCParticipantSocketImpl.java
@@ -1,16 +1,9 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.node.socket.businessactivity.participantcompletion.BAPCEventType;
 import won.node.socket.businessactivity.participantcompletion.BAPCState;
 import won.node.socket.businessactivity.statemanager.BAStateManager;
@@ -21,12 +14,15 @@ import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
 import won.protocol.util.WonRdfUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 16.1.14. Time: 16.30 To
  * change this template use File | Settings | File Templates.
  */
 public class BAPCParticipantSocketImpl extends AbstractBASocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private BAStateManager stateManager;
 

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/ChatSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/ChatSocketImpl.java
@@ -1,9 +1,6 @@
 package won.node.socket.impl;
 
 import org.apache.jena.rdf.model.Model;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import won.protocol.exception.ConnectionAlreadyExistsException;
 import won.protocol.exception.IllegalMessageForAtomStateException;
 import won.protocol.exception.NoSuchAtomException;
@@ -16,8 +13,6 @@ import won.protocol.model.SocketType;
  * change this template use File | Settings | File Templates.
  */
 public class ChatSocketImpl extends AbstractSocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
     @Override
     public SocketType getSocketType() {
         return SocketType.ChatSocket;

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentModeratedSocket.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentModeratedSocket.java
@@ -5,7 +5,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.PrefixMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.exception.ConnectionAlreadyExistsException;
 import won.protocol.exception.IllegalMessageForAtomStateException;
 import won.protocol.exception.NoSuchAtomException;
@@ -15,11 +14,13 @@ import won.protocol.model.SocketType;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.SIOC;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: gabriel Date: 17/01/14
  */
 public class CommentModeratedSocket extends AbstractSocket {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public SocketType getSocketType() {

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentSocket.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentSocket.java
@@ -1,30 +1,30 @@
 package won.node.socket.impl;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.PrefixMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.exception.IllegalMessageForConnectionStateException;
 import won.protocol.exception.NoSuchConnectionException;
 import won.protocol.message.WonMessage;
+import won.protocol.model.Atom;
 import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
-import won.protocol.model.Atom;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.SIOC;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * User: gabriel Date: 17/01/14
  */
 public class CommentSocket extends AbstractSocket {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public SocketType getSocketType() {

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentUnrestrictedSocket.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/CommentUnrestrictedSocket.java
@@ -5,22 +5,23 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.PrefixMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.exception.ConnectionAlreadyExistsException;
 import won.protocol.exception.IllegalMessageForAtomStateException;
 import won.protocol.exception.NoSuchAtomException;
 import won.protocol.message.WonMessage;
+import won.protocol.model.Atom;
 import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
-import won.protocol.model.Atom;
 import won.protocol.util.RdfUtils;
 import won.protocol.vocabulary.SIOC;
+
+import java.lang.invoke.MethodHandles;
 
 /**
  * User: gabriel Date: 17/01/14
  */
 public class CommentUnrestrictedSocket extends AbstractSocket {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public SocketType getSocketType() {

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/CoordinatorSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/CoordinatorSocketImpl.java
@@ -1,7 +1,5 @@
 package won.node.socket.impl;
 
-import java.util.List;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -9,12 +7,7 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import won.protocol.exception.ConnectionAlreadyExistsException;
-import won.protocol.exception.IllegalMessageForConnectionStateException;
-import won.protocol.exception.IllegalMessageForAtomStateException;
-import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.exception.NoSuchAtomException;
+import won.protocol.exception.*;
 import won.protocol.message.WonMessage;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionState;
@@ -22,12 +15,15 @@ import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.vocabulary.WON;
 
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 9.12.13. Time: 19.20 To
  * change this template use File | Settings | File Templates.
  */
 public class CoordinatorSocketImpl extends AbstractSocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
 

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/ParticipantSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/ParticipantSocketImpl.java
@@ -7,24 +7,21 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import won.protocol.exception.ConnectionAlreadyExistsException;
-import won.protocol.exception.IllegalMessageForConnectionStateException;
-import won.protocol.exception.IllegalMessageForAtomStateException;
-import won.protocol.exception.NoSuchConnectionException;
-import won.protocol.exception.NoSuchAtomException;
+import won.protocol.exception.*;
 import won.protocol.message.WonMessage;
 import won.protocol.model.Connection;
 import won.protocol.model.SocketType;
 import won.protocol.repository.ConnectionRepository;
 import won.protocol.vocabulary.WON;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Created with IntelliJ IDEA. User: Danijel Date: 9.12.13. Time: 19.19 To
  * change this template use File | Settings | File Templates.
  */
 public class ParticipantSocketImpl extends AbstractSocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private ConnectionRepository connectionRepository;
 

--- a/webofneeds/won-node/src/main/java/won/node/socket/impl/ReviewSocketImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/socket/impl/ReviewSocketImpl.java
@@ -1,9 +1,6 @@
 package won.node.socket.impl;
 
 import org.apache.jena.rdf.model.Model;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import won.protocol.exception.ConnectionAlreadyExistsException;
 import won.protocol.exception.IllegalMessageForAtomStateException;
 import won.protocol.exception.NoSuchAtomException;
@@ -15,8 +12,6 @@ import won.protocol.model.SocketType;
  * created by MS on 12.12.2018
  */
 public class ReviewSocketImpl extends AbstractSocket {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
     @Override
     public SocketType getSocketType() {
         return SocketType.ReviewSocket;

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/ClientCertificateNoWebIdUserDetailsService.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/ClientCertificateNoWebIdUserDetailsService.java
@@ -10,12 +10,6 @@
  */
 package won.node.springsecurity;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -26,6 +20,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Assumes that the provided username is a linked data URI that contains WebID
  * information. The URI is accessed and the RDF is downloaded and added to the
@@ -33,7 +34,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
  */
 public class ClientCertificateNoWebIdUserDetailsService
                 implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public UserDetails loadUserDetails(final PreAuthenticatedAuthenticationToken token)

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/DefaultWoNAccessDecisionVoter.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/DefaultWoNAccessDecisionVoter.java
@@ -10,10 +10,6 @@
  */
 package won.node.springsecurity;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,14 +20,18 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.util.StopWatch;
-
 import won.cryptography.webid.AccessControlRules;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Created by fkleedorfer on 28.11.2016.
  */
 public class DefaultWoNAccessDecisionVoter implements AccessDecisionVoter {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     AccessControlRules defaultAccessControlRules;
 

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/WebIdUserDetailsService.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/WebIdUserDetailsService.java
@@ -10,12 +10,6 @@
  */
 package won.node.springsecurity;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,8 +21,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.util.StopWatch;
-
 import won.cryptography.webid.WebIDVerificationAgent;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Assumes that the provided username is a linked data URI that contains WebID
@@ -36,7 +36,7 @@ import won.cryptography.webid.WebIDVerificationAgent;
  * UserDetails for future reference.
  */
 public class WebIdUserDetailsService implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private WebIDVerificationAgent webIDVerificationAgent;
 

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/WonDefaultAccessControlRules.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/WonDefaultAccessControlRules.java
@@ -1,23 +1,23 @@
 package won.node.springsecurity;
 
-import java.net.URI;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.cryptography.webid.AccessControlRules;
 import won.node.service.impl.URIService;
+import won.protocol.repository.AtomMessageContainerRepository;
 import won.protocol.repository.ConnectionMessageContainerRepository;
 import won.protocol.repository.MessageEventRepository;
-import won.protocol.repository.AtomMessageContainerRepository;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.List;
 
 /**
  * User: ypanchenko Date: 28.07.2015
  */
 public class WonDefaultAccessControlRules implements AccessControlRules {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // TODO this is tepmorary, untill the acl source is defined
     @Autowired
     protected MessageEventRepository messageEventRepository;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -1,13 +1,5 @@
 package won.owner.web;
 
-import java.io.File;
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
 import org.apache.jena.query.Dataset;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -18,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-
 import won.owner.model.EmailVerificationToken;
 import won.owner.model.User;
 import won.owner.service.impl.URIService;
@@ -26,11 +17,20 @@ import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.utils.mail.WonMailSender;
 
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
 /**
  * User: ypanchenko Date: 23.02.2015
  */
 public class WonOwnerMailSender {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String OWNER_TARGET_ATOM_LINK = "/#!post/?postUri=";
     private static final String OWNER_CONNECTION_LINK = "/#!connections?connectionUri=%s";
     private static final String OWNER_LOCAL_ATOM_LINK = "/#!post/?postUri=";

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/listener/ExportListener.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/listener/ExportListener.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.security.KeyStoreException;
@@ -38,7 +39,7 @@ import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
 @Component
 public class ExportListener implements ApplicationListener<OnExportUserEvent> {
-    private static final Logger logger = LoggerFactory.getLogger(ExportListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private LinkedDataSource linkedDataSourceOnBehalfOfAtom;
     @Autowired
@@ -116,7 +117,7 @@ public class ExportListener implements ApplicationListener<OnExportUserEvent> {
     }
 
     private static boolean recrawl(Set<URI> recrawled, URI atomUri, LinkedDataSource linkedDataSource, URI... uris) {
-        Set<URI> urisToCrawl = new HashSet<URI>();
+        Set<URI> urisToCrawl = new HashSet<>();
         Arrays.stream(uris).filter(x -> !recrawled.contains(x)).forEach(urisToCrawl::add);
         if (urisToCrawl.isEmpty()) {
             if (logger.isDebugEnabled()) {
@@ -143,8 +144,7 @@ public class ExportListener implements ApplicationListener<OnExportUserEvent> {
         while (true) {
             // we leave the loop either with a runtime exception or with the result
             try {
-                Dataset atomDataset = WonLinkedDataUtils.getFullAtomDataset(atomUri, linkedDataSourceOnBehalfOfAtom);
-                return atomDataset;
+                return WonLinkedDataUtils.getFullAtomDataset(atomUri, linkedDataSourceOnBehalfOfAtom);
             } catch (LinkedDataFetchingException e) {
                 // we may have tried to crawl a conversation dataset of which messages
                 // were still in-flight. we allow one re-crawl attempt per exception before

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/AgreementProtocolController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/AgreementProtocolController.java
@@ -1,12 +1,7 @@
 package won.owner.web.rest;
 
-import java.net.URI;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +9,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
 import won.protocol.agreement.AgreementProtocolState;
 import won.protocol.agreement.AgreementProtocolUris;
 import won.protocol.agreement.effect.MessageEffect;
@@ -22,10 +16,12 @@ import won.protocol.util.AuthenticationThreadLocal;
 import won.protocol.util.WonConversationUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.net.URI;
+import java.util.Set;
+
 @Controller
 @RequestMapping("/rest/agreement")
 public class AgreementProtocolController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private LinkedDataSource linkedDataSourceOnBehalfOfAtom;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/PetriNetController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/PetriNetController.java
@@ -1,10 +1,5 @@
 package won.owner.web.rest;
 
-import java.net.URI;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +7,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
 import won.protocol.agreement.AgreementProtocolState;
 import won.protocol.agreement.petrinet.PetriNetStates;
 import won.protocol.agreement.petrinet.PetriNetUris;
@@ -20,10 +14,12 @@ import won.protocol.util.AuthenticationThreadLocal;
 import won.protocol.util.WonConversationUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.net.URI;
+import java.util.Set;
+
 @Controller
 @RequestMapping("/rest/petrinet")
 public class PetriNetController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private LinkedDataSource linkedDataSourceOnBehalfOfAtom;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/RestUserController.java
@@ -4,17 +4,6 @@
  */
 package won.owner.web.rest;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import nl.martijndwars.webpush.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,11 +12,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.CredentialsExpiredException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -39,30 +24,12 @@ import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
-
 import won.owner.model.*;
-import won.owner.pojo.AnonymousLinkPojo;
-import won.owner.pojo.ChangePasswordPojo;
-import won.owner.pojo.ResetPasswordPojo;
-import won.owner.pojo.RestStatusResponse;
-import won.owner.pojo.TransferUserPojo;
-import won.owner.pojo.UserPojo;
-import won.owner.pojo.UserSettingsPojo;
-import won.owner.pojo.UsernamePojo;
-import won.owner.pojo.VerificationTokenPojo;
+import won.owner.pojo.*;
 import won.owner.repository.UserAtomRepository;
-import won.owner.service.impl.IncorrectPasswordException;
-import won.owner.service.impl.KeystoreEnabledPersistentRememberMeServices;
-import won.owner.service.impl.KeystoreEnabledUserDetails;
-import won.owner.service.impl.UserAlreadyExistsException;
-import won.owner.service.impl.UserNotFoundException;
-import won.owner.service.impl.UserService;
+import won.owner.service.impl.*;
 import won.owner.web.WonOwnerMailSender;
 import won.owner.web.events.OnExportUserEvent;
 import won.owner.web.events.OnPasswordChangedEvent;
@@ -72,13 +39,24 @@ import won.owner.web.validator.PasswordChangeValidator;
 import won.owner.web.validator.ResetPasswordValidator;
 import won.owner.web.validator.UserRegisterValidator;
 
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * User: t.kozel Date: 11/12/13
  */
 @Controller
 @RequestMapping("/rest/users")
 public class RestUserController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private AuthenticationManager authenticationManager;
     private SecurityContextRepository securityContextRepository;
     private UserRegisterValidator userRegisterValidator;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/ServerSideActionController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/ServerSideActionController.java
@@ -1,12 +1,5 @@
 package won.owner.web.rest;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +8,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
 import won.owner.model.User;
 import won.owner.model.UserAtom;
 import won.owner.pojo.SocketToConnect;
@@ -23,10 +15,14 @@ import won.owner.repository.UserAtomRepository;
 import won.owner.service.impl.UserService;
 import won.owner.web.service.ServerSideActionService;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 @Controller
 @RequestMapping("/rest/action")
 public class ServerSideActionController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private UserAtomRepository userAtomRepository;
     @Autowired

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/service/serversideaction/EventTriggeredAction.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/service/serversideaction/EventTriggeredAction.java
@@ -7,15 +7,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class EventTriggeredAction<E> {
     private Predicate<Optional<E>> triggerPredicate;
     // a function accepting one event of type T, and produces zero or more
     // EventTriggeredActions
     private Function<Optional<E>, Collection<EventTriggeredAction<E>>> action;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private String name;
     private Date created = new Date();
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/service/serversideaction/EventTriggeredActionContainer.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/service/serversideaction/EventTriggeredActionContainer.java
@@ -1,25 +1,19 @@
 package won.owner.web.service.serversideaction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.protocol.util.LoggingUtils;
+
+import java.lang.invoke.MethodHandles;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import won.protocol.util.LoggingUtils;
-
 public class EventTriggeredActionContainer<E> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<EventTriggeredAction<E>> actions = new ArrayList<>();
     private List<EventTriggeredAction<E>> actionsToAdd = new ArrayList<>();
     private Duration maxAge = Duration.ofMinutes(10);

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/sitemap/SitemapController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/sitemap/SitemapController.java
@@ -1,10 +1,5 @@
 package won.owner.web.sitemap;
 
-import java.io.IOException;
-import java.io.Writer;
-
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,10 +9,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.invoke.MethodHandles;
+
 @Controller
 @RequestMapping("/")
 public class SitemapController {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private SitemapService sitemapService;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/PasswordChangeValidator.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/PasswordChangeValidator.java
@@ -4,13 +4,10 @@
  */
 package won.owner.web.validator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-
 import won.owner.model.User;
 import won.owner.pojo.ChangePasswordPojo;
 import won.owner.pojo.UserPojo;
@@ -18,7 +15,6 @@ import won.owner.service.impl.WONUserDetailService;
 
 @Component
 public class PasswordChangeValidator implements Validator {
-    private final static Logger log = LoggerFactory.getLogger(PasswordChangeValidator.class);
     private final Validator validator;
     private final WONUserDetailService wonUserDetailService;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/ResetPasswordValidator.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/ResetPasswordValidator.java
@@ -4,13 +4,10 @@
  */
 package won.owner.web.validator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-
 import won.owner.model.User;
 import won.owner.pojo.ResetPasswordPojo;
 import won.owner.pojo.UserPojo;
@@ -18,7 +15,6 @@ import won.owner.service.impl.WONUserDetailService;
 
 @Component
 public class ResetPasswordValidator implements Validator {
-    private final static Logger log = LoggerFactory.getLogger(ResetPasswordValidator.class);
     private final Validator validator;
     private final WONUserDetailService wonUserDetailService;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/UserRegisterValidator.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/validator/UserRegisterValidator.java
@@ -4,13 +4,10 @@
  */
 package won.owner.web.validator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-
 import won.owner.model.User;
 import won.owner.pojo.UserPojo;
 import won.owner.service.impl.WONUserDetailService;
@@ -20,7 +17,6 @@ import won.owner.service.impl.WONUserDetailService;
  */
 @Component
 public class UserRegisterValidator implements Validator {
-    private final static Logger log = LoggerFactory.getLogger(UserRegisterValidator.class);
     private final Validator validator;
     private final WONUserDetailService wonUserDetailService;
 

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/EagerlyCachePopulatingMessageProcessor.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/EagerlyCachePopulatingMessageProcessor.java
@@ -1,15 +1,8 @@
 package won.owner.web.websocket;
 
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ThreadPoolExecutor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
@@ -17,8 +10,15 @@ import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.CachingLinkedDataSource;
 import won.protocol.util.linkeddata.LinkedDataSource;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+
 public class EagerlyCachePopulatingMessageProcessor implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private LinkedDataSource linkedDataSourceOnBehalfOfAtom;
     @Autowired

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WebSocketSessionMapping.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WebSocketSessionMapping.java
@@ -1,14 +1,15 @@
 package won.owner.web.websocket;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.socket.WebSocketSession;
 
 /**
  * This service stores the connection between the WebSocket sessions and a given
@@ -17,7 +18,7 @@ import org.springframework.web.socket.WebSocketSession;
  * @author Fabian Salcher
  */
 public class WebSocketSessionMapping<T> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // ToDo (FS): make this persistent
     private Map<T, Set<WebSocketSession>> mapping = new HashMap<T, Set<WebSocketSession>>();
     private Object lock;

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonHandshakeInterceptor.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonHandshakeInterceptor.java
@@ -10,12 +10,6 @@
  */
 package won.owner.web.websocket;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.http.HttpSession;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.server.ServerHttpRequest;
@@ -25,11 +19,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
+import javax.servlet.http.HttpSession;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * User: LEIH-NB Date: 09.10.2014
  */
 public class WonHandshakeInterceptor extends HttpSessionHandshakeInterceptor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final String SESSION_ATTR = "HTTP.SESSION.ID";
     public static final String USERNAME_ATTR = "username";
     private static final List<String> ATTRIBUTE_NAMES = new ArrayList<>(2);

--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -10,25 +10,6 @@
  */
 package won.owner.web.websocket;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.Principal;
-import java.text.MessageFormat;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.persistence.criteria.CriteriaBuilder.Case;
-
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
@@ -49,7 +30,6 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
-
 import won.owner.model.User;
 import won.owner.model.UserAtom;
 import won.owner.repository.UserAtomRepository;
@@ -60,11 +40,7 @@ import won.owner.service.impl.URIService;
 import won.owner.web.WonOwnerMailSender;
 import won.owner.web.WonOwnerPushSender;
 import won.owner.web.service.ServerSideActionService;
-import won.protocol.message.WonMessage;
-import won.protocol.message.WonMessageDecoder;
-import won.protocol.message.WonMessageDirection;
-import won.protocol.message.WonMessageEncoder;
-import won.protocol.message.WonMessageType;
+import won.protocol.message.*;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.model.AtomState;
 import won.protocol.util.AuthenticationThreadLocal;
@@ -74,12 +50,25 @@ import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.utils.batch.BatchingConsumer;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.text.MessageFormat;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
 /**
  * User: syim Date: 06.08.14
  */
 public class WonWebSocketHandler extends TextWebSocketHandler
                 implements WonMessageProcessor, InitializingBean, DisposableBean {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // if we're receiving a partial message, a StringBuilder will be in the
     // session's attributes map under this key
     private static final String SESSION_ATTRIBUTE_PARTIAL_MESSAGE = "partialMessage";

--- a/webofneeds/won-owner/src/main/java/won/owner/camel/routes/OwnerApplicationListenerRouteBuilder.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/camel/routes/OwnerApplicationListenerRouteBuilder.java
@@ -10,17 +10,17 @@
  */
 package won.owner.camel.routes;
 
-import java.net.URI;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.PredicateBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.message.processor.camel.WonCamelConstants;
 import won.protocol.vocabulary.WONMSG;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 // TODO: This route builder should not be loaded on startup, but it's being
 // loaded..
@@ -30,7 +30,7 @@ import won.protocol.vocabulary.WONMSG;
  * generate routes dynamically in runtime that listen to those queues.
  */
 public class OwnerApplicationListenerRouteBuilder extends RouteBuilder {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String endpoint;
     private URI brokerUri;
 

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCamelConfiguratorImpl.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerProtocolCamelConfiguratorImpl.java
@@ -10,22 +10,14 @@
  */
 package won.owner.messaging;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-
 import won.cryptography.ssl.MessagingContext;
 import won.owner.camel.routes.OwnerApplicationListenerRouteBuilder;
 import won.owner.camel.routes.OwnerProtocolDynamicRoutes;
@@ -33,8 +25,15 @@ import won.protocol.exception.CamelConfigurationFailedException;
 import won.protocol.jms.BrokerComponentFactory;
 import won.protocol.jms.OwnerProtocolCamelConfigurator;
 import won.protocol.model.MessagingType;
-import won.protocol.repository.ConnectionRepository;
 import won.protocol.repository.AtomRepository;
+import won.protocol.repository.ConnectionRepository;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * User: LEIH-NB Date: 28.01.14
@@ -48,7 +47,7 @@ public class OwnerProtocolCamelConfiguratorImpl implements OwnerProtocolCamelCon
     private ConnectionRepository connectionRepository;
     @Autowired
     private BrokerComponentFactory brokerComponentFactory;
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private BiMap<URI, String> endpointMap = HashBiMap.create();
     private Map<URI, String> startingComponentMap = new HashMap<>();
     private BiMap<URI, String> brokerComponentMap = HashBiMap.create();

--- a/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/messaging/OwnerWonMessageSenderJMSBased.java
@@ -10,17 +10,11 @@
  */
 package won.owner.messaging;
 
-import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
-
 import won.protocol.jms.MessagingService;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageEncoder;
@@ -29,15 +23,21 @@ import won.protocol.message.processor.impl.SignatureAddingWonMessageProcessor;
 import won.protocol.message.sender.WonMessageSender;
 import won.protocol.model.WonNode;
 import won.protocol.repository.WonNodeRepository;
-import won.protocol.util.RdfUtils;
 import won.protocol.util.LoggingUtils;
+import won.protocol.util.RdfUtils;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * User: LEIH-NB Date: 17.10.13 Instance of this class receives events upon
  * which it tries to register at the default won node using JMS.
  */
 public class OwnerWonMessageSenderJMSBased implements ApplicationListener<WonNodeRegistrationEvent>, WonMessageSender {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private boolean isDefaultWonNodeRegistered = false;
     private MessagingService messagingService;
     private URI defaultNodeURI;

--- a/webofneeds/won-owner/src/main/java/won/owner/model/KeystoreHolder.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/model/KeystoreHolder.java
@@ -1,22 +1,15 @@
 package won.owner.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.security.KeyStore;
-import java.security.cert.CertificateException;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Entity
 @Table(name = "keystore")
@@ -29,7 +22,7 @@ public class KeystoreHolder {
     @Column(name = "id")
     private Long id;
     @Transient
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     // the keystore as a byte array
     @Lob
     @Column(name = "keystore_data", nullable = false, length = 10000000)

--- a/webofneeds/won-owner/src/main/java/won/owner/protocol/message/LinkedDataCacheInvalidator.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/protocol/message/LinkedDataCacheInvalidator.java
@@ -1,11 +1,8 @@
 package won.owner.protocol.message;
 
-import java.net.URI;
-
 import org.apache.jena.query.Dataset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageType;
 import won.protocol.message.processor.WonMessageProcessor;
@@ -14,12 +11,15 @@ import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.linkeddata.CachingLinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 /**
  * Removes elements from the linked data cache when certain messages are seen.
  * User: ypanchenko Date: 27.10.2015
  */
 public class LinkedDataCacheInvalidator implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void setLinkedDataSource(final CachingLinkedDataSource linkedDataSource) {
         this.linkedDataSource = linkedDataSource;

--- a/webofneeds/won-owner/src/main/java/won/owner/protocol/message/LinkedDataCacheUpdater.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/protocol/message/LinkedDataCacheUpdater.java
@@ -1,16 +1,16 @@
 package won.owner.protocol.message;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.util.linkeddata.CachingLinkedDataSource;
 import won.protocol.util.linkeddata.LinkedDataSource;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
 
 /**
  * Processor for incoming messages on the owner side. Will put incoming (hence
@@ -19,7 +19,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
  * @author fkleedorfer
  */
 public class LinkedDataCacheUpdater implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private LinkedDataSource linkedDataSourceOnBehalfOfAtom;
 

--- a/webofneeds/won-owner/src/main/java/won/owner/protocol/message/base/DatasetBackedOwnerCallbackAdapter.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/protocol/message/base/DatasetBackedOwnerCallbackAdapter.java
@@ -10,20 +10,9 @@
  */
 package won.owner.protocol.message.base;
 
-import java.net.URI;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.tdb.TDB;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import won.owner.protocol.message.OwnerCallback;
 import won.protocol.exception.DataIntegrityException;
 import won.protocol.message.WonMessage;
@@ -31,9 +20,10 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.model.Connection;
 import won.protocol.model.ConnectionState;
 import won.protocol.util.RdfUtils;
-import won.protocol.util.WonRdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.vocabulary.WON;
+
+import java.net.URI;
 
 /**
  * Implementation of the WonMessageHandlerAdapter that uses a Dataset for
@@ -48,7 +38,6 @@ public class DatasetBackedOwnerCallbackAdapter extends OwnerCallbackAdapter {
                     + "  ?con won:sourceAtom ?atom; " + "     won:atomState ?state; " + "     won:socket ?type; "
                     + "     won:targetAtom ?targetAtom." + "  OPTIONAL { " + "    ?con won:targetConnection ?remoteCon"
                     + "  } " + "} ";
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private Dataset dataset;
     @Autowired

--- a/webofneeds/won-owner/src/main/java/won/owner/protocol/message/base/OwnerCallbackAdapter.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/protocol/message/base/OwnerCallbackAdapter.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-
 import won.owner.protocol.message.OwnerCallback;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageType;
@@ -24,13 +23,15 @@ import won.protocol.message.processor.exception.WonMessageProcessingException;
 import won.protocol.model.Connection;
 import won.protocol.util.RdfUtils;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Maps incoming messages from the WonMessageProcessor interface to the
  * WonEventCallback interface. Outgoing messages sent by calling the adaptee's
  * send(msg) method are delegated to the
  */
 public abstract class OwnerCallbackAdapter implements WonMessageProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private OwnerCallback adaptee;
 
     protected OwnerCallbackAdapter() {

--- a/webofneeds/won-owner/src/main/java/won/owner/service/impl/KeystoreEnabledDaoAuthenticationProvider.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/service/impl/KeystoreEnabledDaoAuthenticationProvider.java
@@ -1,16 +1,9 @@
 package won.owner.service.impl;
 
-import java.security.KeyStore;
-
-import javax.transaction.Transactional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.Authentication;
-
 import won.owner.model.KeystoreHolder;
 import won.owner.model.KeystorePasswordHolder;
 import won.owner.model.User;
@@ -18,8 +11,10 @@ import won.owner.repository.KeystoreHolderRepository;
 import won.owner.repository.KeystorePasswordRepository;
 import won.owner.repository.UserRepository;
 
+import javax.transaction.Transactional;
+import java.security.KeyStore;
+
 public class KeystoreEnabledDaoAuthenticationProvider extends DaoAuthenticationProvider {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     UserRepository userRepository;
     @Autowired

--- a/webofneeds/won-owner/src/main/java/won/owner/service/impl/OwnerApplicationService.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/service/impl/OwnerApplicationService.java
@@ -9,12 +9,14 @@ import won.protocol.message.WonMessage;
 import won.protocol.message.processor.WonMessageProcessor;
 import won.protocol.message.sender.WonMessageSender;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Service that connects client-side logic (e.g. the WonWebSocketHandler in
  * won-owner-webapp) with facilities for sending and receiving messages.
  */
 public class OwnerApplicationService implements WonMessageProcessor, WonMessageSender {
-    private static final Logger logger = LoggerFactory.getLogger(OwnerApplicationService.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     @Qualifier("default")
     private WonMessageSender wonMessageSenderDelegate;

--- a/webofneeds/won-owner/src/main/java/won/owner/service/impl/PerUserKeystoreService.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/service/impl/PerUserKeystoreService.java
@@ -1,23 +1,19 @@
 package won.owner.service.impl;
 
-import java.security.KeyStore;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
 import won.cryptography.service.keystore.AbstractKeyStoreService;
 import won.owner.model.User;
 import won.owner.repository.KeystoreHolderRepository;
 import won.protocol.util.AuthenticationThreadLocal;
 
+import java.security.KeyStore;
+
 @Component
 public class PerUserKeystoreService extends AbstractKeyStoreService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private AuthenticationManager authenticationManager;
     @Autowired

--- a/webofneeds/won-owner/src/main/java/won/owner/service/impl/UserService.java
+++ b/webofneeds/won-owner/src/main/java/won/owner/service/impl/UserService.java
@@ -1,15 +1,5 @@
 package won.owner.service.impl;
 
-import java.security.Key;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,17 +9,23 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
 import won.owner.model.*;
 import won.owner.repository.*;
 import won.protocol.util.ExpensiveSecureRandomString;
+
+import java.lang.invoke.MethodHandles;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Created by fsuda on 28.05.2018.
  */
 @Service
 public class UserService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     @Autowired
     private UserRepository userRepository;
     @Autowired

--- a/webofneeds/won-utils/won-utils-batch/src/main/java/won/utils/batch/BatchingConsumer.java
+++ b/webofneeds/won-utils/won-utils-batch/src/main/java/won/utils/batch/BatchingConsumer.java
@@ -2,13 +2,7 @@ package won.utils.batch;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -17,9 +11,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Accepts items together with a key for grouping them, a
@@ -51,7 +42,6 @@ import org.slf4j.LoggerFactory;
  * @author fkleedorfer
  */
 public class BatchingConsumer<K, I> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Map<K, Batch<K, I>> batches = new HashMap<K, Batch<K, I>>(10);
     ScheduledExecutorService executorSvc = Executors.newSingleThreadScheduledExecutor();
     private Config defaultConfig = new ConfigBuilder()

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/AgreementProtocolState.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/AgreementProtocolState.java
@@ -1,34 +1,13 @@
 package won.protocol.agreement;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.PriorityQueue;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.ResIterator;
-import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdf.model.impl.ResourceImpl;
 import org.apache.jena.rdf.model.impl.StatementImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import won.protocol.agreement.effect.MessageEffect;
 import won.protocol.agreement.effect.MessageEffectsBuilder;
 import won.protocol.agreement.effect.ProposalType;
@@ -40,8 +19,15 @@ import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 import won.protocol.vocabulary.WONAGR;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class AgreementProtocolState {
-    private final Logger logger = LoggerFactory.getLogger(AgreementProtocolState.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final Dataset pendingProposals = DatasetFactory.createGeneral();
     private final Dataset agreements = DatasetFactory.createGeneral();
     private final Dataset claims = DatasetFactory.createGeneral();

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/petrinet/PetriNetLoader.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/petrinet/PetriNetLoader.java
@@ -1,19 +1,15 @@
 package won.protocol.agreement.petrinet;
 
+import uk.ac.imperial.pipe.io.PetriNetIO;
+import uk.ac.imperial.pipe.io.PetriNetIOImpl;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Base64;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.imperial.pipe.io.PetriNetIO;
-import uk.ac.imperial.pipe.io.PetriNetIOImpl;
-import uk.ac.imperial.pipe.models.petrinet.PetriNet;
-
 public class PetriNetLoader {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private Optional<PetriNetIOImpl> petriNetIO = Optional.empty();
 
     private synchronized PetriNetIO getPetriNetIO() {

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/petrinet/PetriNetStates.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/agreement/petrinet/PetriNetStates.java
@@ -1,13 +1,5 @@
 package won.protocol.agreement.petrinet;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -15,13 +7,16 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 import won.protocol.agreement.AgreementProtocolState;
 import won.protocol.vocabulary.WONWF;
 
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.*;
+
 public class PetriNetStates {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private AgreementProtocolState agreementProtocolState;
     private Dataset conversation;
     private Map<URI, PetriNetState> petrinetStates = new HashMap<>();

--- a/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/util/WonConversationUtils.java
+++ b/webofneeds/won-utils/won-utils-conversation/src/main/java/won/protocol/util/WonConversationUtils.java
@@ -1,5 +1,6 @@
 package won.protocol.util;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -20,7 +21,7 @@ import won.protocol.util.linkeddata.LinkedDataSource;
 import won.protocol.util.linkeddata.WonLinkedDataUtils;
 
 public class WonConversationUtils {
-    private static final Logger logger = LoggerFactory.getLogger(WonConversationUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static <T> T getFirstOrNull(Dataset dataset, Function<Dataset, List<T>> function) {
         // RDFDataMgr.write(System.err, dataset, Lang.TRIG);
@@ -126,7 +127,7 @@ public class WonConversationUtils {
 
     private static boolean recrawl(Set<URI> recrawled, URI connectionUri, URI atomUri,
                     LinkedDataSource linkedDataSource, URI... uris) {
-        Set<URI> urisToCrawl = new HashSet<URI>();
+        Set<URI> urisToCrawl = new HashSet<>();
         Arrays.stream(uris).filter(x -> !recrawled.contains(x)).forEach(urisToCrawl::add);
         if (urisToCrawl.isEmpty()) {
             if (logger.isDebugEnabled()) {

--- a/webofneeds/won-utils/won-utils-crawl/src/main/java/won/utils/crawl/app/CLRunnerBean.java
+++ b/webofneeds/won-utils/won-utils-crawl/src/main/java/won/utils/crawl/app/CLRunnerBean.java
@@ -2,6 +2,7 @@ package won.utils.crawl.app;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -42,7 +43,7 @@ import won.protocol.vocabulary.sparql.WonQueries;
  */
 @Component
 public class CLRunnerBean implements CommandLineRunner {
-    private static final Logger logger = LoggerFactory.getLogger(CLRunnerBean.class);
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private LinkedDataSource linkedDataSource;
 
     @Override
@@ -165,7 +166,7 @@ public class CLRunnerBean implements CommandLineRunner {
      * Build the property paths needed for crawling atom data
      */
     private static List<Path> configurePropertyPaths() {
-        List<Path> propertyPaths = new ArrayList<Path>();
+        List<Path> propertyPaths = new ArrayList<>();
         addPropertyPath(propertyPaths, "<" + WON.connections + ">");
         addPropertyPath(propertyPaths, "<" + WON.connections + ">" + "/" + "rdfs:member");
         addPropertyPath(propertyPaths,
@@ -178,7 +179,7 @@ public class CLRunnerBean implements CommandLineRunner {
     }
 
     private static List<Path> configurePropertyPathAll() {
-        List<Path> propertyPaths = new ArrayList<Path>();
+        List<Path> propertyPaths = new ArrayList<>();
         addPropertyPath(propertyPaths, "rdfs:member");
         addPropertyPath(propertyPaths, "rdfs:member/" + "<" + WON.connections + ">");
         addPropertyPath(propertyPaths, "rdfs:member/" + "<" + WON.connections + ">" + "/" + "rdfs:member");

--- a/webofneeds/won-utils/won-utils-mail/src/main/java/won/utils/mail/WonMailSender.java
+++ b/webofneeds/won-utils/won-utils-mail/src/main/java/won/utils/mail/WonMailSender.java
@@ -1,9 +1,5 @@
 package won.utils.mail;
 
-import java.io.File;
-
-import javax.mail.internet.MimeMessage;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mail.MailException;
@@ -11,13 +7,17 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
+import javax.mail.internet.MimeMessage;
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+
 /**
  * User: ypanchenko Date: 23.02.2015
  */
 public class WonMailSender {
     private JavaMailSender mailSender;
     private SimpleMailMessage templateMessage;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public void setMailSender(JavaMailSender mailSender) {
         this.mailSender = mailSender;


### PR DESCRIPTION
- Refactors all Logger instances into static final and private vars.
- Removes all unused loggers to reduce footprint (doesnt do much though)
- All loggers are now named `logger` not LOGGER or log

i decided to make all loggers static after all, due to the hints given within https://www.slf4j.org/faq.html#declared_static

If it ever becomes a classLoader issue (which i doubt it will) we can easily adapt them and make them non static,