### PR TITLE
Fixes matcher_service crawling

### DIFF
--- a/webofneeds/conf/matcher-rescal/application.conf
+++ b/webofneeds/conf/matcher-rescal/application.conf
@@ -12,11 +12,16 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
+    maximum-payload-bytes = 15000000 bytes
     netty.tcp {
       bind-hostname = 0.0.0.0
       # bind-port set by application
       # hostname set by application
       # port set by application
+      message-frame-size =  15000000b
+      send-buffer-size =  15000000b
+      receive-buffer-size =  15000000b
+      maximum-frame-size = 15000000b
     }
   }
 }

--- a/webofneeds/conf/matcher-service/application.conf
+++ b/webofneeds/conf/matcher-service/application.conf
@@ -19,11 +19,16 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
+    maximum-payload-bytes = 15000000 bytes
     netty.tcp {
       bind-hostname = 0.0.0.0
       # bind-port set by application
       # hostname set by application
       # port set by application
+      message-frame-size =  15000000b
+      send-buffer-size =  15000000b
+      receive-buffer-size =  15000000b
+      maximum-frame-size = 15000000b
     }
   }
 }

--- a/webofneeds/conf/matcher-solr/application.conf
+++ b/webofneeds/conf/matcher-solr/application.conf
@@ -19,11 +19,16 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
+    maximum-payload-bytes = 15000000 bytes
     netty.tcp {
       bind-hostname = 0.0.0.0
       # bind-port set by application
       # hostname set by application
       # port set by application
+      message-frame-size =  15000000b
+      send-buffer-size =  15000000b
+      receive-buffer-size =  15000000b
+      maximum-frame-size = 15000000b
     }
   }
 }

--- a/webofneeds/conf/matcher-sparql/application.conf
+++ b/webofneeds/conf/matcher-sparql/application.conf
@@ -19,11 +19,16 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
+    maximum-payload-bytes = 15000000 bytes
     netty.tcp {
       bind-hostname = 0.0.0.0
       # bind-port set by application
       # hostname set by application
       # port set by application
+      message-frame-size =  15000000b
+      send-buffer-size =  15000000b
+      receive-buffer-size =  15000000b
+      maximum-frame-size = 15000000b
     }
   }
 }

--- a/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/int_satvm05/docker-compose.yml
@@ -430,29 +430,29 @@ services:
       - matcher_service
 
   # rescal matcher and connect to matcher service
-  matcher_rescal:
-    restart: always
-    build: ../../image/matcher-rescal
-    image: webofneeds/matcher_rescal:int
-    environment:
-      - "node.host=satvm05.researchstudio.at"
-      - "cluster.seedNodes=satvm05.researchstudio.at:2551,satvm05.researchstudio.at:2553"
-      - "cluster.local.port=2553"
-      - "matcher.rescal.uri.public=http://satvm05.researchstudio.at/rescal/"
-      - "matcher.rescal.uri.sparql.endpoint=http://satvm05.researchstudio.at:9999/blazegraph/namespace/kb/sparql"
-      - "matcher.rescal.executionDurationMinutes=5"
-      - "matcher.rescal.threshold=0.15"
-      - "matcher.rescal.rank=10"
-      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
-      - "JMX_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=62922,server=y,suspend=n
-        -Dcom.sun.management.jmxremote.port=9022 -Dcom.sun.management.jmxremote.authenticate=false
-        -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port=9022
-        -Djava.rmi.server.hostname=satvm05.researchstudio.at"
-    ports:
-      - "2553:2553"
-      - "9022:9022"
-      - "62922:62922"
-    volumes:
-      - $base_folder/agent:/opt/agent/
-    depends_on:
-      - matcher_service
+#  matcher_rescal:
+#    restart: always
+#    build: ../../image/matcher-rescal
+#    image: webofneeds/matcher_rescal:int
+#    environment:
+#      - "node.host=satvm05.researchstudio.at"
+#      - "cluster.seedNodes=satvm05.researchstudio.at:2551,satvm05.researchstudio.at:2553"
+#      - "cluster.local.port=2553"
+#      - "matcher.rescal.uri.public=http://satvm05.researchstudio.at/rescal/"
+#      - "matcher.rescal.uri.sparql.endpoint=http://satvm05.researchstudio.at:9999/blazegraph/namespace/kb/sparql"
+#      - "matcher.rescal.executionDurationMinutes=5"
+#      - "matcher.rescal.threshold=0.15"
+#      - "matcher.rescal.rank=10"
+#      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
+#      - "JMX_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=62922,server=y,suspend=n
+#        -Dcom.sun.management.jmxremote.port=9022 -Dcom.sun.management.jmxremote.authenticate=false
+#        -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port=9022
+#        -Djava.rmi.server.hostname=satvm05.researchstudio.at"
+#    ports:
+#      - "2553:2553"
+#      - "9022:9022"
+#      - "62922:62922"
+#    volumes:
+#      - $base_folder/agent:/opt/agent/
+#    depends_on:
+#      - matcher_service

