### PR TITLE
Fix  matcher too many updates

### DIFF
--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
@@ -198,6 +198,7 @@ public class RematchSparqlService extends SparqlService {
         pps.setLiteral("now", System.currentTimeMillis());
         Set<BulkAtomEvent> bulks = new HashSet<>();
         BulkAtomEvent bulkAtomEvent = new BulkAtomEvent();
+        bulks.add(bulkAtomEvent);
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             // load all the atoms into one bulk atom event
@@ -214,8 +215,8 @@ public class RematchSparqlService extends SparqlService {
                                     Cause.SCHEDULED_FOR_REMATCH);
                     bulkAtomEvent.addAtomEvent(atomEvent);
                     if (++i >= MAX_ATOMS_PER_REMATCH_BULK) {
-                        bulks.add(bulkAtomEvent);
                         bulkAtomEvent = new BulkAtomEvent();
+                        bulks.add(bulkAtomEvent);
                     }
                 }
             }

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
@@ -202,7 +202,6 @@ public class RematchSparqlService extends SparqlService {
         try (QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlEndpoint, pps.asQuery())) {
             ResultSet results = qexec.execSelect();
             // load all the atoms into one bulk atom event
-            int i = 0;
             while (results.hasNext()) {
                 QuerySolution qs = results.nextSolution();
                 String atomUri = qs.get("atomUri").asResource().getURI();
@@ -214,7 +213,7 @@ public class RematchSparqlService extends SparqlService {
                                     System.currentTimeMillis(), sw.toString(), RDFFormat.TRIG.getLang(),
                                     Cause.SCHEDULED_FOR_REMATCH);
                     bulkAtomEvent.addAtomEvent(atomEvent);
-                    if (++i >= MAX_ATOMS_PER_REMATCH_BULK) {
+                    if (bulkAtomEvent.getAtomEvents().size() >= MAX_ATOMS_PER_REMATCH_BULK) {
                         bulkAtomEvent = new BulkAtomEvent();
                         bulks.add(bulkAtomEvent);
                     }


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Matcher has some problems
* the rematch subsystem generates BulkAtomEvents that become too big, resulting in errors and rematching not performed
* the rematch subsystem also generates SPARQL updates that become too big for the sparql parser and therefore fail
* ResourceCrawlEvents that contain the data we would otherwise have to crawl, ('SAVE' events) are are handled like normal crawl events, but not everywhere, leading to these events remaining in the 'pending' list, which prevents regular re-crawls of a node.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
All these problems should be fixed now, resulting in regular recrawling and rematching.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
