### PR TITLE
Fixed input reset in atom picker

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
@@ -134,7 +134,6 @@ class WonSuggestAtomPicker extends React.Component {
       !uriToFetchLoading &&
       !uriToFetchFailedToLoad &&
       get(props.allSuggestableAtoms, state.uriToFetch);
-    console.debug("TODO: HANDLE URITOFETCHSUCCESS: ", uriToFetchSuccess);
     const uriToFetchFailed =
       state.uriToFetch &&
       !uriToFetchLoading &&
@@ -142,7 +141,7 @@ class WonSuggestAtomPicker extends React.Component {
         uriToFetchIsExcluded ||
         uriToFetchIsNotAllowed);
 
-    if (uriToFetchSuccess) {
+    if (uriToFetchSuccess && state.fetching) {
       if (state.uriToFetch && state.uriToFetch.trim().length > 0) {
         props.onUpdate({ value: state.uriToFetch });
       } else {
@@ -156,6 +155,7 @@ class WonSuggestAtomPicker extends React.Component {
         uriToFetchIsNotAllowed: uriToFetchIsNotAllowed,
         uriToFetchIsExcluded: uriToFetchIsExcluded,
         uriToFetch: "",
+        fetching: false,
         showResetButton: false,
         showFetchButton: false,
       };
@@ -327,7 +327,9 @@ class WonSuggestAtomPicker extends React.Component {
       !getIn(this.props.allSuggestableAtoms, this.state.uriToFetch) &&
       !get(this.props.allForbiddenAtoms, this.state.uriToFetch)
     ) {
-      this.props.fetchAtom(this.state.uriToFetch);
+      this.setState({ fetching: true }, () =>
+        this.props.fetchAtom(this.state.uriToFetch)
+      );
     } else {
       this.update(this.state.uriToFetch);
     }
@@ -342,6 +344,7 @@ class WonSuggestAtomPicker extends React.Component {
     }
   }
 }
+
 WonSuggestAtomPicker.propTypes = {
   initialValue: PropTypes.any,
   detail: PropTypes.any,


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Fixes: #3033  When typing a url that is already known by the suggest atom picker into the custom url field, it is suddenly deleted


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The suggest atom picker now checks whether it has just finished a load before clearing the input, instead of clearing it whenever the url in the input is already present in the suggestions

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

The introduced state variable that tracks whether a request is in progress loses its value on the first fetch because the component is recreated. This is a problem in [`create-isseeks.jsx`](https://github.com/researchstudio-sat/webofneeds/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-isseeks.jsx).
