### PR TITLE
Check if message is prepared

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/eventbot/action/EventBotActionUtils.java
@@ -20,11 +20,12 @@ import won.bot.framework.eventbot.EventListenerContext;
 import won.bot.framework.eventbot.event.Event;
 import won.bot.framework.eventbot.event.impl.wonmessage.FailureResponseEvent;
 import won.bot.framework.eventbot.event.impl.wonmessage.SuccessResponseEvent;
-import won.bot.framework.eventbot.filter.impl.RemoteResponseEventFilter;
 import won.bot.framework.eventbot.filter.impl.LocalResponseEventFilter;
+import won.bot.framework.eventbot.filter.impl.RemoteResponseEventFilter;
 import won.bot.framework.eventbot.listener.EventListener;
 import won.bot.framework.eventbot.listener.impl.ActionOnFirstEventListener;
 import won.protocol.message.WonMessage;
+import won.protocol.message.WonMessageUtils;
 
 /**
  * User: fkleedorfer Date: 02.02.14
@@ -72,6 +73,7 @@ public class EventBotActionUtils {
                     EventListenerContext context) {
         // create an event listener that processes the response to the wonMessage we're
         // about to send
+        checkMessageURI(outgoingMessage);
         EventListener listener = new ActionOnFirstEventListener(context,
                         LocalResponseEventFilter.forWonMessage(outgoingMessage),
                         new BaseEventBotAction(context) {
@@ -87,6 +89,14 @@ public class EventBotActionUtils {
         context.getEventBus().subscribe(SuccessResponseEvent.class, listener);
         context.getEventBus().subscribe(FailureResponseEvent.class, listener);
         return listener;
+    }
+
+    public static void checkMessageURI(final WonMessage message) {
+        if (!WonMessageUtils.isValidMessageUri(message.getMessageURIRequired())) {
+            throw new IllegalArgumentException("Specified message has invalid message URI "
+                            + message.getMessageURIRequired()
+                            + ", cannot register a response listener. Make sure to prepare the message befor passing it here.");
+        }
     }
 
     /**
@@ -105,6 +115,7 @@ public class EventBotActionUtils {
                     EventListenerContext context) {
         // create an event listener that processes the remote response to the wonMessage
         // we're about to send
+        checkMessageURI(outgoingMessage);
         EventListener listener = new ActionOnFirstEventListener(context,
                         RemoteResponseEventFilter.forWonMessage(outgoingMessage),
                         new BaseEventBotAction(context) {


### PR DESCRIPTION
... before registering a response listener for it.

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A response listener can be registered for an unprepared message, i.e. its URI is still `wm:/SELF`. Such a listener will never be activated and never removed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Response listeners cannot be registered for unprepared messages.
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

There are potentially more locations where an unprepared message might be used assuming the message URI will not change. One may want to look into that.