--- a/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/live_satvm01/docker-compose.yml
@@ -207,25 +207,25 @@ services:
       - matcher_service
 
   # rescal matcher and connect to matcher service
-  matcher_rescal:
-    restart: always
-    build: ../../image/matcher-rescal
-    image: webofneeds/matcher_rescal:live
-    environment:
-      - "node.host=satvm01.researchstudio.at"
-      - "cluster.seedNodes=satvm01.researchstudio.at:2561,satvm01.researchstudio.at:2563"
-      - "cluster.local.port=2563"
-      - "matcher.rescal.uri.public=http://satvm01.researchstudio.at/rescal/"
-      - "matcher.rescal.uri.sparql.endpoint=http://satvm01.researchstudio.at:10000/blazegraph/namespace/kb/sparql"
-      - "matcher.rescal.executionDurationMinutes=30"
-      - "matcher.rescal.threshold=0.2"
-      - "matcher.rescal.rank=10"
-      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
-    ports:
-      - "2563:2563"
-    depends_on:
-      - bigdata
-      - matcher_service
+#  matcher_rescal:
+#    restart: always
+#    build: ../../image/matcher-rescal
+#    image: webofneeds/matcher_rescal:live
+#    environment:
+#      - "node.host=satvm01.researchstudio.at"
+#      - "cluster.seedNodes=satvm01.researchstudio.at:2561,satvm01.researchstudio.at:2563"
+#      - "cluster.local.port=2563"
+#      - "matcher.rescal.uri.public=http://satvm01.researchstudio.at/rescal/"
+#      - "matcher.rescal.uri.sparql.endpoint=http://satvm01.researchstudio.at:10000/blazegraph/namespace/kb/sparql"
+#      - "matcher.rescal.executionDurationMinutes=30"
+#      - "matcher.rescal.threshold=0.2"
+#      - "matcher.rescal.rank=10"
+#      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
+#    ports:
+#      - "2563:2563"
+#    depends_on:
+#      - bigdata
+#      - matcher_service
 
   # mongodb for persistent debug bot
   mongodb:

--- a/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
+++ b/webofneeds/won-docker/deploy/master_satvm02/docker-compose.yml
@@ -397,32 +397,32 @@ services:
       - matcher_service
 
   # rescal matcher and connect to matcher service
-  matcher_rescal:
-    restart: always
-    build: ../../image/matcher-rescal
-    image: webofneeds/matcher_rescal:master
-    environment:
-      - "node.host=satvm02.researchstudio.at"
-      - "cluster.seedNodes=satvm02.researchstudio.at:2551,satvm02.researchstudio.at:2553"
-      - "cluster.local.port=2553"
-      - "matcher.rescal.uri.public=http://satvm02.researchstudio.at/rescal/"
-      - "matcher.rescal.uri.sparql.endpoint=http://satvm02.researchstudio.at:9999/blazegraph/namespace/kb/sparql"
-      - "matcher.rescal.executionDurationMinutes=5"
-      - "matcher.rescal.threshold=0.15"
-      - "matcher.rescal.rank=10"
-      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
-      - "JMX_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=62922,server=y,suspend=n
-        -Dcom.sun.management.jmxremote.port=9022 -Dcom.sun.management.jmxremote.authenticate=false
-        -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port=9022
-        -Djava.rmi.server.hostname=satvm02.researchstudio.at"
-    ports:
-      - "2553:2553"
-      - "9022:9022"
-      - "62922:62922"
-    volumes:
-      - $base_folder/agent:/opt/agent/
-    depends_on:
-      - matcher_service
+#  matcher_rescal:
+#    restart: always
+#    build: ../../image/matcher-rescal
+#    image: webofneeds/matcher_rescal:master
+#    environment:
+#      - "node.host=satvm02.researchstudio.at"
+#      - "cluster.seedNodes=satvm02.researchstudio.at:2551,satvm02.researchstudio.at:2553"
+#      - "cluster.local.port=2553"
+#      - "matcher.rescal.uri.public=http://satvm02.researchstudio.at/rescal/"
+#      - "matcher.rescal.uri.sparql.endpoint=http://satvm02.researchstudio.at:9999/blazegraph/namespace/kb/sparql"
+#      - "matcher.rescal.executionDurationMinutes=5"
+#      - "matcher.rescal.threshold=0.15"
+#      - "matcher.rescal.rank=10"
+#      - "JMEM_OPTS=-XX:+HeapDumpOnOutOfMemoryError"
+#      - "JMX_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=62922,server=y,suspend=n
+#        -Dcom.sun.management.jmxremote.port=9022 -Dcom.sun.management.jmxremote.authenticate=false
+#        -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port=9022
+#        -Djava.rmi.server.hostname=satvm02.researchstudio.at"
+#    ports:
+#      - "2553:2553"
+#      - "9022:9022"
+#      - "62922:62922"
+#    volumes:
+#      - $base_folder/agent:/opt/agent/
+#    depends_on:
+#      - matcher_service
 
   matcher_sparql:
     restart: always

