### PR TITLE
Feat  atom action add buddy

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -22,12 +22,17 @@ export default class WonAddBuddy extends React.Component {
       <div className="add-buddy__addbuddymenu">
         <div className="add-buddy__addbuddymenu__content">
           <div className="topline">
-            <svg
-              className="add-buddy__icon__small__addbuddymenu clickable"
+            <div
+              className="add-buddy__addbuddymenu__header clickable"
               onClick={() => this.setState({ contextMenuOpen: false })}
             >
-              <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
-            </svg>
+              <svg className="add-buddy__addbuddymenu__header__icon">
+                <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
+              </svg>
+              <span className="add-buddy__addbuddymenu__header__text hide-in-responsive">
+                Add as Buddy
+              </span>
+            </div>
           </div>
           TODO Buddy Selection
         </div>
@@ -39,12 +44,17 @@ export default class WonAddBuddy extends React.Component {
         class={this.props.className ? this.props.className : ""}
         ref={node => (this.node = node)}
       >
-        <svg
-          className="add-buddy__icon__small clickable"
+        <div
+          className="add-buddy__addbuddymenu__header clickable"
           onClick={() => this.setState({ contextMenuOpen: true })}
         >
-          <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
-        </svg>
+          <svg className="add-buddy__addbuddymenu__header__icon">
+            <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
+          </svg>
+          <span className="add-buddy__addbuddymenu__header__text hide-in-responsive">
+            Add as Buddy
+          </span>
+        </div>
         {dropdownElement}
       </won-add-buddy>
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -205,7 +205,7 @@ class WonAddBuddy extends React.Component {
         // also includes suggested (BuddySocket)Connections
         connectionStateClass = "requestable";
         connectionStateIcon = "#ico36_plus_circle";
-        connectionStateLabel = "Accept as Buddy";
+        connectionStateLabel = "Add as Buddy";
         onClickAction = () => {
           console.debug(
             "IMMEDIATE CONNECT FROM",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -34,7 +34,9 @@ export default class WonAddBuddy extends React.Component {
               </span>
             </div>
           </div>
-          TODO Buddy Selection
+          <div className="add-buddy__addbuddymenu__content__selection">
+            TODO Buddy Selection
+          </div>
         </div>
       </div>
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -1,14 +1,33 @@
 import React from "react";
-
+import { connect } from "react-redux";
+import { get } from "../utils.js";
+import * as atomUtils from "../redux/utils/atom-utils.js";
+import * as generalSelectors from "../redux/selectors/general-selectors.js";
+import WonAtomHeader from "../components/atom-header.jsx";
 import PropTypes from "prop-types";
 
 import "~/style/_add-buddy.scss";
 
-// TODO: Action Label in desktopView
+const mapStateToProps = (state, ownProps) => {
+  const ownedAtomsWithBuddySocket = generalSelectors.getOwnedAtomsWithBuddySocket(
+    state
+  );
+
+  return {
+    ownedAtomsWithBuddySocketArray:
+      ownedAtomsWithBuddySocket &&
+      ownedAtomsWithBuddySocket
+        .filter(atom => atomUtils.isActive(atom))
+        .filter(atom => get(atom, "uri") !== ownProps.atomUri)
+        .toArray(),
+    atomUri: ownProps.atomUri,
+  };
+};
+
 // TODO: Change Icon maybe PersonIcon with a Plus
 // TODO: Immediate Action if only one Persona is owned by the User -> Open Modal Dialog to ask
 // TODO: Display Possible Personas and Personas that are already Buddies or have pending requests
-export default class WonAddBuddy extends React.Component {
+class WonAddBuddy extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -18,6 +37,22 @@ export default class WonAddBuddy extends React.Component {
   }
 
   render() {
+    let buddySelectionElement =
+      this.props.ownedAtomsWithBuddySocketArray &&
+      this.props.ownedAtomsWithBuddySocketArray.map(atom => {
+        return (
+          <div
+            className="add-buddy__addbuddymenu__content__selection__buddy"
+            key={get(atom, "uri")}
+          >
+            <WonAtomHeader atomUri={get(atom, "uri")} hideTimestamp={true} />
+            <svg className="add-buddy__addbuddymenu__content__selection__buddy__status">
+              <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
+            </svg>
+          </div>
+        );
+      });
+
     const dropdownElement = this.state.contextMenuOpen && (
       <div className="add-buddy__addbuddymenu">
         <div className="add-buddy__addbuddymenu__content">
@@ -35,7 +70,7 @@ export default class WonAddBuddy extends React.Component {
             </div>
           </div>
           <div className="add-buddy__addbuddymenu__content__selection">
-            TODO Buddy Selection
+            {buddySelectionElement}
           </div>
         </div>
       </div>
@@ -80,4 +115,7 @@ export default class WonAddBuddy extends React.Component {
 WonAddBuddy.propTypes = {
   atomUri: PropTypes.string.isRequired,
   className: PropTypes.string,
+  ownedAtomsWithBuddySocketArray: PropTypes.arrayOf(PropTypes.object),
 };
+
+export default connect(mapStateToProps)(WonAddBuddy);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -65,6 +65,9 @@ const mapDispatchToProps = dispatch => {
         )
       );
     },
+    connectionOpen: (connectionUri, message) => {
+      dispatch(actionCreators.connections__open(connectionUri, message));
+    },
   };
 };
 
@@ -288,14 +291,18 @@ class WonAddBuddy extends React.Component {
         {
           caption: "Yes",
           callback: () => {
-            this.props.connect(
-              selectedAtomUri,
-              existingBuddyConnectionUri,
-              this.props.atomUri,
-              message,
-              won.BUDDY.BuddySocketCompacted,
-              won.BUDDY.BuddySocketCompacted
-            );
+            if (connectionUtils.isRequestReceived(existingBuddyConnection)) {
+              this.props.open(existingBuddyConnectionUri, message);
+            } else {
+              this.props.connect(
+                selectedAtomUri,
+                existingBuddyConnectionUri,
+                this.props.atomUri,
+                message,
+                won.BUDDY.BuddySocketCompacted,
+                won.BUDDY.BuddySocketCompacted
+              );
+            }
             this.props.hideModalDialog();
           },
         },
@@ -319,6 +326,7 @@ WonAddBuddy.propTypes = {
   hideModalDialog: PropTypes.func,
   showModalDialog: PropTypes.func,
   connect: PropTypes.func,
+  open: PropTypes.func,
 };
 
 export default connect(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -19,11 +19,11 @@ export default class WonAddBuddy extends React.Component {
 
   render() {
     const dropdownElement = this.state.contextMenuOpen && (
-      <div className="add-buddy__sharemenu">
-        <div className="add-buddy__sharemenu__content">
+      <div className="add-buddy__addbuddymenu">
+        <div className="add-buddy__addbuddymenu__content">
           <div className="topline">
             <svg
-              className="add-buddy__icon__small__sharemenu clickable"
+              className="add-buddy__icon__small__addbuddymenu clickable"
               onClick={() => this.setState({ contextMenuOpen: false })}
             >
               <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/add-buddy.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+import PropTypes from "prop-types";
+
+import "~/style/_add-buddy.scss";
+
+// TODO: Action Label in desktopView
+// TODO: Change Icon maybe PersonIcon with a Plus
+// TODO: Immediate Action if only one Persona is owned by the User -> Open Modal Dialog to ask
+// TODO: Display Possible Personas and Personas that are already Buddies or have pending requests
+export default class WonAddBuddy extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      contextMenuOpen: false,
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  render() {
+    const dropdownElement = this.state.contextMenuOpen && (
+      <div className="add-buddy__sharemenu">
+        <div className="add-buddy__sharemenu__content">
+          <div className="topline">
+            <svg
+              className="add-buddy__icon__small__sharemenu clickable"
+              onClick={() => this.setState({ contextMenuOpen: false })}
+            >
+              <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
+            </svg>
+          </div>
+          TODO Buddy Selection
+        </div>
+      </div>
+    );
+
+    return (
+      <won-add-buddy
+        class={this.props.className ? this.props.className : ""}
+        ref={node => (this.node = node)}
+      >
+        <svg
+          className="add-buddy__icon__small clickable"
+          onClick={() => this.setState({ contextMenuOpen: true })}
+        >
+          <use xlinkHref="#ico36_plus_circle" href="#ico36_plus_circle" />
+        </svg>
+        {dropdownElement}
+      </won-add-buddy>
+    );
+  }
+
+  componentWillMount() {
+    document.addEventListener("mousedown", this.handleClick, false);
+  }
+  componentWillUnmount() {
+    document.removeEventListener("mousedown", this.handleClick, false);
+  }
+
+  handleClick(e) {
+    if (!this.node.contains(e.target) && this.state.contextMenuOpen) {
+      this.setState({ contextMenuOpen: false });
+
+      return;
+    }
+  }
+}
+WonAddBuddy.propTypes = {
+  atomUri: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -7,11 +7,13 @@ import { connect } from "react-redux";
 
 import "~/style/_atom-header-big.scss";
 import * as atomUtils from "../redux/utils/atom-utils";
+import * as accountUtils from "../redux/utils/account-utils";
 import { get, getIn } from "../utils.js";
 
 import WonAtomContextDropdown from "../components/atom-context-dropdown.jsx";
 import WonAtomIcon from "../components/atom-icon.jsx";
 import WonShareDropdown from "../components/share-dropdown.jsx";
+import WonAddBuddy from "../components/add-buddy.jsx";
 
 const mapStateToProps = (state, ownProps) => {
   const atom = state.getIn(["atoms", ownProps.atomUri]);
@@ -26,14 +28,20 @@ const mapStateToProps = (state, ownProps) => {
     ? getIn(state, ["atoms", responseToUri])
     : undefined;
 
+  const atomUri = ownProps.atomUri;
+  const accountState = get(state, "account");
+
   return {
-    atomUri: ownProps.atomUri,
+    atomUri,
     atom,
     personaName,
     isDirectResponse,
     responseToAtom,
     isGroupChatEnabled: atomUtils.hasGroupSocket(atom),
     isChatEnabled: atomUtils.hasChatSocket(atom),
+    showAddBuddyElement:
+      atomUtils.hasBuddySocket(atom) &&
+      !accountUtils.isAtomOwned(accountState, atomUri),
     atomTypeLabel: atom && atomUtils.generateTypeLabel(atom),
   };
 };
@@ -64,6 +72,10 @@ class WonAtomHeaderBig extends React.Component {
       </span>
     );
 
+    const buddyActionElement = this.props.showAddBuddyElement && (
+      <WonAddBuddy atomUri={this.props.atomUri} />
+    );
+
     return (
       <won-atom-header-big>
         <nav className="atom-header-big">
@@ -79,6 +91,7 @@ class WonAtomHeaderBig extends React.Component {
               </div>
             </hgroup>
           </div>
+          {buddyActionElement}
           <WonShareDropdown atomUri={this.props.atomUri} />
           <WonAtomContextDropdown atomUri={this.props.atomUri} />
         </nav>
@@ -111,6 +124,7 @@ WonAtomHeaderBig.propTypes = {
   responseToAtom: PropTypes.object,
   isGroupChatEnabled: PropTypes.bool,
   isChatEnabled: PropTypes.bool,
+  showAddBuddyElement: PropTypes.bool,
   atomTypeLabel: PropTypes.string,
 };
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -14,6 +14,7 @@ import WonAtomContextDropdown from "../components/atom-context-dropdown.jsx";
 import WonAtomIcon from "../components/atom-icon.jsx";
 import WonShareDropdown from "../components/share-dropdown.jsx";
 import WonAddBuddy from "../components/add-buddy.jsx";
+import * as generalSelectors from "../redux/selectors/general-selectors";
 
 const mapStateToProps = (state, ownProps) => {
   const atom = state.getIn(["atoms", ownProps.atomUri]);
@@ -31,6 +32,15 @@ const mapStateToProps = (state, ownProps) => {
   const atomUri = ownProps.atomUri;
   const accountState = get(state, "account");
 
+  const ownedAtomsWithBuddySocket = generalSelectors.getOwnedAtomsWithBuddySocket(
+    state
+  );
+  const hasOwnedAtomsWithBuddySocket =
+    ownedAtomsWithBuddySocket &&
+    ownedAtomsWithBuddySocket
+      .filter(atom => atomUtils.isActive(atom))
+      .filter(atom => get(atom, "uri") !== atomUri).size > 0;
+
   return {
     atomUri,
     atom,
@@ -41,6 +51,7 @@ const mapStateToProps = (state, ownProps) => {
     isChatEnabled: atomUtils.hasChatSocket(atom),
     showAddBuddyElement:
       atomUtils.hasBuddySocket(atom) &&
+      hasOwnedAtomsWithBuddySocket &&
       !accountUtils.isAtomOwned(accountState, atomUri),
     atomTypeLabel: atom && atomUtils.generateTypeLabel(atom),
   };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
@@ -45,7 +45,9 @@ const mapStateToProps = (state, ownProps) => {
     isDirectResponse: isDirectResponse,
     isGroupChatEnabled: atomUtils.hasGroupSocket(atom),
     isChatEnabled: atomUtils.hasChatSocket(atom),
+    hideTimestamp: ownProps.hideTimestamp,
     friendlyTimestamp:
+      !ownProps.hideTimestamp &&
       atom &&
       relativeTime(selectLastUpdateTime(state), get(atom, "lastUpdateDate")),
   };
@@ -162,9 +164,11 @@ class WonAtomHeader extends React.Component {
               )}
               <span>{this.props.atomTypeLabel}</span>
             </span>
-            <div className="ph__right__subtitle__date">
-              {this.props.friendlyTimestamp}
-            </div>
+            {!this.props.hideTimestamp && (
+              <div className="ph__right__subtitle__date">
+                {this.props.friendlyTimestamp}
+              </div>
+            )}
           </div>
         </div>
       );
@@ -228,6 +232,7 @@ class WonAtomHeader extends React.Component {
 
 WonAtomHeader.propTypes = {
   atomUri: PropTypes.string.isRequired,
+  hideTimestamp: PropTypes.bool,
   onClick: PropTypes.func,
   fetchAtom: PropTypes.func,
   responseToAtom: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -323,6 +323,11 @@ export function getOwnedPersonas(state) {
   return atoms && atoms.filter(atom => atomUtils.isPersona(atom));
 }
 
+export function getOwnedAtomsWithBuddySocket(state) {
+  const atoms = getOwnedAtoms(state);
+  return atoms && atoms.filter(atom => atomUtils.hasBuddySocket(atom));
+}
+
 /**
  * Returns all owned Personas as a List, condenses the information of the persona so that only some attributes are included.
  * This Function is currently used for persona lists/views based on elm (as they are not based on our general atom-structure)

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -3978,9 +3978,9 @@
       }
     },
     "elm": {
-      "version": "0.19.1-1",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-1.tgz",
-      "integrity": "sha512-iE3sWjMMX6TSyBNIOEqotLT4UvFjHczY68/az3MHBoasdKuwZyxyRrI3qGUqc2oBkxu/KS/54qIVE2nMn4dClw==",
+      "version": "0.19.1-3",
+      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-3.tgz",
+      "integrity": "sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==",
       "dev": true,
       "requires": {
         "request": "^2.88.0"

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -72,7 +72,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "cross-env": "^5.2.0",
-    "elm": "^0.19.1-1",
+    "elm": "^0.19.1-3",
     "elm-hot": "^1.1.2",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^2.10.0",

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -9,17 +9,15 @@ won-add-buddy {
 
   .add-buddy__addbuddymenu__header {
     white-space: nowrap;
-    display: flex;
+    display: grid;
+    grid-gap: 0.25rem;
+    grid-auto-flow: column;
     --local-primary: #{$won-secondary-color};
     color: $won-secondary-color;
-    padding-left: 0.25rem;
+    padding: 0 0.25rem;
 
     &__icon {
       @include fixed-square($postIconSizeMobile);
-      padding-right: 0.25rem;
-    }
-    &__text {
-      padding-right: 0.25rem;
     }
   }
 
@@ -46,15 +44,13 @@ won-add-buddy {
         float: right;
         right: -0.3rem;
 
-        &__icon {
-          @media (max-width: $responsivenessBreakPoint) {
-            padding-right: 0;
-          }
-        }
-
-        &__text {
+        @media (max-width: $responsivenessBreakPoint) {
           padding-right: 0;
         }
+      }
+
+      &__selection {
+        border-top: $thinGrayBorder;
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -19,6 +19,25 @@ won-add-buddy {
     &__icon {
       @include fixed-square($postIconSizeMobile);
     }
+
+    &.requestable,
+    &.received {
+      cursor: pointer;
+      &:hover {
+        --local-primary: #{$won-primary-color};
+        background: $won-light-gray;
+      }
+    }
+
+    &.connected {
+      --local-primary: green;
+    }
+
+    &.sent,
+    &.closed {
+      filter: opacity(0.5);
+      --local-primary: #{$won-dark-gray};
+    }
   }
 
   .add-buddy__addbuddymenu {
@@ -42,7 +61,7 @@ won-add-buddy {
         --local-primary: black;
         color: black;
         float: right;
-        right: -0.5rem;
+        right: -0.55rem;
       }
 
       &__selection {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -42,15 +42,35 @@ won-add-buddy {
         --local-primary: black;
         color: black;
         float: right;
-        right: -0.3rem;
-
-        @media (max-width: $responsivenessBreakPoint) {
-          padding-right: 0;
-        }
+        right: -0.5rem;
       }
 
       &__selection {
         border-top: $thinGrayBorder;
+        display: grid;
+        padding-top: 0.5rem;
+
+        &__buddy {
+          display: grid;
+          grid-template-areas: "buddy_atom buddy_status";
+          grid-gap: 0.5rem;
+          grid-template-columns: 1fr min-content;
+          align-items: center;
+          padding: 0.25rem;
+
+          &:hover {
+            background: $won-light-gray;
+          }
+
+          won-atom-header {
+            grid-area: buddy_atom;
+          }
+
+          .add-buddy__addbuddymenu__content__selection__buddy__status {
+            grid-area: buddy_status;
+            @include fixed-square($postIconSizeMobile);
+          }
+        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -58,8 +58,23 @@ won-add-buddy {
           align-items: center;
           padding: 0.25rem;
 
-          &:hover {
-            background: $won-light-gray;
+          &.requestable,
+          &.received {
+            cursor: pointer;
+            &:hover {
+              --local-primary: #{$won-primary-color};
+              background: $won-light-gray;
+            }
+          }
+
+          &.connected {
+            --local-primary: green;
+          }
+
+          &.sent,
+          &.closed {
+            filter: opacity(0.5);
+            --local-primary: #{$won-dark-gray};
           }
 
           won-atom-header {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -1,0 +1,60 @@
+@import "sizing-utils";
+@import "won-config";
+@import "animate";
+
+won-add-buddy {
+  .add-buddy__icon__small {
+    --local-primary: #{$won-secondary-color};
+    @include fixed-square($postIconSizeMobile);
+    padding-left: 0.5rem;
+    padding-right: 0.25rem;
+  }
+
+  .topline {
+    height: 2rem;
+  }
+
+  .add-buddy__icon__small__sharemenu {
+    --local-primary: black;
+    @include fixed-square($postIconSizeMobile);
+    //padding-left: 0.5rem;
+    position: relative;
+    right: -0.35rem;
+    /*the correct right value would be "calc(-0.5rem - #{$thinBorderWidth});"
+    however, it is not displayed correct so we assume the right value with -0.6rem*/
+    float: right;
+  }
+
+  .add-buddy__sharemenu {
+    position: relative;
+    height: 0;
+    z-index: 1000;
+    top: calc((#{$postIconSizeMobile} + #{$thinBorderWidth} + 0.5rem) * -1);
+    right: $thinBorderWidth;
+
+    .add-buddy__sharemenu__content {
+      background: white;
+      border: $thinGrayBorder;
+      padding: 0.5rem;
+      max-width: 15rem;
+      position: absolute;
+      right: -1px;
+      top: -5px;
+      min-width: 15rem;
+
+      a.won-button--outlined,
+      button {
+        width: 100%;
+        white-space: nowrap;
+      }
+
+      a.won-button--outlined {
+        cursor: pointer;
+        display: flex;
+        align-content: center;
+        align-items: center;
+        box-sizing: border-box;
+      }
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -14,7 +14,7 @@ won-add-buddy {
     height: 2rem;
   }
 
-  .add-buddy__icon__small__sharemenu {
+  .add-buddy__icon__small__addbuddymenu {
     --local-primary: black;
     @include fixed-square($postIconSizeMobile);
     //padding-left: 0.5rem;
@@ -25,14 +25,14 @@ won-add-buddy {
     float: right;
   }
 
-  .add-buddy__sharemenu {
+  .add-buddy__addbuddymenu {
     position: relative;
     height: 0;
     z-index: 1000;
     top: calc((#{$postIconSizeMobile} + #{$thinBorderWidth} + 0.5rem) * -1);
     right: $thinBorderWidth;
 
-    .add-buddy__sharemenu__content {
+    .add-buddy__addbuddymenu__content {
       background: white;
       border: $thinGrayBorder;
       padding: 0.5rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_add-buddy.scss
@@ -3,26 +3,24 @@
 @import "animate";
 
 won-add-buddy {
-  .add-buddy__icon__small {
-    --local-primary: #{$won-secondary-color};
-    @include fixed-square($postIconSizeMobile);
-    padding-left: 0.5rem;
-    padding-right: 0.25rem;
-  }
-
   .topline {
     height: 2rem;
   }
 
-  .add-buddy__icon__small__addbuddymenu {
-    --local-primary: black;
-    @include fixed-square($postIconSizeMobile);
-    //padding-left: 0.5rem;
-    position: relative;
-    right: -0.35rem;
-    /*the correct right value would be "calc(-0.5rem - #{$thinBorderWidth});"
-    however, it is not displayed correct so we assume the right value with -0.6rem*/
-    float: right;
+  .add-buddy__addbuddymenu__header {
+    white-space: nowrap;
+    display: flex;
+    --local-primary: #{$won-secondary-color};
+    color: $won-secondary-color;
+    padding-left: 0.25rem;
+
+    &__icon {
+      @include fixed-square($postIconSizeMobile);
+      padding-right: 0.25rem;
+    }
+    &__text {
+      padding-right: 0.25rem;
+    }
   }
 
   .add-buddy__addbuddymenu {
@@ -39,21 +37,24 @@ won-add-buddy {
       max-width: 15rem;
       position: absolute;
       right: -1px;
-      top: -5px;
       min-width: 15rem;
 
-      a.won-button--outlined,
-      button {
-        width: 100%;
-        white-space: nowrap;
-      }
+      .add-buddy__addbuddymenu__header {
+        position: relative;
+        --local-primary: black;
+        color: black;
+        float: right;
+        right: -0.3rem;
 
-      a.won-button--outlined {
-        cursor: pointer;
-        display: flex;
-        align-content: center;
-        align-items: center;
-        box-sizing: border-box;
+        &__icon {
+          @media (max-width: $responsivenessBreakPoint) {
+            padding-right: 0;
+          }
+        }
+
+        &__text {
+          padding-right: 0;
+        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
@@ -57,6 +57,7 @@
     }
   }
 
+  > won-add-buddy,
   > won-atom-context-dropdown,
   > won-share-dropdown {
     margin-top: 1rem;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_persona-card.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_persona-card.scss
@@ -41,6 +41,7 @@ won-persona-card {
 
   .card__main {
     grid-area: card__main;
+    overflow: hidden;
 
     &__name {
       min-width: 0;


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Adding a persona as a Buddy is very tedious (you have to select the buddy tab of an owned buddySocket atom and select the buddyatom out of the list below (or add the atom with the atom-picker if the atom was not loaded yet)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Adds a buddyAction next to the share action for non-owned atoms which have the BuddySocket
- Adds the ability to send/accept BuddyRequests directly from that page
  - Either with a List of all possible owned BuddyAtoms (if more than one buddyAtom is owned)
  - Or with an immediate Action (if only one buddy atom is owned)
- The atoms in the dropdown as well as the immediate Action will represent the current buddy Connection state (Buddy pending, Accepted etc...)

What happens:
- "Add as Buddy..." Action is available when looking at the AtomInfo of a Non-Owned Atom with the BuddySocket (only if you have at least one active Persona yourself)
- Click on the Button will: a) open a dropdown if you have more than one active persona b) execute an immediate buddyRequest with the single active owned Persona
- A ModalDialog will open to check if the action should be executed (yes/no) option -> no will just close the dialog and will not cancel the request for now (if the state was that one received a buddyRequest from that persona)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- Currently the used Icons in the `add-buddy.jsx`-Component are not styled yet, these Icons will have to be replaced/adapted later on, but since this has no impact on the functionality we can do this in a sep. PR/Issue

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
