### PR TITLE
Fix text/html responses via LD bridge

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/rest/BridgeForLinkedDataController.java
@@ -177,24 +177,22 @@ public class BridgeForLinkedDataController implements InitializingBean {
             response.setStatus(originalResponse.getRawStatusCode());
         } else {
             if (RDFMediaType.isRDFMediaType(originalResponseMediaType)
-                            || originalResponseMediaType.equals(MediaType.TEXT_HTML)) {
+                            || originalResponseMediaType.isCompatibleWith(MediaType.TEXT_HTML)) {
                 copyLinkedDataResponseRelevantHeaders(originalResponse.getHeaders(), response);
                 response.setStatus(originalResponse.getRawStatusCode());
                 // create response body
                 copyResponseBody(originalResponse, response);
                 // close response output stream
             } else {
-                // the content type is not an RDF media type. We don't like to handle such
-                // requests. indicate this with
-                // the BAD GATEWAY response status
-                copyResponseBody(originalResponse, response);
+                // the content type is not an RDF media type and not text/html, which we need
+                // for the human-readable view of linked data resources. We don't like to handle
+                // such requests. Indicate this with the BAD GATEWAY response status and explain
+                // in the response body.
                 response.setStatus(HttpStatus.SC_BAD_GATEWAY);
-                /*
-                 * response.getOutputStream().print("The nodes' response was of type " +
-                 * originalResponseMediaType +
-                 * ". For security reasons the owner-server only forwards responses of the following types "
-                 * + RDFMediaType.rdfMediaTypes.toString());
-                 */
+                response.getOutputStream().print("The target server's response was of type " +
+                                originalResponseMediaType +
+                                ". We only forward responses of the following types "
+                                + RDFMediaType.rdfMediaTypes.toString() + " and " + MediaType.TEXT_HTML_VALUE);
             }
         }
         response.getOutputStream().flush();


### PR DESCRIPTION

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
text/html responses from the node are not passed on properly by the linked data bridge in th owner webapp. They cause a 502 (bad gateway) status, and the headers are not copied, the response body is copied.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- The media type generated by the node when it returns html is parsed correctly, and the headers as well as the body are copied to the response
- If the media type of the response is anything but `text/html` or the RDF media types, neither the headers nor the body are delivered and the status is 502.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
