### PR TITLE
Improve activemq settings

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/jms/WonJmsConfiguration.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/jms/WonJmsConfiguration.java
@@ -26,7 +26,7 @@ public class WonJmsConfiguration extends JmsConfiguration {
                                 // registration situation, when we actually want to get a result from the
                                 // wonnode.
         setDeliveryPersistent(false);
-        setAcknowledgementModeName("CLIENT_ACKNOWLEDGE"); // make each consumer explicitly acknowledge each message
+        setAcknowledgementModeName("DUPS_OK_ACKNOWLEDGE"); // make each consumer explicitly acknowledge each message
         setDisableReplyTo(true);
         setExplicitQosEnabled(true); // required for the TTL to have an effect
         setTimeToLive(10);
@@ -35,9 +35,10 @@ public class WonJmsConfiguration extends JmsConfiguration {
     }
 
     public void configureJmsConfigurationForQueues() {
-        setConcurrentConsumers(5);
+        setConcurrentConsumers(1);
     }
 
     public void configureJmsConfigurationForTopics() {
+        setConcurrentConsumers(1);
     }
 }

--- a/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
+++ b/webofneeds/won-node/src/main/resources/spring/component/broker/activemq.xml
@@ -34,59 +34,32 @@
 
     <broker xmlns="http://activemq.apache.org/schema/core" brokerName="wonBroker" persistent="false" >
 
-
-
-        <!--
-            For better performances use VM cursor and small memory limit.
-            For more information, see:
-
-            http://activemq.apache.org/message-cursors.html
-
-            Also, if your producer is "hanging", it's probably due to producer flow control.
-            For more information, see:
-            http://activemq.apache.org/producer-flow-control.html
-        -->
-        <!--destinations>
-            <queue physicalName="WON.CREATEATOM"></queue>
-        </destinations-->
         <destinationPolicy>
             <policyMap>
               <policyEntries>
-                <policyEntry topic=">" producerFlowControl="true">
-                    <!-- The constantPendingMessageLimitStrategy is used to prevent
-                         slow topic consumers to block producers and affect other consumers
-                         by limiting the number of messages that are retained
-                         For more information, see:
-
-                         http://activemq.apache.org/slow-consumer-handling.html
-
-                    -->
-                  <pendingMessageLimitStrategy>
-                    <constantPendingMessageLimitStrategy limit="50"/>
-                  </pendingMessageLimitStrategy>
-                </policyEntry>
-                <policyEntry queue=">" producerFlowControl="true" memoryLimit="10mb">
-                  <!-- Use VM cursor for better latency
-                       For more information, see:
-
-                       http://activemq.apache.org/message-cursors.html
-                   -->
-                  <pendingQueuePolicy>
-                    <vmQueueCursor/>
-                  </pendingQueuePolicy>
-
-                </policyEntry>
-                <policyEntry queue=">">
-					         <!-- 
-					           Tell the dead letter strategy not to process expired messages
-					           so that they will just be discarded instead of being sent to
-					           the DLQ 
-					         -->
-					         <deadLetterStrategy>
-					           <sharedDeadLetterStrategy processExpired="false" />
-					         </deadLetterStrategy>
-					       </policyEntry>
-              </policyEntries>
+              	<!-- producer flow control causes congestion in our setting. disable and discard pending messages -->
+              	<!-- decided after reviewing https://access.redhat.com/documentation/en-US/Fuse_ESB_Enterprise/7.1/html-single/ActiveMQ_Tuning_Guide/index.html -->
+              	<policyEntry topic=">" producerFlowControl="false" memoryLimit="5mb" optimizedDispatch="true" queuePrefetch="1">
+              		<pendingMessageLimitStrategy>
+                    	<constantPendingMessageLimitStrategy limit="10"/>
+                  	</pendingMessageLimitStrategy>
+              	</policyEntry>
+              	<policyEntry queue=">" producerFlowControl="false" memoryLimit="5mb" optimizedDispatch="true" queuePrefetch="1">
+              		<pendingMessageLimitStrategy>
+                    	<constantPendingMessageLimitStrategy limit="10"/> 
+                  	</pendingMessageLimitStrategy>
+              	</policyEntry>
+                	<policyEntry queue=">">
+						<!-- 
+				           Tell the dead letter strategy not to process expired messages
+				           so that they will just be discarded instead of being sent to
+				           the DLQ 
+				         -->
+				         <deadLetterStrategy>
+							<sharedDeadLetterStrategy processExpired="false" />
+				         </deadLetterStrategy>
+		       		</policyEntry>
+            	</policyEntries>
             </policyMap>
         </destinationPolicy>
 
@@ -167,9 +140,9 @@
             <!--transportConnector name="ssl"
                                 uri="${uri.protocol.activemq}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600&amp;needClientAuth=true&amp;trace=true" /-->
 
-            <transportConnector name="${activemq.broker.scheme}"
+	            <transportConnector name="${activemq.broker.scheme}"
                                 uri="${activemq.broker.scheme}://0.0.0.0:${activemq.broker.port}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600&amp;needClientAuth=true&amp;jms.useAsyncSend=true&amp;transport.useInactivityMonitor=false&amp;wireFormat.maxInactivityDuration=0&amp;maximumRedeliveries=0" />
-
+ 
             <!--transportConnector name="ssl"
                                 uri="${uri.protocol.activemq}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600&amp;needClientAuth=true&amp;transport.enabledProtocols=TLSv1.2" /-->
             <!-- &amp;transport.enabledProtocols=TLSv1.2-->


### PR DESCRIPTION
* use DUPS_OK_ACKNOWLEDGE jms acknowledgment mode
* disable flow control because it seems to cause congestion
* discard messages for slow consumers

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

Configuration of activemq/jms changed.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Clients (consumers) do not receive messages after some time. For each client, this is a permanent error, client restart does not help. Server restart helps, as does forcing a new client id by deleting the owner's keypair. This situation probably arises due to flow-control, when clients are registered for a topic (such as the topic for receiving AtomCreatedNotifications) and then are stopped. The broker keeps a message queue for such a client and keeps adding the messages. however, when a memory limit is exceeded, it starts throttling the producer (which would be the node in this situation).  

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

producer flow control is disabled, the prefetch limit is set to 1, and the limits used to determine if a consumer is gone are set low (10 messages, 5mb), such that the system is not strained by clients coming on and off again.
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
