### PR TITLE
Fix  deployment debug bot

### DIFF
--- a/webofneeds/won-docker/deploy/hackathon_satvm02/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/hackathon_satvm02/docker-compose.yml
@@ -115,26 +115,25 @@ services:
   #   volumes:
   #     - $base_folder/mongodb/data/db:/data/db
 
-  # #debug bot used to test atom communication connect to wonnodes
-  # debug_bot:
-  #   restart: always
-  #   build: ../../image/bots
-  #   #image: webofneeds/bots:master
-  #   environment:
-  #     - "node.default.host=hackathonnode.matchat.org"
-  #     - "node.default.http.port=443"
-  #     - "uri.prefix.owner=https://hackathon.matchat.org/debug_bot" # set this for the trust store alias
-  #     - "won.node.uris=https://hackathonnode.matchat.org/won/resource"
-  #     - "uri.prefix.node.default=https://hackathonnode.matchat.org/won"
-  #     - "botContext.impl=mongoBotContext"
-  #     - "botContext.mongodb.user=won"
-  #     - "botContext.mongodb.pass=$mongo_db_passwd"
-  #     - "botContext.mongodb.host=satvm02.researchstudio.at"
-  #     - "botContext.mongodb.port=27019"
-  #     - "botContext.mongodb.database=hackathon_bot"
-  #   depends_on:
-  #     - mongodb
-  #     - wonnode
+#  # debug bot used to test atom communication, connect to wonnodes 1 and 2
+#  debug_bot:
+#    restart: always
+#    image: webofneeds/won-debugbot:latest
+#    environment:
+#      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+#      - "WON_NODE_URI=https://hackathonnode.matchat.org/won"
+#      - "uri.prefix.owner=https://hackathon.matchat.org/debug_bot" # set this for the trust store alias
+#      - "botContext.impl=mongoBotContext"
+#      - "botContext.mongodb.user=won"
+#      - "botContext.mongodb.pass=$mongo_db_passwd"
+#      - "botContext.mongodb.host=satvm02.researchstudio.at"
+#      - "botContext.mongodb.port=27019"
+#      - "botContext.mongodb.database=hackathon_bot"
+#    volumes:
+#      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+#    depends_on:
+#      - wonnode
+#      - mongodb
 
   # hokify_bot:
   #   restart: always

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -228,22 +228,22 @@ services:
     environment:
       - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
       - "WON_NODE_URI=https://satvm05.researchstudio.at/won"
-#      - "logging.config=/usr/src/bots/logback.xml"
+      - "logging.config=/usr/src/bots/logback.xml"
       - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
-      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
-      - "botContext.impl=mongoBotContext"
-      - "botContext.mongodb.user=won"
-      - "botContext.mongodb.pass=$mongo_db_passwd"
-      - "botContext.mongodb.host=satvm05.researchstudio.at"
-      - "botContext.mongodb.port=27018"
-      - "botContext.mongodb.database=int_bot"
+#      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
+#      - "botContext.impl=mongoBotContext"
+#      - "botContext.mongodb.user=won"
+#      - "botContext.mongodb.pass=$mongo_db_passwd"
+#      - "botContext.mongodb.host=satvm05.researchstudio.at"
+#      - "botContext.mongodb.port=27018"
+#      - "botContext.mongodb.database=int_bot"
     volumes:
       - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
-#      - $base_folder/logback_debug_bot.xml:/usr/src/bots/logback.xml
+      - $base_folder/logback_debug_bot.xml:/usr/src/bots/logback.xml
     depends_on:
       - wonnode1
       - wonnode2
-      - mongodb
+#      - mongodb
 
 #  hokify_bot:
 #    restart: always

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -228,22 +228,22 @@ services:
     environment:
       - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
       - "WON_NODE_URI=https://satvm05.researchstudio.at/won"
-      - "logging.config=/usr/src/bots/logback.xml"
+#      - "logging.config=/usr/src/bots/logback.xml"
       - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
