### PR TITLE
Add incoming requests icon

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
@@ -10,13 +10,19 @@ import VisibilitySensor from "react-visibility-sensor";
 import { get, getIn } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { connect } from "react-redux";
+import won from "../won-es6";
 import { labels, relativeTime } from "../won-label-utils.js";
 import * as generalSelectors from "../redux/selectors/general-selectors.js";
 import * as messageSelectors from "../redux/selectors/message-selectors.js";
 import * as connectionSelectors from "../redux/selectors/connection-selectors.js";
 import * as atomUtils from "../redux/utils/atom-utils.js";
+import * as connectionUtils from "../redux/utils/connection-utils.js";
 import * as messageUtils from "../redux/utils/message-utils.js";
 import * as processUtils from "../redux/utils/process-utils.js";
+import * as accountUtils from "../redux/utils/account-utils.js";
+import * as viewUtils from "../redux/utils/view-utils.js";
+import Immutable from "immutable";
+
 import { getHumanReadableStringFromMessage } from "../reducers/atom-reducer/parse-message.js";
 
 import "~/style/_connection-header.scss";
@@ -69,6 +75,27 @@ const mapStateToProps = (state, ownProps) => {
     get(targetAtom, "uri")
   );
 
+  const isTargetAtomOwned = accountUtils.isAtomOwned(
+    get(state, "account"),
+    targetAtomUri
+  );
+
+  const groupConnections =
+    isTargetAtomOwned &&
+    get(targetAtom, "connections")
+      .filter(
+        con =>
+          atomUtils.getSocketUri(targetAtom, won.GROUP.GroupSocketCompacted) ===
+          get(con, "socketUri")
+      )
+      .filter(con => connectionUtils.isRequestReceived(con));
+
+  const hasGroupRequests = groupConnections && groupConnections.size > 0;
+  const hasNewGroupRequests = !!(
+    hasGroupRequests &&
+    groupConnections.find(con => connectionUtils.isUnread(con))
+  );
+
   return {
     connectionUri: ownProps.connectionUri,
     onClick: ownProps.onClick,
@@ -83,6 +110,14 @@ const mapStateToProps = (state, ownProps) => {
       generalSelectors.getAtoms(state),
       connection
     ),
+    hasGroupRequests: hasGroupRequests,
+    hasNewGroupRequests: hasNewGroupRequests,
+    visibleTab: viewUtils.getVisibleTabByAtomUri(
+      get(state, "view"),
+      ownProps.atomUri,
+      ownProps.defaultTab
+    ),
+    isTargetAtomOwned: isTargetAtomOwned,
     isDirectResponseFromRemote: atomUtils.isDirectResponseAtom(targetAtom),
     isGroupChatEnabled: atomUtils.hasGroupSocket(targetAtom),
     isChatEnabled: atomUtils.hasChatSocket(targetAtom),
@@ -121,6 +156,17 @@ const mapDispatchToProps = dispatch => {
     fetchAtom: atomUri => {
       dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
     },
+
+    selectTab: (atomUri, tab) => {
+      dispatch(
+        actionCreators.atoms__selectTab(
+          Immutable.fromJS({ atomUri: atomUri, selectTab: tab })
+        )
+      );
+    },
+    routerGo: (path, props) => {
+      dispatch(actionCreators.router__stateGo(path, props));
+    },
   };
 };
 
@@ -154,9 +200,17 @@ class WonConnectionHeader extends React.Component {
       );
     } else {
       const headerIcon = this.props.isConnectionToGroup ? (
-        <WonGroupIcon connectionUri={this.props.connectionUri} />
+        <div
+          className="ch__icon"
+          onClick={this.props.onClick ? () => this.props.onClick() : undefined}
+        >
+          <WonGroupIcon connectionUri={this.props.connectionUri} />
+        </div>
       ) : (
-        <div className="ch__icon">
+        <div
+          className="ch__icon"
+          onClick={this.props.onClick ? () => this.props.onClick() : undefined}
+        >
           <WonAtomIcon atomUri={get(this.props.targetAtom, "uri")} />
         </div>
       );
@@ -275,6 +329,7 @@ class WonConnectionHeader extends React.Component {
             <div className="ch__right__topline">
               {headerRightToplineContent}
             </div>
+
             <div className="ch__right__subtitle">
               <span className="ch__right__subtitle__type">
                 {personaName}
@@ -292,14 +347,43 @@ class WonConnectionHeader extends React.Component {
           </React.Fragment>
         );
       }
+      let incomingRequestsIcon =
+        this.props.isTargetAtomOwned && this.props.hasGroupRequests ? (
+          <div className="ch__indicator">
+            <won-connection-indicators>
+              <svg
+                className={
+                  "indicators__item " +
+                  (!this.props.hasNewGroupRequests
+                    ? " indicators__item--reads "
+                    : "") +
+                  (this.props.hasNewGroupRequests
+                    ? " indicators__item--unreads "
+                    : "")
+                }
+                //TODO
+                onClick={() => this.selectMembersTab()}
+              >
+                <use xlinkHref="#ico36_incoming" href="#ico36_incoming" />
+              </svg>
+            </won-connection-indicators>
+          </div>
+        ) : (
+          undefined
+        );
 
       return (
-        <won-connection-header
-          onClick={this.props.onClick ? () => this.props.onClick() : undefined}
-          class={this.props.onClick ? "clickable" : ""}
-        >
+        <won-connection-header class={this.props.onClick ? "clickable" : ""}>
           {headerIcon}
-          <div className="ch__right">{headerRightContent}</div>
+          <div
+            className="ch__right"
+            onClick={
+              this.props.onClick ? () => this.props.onClick() : undefined
+            }
+          >
+            {headerRightContent}
+          </div>
+          {incomingRequestsIcon}
         </won-connection-header>
       );
     }
