### PR TITLE
Do not eagerly fetch all the suggested connections and their atoms ri…

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -417,7 +417,11 @@ export function fetchConnectionsOfAtomAndDispatch(atomUri, dispatch) {
         }),
       });
       const activeConnectionUris = connectionsWithStateAndSocket
-        .filter(conn => conn.connectionState !== vocab.WON.Closed)
+        .filter(
+          conn =>
+            conn.connectionState !== vocab.WON.Closed &&
+            conn.connectionState !== vocab.WON.Suggested
+        )
         .map(conn => conn.uri);
 
       dispatch({


### PR DESCRIPTION
…ght away

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [ ] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): 
We remove the eager fetching of any connection in state suggested (does not load the corresponding atom(and its holder) on initial load

## What is the current behavior?
Currently we fetch data for every connection that is not closed, the fetched data contains:
- The Remote Atom
- The Remote Atoms Persona
- All message Uris of the connection (in case of suggested connections this should only be one hint messageuri)
- And then fetch the latest 3 messages -> (which is multiplied by 3 to get all the corresponding success/failure responses of these messages as well)

## What is the new behavior?
Since there are way too many suggested connections, we do not need to load them in the initial load process.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Not loading the suggested Connections corresponding atoms on start up makes us loose the ability to categorize the suggested connections based on socketTypes in the suggested view (tab-suggestions), so this might need further refactoring to ensure all remote atoms of suggestions are loaded when looking at a set of suggestions -> still a work in progress

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
