### PR TITLE
Fix parsing of wonnode rdf

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/service/WonNodeInfo.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/WonNodeInfo.java
@@ -71,4 +71,11 @@ public class WonNodeInfo {
     public String getAtomURIPrefix() {
         return atomURIPrefix;
     }
+
+    @Override
+    public String toString() {
+        return "WonNodeInfo [wonNodeURI=" + wonNodeURI + ", eventURIPrefix=" + eventURIPrefix + ", connectionURIPrefix="
+                        + connectionURIPrefix + ", atomURIPrefix=" + atomURIPrefix + ", atomListURI=" + atomListURI
+                        + ", supportedProtocolImpl=" + supportedProtocolImpl + "]";
+    }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -199,25 +199,30 @@ public class WonRdfUtils {
                 NodeIterator it = model.listObjectsOfProperty(WON.uriPrefixSpecification);
                 if (!it.hasNext())
                     return null;
-                RDFNode node = it.next();
+                RDFNode confignode = it.next();
+                StmtIterator stmtit = model.listStatements(null, WON.uriPrefixSpecification, confignode);
+                if (!stmtit.hasNext()) {
+                    return null;
+                }
+                Resource wonNode = stmtit.next().getSubject();
                 WonNodeInfoBuilder wonNodeInfoBuilder = new WonNodeInfoBuilder();
-                wonNodeInfoBuilder.setWonNodeURI(node.asResource().toString());
+                wonNodeInfoBuilder.setWonNodeURI(wonNode.asResource().toString());
                 // set the URI prefixes
-                it = model.listObjectsOfProperty(node.asResource(), WON.atomUriPrefix);
+                it = model.listObjectsOfProperty(confignode.asResource(), WON.atomUriPrefix);
                 if (!it.hasNext())
                     return null;
                 String atomUriPrefix = it.next().asLiteral().getString();
                 wonNodeInfoBuilder.setAtomURIPrefix(atomUriPrefix);
-                it = model.listObjectsOfProperty(node.asResource(), WON.connectionUriPrefix);
+                it = model.listObjectsOfProperty(confignode.asResource(), WON.connectionUriPrefix);
                 if (!it.hasNext())
                     return null;
                 wonNodeInfoBuilder.setConnectionURIPrefix(it.next().asLiteral().getString());
-                it = model.listObjectsOfProperty(node.asResource(), WON.eventUriPrefix);
+                it = model.listObjectsOfProperty(confignode.asResource(), WON.eventUriPrefix);
                 if (!it.hasNext())
                     return null;
                 wonNodeInfoBuilder.setEventURIPrefix(it.next().asLiteral().getString());
                 // set the atom list URI
-                it = model.listObjectsOfProperty(node.asResource(), WON.atomList);
+                it = model.listObjectsOfProperty(confignode.asResource(), WON.atomList);
                 if (it.hasNext()) {
                     wonNodeInfoBuilder.setAtomListURI(it.next().asNode().getURI());
                 } else {

--- a/webofneeds/won-core/src/test/java/won/protocol/model/util/linkeddata/WonRdfUtilsTest.java
+++ b/webofneeds/won-core/src/test/java/won/protocol/model/util/linkeddata/WonRdfUtilsTest.java
@@ -1,7 +1,9 @@
 package won.protocol.model.util.linkeddata;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.riot.Lang;
@@ -10,13 +12,13 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import won.protocol.service.WonNodeInfo;
 import won.protocol.util.WonRdfUtils;
 import won.protocol.vocabulary.WXCHAT;
 import won.protocol.vocabulary.WXGROUP;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
 
 public class WonRdfUtilsTest {
     private InputStream getResourceAsStream(String name) {
@@ -64,5 +66,14 @@ public class WonRdfUtilsTest {
                         URI.create("https://192.168.124.49:8443/won/resource/atom/cbfgi37je6kr#groupSocket1")));
         Assert.assertTrue(sockets.contains(
                         URI.create("https://192.168.124.49:8443/won/resource/atom/cbfgi37je6kr#groupSocket1")));
+    }
+
+    @Test
+    public void testGetWonNodeInfo() {
+        Dataset nodeDataset = loadTestDatasetFromClasspathResource("wonrdfutils/wonnode.trig");
+        WonNodeInfo info = WonRdfUtils.WonNodeUtils.getWonNodeInfo(nodeDataset);
+        Assert.assertEquals("won node uri is wrong", "https://satvm05.researchstudio.at/won/resource",
+                        info.getWonNodeURI());
+        System.out.println(info);
     }
 }

--- a/webofneeds/won-core/src/test/resources/wonrdfutils/wonnode.trig
+++ b/webofneeds/won-core/src/test/resources/wonrdfutils/wonnode.trig
@@ -1,0 +1,43 @@
+@prefix msg:   <https://w3id.org/won/message#> .
+@prefix conn:  <https://satvm05.researchstudio.at/won/resource/connection/> .
+@prefix con:   <https://w3id.org/won/content#> .
+@prefix rdfg:  <http://www.w3.org/2004/03/trix/rdfg-1/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix match: <https://w3id.org/won/matching#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix cert:  <http://www.w3.org/ns/auth/cert#> .
+@prefix local: <https://satvm05.researchstudio.at/won/resource/> .
+@prefix s:     <http://schema.org/> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix won:   <https://w3id.org/won/core#> .
+@prefix event: <https://satvm05.researchstudio.at/won/resource/msg/> .
+@prefix atom:  <https://satvm05.researchstudio.at/won/resource/atom/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<https://satvm05.researchstudio.at/won/resource#data> {
+    <https://satvm05.researchstudio.at/won/resource>
+            cert:key                     [ cert:PublicKey
+                              [ a                  won:ECCPublicKey ;
+                                won:ecc_algorithm  "EC" ;
+                                won:ecc_curveId    "secp384r1" ;
+                                won:ecc_qx         "48d1c98e315c03662d0d89483e271a3df6d9f491f2683cbcb743c953e477816598b91119e8f4500f2412b01317aeeaaa" ;
+                                won:ecc_qy         "da6de9c468e16b43bbaa306302fd971e2fd520ac6e901d9a05ed8c599b1eda083da992976f7bf6a50b971a1586aa6b79"
+                              ] ] ;
+            won:atomList                 local:atom ;
+            won:supportsWonProtocolImpl  [ a                         won:WonOverActiveMq ;
+                                           won:atomActivatedTopic    "MatcherProtocol.Out.Atom" ;
+                                           won:atomCreatedTopic      "MatcherProtocol.Out.Atom" ;
+                                           won:atomDeactivatedTopic  "MatcherProtocol.Out.Atom" ;
+                                           won:atomDeletedTopic      "MatcherProtocol.Out.Atom" ;
+                                           won:brokerUri             <ssl://satvm05.researchstudio.at:61617> ;
+                                           won:matcherQueue          "MatcherProtocol.in" ;
+                                           won:nodeQueue             "AtomProtocol.in" ;
+                                           won:ownerQueue            "OwnerProtocol.in"
+                                         ] ;
+            won:uriPrefixSpecification   [ won:atomUriPrefix        "https://satvm05.researchstudio.at/won/resource/atom" ;
+                                           won:connectionUriPrefix  "https://satvm05.researchstudio.at/won/resource/connection" ;
+                                           won:eventUriPrefix       "https://satvm05.researchstudio.at/won/resource/msg"
+                                         ] .
+}


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Parsing of won node rdf yielded a WonNodeInfo object with a blank node id for Won node URI. Chaos ensued. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
the WoN node URI is parsed correctly

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
