### PR TITLE
Added handler for clicking on map

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.jsx
@@ -123,7 +123,11 @@ export default class WonLocationPicker extends React.Component {
 
     if (selectedLocationCoordinates) {
       selectedLocationMarker = (
-        <Marker position={selectedLocationCoordinates} icon={locationIcon} />
+        <Marker
+          position={selectedLocationCoordinates}
+          icon={locationIcon}
+          onClick={() => false}
+        />
       );
     }
 
@@ -184,6 +188,7 @@ export default class WonLocationPicker extends React.Component {
         <Map
           className="lp__mapmount"
           zoom={13}
+          onClick={e => this.mapClicked(e)}
           center={
             selectedLocationCoordinates ||
             currentLocationCoordinates || [48.210033, 16.363449]
@@ -253,6 +258,7 @@ export default class WonLocationPicker extends React.Component {
   }
 
   selectLocation(location) {
+    console.log(location);
     this.setState(
       {
         pickedLocation: location,
@@ -264,6 +270,10 @@ export default class WonLocationPicker extends React.Component {
         this.update();
       }
     );
+  }
+
+  mapClicked({ latlng }) {
+    this.selectLocation({ ...latlng, name: `${latlng.lat}, ${latlng.lng}` });
   }
 
   resetLocation(callback) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/location-picker.jsx
@@ -273,7 +273,12 @@ export default class WonLocationPicker extends React.Component {
   }
 
   mapClicked({ latlng }) {
-    this.selectLocation({ ...latlng, name: `${latlng.lat}, ${latlng.lng}` });
+    this.selectLocation({
+      ...latlng,
+      name: `${latlng.lat}, ${latlng.lng}`,
+      nwCorner: latlng,
+      seCorner: latlng,
+    });
   }
 
   resetLocation(callback) {


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Fixes #3091 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When clicking on the map in the location picker, a marker is placed at the selected position and the location bar is updated with the corrdinates of the marker.
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Having the coordinates in the location bar is not very elegant, especially since right now they can't be entered that way. An alternative would be to use nominatim to reverse-search an address, but trying that I had very inconsistent results.

A third option would be to use the original lat and lng, but use the location name provided by nominatim. I am not sure how this would affect later matching of the created atoms though.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
