### PR TITLE
Feat  persona to persona chat

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
@@ -12,7 +12,7 @@ import * as connectionUtils from "../redux/utils/connection-utils";
 import won from "../won-es6";
 import WonLabelledHr from "./labelled-hr.jsx";
 import WonSuggestAtomPicker from "./details/picker/suggest-atom-picker.jsx";
-import WonAtomCard from "./atom-card.jsx";
+import WonAtomHeader from "./atom-header.jsx";
 
 import "~/style/_atom-content-buddies.scss";
 import VisibilitySensor from "react-visibility-sensor";
@@ -101,6 +101,9 @@ const mapDispatchToProps = dispatch => {
           targetSocket
         )
       );
+    },
+    routerGo: (path, props) => {
+      dispatch(actionCreators.router__stateGo(path, props));
     },
   };
 };
@@ -220,11 +223,14 @@ class WonAtomContentBuddies extends React.Component {
                     (connectionUtils.isUnread(conn) ? " won-unread " : "")
                   }
                 >
-                  <WonAtomCard
+                  <WonAtomHeader
                     atomUri={get(conn, "targetAtomUri")}
-                    currentLocation={this.props.currentLocation}
-                    showSuggestions={false}
-                    showPersona={false}
+                    hideTimestamp={true}
+                    onClick={() =>
+                      this.props.routerGo("post", {
+                        postUri: get(conn, "targetAtomUri"),
+                      })
+                    }
                   />
                   {actionButtons}
                 </div>
@@ -265,11 +271,14 @@ class WonAtomContentBuddies extends React.Component {
         buddies = this.props.buddiesArray.map(memberUri => {
           return (
             <div className="acb__buddy" key={memberUri}>
-              <WonAtomCard
+              <WonAtomHeader
                 atomUri={memberUri}
-                currentLocation={this.props.currentLocation}
-                showSuggestions={false}
-                showPersona={false}
+                hideTimestamp={true}
+                onClick={() =>
+                  this.props.routerGo("post", {
+                    postUri: memberUri,
+                  })
+                }
               />
               <div className="acb__buddy__actions" />
             </div>
@@ -388,6 +397,7 @@ WonAtomContentBuddies.propTypes = {
   connectionClose: PropTypes.func,
   connectionOpen: PropTypes.func,
   connect: PropTypes.func,
+  routerGo: PropTypes.func,
 };
 
 export default connect(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.jsx
@@ -12,7 +12,7 @@ import * as connectionUtils from "../redux/utils/connection-utils";
 import won from "../won-es6";
 import WonLabelledHr from "./labelled-hr.jsx";
 import WonSuggestAtomPicker from "./details/picker/suggest-atom-picker.jsx";
-import WonAtomCard from "./atom-card.jsx";
+import WonAtomHeader from "./atom-header.jsx";
 
 import "~/style/_atom-content-participants.scss";
 import VisibilitySensor from "react-visibility-sensor";
@@ -90,6 +90,9 @@ const mapDispatchToProps = dispatch => {
     },
     rateConnection: (connectionUri, rating) => {
       dispatch(actionCreators.connections__rate(connectionUri, rating));
+    },
+    routerGo: (path, props) => {
+      dispatch(actionCreators.router__stateGo(path, props));
     },
   };
 };
@@ -207,11 +210,14 @@ class WonAtomContentParticipants extends React.Component {
                     (connectionUtils.isUnread(conn) ? " won-unread " : "")
                   }
                 >
-                  <WonAtomCard
+                  <WonAtomHeader
                     atomUri={get(conn, "targetAtomUri")}
-                    currentLocation={this.props.currentLocation}
-                    showSuggestions={false}
-                    showPersona={true}
+                    hideTimestamp={true}
+                    onClick={() =>
+                      this.props.routerGo("post", {
+                        postUri: get(conn, "targetAtomUri"),
+                      })
+                    }
                   />
                   {actionButtons}
                 </div>
@@ -257,11 +263,12 @@ class WonAtomContentParticipants extends React.Component {
         participants = this.props.groupMembersArray.map(memberUri => {
           return (
             <div className="acp__participant" key={memberUri}>
-              <WonAtomCard
+              <WonAtomHeader
                 atomUri={memberUri}
-                currentLocation={this.props.currentLocation}
-                showSuggestions={false}
-                showPersona={true}
+                hideTimestamp={true}
+                onClick={() =>
+                  this.props.routerGo("post", { postUri: memberUri })
+                }
               />
               <div className="acp__participant__actions" />
             </div>
@@ -419,6 +426,7 @@ WonAtomContentParticipants.propTypes = {
   connectionClose: PropTypes.func,
   connectionOpen: PropTypes.func,
   rateConnection: PropTypes.func,
+  routerGo: PropTypes.func,
 };
 
 export default connect(

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
@@ -18,6 +18,10 @@ won-atom-content-buddies {
     border: $thinGrayBorder;
     background: $won-light-gray;
 
+    won-atom-header {
+      padding: 0.5rem;
+    }
+
     &.won-unread {
       border-color: $won-unread-attention;
       /*box-shadow: 0px 0px 5px 5px var(--won-primary-color);*/

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-participants.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-participants.scss
@@ -18,6 +18,10 @@ won-atom-content-participants {
     border: $thinGrayBorder;
     background: $won-light-gray;
 
+    won-atom-header {
+      padding: 0.5rem;
+    }
+
     &.won-unread {
       border-color: $won-unread-attention;
       /*box-shadow: 0px 0px 5px 5px var(--won-primary-color);*/


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Trying to contact any targetatom that does not have an reactionUseCase adds the option of creating an adhoc atom that connects to the targetatom, if a persona is selected a persona will be attached to the adhoc atom.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Instead of creating an adHoc Atom with an attached persona we simply connect the chatSocket of the selected persona with the targetAtom (thus enabling persona2persona chats)
- Changes the styling of the participants(groupmembers) and buddies content info from Atom-Cards to atom-headers

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Additional call-to-actions to create or goTo a persona2persona chat will be included in separate pull requests