### PR TITLE
Dedupes requests

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/api/owner-api.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/api/owner-api.js
@@ -2,6 +2,7 @@ import urljoin from "url-join";
 import { ownerBaseUrl } from "~/config/default.js";
 import * as wonUtils from "../won-utils.js";
 import vocab from "../service/vocab.js";
+import { bestfetch } from "bestfetch";
 
 /**
  * Created by quasarchimaere on 11.06.2019.
@@ -482,17 +483,11 @@ export function getJsonLdDataset(uri, params = {}) {
 
   const requestUri = queryString(uri, params);
 
-  /*console.debug(
-    "called ownerApi.getJsonLdDataset: ",
-    requestUri,
-    "params: ",
-    params
-  );*/
-
-  return fetch(requestUri, {
+  return bestfetch(requestUri, {
     method: "get",
     credentials: "same-origin",
     headers: {
+      cachePolicy: "network-only",
       Accept: "application/ld+json",
       Prefer: params.pagingSize
         ? `return=representation; max-member-count="${params.pagingSize}"`
@@ -512,7 +507,7 @@ export function getJsonLdDataset(uri, params = {}) {
         throw error;
       }
     })
-    .then(dataset => dataset.json());
+    .then(dataset => dataset.data);
 }
 
 export function getMetaAtoms(

--- a/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package-lock.json
@@ -2354,6 +2354,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bestfetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bestfetch/-/bestfetch-4.0.0.tgz",
+      "integrity": "sha512-4WeLvYWL1nHJR3KL+q+iDBKnBsB+zCZ/dGzFTKWuMkftSyrsQWrAldwAXeAyprw1zWcLHsfbTDpN8CqcYJJ12A=="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",

--- a/webofneeds/won-owner-webapp/src/main/webapp/package.json
+++ b/webofneeds/won-owner-webapp/src/main/webapp/package.json
@@ -5,6 +5,7 @@
     "@depack/render": "^1.1.4",
     "@webcomponents/custom-elements": "^1.2.1",
     "api": "0.0.1",
+    "bestfetch": "^4.0.0",
     "color": "^3.1.0",
     "geopoint": "^1.0.1",
     "glob-to-regexp": "^0.4.0",


### PR DESCRIPTION
dedupe requests -> makes whats new / suggestions faster if many visible metaatoms would have the same persona, by limiting a getJsonLd request to only have one single in flight per uri -> bestfetch-caching is still disabled otherwise we would run into issues when editing atoms