### PR TITLE
Fix  endless fetch

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
@@ -357,19 +357,11 @@ export default function WonAtomMessages({
     // make sure latest messages are loaded
     const INITIAL_MESSAGECOUNT = 10;
     if (
-      connection &&
-      !connectionUtils.isUsingTemporaryUri(connection) &&
-      !isConnectionLoading &&
-      !isProcessingLoadingMessages &&
       get(connection, "messages").size < INITIAL_MESSAGECOUNT &&
+      !connectionUtils.isUsingTemporaryUri(connection) &&
       hasConnectionMessagesToLoad
     ) {
-      dispatch(
-        actionCreators.connections__showLatestMessages(
-          connectionUri,
-          INITIAL_MESSAGECOUNT
-        )
-      );
+      loadPreviousMessages(INITIAL_MESSAGECOUNT);
     }
   }
 
@@ -517,13 +509,12 @@ export default function WonAtomMessages({
         });
     }
   }
-  function loadPreviousMessages() {
-    const MORE_MESSAGECOUNT = 5;
+  function loadPreviousMessages(messagesToLoadCount = 5) {
     if (connection && !isConnectionLoading && !isProcessingLoadingMessages) {
       dispatch(
         actionCreators.connections__showMoreMessages(
           connectionUri,
-          MORE_MESSAGECOUNT
+          messagesToLoadCount
         )
       );
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
@@ -357,9 +357,9 @@ export default function WonAtomMessages({
     // make sure latest messages are loaded
     const INITIAL_MESSAGECOUNT = 10;
     if (
-      get(connection, "messages").size < INITIAL_MESSAGECOUNT &&
+      hasConnectionMessagesToLoad &&
       !connectionUtils.isUsingTemporaryUri(connection) &&
-      hasConnectionMessagesToLoad
+      get(connection, "messages").size < INITIAL_MESSAGECOUNT
     ) {
       loadPreviousMessages(INITIAL_MESSAGECOUNT);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/pokemon-raid-card.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/pokemon-raid-card.jsx
@@ -252,12 +252,15 @@ export default function PokemonRaidCard({
       : undefined;
 
   const cardIcon = (
-    <div
+    <Link
       className={
         "card__icon clickable " +
         (isInactive ? " inactive " : "") +
         (showMap ? "card__icon--map" : "") +
         (pokemonImageUrl ? "card__icon--pkm" : "")
+      }
+      to={location =>
+        generateLink(location, { postUri: atomUri, tab: "DETAIL" }, "/post")
       }
       style={style}
     >
@@ -294,7 +297,7 @@ export default function PokemonRaidCard({
       ) : (
         undefined
       )}
-    </div>
+    </Link>
   );
 
   const cardMain = (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
@@ -214,9 +214,9 @@ export default function WonGroupAtomMessages({
     // make sure latest messages are loaded
     const INITIAL_MESSAGECOUNT = 10;
     if (
-      get(connection, "messages").size < INITIAL_MESSAGECOUNT &&
+      hasConnectionMessagesToLoad &&
       !connectionUtils.isUsingTemporaryUri(connection) &&
-      hasConnectionMessagesToLoad
+      get(connection, "messages").size < INITIAL_MESSAGECOUNT
     ) {
       loadPreviousMessages(INITIAL_MESSAGECOUNT);
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
@@ -211,30 +211,23 @@ export default function WonGroupAtomMessages({
   }
 
   function ensureMessagesAreLoaded() {
+    // make sure latest messages are loaded
     const INITIAL_MESSAGECOUNT = 10;
     if (
-      connection &&
-      !isConnectionLoading &&
-      !isProcessingLoadingMessages &&
       get(connection, "messages").size < INITIAL_MESSAGECOUNT &&
+      !connectionUtils.isUsingTemporaryUri(connection) &&
       hasConnectionMessagesToLoad
     ) {
-      dispatch(
-        actionCreators.connections__showLatestMessages(
-          connectionUri,
-          INITIAL_MESSAGECOUNT
-        )
-      );
+      loadPreviousMessages(INITIAL_MESSAGECOUNT);
     }
   }
 
-  function loadPreviousMessages() {
-    const MORE_MESSAGECOUNT = 5;
+  function loadPreviousMessages(messagesToLoadCount = 5) {
     if (connection && !isConnectionLoading && !isProcessingLoadingMessages) {
       dispatch(
         actionCreators.connections__showMoreMessages(
           connectionUri,
-          MORE_MESSAGECOUNT
+          messagesToLoadCount
         )
       );
     }


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [] Affected Tests have been added/altered (for bug fixes / features)
- [] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- Viewing a chat or groupchat that has less than 10 messages stored in the state after the initialFetch will lead to an endless fetch loop
- Pokemon Raid Cards dont have a Clickable/Link Image


## What is the new behavior?
- Endless fetch is omitted
- Pokemon Raid Cards have a Link/Click handler on the image now

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
