### PR TITLE
Feat  update jsonld

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -452,11 +452,11 @@ function hierarchy2Creators(actionHierarchy) {
           /* leaf can either be a defined creator or a
                  * placeholder asking to generate one.
                  */
-          const potentialCreator = won.lookup(actionHierarchy, path);
+          const potentialCreator = lookup(actionHierarchy, path);
           if (typeof potentialCreator === "function") {
             return potentialCreator; //already a defined creator. hopefully.
           } else {
-            const type = won.lookup(actionTypes, path);
+            const type = lookup(actionTypes, path);
             return createActionCreator(type);
           }
         },
@@ -466,6 +466,28 @@ function hierarchy2Creators(actionHierarchy) {
       "__"
     )
   );
+}
+
+/**
+ * Traverses a path of properties over the object, where the folllowing holds:
+ *
+ *     o.propA[1].moreprop === lookup(o, ['propA', 1, 'moreprop'])
+ *
+ * @param o
+ * @param propertyPath
+ * @returns {*}
+ */
+function lookup(o, propertyPath) {
+  //TODO this should be in a utils file
+  if (!o || !propertyPath) {
+    return undefined;
+  }
+  const resolvedStep = o[propertyPath[0]];
+  if (propertyPath.length === 1) {
+    return resolvedStep;
+  } else {
+    return lookup(resolvedStep, propertyPath.slice(1));
+  }
 }
 
 function createActionCreator(type) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -202,7 +202,7 @@ class WonTopnav extends React.Component {
   }
 
   componentDidUpdate() {
-    const MESSAGECOUNT = 10;
+    const MESSAGECOUNT = 3;
 
     if (
       this.props.connectionsToCrawl &&
@@ -220,7 +220,8 @@ class WonTopnav extends React.Component {
 
         if (messageCount == 0) {
           this.props.showLatestMessages(get(conn, "uri"), MESSAGECOUNT);
-        } else {
+        } /* else {
+          // WORKAROUND FOR SLOW LOAD: Remove loading of more Messages until a read one appears will be excluded
           const receivedMessages = messages.filter(
             msg => !get(msg, "outgoingMessage")
           );
@@ -231,7 +232,7 @@ class WonTopnav extends React.Component {
           if (!receivedMessagesReadPresent) {
             this.props.showMoreMessages(get(conn, "uri"), MESSAGECOUNT);
           }
-        }
+        } */
       });
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -417,11 +417,7 @@ export function fetchConnectionsOfAtomAndDispatch(atomUri, dispatch) {
         }),
       });
       const activeConnectionUris = connectionsWithStateAndSocket
-        .filter(
-          conn =>
-            conn.connectionState !== vocab.WON.Closed &&
-            conn.connectionState !== vocab.WON.Suggested
-        )
+        .filter(conn => conn.connectionState !== vocab.WON.Closed)
         .map(conn => conn.uri);
 
       dispatch({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/jsonld-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/jsonld-utils.js
@@ -460,3 +460,25 @@ function throwParsingError(val, type, prependedMsg = "") {
   );
   throw new Error(fullMsg.trim());
 }
+
+// Helper Method to get Data out of jsonld, since the jsonld update some messages dont have a @graph array wrapped around the content (["@graph"][0])
+export function getProperty(jsonld, property) {
+  if (jsonld && property) {
+    if (jsonld["@graph"] && jsonld["@graph"][0]) {
+      return jsonld["@graph"][0][property];
+    } else {
+      return jsonld[property];
+    }
+  }
+  return undefined;
+}
+
+export function setProperty(jsonld, property, val) {
+  if (jsonld && property && val) {
+    if (jsonld["@graph"] && jsonld["@graph"][0]) {
+      jsonld["@graph"][0][property] = val;
+    } else {
+      jsonld[property] = val;
+    }
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/vocab.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/vocab.js
@@ -1,5 +1,11 @@
 let vocab = {};
 
+vocab.RDFS = {};
+vocab.RDFS.prefix = "rdfs";
+vocab.RDFS.baseUri = "http://www.w3.org/2000/01/rdf-schema#";
+vocab.RDFS.memberCompacted = vocab.RDFS.prefix + ":member";
+vocab.RDFS.member = vocab.RDFS.baseUri + "member";
+
 vocab.WON = {};
 vocab.WON.baseUri = "https://w3id.org/won/core#";
 vocab.WON.matcherURI = "https://localhost:8443/matcher/search/";

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -6709,24 +6709,87 @@
       }
     },
     "jsonld": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-      "integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-3.0.1.tgz",
+      "integrity": "sha512-/lLx3sSvlqKHu3215+n4Fcmz7Ah8bixVa91CnXpW8XFZd6qCfAMQi/qEYF3u9fghKNqHjAD0TwCUH7fg6IszYg==",
       "requires": {
         "canonicalize": "^1.0.1",
         "lru-cache": "^5.1.1",
+        "object.fromentries": "^2.0.2",
         "rdf-canonize": "^1.0.2",
         "request": "^2.88.0",
         "semver": "^6.3.0",
         "xmldom": "0.1.19"
       },
       "dependencies": {
+        "es-abstract": {
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+        },
+        "object.fromentries": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+          "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
           }
         },
         "semver": {
@@ -10596,6 +10659,24 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -15,7 +15,7 @@
     "glob-to-regexp": "^0.4.0",
     "identicon.js": "^2.3.3",
     "immutable": "^3.8.2",
-    "jsonld": "^2.0.2",
+    "jsonld": "^3.0.1",
     "leaflet": "^1.5.1",
     "loadcss": "^0.0.2",
     "lodash": "^4.17.15",


### PR DESCRIPTION
- Remove the workaround because of the jsonld framing spec error
- Reduce message parsing by one framing roundtrip for each message
- Refactor and declutter `won.js`
- Only load the latest 3 Messages for each open chat/group connection instead of the last 10
