### PR TITLE
Debugbot sends SocketHint, not AtomHint

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/impl/debugbot/CreateDebugAtomWithSocketsAction.java
@@ -126,7 +126,7 @@ public class CreateDebugAtomWithSocketsAction extends AbstractCreateAtomAction {
                 // save the mapping between the original and the reaction in to the context.
                 getEventListenerContext().getBotContextWrapper().addUriAssociation(reactingToAtomUri, atomURI);
                 if (origEvent instanceof HintDebugCommandEvent || isInitialForHint) {
-                    HintType hintType = HintType.ATOM_HINT;
+                    HintType hintType = HintType.RANDOM_SOCKET_HINT; // default: hint to random compatible sockets
                     if (origEvent instanceof HintDebugCommandEvent) {
                         hintType = ((HintDebugCommandEvent) origEvent).getHintType();
                         bus.publish(new AtomCreatedEventForDebugHint(origEvent, atomURI, wonNodeUri,


### PR DESCRIPTION
As the AtomHint isn't fully implmented at all layers yet, the debugbot is changed with this PR to send a SocketHint by default instead of an AtomHint