-#      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm05.researchstudio.at"
-#      - "botContext.mongodb.port=27018"
-#      - "botContext.mongodb.database=int_bot"
+      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=won"
+      - "botContext.mongodb.pass=$mongo_db_passwd"
+      - "botContext.mongodb.host=satvm05.researchstudio.at"
+      - "botContext.mongodb.port=27018"
+      - "botContext.mongodb.database=int_bot"
     volumes:
       - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
-      - $base_folder/logback_debug_bot.xml:/usr/src/bots/logback.xml
+#      - $base_folder/logback_debug_bot.xml:/usr/src/bots/logback.xml
     depends_on:
       - wonnode1
       - wonnode2
-#      - mongodb
+      - mongodb
 
 #  hokify_bot:
 #    restart: always

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -222,25 +222,28 @@ services:
       - $base_folder/mongodb/data/db:/data/db
 
   # debug bot used to test atom communication, connect to wonnodes 1 and 2
-#  debug_bot:
-#    restart: always
-#    build: ../../image/bots
-#    image: webofneeds/bots:int
-#    environment:
-#      - "node.default.host=satvm05.researchstudio.at"
-#      - "node.default.http.port=8888"
-#      - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
-#      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm05.researchstudio.at"
-#      - "botContext.mongodb.port=27018"
-#      - "botContext.mongodb.database=int_bot"
-#    depends_on:
-#      - mongodb
-#      - wonnode1
-#      - wonnode2
+  debug_bot:
+    restart: always
+    image: webofneeds/won-debugbot:latest
+    environment:
+      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+      - "WON_NODE_URI=https://satvm05.researchstudio.at/won"
+      - "logging.config=/usr/src/bots/logback.xml"
+      - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
+      - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=won"
+      - "botContext.mongodb.pass=$mongo_db_passwd"
+      - "botContext.mongodb.host=satvm05.researchstudio.at"
+      - "botContext.mongodb.port=27018"
+      - "botContext.mongodb.database=int_bot"
+    volumes:
+      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+#      - $base_folder/logback_debug_bot.xml:/usr/src/bots/logback.xml
+    depends_on:
+      - wonnode1
+      - wonnode2
+      - mongodb
 
 #  hokify_bot:
 #    restart: always

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -228,7 +228,7 @@ services:
     environment:
       - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
       - "WON_NODE_URI=https://satvm05.researchstudio.at/won"
-      - "logging.config=/usr/src/bots/logback.xml"
+#      - "logging.config=/usr/src/bots/logback.xml"
       - "uri.prefix.owner=https://satvm05.researchstudio.at/debug_bot" # set this for the trust store alias
       - "won.node.uris=https://satvm05.researchstudio.at:8888/won/resource https://satvm05.researchstudio.at/won/resource"
       - "botContext.impl=mongoBotContext"

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -241,7 +241,7 @@ services:
     volumes:
       - $base_folder/mongodb/data/db:/data/db
 
-  # debug bot used to test atom communication, connect to wonnodes 1 and 2
+  # debug bot used to test atom communication, connect to wonnode
   debug_bot:
     restart: always
     image: webofneeds/won-debugbot:latest
@@ -261,27 +261,6 @@ services:
     depends_on:
       - wonnode
       - mongodb
-
-  # debug bot used to test atom communication, connect to wonnodes (proxied: node.matchat.org)
-#  debug_bot:
-#    restart: always
-#    build: ../../image/bots
-#    image: webofneeds/bots:live
-#    environment:
-
-#      - "node.default.host=node.matchat.org"
-#      - "node.default.http.port=443"
-#      - "uri.prefix.node.default=https://node.matchat.org/won"
-#      - "won.node.uris=https://node.matchat.org/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm01.researchstudio.at"
-#      - "botContext.mongodb.port=27017"
-#      - "botContext.mongodb.database=live_bot"
-#    depends_on:
-#      - wonnode
-#      - mongodb
 
   # job bot connecting hokify to WoN
 #  hokify_bot:

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -241,13 +241,34 @@ services:
     volumes:
       - $base_folder/mongodb/data/db:/data/db
 
