### PR TITLE
Fix  matcher sparql updates

### DIFF
--- a/webofneeds/won-matcher-service/pom.xml
+++ b/webofneeds/won-matcher-service/pom.xml
@@ -89,6 +89,10 @@
 			<artifactId>bcprov-jdk15on</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/common/service/sparql/SparqlService.java
@@ -97,7 +97,6 @@ public class SparqlService {
         try {
             final PipedOutputStream pout = new PipedOutputStream();
             final PipedInputStream pin = new PipedInputStream(pout);
-            System.out.println("writing to the pipedwriter");
             executorService.execute(() -> {
                 try {
                     RDFDataMgr.write(pout, model, Lang.NTRIPLES);


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The matcher-service can't update a graph in the rdfstore if the respective graph is too big (or has too many triples with the same subject, as containers do via `rfds:member`). The result is a stack overflow logged in the matcher-service log

## What is the new behavior?
Updates to graphs are split in batches of <= 250 triples

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
