### PR TITLE
Feat  contextsensitive actions #3111

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
@@ -248,7 +248,6 @@ class WonAtomContentBuddies extends React.Component {
                   >
                     <use xlinkHref="#ico36_message" href="#ico36_message" />
                   </svg>
-
                   <svg
                     className="acb__buddy__actions__icon secondary won-icon"
                     onClick={() => this.closeConnection(conn)}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
@@ -164,112 +164,100 @@ class WonAtomContentBuddies extends React.Component {
               headerClassName = "status--received";
               actionButtons = (
                 <div className="acb__buddy__actions">
-                  <div
-                    className="acb__buddy__actions__icon"
+                  <svg
+                    className="acb__buddy__actions__icon request won-icon"
                     onClick={() => this.openRequest(conn)}
                   >
-                    <svg className="acb__buddy__actions__icon--request">
-                      <use
-                        xlinkHref="#ico32_buddy_accept"
-                        href="#ico32_buddy_accept"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    className="acb__buddy__actions__icon"
+                    <use
+                      xlinkHref="#ico32_buddy_accept"
+                      href="#ico32_buddy_accept"
+                    />
+                  </svg>
+                  <svg
+                    className="acb__buddy__actions__icon primary won-icon"
                     onClick={() =>
                       this.closeConnection(conn, "Reject Buddy Request?")
                     }
                   >
-                    <svg className="acb__buddy__actions__icon--primary">
-                      <use
-                        xlinkHref="#ico32_buddy_deny"
-                        href="#ico32_buddy_deny"
-                      />
-                    </svg>
-                  </div>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isSuggested(conn)) {
               headerClassName = "status--suggested";
               actionButtons = (
                 <div className="acb__buddy__actions">
-                  <div
-                    className="acb__buddy__actions__icon"
+                  <svg
+                    className="acb__buddy__actions__icon request won-icon"
                     onClick={() => this.requestBuddy(conn)}
                   >
-                    <svg className="acb__buddy__actions__icon--request">
-                      <use
-                        xlinkHref="#ico32_buddy_accept"
-                        href="#ico32_buddy_accept"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    className="acb__buddy__actions__icon"
+                    <use
+                      xlinkHref="#ico32_buddy_accept"
+                      href="#ico32_buddy_accept"
+                    />
+                  </svg>
+                  <svg
+                    className="acb__buddy__actions__icon primary won-icon"
                     onClick={() =>
                       this.closeConnection(conn, "Reject Buddy Suggestion?")
                     }
                   >
-                    <svg className="acb__buddy__actions__icon--primary">
-                      <use
-                        xlinkHref="#ico32_buddy_deny"
-                        href="#ico32_buddy_deny"
-                      />
-                    </svg>
-                  </div>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isRequestSent(conn)) {
               headerClassName = "status--sent";
               actionButtons = (
                 <div className="acb__buddy__actions">
-                  <div className="acb__buddy__actions__icon" disabled={true}>
-                    <svg className="acb__buddy__actions__icon--disabled">
-                      <use
-                        xlinkHref="#ico32_buddy_waiting"
-                        href="#ico32_buddy_waiting"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    className="acb__buddy__actions__icon"
+                  <svg
+                    className="acb__buddy__actions__icon disabled won-icon"
+                    disabled={true}
+                  >
+                    <use
+                      xlinkHref="#ico32_buddy_waiting"
+                      href="#ico32_buddy_waiting"
+                    />
+                  </svg>
+                  <svg
+                    className="acb__buddy__actions__icon secondary won-icon"
                     onClick={() =>
                       this.closeConnection(conn, "Cancel Buddy Request?")
                     }
                   >
-                    <svg className="acb__buddy__actions__icon--secondary">
-                      <use
-                        xlinkHref="#ico32_buddy_deny"
-                        href="#ico32_buddy_deny"
-                      />
-                    </svg>
-                  </div>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isConnected(conn)) {
               //TODO: Check chat socket connection
               actionButtons = (
                 <div className="acb__buddy__actions">
-                  <div
-                    className="acb__buddy__actions__icon"
+                  <svg
+                    className="acb__buddy__actions__icon primary won-icon"
                     onClick={() => this.sendChatMessage(conn)}
                   >
-                    <svg className="acb__buddy__actions__icon--primary">
-                      <use xlinkHref="#ico36_message" href="#ico36_message" />
-                    </svg>
-                  </div>
-                  <div
-                    className="acb__buddy__actions__icon"
+                    <use xlinkHref="#ico36_message" href="#ico36_message" />
+                  </svg>
+
+                  <svg
+                    className="acb__buddy__actions__icon secondary won-icon"
                     onClick={() => this.closeConnection(conn)}
                   >
-                    <svg className="acb__buddy__actions__icon--secondary">
-                      <use
-                        xlinkHref="#ico32_buddy_deny"
-                        href="#ico32_buddy_deny"
-                      />
-                    </svg>
-                  </div>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isClosed(conn)) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
@@ -165,18 +165,28 @@ class WonAtomContentBuddies extends React.Component {
               actionButtons = (
                 <div className="acb__buddy__actions">
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() => this.openRequest(conn)}
                   >
-                    Accept
+                    <svg className="acb__buddy__actions__icon--request">
+                      <use
+                        xlinkHref="#ico32_buddy_accept"
+                        href="#ico32_buddy_accept"
+                      />
+                    </svg>
                   </div>
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() =>
                       this.closeConnection(conn, "Reject Buddy Request?")
                     }
                   >
-                    Reject
+                    <svg className="acb__buddy__actions__icon--primary">
+                      <use
+                        xlinkHref="#ico32_buddy_deny"
+                        href="#ico32_buddy_deny"
+                      />
+                    </svg>
                   </div>
                 </div>
               );
@@ -185,18 +195,28 @@ class WonAtomContentBuddies extends React.Component {
               actionButtons = (
                 <div className="acb__buddy__actions">
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() => this.requestBuddy(conn)}
                   >
-                    Request
+                    <svg className="acb__buddy__actions__icon--request">
+                      <use
+                        xlinkHref="#ico32_buddy_accept"
+                        href="#ico32_buddy_accept"
+                      />
+                    </svg>
                   </div>
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() =>
                       this.closeConnection(conn, "Reject Buddy Suggestion?")
                     }
                   >
-                    Remove
+                    <svg className="acb__buddy__actions__icon--primary">
+                      <use
+                        xlinkHref="#ico32_buddy_deny"
+                        href="#ico32_buddy_deny"
+                      />
+                    </svg>
                   </div>
                 </div>
               );
@@ -204,19 +224,26 @@ class WonAtomContentBuddies extends React.Component {
               headerClassName = "status--sent";
               actionButtons = (
                 <div className="acb__buddy__actions">
-                  <button
-                    className="acb__buddy__actions__button red won-button--outlined thin"
-                    disabled={true}
-                  >
-                    Pending...
-                  </button>
+                  <div className="acb__buddy__actions__icon" disabled={true}>
+                    <svg className="acb__buddy__actions__icon--disabled">
+                      <use
+                        xlinkHref="#ico32_buddy_waiting"
+                        href="#ico32_buddy_waiting"
+                      />
+                    </svg>
+                  </div>
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() =>
                       this.closeConnection(conn, "Cancel Buddy Request?")
                     }
                   >
-                    Cancel Request
+                    <svg className="acb__buddy__actions__icon--secondary">
+                      <use
+                        xlinkHref="#ico32_buddy_deny"
+                        href="#ico32_buddy_deny"
+                      />
+                    </svg>
                   </div>
                 </div>
               );
@@ -228,15 +255,20 @@ class WonAtomContentBuddies extends React.Component {
                     className="acb__buddy__actions__icon"
                     onClick={() => this.sendChatMessage(conn)}
                   >
-                    <svg>
+                    <svg className="acb__buddy__actions__icon--primary">
                       <use xlinkHref="#ico36_message" href="#ico36_message" />
                     </svg>
                   </div>
                   <div
-                    className="acb__buddy__actions__button red won-button--outlined thin"
+                    className="acb__buddy__actions__icon"
                     onClick={() => this.closeConnection(conn)}
                   >
-                    Remove
+                    <svg className="acb__buddy__actions__icon--secondary">
+                      <use
+                        xlinkHref="#ico32_buddy_deny"
+                        href="#ico32_buddy_deny"
+                      />
+                    </svg>
                   </div>
                 </div>
               );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-buddies.jsx
@@ -199,6 +199,18 @@ class WonAtomContentBuddies extends React.Component {
               actionButtons = (
                 <div className="acb__buddy__actions">
                   <div
+                    className="acb__buddy__actions__button won-button--icon"
+                    onClick={() =>
+                      this.props.routerGo("connections", {
+                        connectionUri: get(conn, "uri"),
+                      })
+                    }
+                  >
+                    <svg>
+                      <use xlinkHref="#ico36_message" href="#ico36_message" />
+                    </svg>
+                  </div>
+                  <div
                     className="acb__buddy__actions__button red won-button--outlined thin"
                     onClick={() => this.closeConnection(conn)}
                   >

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content-participants.jsx
@@ -124,34 +124,43 @@ class WonAtomContentParticipants extends React.Component {
               headerClassName = "status--received";
               actionButtons = (
                 <div className="acp__participant__actions">
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                  <svg
+                    className="acp__participant__actions__icon request won-icon"
                     onClick={() => this.openRequest(conn)}
                   >
-                    Accept
-                  </button>
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                    <use
+                      xlinkHref="#ico32_buddy_accept"
+                      href="#ico32_buddy_accept"
+                    />
+                  </svg>
+                  <svg
+                    className="acp__participant__actions__icon primary won-icon"
                     onClick={() =>
                       this.closeConnection(conn, "Reject Participant Request?")
                     }
                   >
-                    Reject
-                  </button>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isSuggested(conn)) {
               headerClassName = "status--suggested";
               actionButtons = (
                 <div className="acp__participant__actions">
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                  <svg
+                    className="acp__participant_actions__icon request won-icon"
                     onClick={() => this.sendRequest(conn)}
                   >
-                    Request
-                  </button>
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                    <use
+                      xlinkHref="#ico32_buddy_accept"
+                      href="#ico32_buddy_accept"
+                    />
+                  </svg>
+                  <svg
+                    className="acb__buddy__actions__icon primary won-icon"
                     onClick={() =>
                       this.closeConnection(
                         conn,
@@ -159,39 +168,51 @@ class WonAtomContentParticipants extends React.Component {
                       )
                     }
                   >
-                    Remove
-                  </button>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isRequestSent(conn)) {
               headerClassName = "status--sent";
               actionButtons = (
                 <div className="acp__participant__actions">
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                  <svg
+                    className="acp__participant__actions__icon disabled won-icon"
                     disabled={true}
                   >
-                    Waiting for Accept...
-                  </button>
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                    <use
+                      xlinkHref="#ico32_buddy_waiting"
+                      href="#ico32_buddy_waiting"
+                    />
+                  </svg>
+                  <svg
+                    className="acp__participant__actions__icon secondary won-icon"
                     onClick={() =>
                       this.closeConnection(conn, "Cancel Participant Request?")
                     }
                   >
-                    Cancel
-                  </button>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isConnected(conn)) {
               actionButtons = (
                 <div className="acp__participant__actions">
-                  <button
-                    className="acp__participant__actions__button red won-button--outlined thin"
+                  <svg
+                    className="acp__participant__actions__icon secondary won-icon"
                     onClick={() => this.closeConnection(conn)}
                   >
-                    Remove
-                  </button>
+                    <use
+                      xlinkHref="#ico32_buddy_deny"
+                      href="#ico32_buddy_deny"
+                    />
+                  </svg>
                 </div>
               );
             } else if (connectionUtils.isClosed(conn)) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-context-swipeable-view.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-context-swipeable-view.jsx
@@ -48,8 +48,16 @@ class WonAtomContextSwipeableView extends React.Component {
       />
     );
 
+    let buttons = this.props.actionButtons;
+
     if (this.props.actionButtons) {
       const show = this.state.show;
+      buttons = (
+        <div onClick={() => this.handleClick(show)}>
+          {this.props.actionButtons}
+        </div>
+      );
+
       let triggerIcon = (
         <React.Fragment>
           <svg
@@ -81,7 +89,7 @@ class WonAtomContextSwipeableView extends React.Component {
               enableMouseEvents={this.props.enableMouseEvents}
             >
               {headerElement}
-              {this.props.actionButtons}
+              {buttons}
             </SwipeableViews>
           </div>
           {triggerIcon}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
@@ -41,6 +41,10 @@ won-atom-content-buddies {
         font-size: $smallFontSize;
         padding: 0.5rem;
       }
+
+      &__button.won-button--icon {
+        display: block;
+      }
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
@@ -42,8 +42,11 @@ won-atom-content-buddies {
         padding: 0.5rem;
       }
 
-      &__button.won-button--icon {
-        display: block;
+      &__icon {
+        display: flex;
+        align-self: center;
+        @include fixed-square($postIconSize);
+        --local-primary: #{$won-primary-color};
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
@@ -42,27 +42,14 @@ won-atom-content-buddies {
         padding: 0.5rem;
       }
 
-      &__icon {
+      &__icon.won-icon.primary,
+      &__icon.won-icon.secondary,
+      &__icon.won-icon.disabled,
+      &__icon.won-icon.request {
         display: flex;
         align-self: center;
         margin: auto;
         @include fixed-square($postIconSize);
-
-        &--primary {
-          --local-primary: #{$won-primary-color};
-        }
-
-        &--secondary {
-          --local-primary: #{$won-secondary-color};
-        }
-
-        &--disabled {
-          --local-primary: #{$won-disabled-color};
-        }
-
-        &--request {
-          --local-primary: green;
-        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-buddies.scss
@@ -45,8 +45,24 @@ won-atom-content-buddies {
       &__icon {
         display: flex;
         align-self: center;
+        margin: auto;
         @include fixed-square($postIconSize);
-        --local-primary: #{$won-primary-color};
+
+        &--primary {
+          --local-primary: #{$won-primary-color};
+        }
+
+        &--secondary {
+          --local-primary: #{$won-secondary-color};
+        }
+
+        &--disabled {
+          --local-primary: #{$won-disabled-color};
+        }
+
+        &--request {
+          --local-primary: green;
+        }
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-participants.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content-participants.scss
@@ -54,6 +54,16 @@ won-atom-content-participants {
         font-size: $smallFontSize;
         padding: 0.5rem;
       }
+
+      &__icon.won-icon.primary,
+      &__icon.won-icon.secondary,
+      &__icon.won-icon.disabled,
+      &__icon.won-icon.request {
+        display: flex;
+        align-self: center;
+        margin: auto;
+        @include fixed-square($postIconSize);
+      }
     }
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_icon.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_icon.scss
@@ -1,0 +1,17 @@
+.won-icon {
+  &.primary {
+    --local-primary: #{$won-primary-color};
+  }
+
+  &.secondary {
+    --local-primary: #{$won-secondary-color};
+  }
+
+  &.disabled {
+    --local-primary: #{$won-disabled-color};
+  }
+
+  &.request {
+    --local-primary: green;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_slidein.scss
@@ -1,5 +1,6 @@
 @import "won-config";
 @import "button";
+@import "icon";
 @import "responsiveness-utils";
 @import "animate";
 
@@ -77,6 +78,7 @@ won-slide-in {
   .si__termsofservice {
     @include slide-in();
   }
+
   .si__disclaimer {
     @include slide-in();
 
@@ -143,6 +145,7 @@ won-slide-in {
       font-size: $smallFontSize;
       overflow-y: auto;
       text-align: left;
+
       a {
         color: white;
         text-decoration: underline;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_topnav.scss
@@ -1,5 +1,6 @@
 @import "flex-layout";
 @import "button";
+@import "icon";
 @import "positioning-utils";
 
 won-topnav {
@@ -69,6 +70,7 @@ won-topnav {
         @include fixed-square(1.5rem);
         --local-primary: #{$won-secondary-color};
       }
+
       > .topnav__slideintoggle__carret {
         @include fixed-square(1.5rem);
         --local-primary: #{$won-secondary-color};
@@ -77,6 +79,7 @@ won-topnav {
           transform: rotate(-180deg);
           transition: transform linear 0.2s;
         }
+
         &:not(.topnav__slideintoggle__carret--expanded) {
           transform: rotate(0deg);
           transition: transform linear 0.2s;


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [ ] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
To send/accept/reject buddy requests we have buttons. It was not possible to send a direct chatConnectionRequest/Message, via this view.

- Fixes: #3111


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Icons instead of buttons
- SendMessageIcon opens existing, or sends request for new, chatConnection to message directly from persona to persona

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
As described in #3111 following features are implemented:

- for owned atoms:
  - [x] Add/Remove/Accept Buddy
  - [x] Direct Message to Buddy
- for non owned atoms:
  - [x] Add as Buddy

Group Atoms:
- for owned atoms:
  - [x] Add/Remove/Accept Participant
  - [x] Add/Remove/Accept Buddy (if applicable -> if atom in question has buddySocket)
- for non owned atoms:
  - [ ] Add as Buddy (if applicable -> if atom in question has BuddySocket) **Not implemented yet** we probalby need to fix the grid solution first to integrate a dropdown to select own persona to send the request.

