### PR TITLE
Allow * as reaction usecase

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card-grid.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card-grid.jsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import WonAtomCard from "./atom-card.jsx";
-import { get } from "../utils.js";
+import { get, generateLink } from "../utils.js";
 import PropTypes from "prop-types";
 
 import ico32_buddy_add from "~/images/won-icons/ico32_buddy_add.svg";
@@ -34,7 +34,10 @@ export default function WonAtomCardGrid({
     });
 
   const createAtom = showCreate ? (
-    <Link className="won-create-card" to="/create">
+    <Link
+      className="won-create-card"
+      to={location => generateLink(location, {}, "/create", false)}
+    >
       <svg className="createcard__icon" title="Create a new post">
         <use xlinkHref={ico36_plus} href={ico36_plus} />
       </svg>
@@ -45,7 +48,19 @@ export default function WonAtomCardGrid({
   );
 
   const createPersonaAtom = showCreatePersona ? (
-    <Link className="won-create-card" to="/create?useCase=persona">
+    <Link
+      className="won-create-card"
+      to={location =>
+        generateLink(
+          location,
+          {
+            useCase: "persona",
+          },
+          "/create",
+          false
+        )
+      }
+    >
       <svg className="createcard__icon" title="Create a new post">
         <use xlinkHref={ico32_buddy_add} href={ico32_buddy_add} />
       </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
@@ -184,7 +184,6 @@ export default function WonAtomContent({
             atom={atom}
             socketType={visibleTab}
             ItemComponent={WonParticipantItem}
-            allowAdHoc={true}
             relevantConnections={relevantConnections}
             showAddPicker={showAddPicker}
             toggleAddPicker={toggleAddPicker}
@@ -229,10 +228,11 @@ export default function WonAtomContent({
         visibleTabFragment = (
           <WonAtomContentChats
             atom={atom}
-            allowAdHoc={!isOwned}
             showAddPicker={showAddPicker}
             toggleAddPicker={toggleAddPicker}
             // We filter out every chat connection that is not owned, otherwise the count would show non owned chatconnections of non owned atoms
+            // TODO: If isOwned is false, then we need to remove all the Group to Chat connections from the relevantConnections, otherwise we will
+            // otherwise we allow the groupChat owner to send a direct message from the group to one single member
             relevantConnections={relevantConnections.filter(
               conn =>
                 isOwned || connectionUtils.hasTargetSocketUri(conn, socketUri)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-chats.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-chats.jsx
@@ -27,7 +27,6 @@ import "~/style/_atom-content-chats.scss";
 
 export default function AtomContentChats({
   atom,
-  allowAdHoc,
   relevantConnections,
   showAddPicker,
   toggleAddPicker,
@@ -131,11 +130,11 @@ export default function AtomContentChats({
         />
       </div>
       {!showAddPicker ? (
-        activeChatConnections.size > 0 || reactions || allowAdHoc ? (
+        activeChatConnections.size > 0 || reactions ? (
           <div className="acc__segment">
             <div className="acc__segment__content borderTop">
               {generateConnectionItems(activeChatConnections)}
-              {atomUtils.isActive(atom) && (reactions || allowAdHoc) ? (
+              {atomUtils.isActive(atom) && reactions ? (
                 <WonSocketAddButton
                   senderReactions={reactions}
                   isAtomOwned={isAtomOwned}
@@ -208,7 +207,6 @@ export default function AtomContentChats({
           addToAtom={atom}
           storedAtoms={filteredStoredAtoms}
           addToSocketType={vocab.CHAT.ChatSocketCompacted}
-          allowAdHoc={allowAdHoc}
           reactions={reactions}
           accountState={accountState}
           onClose={() => toggleAddPicker(!showAddPicker)}
@@ -223,7 +221,6 @@ export default function AtomContentChats({
 AtomContentChats.propTypes = {
   atom: PropTypes.object.isRequired,
   relevantConnections: PropTypes.object.isRequired,
-  allowAdHoc: PropTypes.bool,
   showAddPicker: PropTypes.bool.isRequired,
   toggleAddPicker: PropTypes.func.isRequired,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
@@ -29,7 +29,6 @@ export default function WonAtomContentSocket({
   atom,
   socketType,
   ItemComponent,
-  allowAdHoc,
   relevantConnections,
   showAddPicker,
   toggleAddPicker,
@@ -151,11 +150,11 @@ export default function WonAtomContentSocket({
         />
       </div>
       {!showAddPicker ? (
-        activeConnections.size > 0 || reactions || allowAdHoc ? (
+        activeConnections.size > 0 || reactions ? (
           <div className="acs__segment">
             <div className="acs__segment__content">
               {generateConnectionItems(activeConnections)}
-              {atomUtils.isActive(atom) && (reactions || allowAdHoc) ? (
+              {atomUtils.isActive(atom) && reactions ? (
                 <WonSocketAddButton
                   senderReactions={reactions}
                   isAtomOwned={isAtomOwned}
@@ -264,7 +263,6 @@ export default function WonAtomContentSocket({
           addToAtom={atom}
           storedAtoms={filteredStoredAtoms}
           addToSocketType={socketType}
-          allowAdHoc={allowAdHoc}
           reactions={reactions}
           accountState={accountState}
           onClose={() => toggleAddPicker(!showAddPicker)}
@@ -281,7 +279,6 @@ WonAtomContentSocket.propTypes = {
   relevantConnections: PropTypes.object.isRequired,
   socketType: PropTypes.string.isRequired,
   ItemComponent: PropTypes.func.isRequired,
-  allowAdHoc: PropTypes.bool,
   showAddPicker: PropTypes.bool.isRequired,
   toggleAddPicker: PropTypes.func.isRequired,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-context-dropdown.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-context-dropdown.jsx
@@ -58,6 +58,9 @@ export default function WonAtomContextDropdown({ atom, className }) {
     generalSelectors.isAtomUsableAsTemplate(atomUri)
   );
   const isEditable = useSelector(generalSelectors.isAtomEditable(atomUri));
+
+  const useCaseIdentifier = atomUtils.getMatchedUseCaseIdentifier(atom);
+
   const atomLoading =
     !atom || processUtils.isAtomLoading(process, get(atom, "uri"));
   const atomFailedToLoad =
@@ -184,9 +187,11 @@ export default function WonAtomContextDropdown({ atom, className }) {
                 history.location,
                 {
                   fromAtomUri: atomUri,
+                  useCase: useCaseIdentifier,
                   mode: "DUPLICATE",
                 },
-                "/create"
+                "/create",
+                false
               )
             )
           }
@@ -205,9 +210,11 @@ export default function WonAtomContextDropdown({ atom, className }) {
                 history.location,
                 {
                   fromAtomUri: atomUri,
+                  useCase: useCaseIdentifier,
                   mode: "EDIT",
                 },
-                "/create"
+                "/create",
+                false
               )
             )
           }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
@@ -65,7 +65,7 @@ export default function WonAtomHeader({
   let atomHeaderContent;
   let atomHeaderIcon;
 
-  if (atomLoading) {
+  if (atomLoading || atomToLoad) {
     //Loading View
 
     atomHeaderIcon = <div className="ph__icon__skeleton" />;
@@ -181,7 +181,7 @@ export default function WonAtomHeader({
     </Link>
   ) : (
     <won-atom-header
-      className={
+      class={
         (atomLoading ? " won-is-loading " : "") +
         (atomToLoad ? " won-to-load " : "") +
         (onClick ? " clickable " : "") +

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.jsx
@@ -69,6 +69,11 @@ export default function WonConnectionContextDropdown({
   const isTargetAtomEditable = useSelector(
     generalSelectors.isAtomEditable(targetAtomUri)
   );
+
+  const targetAtomUseCaseIdentifier = atomUtils.getMatchedUseCaseIdentifier(
+    targetAtom
+  );
+
   const connectionLoading =
     !connection || processUtils.isConnectionLoading(process, connectionUri);
 
@@ -198,9 +203,11 @@ export default function WonConnectionContextDropdown({
               location,
               {
                 fromAtomUri: targetAtomUri,
+                useCase: targetAtomUseCaseIdentifier,
                 mode: "DUPLICATE",
               },
-              "/create"
+              "/create",
+              false
             )
           }
         >
@@ -217,9 +224,11 @@ export default function WonConnectionContextDropdown({
               location,
               {
                 fromAtomUri: targetAtomUri,
+                useCase: targetAtomUseCaseIdentifier,
                 mode: "EDIT",
               },
-              "/create"
+              "/create",
+              false
             )
           }
         >

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
@@ -64,9 +64,10 @@ const mapStateToProps = (state, ownProps) => {
   const suggestedAtom = get(allSuggestableAtoms, suggestedAtomUri);
   const sortedActiveAtomsArray =
     allSuggestableAtoms &&
-    sortBy(allSuggestableAtoms, elem =>
-      (elem.get("humanReadable") || "").toLowerCase()
-    );
+    sortBy(allSuggestableAtoms, elem => {
+      const humanReadable = get(elem, "humanReadable");
+      return humanReadable ? humanReadable.toLowerCase() : undefined;
+    });
 
   return {
     initialValue: ownProps.initialValue,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/howto.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/howto.jsx
@@ -4,7 +4,7 @@ import Immutable from "immutable";
 import { useDispatch, useSelector } from "react-redux";
 import { actionCreators } from "../actions/actions.js";
 import * as generalSelectors from "../redux/selectors/general-selectors.js";
-import { get } from "../utils.js";
+import { get, generateLink } from "../utils.js";
 
 import WonLabelledHr from "./labelled-hr.jsx";
 
@@ -217,7 +217,9 @@ export default function WonHowTo({ className }) {
           label="Or"
         />
         <Link
-          to="/create?useCase=persona"
+          to={location =>
+            generateLink(location, { useCase: "persona" }, "/create", "false")
+          }
           className="won-button--filled red howto__createx__spanbutton"
         >
           <span>Create your Persona!</span>
@@ -227,7 +229,7 @@ export default function WonHowTo({ className }) {
           label="Or"
         />
         <Link
-          to="/create"
+          to={location => generateLink(location, {}, "/create", "false")}
           className="won-button--filled red howto__createx__spanbutton"
         >
           <span>Post something now!</span>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -118,14 +118,12 @@ export default function WonSocketAddAtom({
       .map((reaction, socketType) => {
         const allowedUseCaseList = get(reaction, "useCaseIdentifiers");
 
-        return allowedUseCaseList
-          .filter(ucIdentifier => ucIdentifier !== "*") //TODO: REMOVE THIS ONCE WE KNOW HOW TO HANDLE WILDCARD USECASES
-          .map(ucIdentifier =>
-            createAtomReactionsArray.push({
-              ucIdentifier: ucIdentifier,
-              socketType: socketType,
-            })
-          );
+        return allowedUseCaseList.map(ucIdentifier =>
+          createAtomReactionsArray.push({
+            ucIdentifier: ucIdentifier,
+            socketType: socketType,
+          })
+        );
       });
 
   const sortedPossibleAtomsArray =
@@ -386,7 +384,7 @@ export default function WonSocketAddAtom({
               generateLink(
                 location,
                 {
-                  useCase: ucIdentifier,
+                  useCase: ucIdentifier !== "*" ? ucIdentifier : undefined,
                   fromAtomUri: addToAtomUri,
                   senderSocketType: socketType,
                   targetSocketType: addToSocketType,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -126,9 +126,10 @@ export default function WonSocketAddAtom({
 
   const sortedPossibleAtomsArray =
     sortedPossibleAtoms &&
-    sortBy(sortedPossibleAtoms, elem =>
-      (get(elem, "humanReadable") || "").toLowerCase()
-    );
+    sortBy(sortedPossibleAtoms, elem => {
+      const humanReadable = get(elem, "humanReadable");
+      return humanReadable ? humanReadable.toLowerCase() : undefined;
+    });
 
   function selectAtom(selectedAtom) {
     const selectedAtomUri = get(selectedAtom, "uri");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -31,7 +31,6 @@ import Immutable from "immutable";
  * @param reactions - useCase reactions: json object see uc-persona.js as an example
  * @param accountState - accountState redux store -> to determine ownership of the storedAtoms, and login status
  * @param onClose - function that is executed when the close Button is clicked
- * @param allowAdHoc - if true then the adHoc Connect textfield will be visible, connecting Generated Persona or Personas with the addToAtom
  * @returns {*}
  */
 export default function WonSocketAddAtom({
@@ -41,7 +40,6 @@ export default function WonSocketAddAtom({
   reactions,
   accountState,
   onClose,
-  allowAdHoc,
 }) {
   const dispatch = useDispatch();
   const history = useHistory();
@@ -49,13 +47,13 @@ export default function WonSocketAddAtom({
   const addToAtomSocketUri = atomUtils.getSocketUri(addToAtom, addToSocketType);
   const isAddToAtomOwned = accountUtils.isAtomOwned(accountState, addToAtomUri);
 
-  if (!isAddToAtomOwned) {
-    console.error(
-      "Atom: ",
-      addToAtom,
-      " is not owned, yet the component refuses to allow Owned Atoms to connect -> you are gonna have a bad time :-("
-    );
-  }
+  const allowAdHoc = !!reactions.find(
+    (reaction, socketType) =>
+      socketType === vocab.CHAT.ChatSocketCompacted &&
+      (get(reaction, "useCaseIdentifiers", "*") ||
+        (get(reaction, "useCaseIdentifiers", "persona") &&
+          !(isAddToAtomOwned && get(reaction, "refuseOwned"))))
+  );
 
   //If the addToAtom is Owned, we preselect the holderUri (if present) to be used as the holder of the new atom to establish a connection with
   const addHolderUri = isAddToAtomOwned
@@ -438,7 +436,9 @@ export default function WonSocketAddAtom({
             submitButtonLabel={
               addToSocketType === vocab.CHAT.ChatSocketCompacted
                 ? "Ask to Chat"
-                : "Join Group"
+                : isAddToAtomOwned
+                  ? "Join"
+                  : "Ask to Join"
             }
             onSubmit={({ value, selectedPersona }) =>
               sendAdHocRequest(
@@ -462,5 +462,4 @@ WonSocketAddAtom.propTypes = {
   storedAtoms: PropTypes.object.isRequired,
   accountState: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
-  allowAdHoc: PropTypes.bool,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-group.jsx
@@ -1,18 +1,16 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
 import * as useCaseUtils from "../usecase-utils.js";
-import * as generalSelectors from "../redux/selectors/general-selectors.js";
 
 import "~/style/_usecase-group.scss";
 import { getQueryParams, generateLink } from "../utils";
 import { Link, useHistory } from "react-router-dom";
 
-export default function WonUseCaseGroup() {
+export default function WonUseCaseGroup({
+  visibleUseCasesByConfig,
+  filterBySocketType,
+}) {
   const history = useHistory();
-  const visibleUseCasesByConfig = useSelector(
-    generalSelectors.getVisibleUseCasesByConfig
-  );
-
   const { useCaseGroup } = getQueryParams(history.location);
 
   const visibleUseCaseGroup =
@@ -58,7 +56,8 @@ export default function WonUseCaseGroup() {
                 (subItem, index) =>
                   useCaseUtils.isDisplayableItem(
                     subItem,
-                    visibleUseCasesByConfig
+                    visibleUseCasesByConfig,
+                    filterBySocketType
                   ) ? (
                     <Link
                       key={subItem.identifier + "-" + index}
@@ -90,3 +89,7 @@ export default function WonUseCaseGroup() {
     </won-usecase-group>
   );
 }
+WonUseCaseGroup.propTypes = {
+  visibleUseCasesByConfig: PropTypes.object.isRequired,
+  filterBySocketType: PropTypes.string,
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/usecase-picker.jsx
@@ -1,35 +1,36 @@
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 import { generateLink } from "../utils.js";
-import * as generalSelectors from "../redux/selectors/general-selectors.js";
-import { useSelector } from "react-redux";
 import WonTitlePicker from "./details/picker/title-picker.jsx";
 import * as useCaseUtils from "../usecase-utils.js";
 
 import "~/style/_usecase-picker.scss";
 import { Link } from "react-router-dom";
 
-export default function WonUseCasePicker() {
+export default function WonUseCasePicker({
+  visibleUseCasesByConfig,
+  filterBySocketType,
+}) {
   const [state, setState] = useState({
     searchText: "",
     searchResults: [],
   });
 
-  const visibleUseCasesByConfig = useSelector(
-    generalSelectors.getVisibleUseCasesByConfig
-  );
   const showGroupsThreshold = 1;
   const customUseCase = useCaseUtils.getCustomUseCase();
   const visibleUseCaseGroups =
     visibleUseCasesByConfig &&
     useCaseUtils.getVisibleUseCaseGroups(
       showGroupsThreshold,
-      visibleUseCasesByConfig
+      visibleUseCasesByConfig,
+      filterBySocketType
     );
   const ungroupedUseCases =
     visibleUseCasesByConfig &&
     useCaseUtils.getUnGroupedUseCases(
       showGroupsThreshold,
-      visibleUseCasesByConfig
+      visibleUseCasesByConfig,
+      filterBySocketType
     );
 
   function startFromRoute(location, selectedUseCase) {
@@ -37,9 +38,7 @@ export default function WonUseCasePicker() {
       selectedUseCase && selectedUseCase.identifier;
 
     if (selectedUseCaseIdentifier) {
-      return `${location.pathname}?useCase=${encodeURIComponent(
-        selectedUseCaseIdentifier
-      )}`;
+      return generateLink(location, { useCase: selectedUseCaseIdentifier });
     } else {
       console.warn("No identifier found for given usecase, ", selectedUseCase);
     }
@@ -65,7 +64,8 @@ export default function WonUseCasePicker() {
     if (value && value.trim().length > 1) {
       searchResults = useCaseUtils.filterUseCasesBySearchQuery(
         value,
-        visibleUseCasesByConfig
+        visibleUseCasesByConfig,
+        filterBySocketType
       );
 
       if (searchResults) {
@@ -204,3 +204,7 @@ export default function WonUseCasePicker() {
     </won-usecase-picker>
   );
 }
+WonUseCasePicker.propTypes = {
+  visibleUseCasesByConfig: PropTypes.object.isRequired,
+  filterBySocketType: PropTypes.string,
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
@@ -66,7 +66,7 @@ export default function PageCreate() {
   let contentElement;
   let showUseCaseGroup = !useCase && !!useCaseGroup;
 
-  let showCreatePostFromAtom = !!fromAtomUri && !!mode;
+  let showCreatePostFromAtom = !!fromAtomUri && !!mode && !!useCase;
   let showCreatePostFromUseCase = !showCreatePostFromAtom && !!useCase;
 
   let showUseCasePicker = !(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
@@ -43,6 +43,10 @@ export default function PageCreate() {
   const showModalDialog = useSelector(viewSelectors.showModalDialog);
   const showSlideIns = useSelector(viewSelectors.showSlideIns(history));
 
+  const visibleUseCasesByConfig = useSelector(
+    generalSelectors.getVisibleUseCasesByConfig
+  );
+
   const isFromAtomLoading = fromAtomUri
     ? processUtils.isAtomLoading(processState, fromAtomUri)
     : false;
@@ -76,9 +80,19 @@ export default function PageCreate() {
   );
 
   if (showUseCaseGroup) {
-    contentElement = <WonUseCaseGroup />;
+    contentElement = (
+      <WonUseCaseGroup
+        visibleUseCasesByConfig={visibleUseCasesByConfig}
+        filterBySocketType={senderSocketType}
+      />
+    );
   } else if (showUseCasePicker) {
-    contentElement = <WonUseCasePicker />;
+    contentElement = (
+      <WonUseCasePicker
+        visibleUseCasesByConfig={visibleUseCasesByConfig}
+        filterBySocketType={senderSocketType}
+      />
+    );
   } else if (showCreatePostFromAtom) {
     if (
       fromAtom &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-other.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-other.js
@@ -40,7 +40,7 @@ export const otherGroup = {
       reactions: {
         [vocab.GROUP.GroupSocketCompacted]: {
           [vocab.CHAT.ChatSocketCompacted]: {
-            useCaseIdentifiers: ["persona"],
+            useCaseIdentifiers: ["*"],
           },
           [vocab.GROUP.GroupSocketCompacted]: {
             useCaseIdentifiers: ["*"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
@@ -35,7 +35,7 @@ export const bandSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["musicianSearch"],
+        useCaseIdentifiers: ["musicianSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-offer.js
@@ -23,7 +23,7 @@ export const booksOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["booksSearch"],
+        useCaseIdentifiers: ["booksSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-search.js
@@ -23,7 +23,7 @@ export const booksSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["booksOffer"],
+        useCaseIdentifiers: ["booksOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
@@ -27,7 +27,7 @@ export const complain = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["handleComplaint"],
+        useCaseIdentifiers: ["handleComplaint", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
@@ -25,7 +25,7 @@ export const consortiumOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["consortiumSearch"],
+        useCaseIdentifiers: ["consortiumSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
@@ -25,7 +25,7 @@ export const consortiumSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["consortiumOffer"],
+        useCaseIdentifiers: ["consortiumOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-custom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-custom.js
@@ -1,6 +1,7 @@
 import { details, mergeInEmptyDraft } from "../detail-definitions.js";
 import * as jsonLdUtils from "../../app/service/jsonld-utils.js";
 import ico36_uc_custom from "../../images/won-icons/ico36_uc_custom.svg";
+import vocab from "../../app/service/vocab";
 
 export const customUseCase = {
   identifier: "customUseCase",
@@ -8,6 +9,16 @@ export const customUseCase = {
   icon: ico36_uc_custom,
   doNotMatchAfter: jsonLdUtils.findLatestIntervallEndInJsonLdOrNowAndAddMillis,
   draft: { ...mergeInEmptyDraft() },
+  reactions: {
+    [vocab.CHAT.ChatSocketCompacted]: {
+      [vocab.CHAT.ChatSocketCompacted]: {
+        useCaseIdentifiers: ["*"],
+      },
+      [vocab.GROUP.GroupSocketCompacted]: {
+        useCaseIdentifiers: ["*"],
+      },
+    },
+  },
   details: details,
   seeksDetails: details,
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -31,7 +31,7 @@ export const cyclingPlan = {
   reactions: {
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["cyclingInterest"],
+        useCaseIdentifiers: ["cyclingInterest", "persona"],
       },
       [vocab.GROUP.GroupSocketCompacted]: {
         useCaseIdentifiers: ["cyclingPlan"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
@@ -23,7 +23,7 @@ export const goodsOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsServiceSearch"],
+        useCaseIdentifiers: ["goodsServiceSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -32,7 +32,7 @@ export const goodsServiceSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["serviceOffer", "goodsOffer"],
+        useCaseIdentifiers: ["serviceOffer", "goodsOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
@@ -22,7 +22,7 @@ export const goodsTransportOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsTransportSearch"],
+        useCaseIdentifiers: ["goodsTransportSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
@@ -29,7 +29,7 @@ export const goodsTransportSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsTransportOffer"],
+        useCaseIdentifiers: ["goodsTransportOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
@@ -27,7 +27,7 @@ export const handleComplaint = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["complain"],
+        useCaseIdentifiers: ["complain", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
@@ -36,7 +36,7 @@ export const jobOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["jobSearch"],
+        useCaseIdentifiers: ["jobSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
@@ -38,7 +38,7 @@ export const jobSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["jobOffer"],
+        useCaseIdentifiers: ["jobOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
@@ -31,7 +31,7 @@ export const lunchPlan = {
   reactions: {
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["lunchInterest"],
+        useCaseIdentifiers: ["lunchInterest", "persona"],
       },
       [vocab.GROUP.GroupSocketCompacted]: { useCaseIdentifiers: ["lunchPlan"] },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
@@ -35,7 +35,7 @@ export const musicianSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["bandSearch"],
+        useCaseIdentifiers: ["bandSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-persona.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-persona.js
@@ -34,7 +34,7 @@ export const persona = {
     },
     [vocab.BUDDY.BuddySocketCompacted]: {
       [vocab.BUDDY.BuddySocketCompacted]: {
-        useCaseIdentifiers: ["persona"],
+        useCaseIdentifiers: ["persona", "persona"],
         refuseOwned: true,
       },
     },
@@ -46,7 +46,7 @@ export const persona = {
     },
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["persona"],
+        useCaseIdentifiers: ["persona", "persona"],
         refuseOwned: true,
       },
       [vocab.GROUP.GroupSocketCompacted]: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
@@ -25,7 +25,7 @@ export const personalTransportSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["taxiOffer", "rideShareOffer"],
+        useCaseIdentifiers: ["taxiOffer", "rideShareOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
@@ -25,7 +25,7 @@ export const phdOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["phdSearch"],
+        useCaseIdentifiers: ["phdSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
@@ -28,7 +28,7 @@ export const phdSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["phdOffer"],
+        useCaseIdentifiers: ["phdOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -25,7 +25,7 @@ export const pokemonGoRaid = {
   reactions: {
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["pokemonInterest"],
+        useCaseIdentifiers: ["pokemonInterest", "persona"],
       },
       [vocab.GROUP.GroupSocketCompacted]: {
         useCaseIdentifiers: ["pokemonGoRaid"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
@@ -25,7 +25,7 @@ export const postdocOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["postdocSearch"],
+        useCaseIdentifiers: ["postdocSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
@@ -28,7 +28,7 @@ export const postdocSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["postdocOffer"],
+        useCaseIdentifiers: ["postdocOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
@@ -39,7 +39,7 @@ export const rehearsalRoomOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rehearsalRoomSearch"],
+        useCaseIdentifiers: ["rehearsalRoomSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
@@ -39,7 +39,7 @@ export const rehearsalRoomSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rehearsalRoomOffer"],
+        useCaseIdentifiers: ["rehearsalRoomOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -42,7 +42,7 @@ export const rentRealEstateOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rentRealEstateSearch"],
+        useCaseIdentifiers: ["rentRealEstateSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
@@ -42,7 +42,7 @@ export const rentRealEstateSearch = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rentRealEstateOffer"],
+        useCaseIdentifiers: ["rentRealEstateOffer", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
@@ -29,7 +29,7 @@ export const rideShareOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["personalTransportSearch"],
+        useCaseIdentifiers: ["personalTransportSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
@@ -20,7 +20,7 @@ export const serviceOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsServiceSearch"],
+        useCaseIdentifiers: ["goodsServiceSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
@@ -22,7 +22,7 @@ export const taxiOffer = {
   reactions: {
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["personalTransportSearch"],
+        useCaseIdentifiers: ["personalTransportSearch", "persona"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header.scss
@@ -5,6 +5,7 @@
 
 a.won-atom-header,
 won-atom-header {
+  &.won-to-load,
   &.won-is-loading {
     @include animateOpacityHeartBeat();
     pointer-events: none;


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
WonAtomHeader in socket-add-atom did not invoke the fetch of atoms that are in the toLoad state

- Fixes: fetches visible atoms in the socket-add-atom that are in the toLoad state


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Implements the ability to add reactions to any usecase * -> create new atom will go to the usecasepicker and will filter out all usecases that do not have the socketType needed to connect the reaction

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
