### PR TITLE
Disable closing menu...

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/menu.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/menu.jsx
@@ -263,7 +263,9 @@ class WonMenu extends React.Component {
 
   handleClick(e) {
     if (!this.node.contains(e.target) && this.props.isMenuVisible) {
-      this.props.hideMenu();
+      // TODO: Fix me.
+      // Handler is closing menu before actual MenuAction is toggled
+      //this.props.hideMenu();
 
       return;
     }


### PR DESCRIPTION
Deactivate the on Click Listener for mobile topnav to close menu by clicking anywhere. 
Had problems with the actual menuAction to open and close the menu.

Solves #3060 