+  # debug bot used to test atom communication, connect to wonnodes 1 and 2
+  debug_bot:
+    restart: always
+    image: webofneeds/won-debugbot:latest
+    environment:
+      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+      - "WON_NODE_URI=https://node.matchat.org/won"
+      - "uri.prefix.owner=https://matchat.org/debug_bot" # set this for the trust store alias
+      # - "won.node.uris=https://node.matchat.org/won/resource" #not necessary because the WON_NODE_URI is added by default if nothing is set
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=won"
+      - "botContext.mongodb.pass=$mongo_db_passwd"
+      - "botContext.mongodb.host=satvm01.researchstudio.at"
+      - "botContext.mongodb.port=27017"
+      - "botContext.mongodb.database=live_bot"
+    volumes:
+      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+    depends_on:
+      - wonnode
+      - mongodb
+
   # debug bot used to test atom communication, connect to wonnodes (proxied: node.matchat.org)
 #  debug_bot:
 #    restart: always
 #    build: ../../image/bots
 #    image: webofneeds/bots:live
 #    environment:
-#      - "uri.prefix.owner=https://matchat.org/debug_bot" # set this for the trust store alias
+
 #      - "node.default.host=node.matchat.org"
 #      - "node.default.http.port=443"
 #      - "uri.prefix.node.default=https://node.matchat.org/won"

--- a/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
@@ -215,47 +215,26 @@ services:
       - $base_folder/mongodb/data/db:/data/db
 
   # debug bot used to test atom communication, connect to wonnodes 1 and 2
-#  debug_bot:
-#    restart: always
-#    image: webofneeds/won-debugbot:latest
-#    environment:
-#      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
-#      - "WON_NODE_URI=https://nodeblue.master.matchat.org/won"
-#      - "uri.prefix.owner=https://master.matchat.org/debug_bot" # set this for the trust store alias
-#      - "won.node.uris=https://nodeblue.master.matchat.org/won/resource https://nodegreen.master.matchat.org/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm02.researchstudio.at"
-#      - "botContext.mongodb.port=27018"
-#      - "botContext.mongodb.database=master_bot"
-#    volumes:
-#      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
-#    depends_on:
-#      - wonnodeblue
-#      - wonnodegreen
-#      - mongodb
-
-  # debug bot used to test atom communication, connect to wonnodes blue and green
-#  debug_bot:
-#    restart: always
-#    build: ../../image/bots
-#    image: webofneeds/bots:master
-#    environment:
-#      - "node.default.host=nodeblue.master.matchat.org"
-#      - "node.default.http.port=443"
-#      - "uri.prefix.owner=https://master.matchat.org/debug_bot" # set this for the trust store alias
-#      - "won.node.uris=https://nodeblue.master.matchat.org/won/resource https://nodegreen.master.matchat.org/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm02.researchstudio.at"
-#      - "botContext.mongodb.port=27018"
-#      - "botContext.mongodb.database=master_bot"
-#    depends_on:
-#      - mongodb
-#      - wonnodeblue
-#      - wonnodegreen
+  debug_bot:
+    restart: always
+    image: webofneeds/won-debugbot:latest
+    environment:
+      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+      - "WON_NODE_URI=https://nodeblue.master.matchat.org/won"
+      - "uri.prefix.owner=https://master.matchat.org/debug_bot" # set this for the trust store alias
+      - "won.node.uris=https://nodeblue.master.matchat.org/won/resource https://nodegreen.master.matchat.org/won/resource"
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=won"
+      - "botContext.mongodb.pass=$mongo_db_passwd"
+      - "botContext.mongodb.host=satvm02.researchstudio.at"
+      - "botContext.mongodb.port=27018"
+      - "botContext.mongodb.database=master_bot"
+    volumes:
+      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+    depends_on:
+      - wonnodeblue
+      - wonnodegreen
+      - mongodb
 
 #  hokify_bot:
 #    restart: always