--- a/webofneeds/won-docker/deploy_live.sh
+++ b/webofneeds/won-docker/deploy_live.sh
@@ -50,7 +50,7 @@ then
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/owner:live
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/matcher_service:live
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/matcher_solr:live
-    docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/matcher_rescal:live
+    # docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/matcher_rescal:live
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/solr:live
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/postgres:live
     docker --tlsverify -H satvm01.researchstudio.at:2376 push webofneeds/bots:live

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/MasterCrawlerActor.java
@@ -324,8 +324,4 @@ public class MasterCrawlerActor extends UntypedActor {
         }
         return uri;
     }
-
-    public static void main(String args[]) {
-        System.out.println("AtomState: " + AtomState.ACTIVE);
-    }
 }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
@@ -185,12 +185,12 @@ public class WorkerCrawlerActor extends UntypedActor {
         } catch (LinkedDataFetchingException e) {
             log.debug("Exception during crawling: " + e);
             Throwable cause = e.getCause();
-            if (cause instanceof HttpClientErrorException) {
-                HttpClientErrorException clientErrorException = (HttpClientErrorException) cause;
-                if (Objects.equals(clientErrorException.getStatusCode(), HttpStatus.GONE)) {
-                    log.debug("Uri used to exist, but has been deleted, marking uri as done");
-                    sendDoneUriMessage(uriMsg, uriMsg.getWonNodeUri(), etags);
-                }
+            if (cause instanceof HttpClientErrorException
+                            && Objects.equals(((HttpClientErrorException) cause).getStatusCode(), HttpStatus.GONE)) {
+                log.debug("Uri used to exist, but has been deleted, marking uri as done");
+                sendDoneUriMessage(uriMsg, uriMsg.getWonNodeUri(), etags);
+            } else {
+                throw new CrawlWrapperException(e, uriMsg);
             }
         } catch (Exception e) {
             log.debug("Exception during crawling: " + e);

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/crawler/actor/WorkerCrawlerActor.java
@@ -3,6 +3,7 @@ package won.matcher.service.crawler.actor;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.jena.query.Dataset;
@@ -10,8 +11,10 @@ import org.apache.jena.shared.Lock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 
 import akka.actor.ActorRef;
@@ -31,6 +34,7 @@ import won.matcher.service.crawler.service.CrawlSparqlService;
 import won.protocol.exception.IncorrectPropertyCountException;
 import won.protocol.model.AtomState;
 import won.protocol.rest.DatasetResponseWithStatusCodeAndHeaders;
+import won.protocol.rest.LinkedDataFetchingException;
 import won.protocol.util.AtomModelWrapper;
 import won.protocol.util.RdfUtils;
 import won.protocol.util.linkeddata.LinkedDataSourceBase;
@@ -178,6 +182,16 @@ public class WorkerCrawlerActor extends UntypedActor {
             // HttpServerErrorException, HttpClientErrorException
             log.debug("Exception during crawling: " + e1);
             throw new CrawlWrapperException(e1, uriMsg);
+        } catch (LinkedDataFetchingException e) {
+            log.debug("Exception during crawling: " + e);
+            Throwable cause = e.getCause();
+            if (cause instanceof HttpClientErrorException) {
+                HttpClientErrorException clientErrorException = (HttpClientErrorException) cause;
+                if (Objects.equals(clientErrorException.getStatusCode(), HttpStatus.GONE)) {
+                    log.debug("Uri used to exist, but has been deleted, marking uri as done");
+                    sendDoneUriMessage(uriMsg, uriMsg.getWonNodeUri(), etags);
+                }
+            }
         } catch (Exception e) {
             log.debug("Exception during crawling: " + e);
             throw new CrawlWrapperException(e, uriMsg);


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently our matcher_service crawls every AtomUri on the configured node, However it will try and reload atoms if any request difficulties arose (e.g. server currently not available). Since we added the 410(GONE) Status and the deletion of atoms, the matcher_service continuously trys to fetch atoms that have been deleted, and thus flooding the node with many requests, depending on the amount of deleted atoms it might even cause other participants connected to the node to get blocked and even unable to execute the sslhandshake due to the vast amount of traffic caused by the matcher_Service -> and thus making every container on the instance unusable.


## What is the new behavior?
- Atoms that have been deleted will still throw an Exception but will be marked as done within the catch branch, and therefore remove them from being crawled again

## Does this introduce a breaking change?

- [ ] Yes
- [X] No