### PR TITLE
Fix multi-valued headers in LD bridge

### DIFF
--- a/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
+++ b/webofneeds/won-node-webapp/src/main/java/won/node/web/LinkedDataWebController.java
@@ -1264,33 +1264,37 @@ public class LinkedDataWebController implements InitializingBean {
     private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
                     final AtomInformationService.PagedResource<Dataset, URI> resource, final int page,
                     String queryPart) {
-        headers.add("Link",
+        headers.add(HttpHeaders.LINK,
                         "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
         // Link: <http://example.org/customer-relations?p=2>; rel="next"
         if (resource.hasNext()) {
             int nextPage = page + 1;
-            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
         }
         if (resource.hasPrevious() && page > 1) {
             int prevPage = page - 1;
-            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
         }
-        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+        headers.add(HttpHeaders.LINK, "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
     }
 
     private void addPagedResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
                     final AtomInformationService.PagedResource<Dataset, URI> resource, String queryPart) {
-        headers.add("Link",
+        headers.add(HttpHeaders.LINK,
                         "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
         if (resource.hasNext()) {
             String id = resource.getResumeAfter().toString();
-            headers.add("Link", "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
         }
         if (resource.hasPrevious()) {
             String id = resource.getResumeBefore().toString();
-            headers.add("Link", "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
         }
-        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+        headers.add(HttpHeaders.LINK, "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
     }
 
     /**
@@ -1314,33 +1318,37 @@ public class LinkedDataWebController implements InitializingBean {
     private void addPagedConnectionResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
                     final AtomInformationService.PagedResource<Dataset, Connection> resource, final int page,
                     String queryPart) {
-        headers.add("Link",
+        headers.add(HttpHeaders.LINK,
                         "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
         // Link: <http://example.org/customer-relations?p=2>; rel="next"
         if (resource.hasNext()) {
             int nextPage = page + 1;
-            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?p=" + nextPage + queryPart + ">; rel=\"next\"");
         }
         if (resource.hasPrevious() && page > 1) {
             int prevPage = page - 1;
-            headers.add("Link", "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?p=" + prevPage + queryPart + ">; rel=\"prev\"");
         }
-        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+        headers.add(HttpHeaders.LINK, "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
     }
 
     private void addPagedConnectionResourceInSequenceHeader(final HttpHeaders headers, final URI canonicalURI,
                     final AtomInformationService.PagedResource<Dataset, Connection> resource, String queryPart) {
-        headers.add("Link",
+        headers.add(HttpHeaders.LINK,
                         "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\", <http://www.w3.org/ns/ldp#Page>; rel=\"type\"");
         if (resource.hasNext()) {
             String id = resource.getResumeAfter().getConnectionURI().toString();
-            headers.add("Link", "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?resumeafter=" + id + queryPart + ">; rel=\"next\"");
         }
         if (resource.hasPrevious()) {
             String id = resource.getResumeBefore().getConnectionURI().toString();
-            headers.add("Link", "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
+            headers.add(HttpHeaders.LINK,
+                            "<" + canonicalURI.toString() + "?resumebefore=" + id + queryPart + ">; rel=\"prev\"");
         }
-        headers.add("Link", "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
+        headers.add(HttpHeaders.LINK, "<" + canonicalURI.toString() + ">; rel=\"canonical\"");
     }
 
     private String getPassableQueryMap(String... nameValue) {

--- a/webofneeds/won-node/src/main/java/won/node/service/linkeddata/generate/LinkedDataServiceImpl.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/linkeddata/generate/LinkedDataServiceImpl.java
@@ -814,7 +814,8 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
         }
         Dataset dataset = newDatasetWithNamedModel(createDataGraphUriFromResource(atomListPageResource), model);
         addBaseUriAndDefaultPrefixes(dataset);
-        return new AtomInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
+        return new AtomInformationService.PagedResource(dataset, slice.hasPrevious() ? resumeBefore : null,
+                        slice.hasNext() ? resumeAfter : null);
     }
 
     private AtomInformationService.PagedResource<Dataset, Connection> toConnectionsContainerPage(String containerUri,
@@ -837,7 +838,8 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
         }
         Dataset dataset = makeConnectionContainer(containerUri, connections);
         addBaseUriAndDefaultPrefixes(dataset);
-        return new AtomInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
+        return new AtomInformationService.PagedResource(dataset, slice.hasPrevious() ? resumeBefore : null,
+                        slice.hasNext() ? resumeAfter : null);
     }
 
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED, readOnly = true)
@@ -895,7 +897,8 @@ public class LinkedDataServiceImpl implements LinkedDataService, InitializingBea
         Dataset dataset = aggregator.aggregate();
         dataset.addNamedModel(createDataGraphUriFromResource(atomListPageResource), model);
         addBaseUriAndDefaultPrefixes(dataset);
-        return new AtomInformationService.PagedResource(dataset, resumeBefore, resumeAfter);
+        return new AtomInformationService.PagedResource(dataset, slice.hasPrevious() ? resumeBefore : null,
+                        slice.hasNext() ? resumeAfter : null);
     }
 
     private void addDeepConnectionData(Dataset dataset, List<URI> connectionURIs) {


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

* The linked data bridge now sets multiple values of the same header if they are present in the response.
This change enables the paging-relevant headers (of which only the last one is in the response without this PR):

Note that it is possible that all these values are sent in one link header value, separated by commas. Example:
```
Link: <http://www.w3.org/ns/ldp#Resource>; rel="type", <http://www.w3.org/ns/ldp#Page>; rel="type"
Link: <https://localhost:8443/won/resource/atom/ln4xs7q6s5dh/c/tyzm8hk2a4bhcnqb0mlp/msg?resumeafter=wm:/W1oreJeV7FDKaASzJ3BsQemZuGTdodjw3m9sSTr4kc1riy>; rel="next"
Link: <https://localhost:8443/won/resource/atom/ln4xs7q6s5dh/c/tyzm8hk2a4bhcnqb0mlp/msg>; rel="canonical"
```
I.e., to get the next link, split all link headers by `,` and select the first that ends with `; rel="next"`

* Multi-valued request headers are now also handled correctly by the bridge

* prev and next links are only generated if a prev or next Slice is expected from the DB

* The header copying code has been made more efficient

* The test for chunked transfer encoding was corrected

* text/html content is forwarded without changing the status code to 502, which caused Chrome to display the response body as text
## Does this introduce a breaking change?

- [ ] Yes
- [x] No