@@ -308,6 +392,11 @@ class WonConnectionHeader extends React.Component {
     if (isVisible) {
       this.ensureAtomIsLoaded();
     }
+  }
+
+  selectMembersTab() {
+    this.props.selectTab(this.props.targetAtomUri, "PARTICIPANTS");
+    this.props.routerGo("post", { postUri: this.props.targetAtomUri });
   }
 
   ensureAtomIsLoaded() {
@@ -323,6 +412,8 @@ class WonConnectionHeader extends React.Component {
 WonConnectionHeader.propTypes = {
   connectionUri: PropTypes.string.isRequired,
   onClick: PropTypes.func,
+  selectTab: PropTypes.func,
+  routerGo: PropTypes.func,
   connection: PropTypes.object,
   groupMembersArray: PropTypes.arrayOf(PropTypes.object),
   groupMembersSize: PropTypes.number,
@@ -330,6 +421,10 @@ WonConnectionHeader.propTypes = {
   targetAtom: PropTypes.object,
   remotePersonaName: PropTypes.string,
   isConnectionToGroup: PropTypes.bool,
+  hasGroupRequests: PropTypes.bool,
+  hasNewGroupRequests: PropTypes.bool,
+  visibleTab: PropTypes.string,
+  isTargetAtomOwned: PropTypes.bool,
   isDirectResponseFromRemote: PropTypes.bool,
   isGroupChatEnabled: PropTypes.bool,
   isChatEnabled: PropTypes.bool,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
@@ -20,7 +20,6 @@ import * as connectionUtils from "../redux/utils/connection-utils.js";
 import * as messageUtils from "../redux/utils/message-utils.js";
 import * as processUtils from "../redux/utils/process-utils.js";
 import * as accountUtils from "../redux/utils/account-utils.js";
-import * as viewUtils from "../redux/utils/view-utils.js";
 import Immutable from "immutable";
 
 import { getHumanReadableStringFromMessage } from "../reducers/atom-reducer/parse-message.js";
@@ -112,11 +111,6 @@ const mapStateToProps = (state, ownProps) => {
     ),
     hasGroupRequests: hasGroupRequests,
     hasNewGroupRequests: hasNewGroupRequests,
-    visibleTab: viewUtils.getVisibleTabByAtomUri(
-      get(state, "view"),
-      ownProps.atomUri,
-      ownProps.defaultTab
-    ),
     isTargetAtomOwned: isTargetAtomOwned,
     isDirectResponseFromRemote: atomUtils.isDirectResponseAtom(targetAtom),
     isGroupChatEnabled: atomUtils.hasGroupSocket(targetAtom),
@@ -423,7 +417,6 @@ WonConnectionHeader.propTypes = {
   isConnectionToGroup: PropTypes.bool,
   hasGroupRequests: PropTypes.bool,
   hasNewGroupRequests: PropTypes.bool,
-  visibleTab: PropTypes.string,
   isTargetAtomOwned: PropTypes.bool,
   isDirectResponseFromRemote: PropTypes.bool,
   isGroupChatEnabled: PropTypes.bool,

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_connection-header.scss
@@ -30,9 +30,9 @@ won-connection-header {
   //padding: 0.5rem;
 
   display: grid;
-  grid-template-areas: "icon main";
-  grid-template-columns: min-content 1fr;
-  grid-column-gap: 0.5rem;
+  grid-template-areas: "icon main indicator";
+  grid-template-columns: min-content 1fr min-content;
+  //grid-column-gap: 0.5rem;
   min-width: 0;
 
   won-group-icon,
@@ -45,11 +45,23 @@ won-connection-header {
     @include square-image($postIconSize);
   }
 
+  .ch__indicator {
+    grid-area: indicator;
+    align-self: center;
+    padding-left: 0.5rem;
+
+    > won-connection-indicators > svg {
+      @include fixed-square($iconSize);
+    }
+  }
+
   .ch__right {
     grid-area: main;
     display: grid;
+    padding-left: 0.5rem;
     grid-template-areas: "topline" "subtitle";
     min-width: 0;
+
     &__topline {
       grid-area: topline;
       min-width: 0;
@@ -62,10 +74,12 @@ won-connection-header {
         font-weight: 400;
         min-width: 0;
       }
-      &__notitle {
-        color: $won-subtitle-gray;
-      }
     }
+
+    &__notitle {
+      color: $won-subtitle-gray;
+    }
+
     &__subtitle {
       grid-area: subtitle;
       display: grid;


### PR DESCRIPTION
 Routing to atom page with group members tab

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Fixes: #3009 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now the "incoming" icon is show to groupchat owners, if there are unseen requests
- Highlightet for new requests
- clicking on the icon will open post info page with open "Group Members" tab

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