--- a/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
@@ -214,6 +214,28 @@ services:
     volumes:
       - $base_folder/mongodb/data/db:/data/db
 
+  # debug bot used to test atom communication, connect to wonnodes 1 and 2
+#  debug_bot:
+#    restart: always
+#    image: webofneeds/won-debugbot:latest
+#    environment:
+#      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+#      - "WON_NODE_URI=https://nodeblue.master.matchat.org/won"
+#      - "uri.prefix.owner=https://master.matchat.org/debug_bot" # set this for the trust store alias
+#      - "won.node.uris=https://nodeblue.master.matchat.org/won/resource https://nodegreen.master.matchat.org/won/resource"
+#      - "botContext.impl=mongoBotContext"
+#      - "botContext.mongodb.user=won"
+#      - "botContext.mongodb.pass=$mongo_db_passwd"
+#      - "botContext.mongodb.host=satvm02.researchstudio.at"
+#      - "botContext.mongodb.port=27018"
+#      - "botContext.mongodb.database=master_bot"
+#    volumes:
+#      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+#    depends_on:
+#      - wonnodeblue
+#      - wonnodegreen
+#      - mongodb
+
   # debug bot used to test atom communication, connect to wonnodes blue and green
 #  debug_bot:
 #    restart: always

--- a/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/uki_satvm06/docker-compose.yml
@@ -169,26 +169,26 @@ services:
     volumes:
       - $base_folder/mongodb/data/db:/data/db
 
-  # debug bot used to test atom communication, connect to wonnodes (proxied: line.uki.or.at)
-#  debug_bot:
-#    restart: always
-#    build: ../../image/bots
-#    environment:
-#      - "uri.prefix.owner=https://cbi.matchat.org/debug_bot"  # set this for the trust store alias
-#      - "node.default.host=cbi.matchat.org"
-#      - "node.default.http.port=443"
-#      - "uri.prefix.node.default=https://cbi.matchat.org/won"
-#      - "won.node.uris=https://cbi.matchat.org/won/resource"
-#      - "botContext.impl=mongoBotContext"
-#      - "botContext.mongodb.user=won"
-#      - "botContext.mongodb.pass=$mongo_db_passwd"
-#      - "botContext.mongodb.host=satvm06.researchstudio.at"
-#      - "botContext.mongodb.port=27017"
-#      - "botContext.mongodb.database=uki_bot"
-#    depends_on:
-#      - wonnode
-#      - mongodb
-
+  # debug bot used to test atom communication, connect to wonnodes 1 and 2
+  debug_bot:
+    restart: always
+    image: webofneeds/won-debugbot:latest
+    environment:
+      - "WON_KEYSTORE_DIR=/usr/src/bots/client-certs/"
+      - "WON_NODE_URI=https://cbi.matchat.org/won"
+      - "uri.prefix.owner=https://cbi.matchat.org/debug_bot" # set this for the trust store alias
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=won"
+      - "botContext.mongodb.pass=$mongo_db_passwd"
+      - "botContext.mongodb.host=satvm06.researchstudio.at"
+      - "botContext.mongodb.port=27017"
+      - "botContext.mongodb.database=uki_bot"
+    volumes:
+      - $base_folder/won-client-certs/debug_bot:/usr/src/bots/client-certs/
+    depends_on:
+      - wonnodeblue
+      - wonnodegreen
+      - mongodb
 
   matcher_sparql:
     restart: always


### PR DESCRIPTION
Includes the debug_bot (from the dockerhub image) directly into our docker compose files

This should enable the debug_bot again for all instances (hackathon, live, integration-test, master, uki...) Be aware that merging this onto live makes it necessary to stop and remove orphan containers.... probably debug_bot hokify_bot mail_bot... in order to run. WARNING, if one does not do this before live deployment starts the build will successfully fail and docker will not start