### PR TITLE
Feat  update ontology

### DIFF
--- a/webofneeds/pom.xml
+++ b/webofneeds/pom.xml
@@ -401,6 +401,19 @@
                 <artifactId>signingframework</artifactId>
                 <version>${de.uni_koblenz.aggrimm.icp.version}</version>
             </dependency>
+	
+			<!--  multihash and base58 -->
+		    <dependency>
+		      <groupId>com.github.multiformats</groupId>
+		      <artifactId>java-multihash</artifactId>
+		      <version>v1.2.1</version>
+		    </dependency>
+	  
+	  		<dependency>
+	            <groupId>com.github.multiformats</groupId>
+	            <artifactId>java-multibase</artifactId>
+	            <version>v1.0.1</version>
+	        </dependency>
 
             <!-- Servlet API -->
             <dependency>

--- a/webofneeds/won-core/src/main/java/won/protocol/service/WonNodeInfo.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/service/WonNodeInfo.java
@@ -19,16 +19,17 @@ import java.util.Set;
  */
 public class WonNodeInfo {
     private String wonNodeURI;
-    private String eventURIPrefix;
+    private String messageURIPrefix;
     private String connectionURIPrefix;
     private String atomURIPrefix;
     private String atomListURI;
     private Map<String, Map<String, String>> supportedProtocolImpl;
 
-    protected WonNodeInfo(String wonNodeURI, String eventURIPrefix, String connectionURIPattern, String atomURIPattern,
+    protected WonNodeInfo(String wonNodeURI, String messageURIPrefix, String connectionURIPattern,
+                    String atomURIPattern,
                     String atomListURI, Map<String, Map<String, String>> supportedProtocolImpl) {
         this.wonNodeURI = wonNodeURI;
-        this.eventURIPrefix = eventURIPrefix;
+        this.messageURIPrefix = messageURIPrefix;
         this.connectionURIPrefix = connectionURIPattern;
         this.atomURIPrefix = atomURIPattern;
         this.atomListURI = atomListURI;
@@ -60,8 +61,8 @@ public class WonNodeInfo {
         return protocolMap.keySet();
     }
 
-    public String getEventURIPrefix() {
-        return eventURIPrefix;
+    public String getMessageURIPrefix() {
+        return messageURIPrefix;
     }
 
     public String getConnectionURIPrefix() {
@@ -74,8 +75,8 @@ public class WonNodeInfo {
 
     @Override
     public String toString() {
-        return "WonNodeInfo [wonNodeURI=" + wonNodeURI + ", eventURIPrefix=" + eventURIPrefix + ", connectionURIPrefix="
-                        + connectionURIPrefix + ", atomURIPrefix=" + atomURIPrefix + ", atomListURI=" + atomListURI
-                        + ", supportedProtocolImpl=" + supportedProtocolImpl + "]";
+        return "WonNodeInfo [wonNodeURI=" + wonNodeURI + ", messageURIPrefix=" + messageURIPrefix
+                        + ", connectionURIPrefix=" + connectionURIPrefix + ", atomURIPrefix=" + atomURIPrefix
+                        + ", atomListURI=" + atomListURI + ", supportedProtocolImpl=" + supportedProtocolImpl + "]";
     }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -217,7 +217,7 @@ public class WonRdfUtils {
                 if (!it.hasNext())
                     return null;
                 wonNodeInfoBuilder.setConnectionURIPrefix(it.next().asLiteral().getString());
-                it = model.listObjectsOfProperty(confignode.asResource(), WON.eventUriPrefix);
+                it = model.listObjectsOfProperty(confignode.asResource(), WON.messageUriPrefix);
                 if (!it.hasNext())
                     return null;
                 wonNodeInfoBuilder.setEventURIPrefix(it.next().asLiteral().getString());

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/uriresolver/WonMessageUriResolver.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/uriresolver/WonMessageUriResolver.java
@@ -64,7 +64,7 @@ public class WonMessageUriResolver {
      * if it could not be converted
      */
     public URI toGenericMessageURI(URI localMessageUri, WonNodeInfo wonNodeInfo) {
-        return WonMessageUriHelper.toGenericMessageURI(localMessageUri, wonNodeInfo.getEventURIPrefix());
+        return WonMessageUriHelper.toGenericMessageURI(localMessageUri, wonNodeInfo.getMessageURIPrefix());
     }
 
     /**
@@ -166,6 +166,6 @@ public class WonMessageUriResolver {
      * <code>genericMessageUri</code> if it could not be converted
      */
     public URI toLocalMessageURI(URI genericMessageUri, WonNodeInfo wonNodeInfo) {
-        return WonMessageUriHelper.toLocalMessageURI(genericMessageUri, wonNodeInfo.getEventURIPrefix());
+        return WonMessageUriHelper.toLocalMessageURI(genericMessageUri, wonNodeInfo.getMessageURIPrefix());
     }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -38,7 +38,7 @@ public class WON {
     public static final Property uriPrefixSpecification = m.createProperty(BASE_URI, "uriPrefixSpecification");
     public static final Property atomUriPrefix = m.createProperty(BASE_URI, "atomUriPrefix");
     public static final Property connectionUriPrefix = m.createProperty(BASE_URI, "connectionUriPrefix");
-    public static final Property eventUriPrefix = m.createProperty(BASE_URI, "eventUriPrefix");
+    public static final Property messageUriPrefix = m.createProperty(BASE_URI, "messageUriPrefix");
     public static final Property atomList = m.createProperty(BASE_URI, "atomList");
     public static final Property supportsWonProtocolImpl = m.createProperty(BASE_URI + "supportsWonProtocolImpl");
     public static final Resource WonOverActiveMq = m.createResource(BASE_URI + "WonOverActiveMq");

--- a/webofneeds/won-cryptography/pom.xml
+++ b/webofneeds/won-cryptography/pom.xml
@@ -25,13 +25,11 @@
 	    <dependency>
 	      <groupId>com.github.multiformats</groupId>
 	      <artifactId>java-multihash</artifactId>
-	      <version>v1.2.1</version>
 	    </dependency>
   
   		<dependency>
             <groupId>com.github.multiformats</groupId>
             <artifactId>java-multibase</artifactId>
-            <version>v1.0.1</version>
         </dependency>
   
         <dependency>

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonSigner.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonSigner.java
@@ -2,14 +2,15 @@ package won.cryptography.rdfsign;
 
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
+import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.apache.jena.ext.com.google.common.collect.Streams;
@@ -21,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
 import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
+import io.ipfs.multibase.Base58;
 import io.ipfs.multihash.Multihash.Type;
 import won.protocol.message.WonSignatureData;
 
@@ -130,8 +132,7 @@ public class WonSigner {
         sig.initSign(privateKey);
         sig.update(sigData.getHash().toByteArray());
         byte[] signatureBytes = sig.sign();
-        // String signature = new BASE64Encoder().encode(signatureBytes);
-        String signature = Base64.getEncoder().encodeToString(signatureBytes);
+        String signature = Base58.encode(signatureBytes);
         // Update Signature Data
         sigData.setSignature(signature);
         sigData.setSignatureMethod(privateKey.getAlgorithm().toLowerCase());

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
@@ -8,7 +8,6 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.security.PublicKey;
 import java.security.Signature;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
 import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
+import io.ipfs.multibase.Base58;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonSignatureData;
 import won.protocol.util.Prefixer;
@@ -174,7 +174,7 @@ public class WonVerifier {
             sig.initVerify(publicKey);
             sig.update(hashValue.toByteArray());
             // Verify
-            byte[] sigBytes = Base64.getDecoder().decode(sigString);
+            byte[] sigBytes = Base58.decode(sigString);
             if (!sig.verify(sigBytes)) {
                 verificationState.setVerificationFailed(wonSignatureData.getSignatureUri(),
                                 "Failed to verify " + wonSignatureData.getSignatureUri() + " with public key "

--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -288,7 +288,7 @@ public class LinkedDataWebController implements InitializingBean {
     @RequestMapping("${uri.path.page}/msg/{identifier}")
     public String showEventPage(@PathVariable(value = "identifier") String identifier, Model model,
                     HttpServletResponse response) {
-        URI eventURI = uriService.createEventURIForId(identifier);
+        URI eventURI = uriService.createMessageURIForId(identifier);
         return createDatasetResponse(model, response, eventURI);
     }
 
@@ -661,8 +661,8 @@ public class LinkedDataWebController implements InitializingBean {
         // for /resource/atom and resource/connection so that crawlers always re-fetch
         // these data
         URI requestUriAsURI = URI.create(requestUri);
-        if (uriService.isConnectionEventsURI(requestUriAsURI)
-                        || uriService.isAtomEventsURI(requestUriAsURI)
+        if (uriService.isConnectionMessagesURI(requestUriAsURI)
+                        || uriService.isAtomMessagesURI(requestUriAsURI)
                         || uriService.isAtomURI(requestUriAsURI)) {
             addMutableResourceHeaders(headers);
         } else {
@@ -1035,7 +1035,7 @@ public class LinkedDataWebController implements InitializingBean {
         return getResponseEntity(identifier, request, new EtagSupportingDataLoader<Dataset>() {
             @Override
             public URI createUriForIdentifier(final String identifier) {
-                return uriService.createEventURIForId(identifier);
+                return uriService.createMessageURIForId(identifier);
             }
 
             @Override

--- a/webofneeds/won-node/src/main/java/won/node/service/linkeddata/generate/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/linkeddata/generate/LinkedDataServiceImpl.java
@@ -90,7 +90,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
     // prefix of a connection resource
     private String connectionResourceURIPrefix;
     // prefix of a event resource
-    private String eventResourceURIPrefix;
+    private String messageResourceURIPrefix;
     // prefix for URIs referring to real-world things
     @Value("${uri.prefix.resource}")
     private String resourceURIPrefix;
@@ -135,9 +135,9 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
     public void afterPropertiesSet() throws Exception {
         this.atomResourceURIPrefix = this.resourceURIPrefix + "/atom";
         this.connectionResourceURIPrefix = this.resourceURIPrefix + "/connection";
-        this.eventResourceURIPrefix = this.resourceURIPrefix + "/msg";
+        this.messageResourceURIPrefix = this.resourceURIPrefix + "/msg";
         logger.info("setting prefixes: atom: {}, connection: {}, event: {}", new Object[] { this.atomResourceURIPrefix,
-                        this.connectionResourceURIPrefix, this.eventResourceURIPrefix });
+                        this.connectionResourceURIPrefix, this.messageResourceURIPrefix });
     }
 
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED, readOnly = true)
@@ -392,7 +392,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
         res.addProperty(WON.uriPrefixSpecification, blankNodeUriSpec);
         blankNodeUriSpec.addProperty(WON.atomUriPrefix, model.createLiteral(this.atomResourceURIPrefix));
         blankNodeUriSpec.addProperty(WON.connectionUriPrefix, model.createLiteral(this.connectionResourceURIPrefix));
-        blankNodeUriSpec.addProperty(WON.eventUriPrefix, model.createLiteral(this.eventResourceURIPrefix));
+        blankNodeUriSpec.addProperty(WON.messageUriPrefix, model.createLiteral(this.messageResourceURIPrefix));
     }
 
     /**
@@ -676,7 +676,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
                     throws NoSuchConnectionException {
         Slice<MessageEvent> slice = atomInformationService.listConnectionEvents(connectionUri, pageNum,
                         preferedSize, msgType);
-        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice,
+        return eventsToContainerPage(this.uriService.createMessagesURIForConnection(connectionUri).toString(), slice,
                         deep);
     }
 
@@ -687,7 +687,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
                     throws NoSuchConnectionException {
         Slice<MessageEvent> slice = atomInformationService.listConnectionEventsAfter(connectionUri, msgURI,
                         preferedSize, msgType);
-        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice,
+        return eventsToContainerPage(this.uriService.createMessagesURIForConnection(connectionUri).toString(), slice,
                         deep);
     }
 
@@ -698,7 +698,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
                     throws NoSuchConnectionException {
         Slice<MessageEvent> slice = atomInformationService.listConnectionEventsBefore(connectionUri, msgURI,
                         preferedSize, msgType);
-        return eventsToContainerPage(this.uriService.createEventsURIForConnection(connectionUri).toString(), slice,
+        return eventsToContainerPage(this.uriService.createMessagesURIForConnection(connectionUri).toString(), slice,
                         deep);
     }
 
@@ -764,7 +764,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
         setNsPrefixes(dataset.getDefaultModel());
         addPrefixForSpecialResources(dataset, "local", this.resourceURIPrefix);
         addPrefixForSpecialResources(dataset, "atom", this.atomResourceURIPrefix);
-        addPrefixForSpecialResources(dataset, "event", this.eventResourceURIPrefix);
+        addPrefixForSpecialResources(dataset, "event", this.messageResourceURIPrefix);
         addPrefixForSpecialResources(dataset, "conn", this.connectionResourceURIPrefix);
         return dataset;
     }
@@ -915,7 +915,7 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
     }
 
     public void setEventResourceURIPrefix(final String eventResourceURIPrefix) {
-        this.eventResourceURIPrefix = eventResourceURIPrefix;
+        this.messageResourceURIPrefix = eventResourceURIPrefix;
     }
 
     public void setResourceURIPrefix(final String resourceURIPrefix) {

--- a/webofneeds/won-node/src/main/java/won/node/service/nodeconfig/URIService.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/nodeconfig/URIService.java
@@ -32,7 +32,7 @@ public class URIService implements InitializingBean {
     // prefix of a connection resource
     private String connectionResourceURIPrefix;
     // prefix of an event resource
-    private String eventResourceURIPrefix;
+    private String messageResourceURIPrefix;
     // prefix of an attachment resource
     private String attachmentResourceURIPrefix;
     // prefix for URISs of RDF data
@@ -41,9 +41,9 @@ public class URIService implements InitializingBean {
     private String resourceURIPrefix;
     // prefix for human readable pages
     private String pageURIPrefix;
-    private Pattern connectionEventsPattern;
+    private Pattern connectionMessagesPattern;
     private Pattern connectionUriPattern;
-    private Pattern atomEventsPattern;
+    private Pattern atomMessagesPattern;
     private Pattern atomUnreadPattern;
     private Pattern atomUriPattern;
 
@@ -51,19 +51,19 @@ public class URIService implements InitializingBean {
     public void afterPropertiesSet() throws Exception {
         this.atomResourceURIPrefix = this.resourceURIPrefix + "/atom";
         this.connectionResourceURIPrefix = this.resourceURIPrefix + "/connection";
-        this.eventResourceURIPrefix = this.resourceURIPrefix + "/msg";
+        this.messageResourceURIPrefix = this.resourceURIPrefix + "/msg";
         this.attachmentResourceURIPrefix = this.resourceURIPrefix + "/attachment";
-        this.connectionEventsPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/c/[a-zA-Z0-9]+/msg");
+        this.connectionMessagesPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/c/[a-zA-Z0-9]+/msg");
         this.connectionUriPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/c/[a-zA-Z0-9]+");
-        this.atomEventsPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/msg");
+        this.atomMessagesPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/msg");
         this.atomUnreadPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+/unread");
         this.atomUriPattern = Pattern.compile(atomResourceURIPrefix + "/[a-zA-Z0-9]+");
     }
 
-    public boolean isEventURI(URI toCheck) {
+    public boolean isMessageURI(URI toCheck) {
         if (toCheck == null)
             return false;
-        return toCheck.toString().startsWith(eventResourceURIPrefix);
+        return toCheck.toString().startsWith(messageResourceURIPrefix);
     }
 
     public boolean isAtomURI(URI toCheck) {
@@ -78,10 +78,10 @@ public class URIService implements InitializingBean {
         return WonUriCheckHelper.isValidConnectionURI(this.atomResourceURIPrefix, toCheck.toString());
     }
 
-    public boolean isAtomEventsURI(URI toCheck) {
+    public boolean isAtomMessagesURI(URI toCheck) {
         if (toCheck == null)
             return false;
-        Matcher m = atomEventsPattern.matcher(toCheck.toString());
+        Matcher m = atomMessagesPattern.matcher(toCheck.toString());
         return m.lookingAt();
     }
 
@@ -92,25 +92,25 @@ public class URIService implements InitializingBean {
         return m.lookingAt();
     }
 
-    public boolean isConnectionEventsURI(URI toCheck) {
+    public boolean isConnectionMessagesURI(URI toCheck) {
         if (toCheck == null)
             return false;
-        Matcher m = connectionEventsPattern.matcher(toCheck.toString());
+        Matcher m = connectionMessagesPattern.matcher(toCheck.toString());
         return m.lookingAt();
     }
 
-    public URI getConnectionURIofConnectionEventsURI(URI connectionEventsURI) {
-        if (connectionEventsURI == null)
+    public URI getConnectionURIofConnectionMessagesURI(URI connectionMessagesURI) {
+        if (connectionMessagesURI == null)
             return null;
-        Matcher m = connectionUriPattern.matcher(connectionEventsURI.toString());
+        Matcher m = connectionUriPattern.matcher(connectionMessagesURI.toString());
         m.find();
         return URI.create(m.group());
     }
 
-    public URI getAtomURIofAtomEventsURI(URI atomEventsURI) {
-        if (atomEventsURI == null)
+    public URI getAtomURIofAtomMessagesURI(URI atomMessagesURI) {
+        if (atomMessagesURI == null)
             return null;
-        Matcher m = atomUriPattern.matcher(atomEventsURI.toString());
+        Matcher m = atomUriPattern.matcher(atomMessagesURI.toString());
         m.find();
         return URI.create(m.group());
     }
@@ -198,11 +198,11 @@ public class URIService implements InitializingBean {
         return URI.create(atomURI.toString() + "/c");
     }
 
-    public URI createEventsURIForConnection(URI connURI) {
+    public URI createMessagesURIForConnection(URI connURI) {
         return URI.create(connURI.toString() + "/msg");
     }
 
-    public URI createEventURIForId(String id) {
+    public URI createMessageURIForId(String id) {
         return WonMessageUriHelper.createMessageURIForId(id);
     }
 
@@ -214,8 +214,8 @@ public class URIService implements InitializingBean {
         return atomResourceURIPrefix;
     }
 
-    public String getEventResourceURIPrefix() {
-        return eventResourceURIPrefix;
+    public String getMessageResourceURIPrefix() {
+        return messageResourceURIPrefix;
     }
 
     public void setDataURIPrefix(final String dataURIPrefix) {
@@ -252,7 +252,7 @@ public class URIService implements InitializingBean {
      * @param eventURI
      * @return
      */
-    public Long getEventIdFromEventURI(final URI eventURI) {
+    public Long getMessageIdFromMessageURI(final URI eventURI) {
         String path = eventURI.getPath();
         return new Long(path.substring(path.lastIndexOf("/") + 1));
     }
@@ -262,10 +262,10 @@ public class URIService implements InitializingBean {
     }
 
     public URI toLocalMessageURI(URI messageURI) {
-        return WonMessageUriHelper.toLocalMessageURI(messageURI, this.eventResourceURIPrefix);
+        return WonMessageUriHelper.toLocalMessageURI(messageURI, this.messageResourceURIPrefix);
     }
 
     public URI toGenericMessageURI(URI localMessageURI) {
-        return WonMessageUriHelper.toGenericMessageURI(localMessageURI, this.eventResourceURIPrefix);
+        return WonMessageUriHelper.toGenericMessageURI(localMessageURI, this.messageResourceURIPrefix);
     }
 }

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/WonDefaultAccessControlRules.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/WonDefaultAccessControlRules.java
@@ -42,27 +42,27 @@ public class WonDefaultAccessControlRules implements AccessControlRules {
             logger.warn("received more than 1 requester webids, only using first one: ", firstWebId);
         }
         URI webId = URI.create(firstWebId);
-        if (uriService.isEventURI(resourceUri)) {
+        if (uriService.isMessageURI(resourceUri)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("checking access for event {} with webID {} ({} of {})",
                                 new Object[] { resourceUri, firstWebId, 1, requesterWebIDs.size() });
             }
             URI messageUri = uriService.toGenericMessageURI(resourceUri);
             return messageEventRepository.isReadPermittedForWebID(messageUri, webId);
-        } else if (uriService.isConnectionEventsURI(resourceUri)) {
+        } else if (uriService.isConnectionMessagesURI(resourceUri)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("checking access for connectionEvent{} with webID {} ({} of {})",
                                 new Object[] { resourceUri, firstWebId, 1, requesterWebIDs.size() });
             }
             return connectionMessageContainerRepository.isReadPermittedForWebID(
-                            uriService.getConnectionURIofConnectionEventsURI(resourceUri), webId);
-        } else if (uriService.isAtomEventsURI(resourceUri)) {
+                            uriService.getConnectionURIofConnectionMessagesURI(resourceUri), webId);
+        } else if (uriService.isAtomMessagesURI(resourceUri)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("checking access for atomEvent {} with webID {} ({} of {})",
                                 new Object[] { resourceUri, firstWebId, 1, requesterWebIDs.size() });
             }
             return this.atomMessageContainerRepository
-                            .isReadPermittedForWebID(uriService.getAtomURIofAtomEventsURI(resourceUri), webId);
+                            .isReadPermittedForWebID(uriService.getAtomURIofAtomMessagesURI(resourceUri), webId);
         } else if (uriService.isAtomUnreadURI(resourceUri)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("checking access for unreadEventsRequest {} with webID {} ({} of {})",

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
@@ -378,12 +378,12 @@ xsd:duration rdf:type rdfs:Datatype .
                      rdfs:label "connectionUriPrefix" .
 
 
-###  https://w3id.org/won/core#eventUriPrefix
-:eventUriPrefix rdf:type owl:DatatypeProperty ;
+###  https://w3id.org/won/core#messageUriPrefix
+:messageUriPrefix rdf:type owl:DatatypeProperty ;
                 rdfs:domain :UriPrefixSpecification ;
                 rdfs:range xsd:string ;
-                rdfs:comment "Specifies the prefix an event must have on the node this specification applies to. This specification allows clients to generate new valid new event (message) URIs."@en ;
-                rdfs:label "eventUriPrefix" .
+                rdfs:comment "Specifies the prefix a message must have on the node to which this specification applies. This specification allows clients to convert between a message URI (prefix 'wm:/') and a dereferencable https URI."@en ;
+                rdfs:label "messageUriPrefix" .
 
 
 ###  https://w3id.org/won/core#matcherQueue

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-core.ttl
@@ -114,6 +114,14 @@ xsd:duration rdf:type rdfs:Datatype .
                  rdfs:isDefinedBy <https://w3id.org/won/core> ;
                  rdfs:label "connectionState" .
 
+###  https://w3id.org/won/core#previousConnectionState
+:previousConnectionState rdf:type owl:ObjectProperty ,
+                          owl:FunctionalProperty ;
+                 rdfs:domain :Connection ;
+                 rdfs:range :previousConnectionState ;
+                 rdfs:comment "Indicates the state in which the Connection was before the current one."@en ;
+                 rdfs:isDefinedBy <https://w3id.org/won/core> ;
+                 rdfs:label "previousConnectionState" .
 
 ###  https://w3id.org/won/core#connections
 :connections rdf:type owl:ObjectProperty ;

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
@@ -151,7 +151,6 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
                rdfs:isDefinedBy <https://w3id.org/won/message> ;
                rdfs:label "connection" .
 
-
 ###  https://w3id.org/won/message#senderSocket
 :sender rdf:type owl:ObjectProperty ;
         rdfs:domain :Message ;
@@ -159,25 +158,6 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
         rdfs:comment "Indicates the sender socket of the message."@en ;
         rdfs:isDefinedBy <https://w3id.org/won/message> ;
         rdfs:label "senderSocket" .
-
-
-###  https://w3id.org/won/message#senderAtom
-:senderAtom rdf:type owl:ObjectProperty ;
-            rdfs:domain :Message ;
-            rdfs:range won:Atom ;
-            rdfs:comment "Indicates the Atom that 'contains' the sender of the message."@en ;
-            rdfs:isDefinedBy <https://w3id.org/won/message> ;
-            rdfs:label "senderAtom" .
-
-
-###  https://w3id.org/won/message#senderNode
-:senderNode rdf:type owl:ObjectProperty ;
-            rdfs:domain :Message ;
-            rdfs:range won:Node ;
-            rdfs:comment "Indicates the WoN Node the message sender is hosted on."@en ;
-            rdfs:isDefinedBy <https://w3id.org/won/message> ;
-            rdfs:label "senderNode" .
-
 
 ###  https://w3id.org/won/message#signedGraph
 :signedGraph rdf:type owl:ObjectProperty ;
@@ -206,8 +186,6 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
              rdfs:range :EnvelopeGraph ;
              rdfs:comment "Links a message to its envelope."@en ;
              rdfs:label "envelope" .
-
-
 
 
 #################################################################

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
@@ -113,7 +113,7 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
                          rdfs:domain :Message ;
                          rdfs:range :MessageType ;
                          rdfs:comment "Used in a response message to indicate the messageType of the original message."@en ;
-                         rdfs:label "isResponsToMessageType" .
+                         rdfs:label "respondingToMessageType" .
 
 
 ###  https://w3id.org/won/message#messageType

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-message.ttl
@@ -63,13 +63,6 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  https://w3id.org/won/message#containsEnvelope
-:containsEnvelope rdf:type owl:ObjectProperty ;
-                  rdfs:domain :EnvelopeGraph ;
-                  rdfs:range :EnvelopeGraph ;
-                  rdfs:comment "Links an envelope to an envelope it 'contains'."@en ;
-                  rdfs:label "containsEnvelope" .
-
 
 ###  https://w3id.org/won/message#containsSignature
 :containsSignature rdf:type owl:ObjectProperty ;
@@ -133,48 +126,39 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
                  rdfs:label "previousMessage" .
 
 
-###  https://w3id.org/won/message#recipient
+###  https://w3id.org/won/message#recipientSocket
 :recipient rdf:type owl:ObjectProperty ;
            rdfs:domain :Message ;
-           rdfs:range [ rdf:type owl:Class ;
-                        owl:unionOf ( won:Atom
-                                      won:Connection
-                                    )
-                      ] ;
-           rdfs:comment "Indicates the receiver of the message, either Socket or Connection."@en ;
+           rdfs:range :Socket ;
+           rdfs:comment "Indicates the recipient socket of the message."@en ;
            rdfs:isDefinedBy <https://w3id.org/won/message> ;
-           rdfs:label "recipient" .
+           rdfs:label "recipientSocket" .
 
 
-###  https://w3id.org/won/message#recipientAtom
-:recipientAtom rdf:type owl:ObjectProperty ;
+###  https://w3id.org/won/message#atom
+:atom rdf:type owl:ObjectProperty ;
                rdfs:domain :Message ;
                rdfs:range won:Atom ;
-               rdfs:comment "Indicates the Atom that 'contains' the receiver of the message."@en ;
+               rdfs:comment "Links the message to its atom. Only used for messages directed at an atom, such as msg:Activate, msg:Deactivate, or msg:AtomHintMessage."@en ;
                rdfs:isDefinedBy <https://w3id.org/won/message> ;
-               rdfs:label "recipientAtom" .
+               rdfs:label "atom" .
 
-
-###  https://w3id.org/won/message#recipientNode
-:recipientNode rdf:type owl:ObjectProperty ;
+###  https://w3id.org/won/message#connection
+:connection rdf:type owl:ObjectProperty ;
                rdfs:domain :Message ;
-               rdfs:range won:Node ;
-               rdfs:comment "Indicates the WoN Node the message recipient is hosted on."@en ;
+               rdfs:range won:Connection ;
+               rdfs:comment "Links the message to its connection. Only used for response messages in a connection; the messages sent by either side of the connection use msg:senderSocket and msg:recipientSocket to identify the connection uniquely"@en ;
                rdfs:isDefinedBy <https://w3id.org/won/message> ;
-               rdfs:label "recipientNode" .
+               rdfs:label "connection" .
 
 
-###  https://w3id.org/won/message#sender
+###  https://w3id.org/won/message#senderSocket
 :sender rdf:type owl:ObjectProperty ;
         rdfs:domain :Message ;
-        rdfs:range [ rdf:type owl:Class ;
-                     owl:unionOf ( won:Atom
-                                   won:Connection
-                                 )
-                   ] ;
-        rdfs:comment "Indicates the sender of the message."@en ;
+        rdfs:range :Socket ;
+        rdfs:comment "Indicates the sender socket of the message."@en ;
         rdfs:isDefinedBy <https://w3id.org/won/message> ;
-        rdfs:label "sender" .
+        rdfs:label "senderSocket" .
 
 
 ###  https://w3id.org/won/message#senderAtom
@@ -201,6 +185,29 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
              rdfs:range :MessageGraph ;
              rdfs:comment "Links a signature to the graph it signs."@en ;
              rdfs:label "signedGraph" .
+
+###  https://w3id.org/won/message#signer
+:signer rdf:type owl:ObjectProperty ;
+             rdfs:domain :Signature ;
+             rdfs:range :Atom ;
+             rdfs:comment "Links a signature to its signer."@en ;
+             rdfs:label "signer" .
+
+###  https://w3id.org/won/message#signature
+:signature rdf:type owl:ObjectProperty ;
+             rdfs:domain :Message ;
+             rdfs:range :Signature ;
+             rdfs:comment "Links a message to its signature."@en ;
+             rdfs:label "signature" .
+
+###  https://w3id.org/won/message#envelope
+:envelope rdf:type owl:ObjectProperty ;
+             rdfs:domain :Message ;
+             rdfs:range :EnvelopeGraph ;
+             rdfs:comment "Links a message to its envelope."@en ;
+             rdfs:label "envelope" .
+
+
 
 
 #################################################################
@@ -438,6 +445,12 @@ won:Node rdf:type owl:Class .
                  rdfs:comment "Indicates that the message was processed successfully."@en ;
                  rdfs:isDefinedBy <https://w3id.org/won/message> ;
                  rdfs:label "SuccessResponse" .
+
+###  https://w3id.org/won/message#Signature
+:Signature rdf:type owl:NamedIndividual ;
+             rdfs:comment "Class of all signatures in WoN."@en ;
+             rdfs:isDefinedBy <https://w3id.org/won/message> ;             
+             rdfs:label "Signature" .
 
 
 #################################################################


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Affected Tests have been added/altered (for bug fixes / features)
- [x] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds
- Build was executed locally, tests with 2 accounts in webapp, also with debugbot are working.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* The message refactoring missed some changes to the ontologies. 
* The representation of hashes and signatures in the message data used to be inconsistent (base58/base64)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

* Changes were made to the ontologies that reflect the refactoring. 
* In addition to that, `won:eventURIPrefix` was replaced with `won:messageURIPrefix`. All related method/property names in java classes have been changed as well
* In the message signatures, all binary data is represented using base58 (except for key exponents, which are still hex strings)

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

* Clients that do not use this PR will not be able to resolve won message URIS (`wm://`) on a WoN node that uses this PR because they are going to look for `won:eventURIPrefix` in the node descriptor. Updating the client (owner) to this version fixes that. 

* Because of changes to the signature representation, old messages/atoms cannot be verified any more


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
