### PR TITLE
Add Missing Sockets to an Atom after EDIT

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
@@ -52,18 +52,19 @@ export default function WonAtomInfo({
     const reactionElements = [];
     reactions &&
       reactions.map((senderSocketReactions, targetSocketType) => {
-        reactionElements.push(
-          <WonSocketAddButton
-            senderReactions={senderSocketReactions}
-            targetSocketType={targetSocketType}
-            isAtomOwned={isAtomOwned}
-            key={targetSocketType}
-            onClick={() => {
-              setVisibleTab(targetSocketType);
-              toggleAddPicker(true);
-            }}
-          />
-        );
+        atomUtils.hasSocket(atom, targetSocketType) &&
+          reactionElements.push(
+            <WonSocketAddButton
+              senderReactions={senderSocketReactions}
+              targetSocketType={targetSocketType}
+              isAtomOwned={isAtomOwned}
+              key={targetSocketType}
+              onClick={() => {
+                setVisibleTab(targetSocketType);
+                toggleAddPicker(true);
+              }}
+            />
+          );
       });
 
     return reactionElements;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/edit-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/edit-atom.jsx
@@ -28,23 +28,13 @@ export default function WonEditAtom({ fromAtom }) {
   );
   const accountState = useSelector(generalSelectors.getAccountState);
 
-  const useCase = useCaseUtils.getUseCase(
-    atomUtils.getMatchedUseCaseIdentifier(fromAtom) || "customUseCase"
+  const useCaseImm = useCaseUtils.getUseCaseImmMergedWithAtom(
+    atomUtils.getMatchedUseCaseIdentifier(fromAtom) || "customUseCase",
+    fromAtom
   );
 
-  const fromAtomContent = get(fromAtom, "content");
-  const fromAtomSeeks = get(fromAtom, "seeks");
-
-  if (fromAtomContent) {
-    useCase.draft.content = fromAtomContent.toJS();
-  }
-  if (fromAtomSeeks) {
-    useCase.draft.seeks = fromAtomSeeks.toJS();
-  }
-
-  const [draftObject, setDraftObject] = useState(
-    JSON.parse(JSON.stringify(useCase.draft))
-  );
+  const useCase = useCaseImm.toJS();
+  const [draftObject, setDraftObject] = useState(useCase.draft);
 
   const loggedIn = accountUtils.isLoggedIn(accountState);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -515,37 +515,7 @@ export function sortByDistanceFrom(atomsImm, location, order = "ASC") {
 
 function getSocketKeysReset(socketsImm) {
   //TODO: Needs to be generic somehow, otherwise every socket that is added would not be able to be reset correctly
-  return socketsImm.mapKeys((key, value) => {
-    switch (value) {
-      case vocab.CHAT.ChatSocketCompacted:
-        return "#chatSocket";
-      case vocab.GROUP.GroupSocketCompacted:
-        return "#groupSocket";
-      case vocab.HOLD.HolderSocketCompacted:
-        return "#holderSocket";
-      case vocab.HOLD.HoldableSocketCompacted:
-        return "#holdableSocket";
-      case vocab.REVIEW.ReviewSocketCompacted:
-        return "#reviewSocket";
-      case vocab.BUDDY.BuddySocketCompacted:
-        return "#buddySocket";
-      case vocab.WXSCHEMA.WorksForInverseSocketCompacted:
-        return "#worksForInverseSocket";
-      case vocab.WXSCHEMA.MemberSocketCompacted:
-        return "#memberSocket";
-      case vocab.WXSCHEMA.AssociatedArticleSocketCompacted:
-        return "#associatedArticleSocket";
-      case vocab.WXSCHEMA.WorksForSocketCompacted:
-        return "#worksForSocket";
-      case vocab.WXSCHEMA.MemberOfSocketCompacted:
-        return "#memberOfSocket";
-      case vocab.WXSCHEMA.AssociatedArticleInverseSocketCompacted:
-        return "#associatedArticleInverseSocket";
-      default:
-        console.warn("Trying to reset an unknown socket: ", value);
-        return "#unknownSocket";
-    }
-  });
+  return socketsImm.mapKeys(key => key.substr(key.lastIndexOf("#")));
 }
 
 /**


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- Atoms that do not have a specific socket that is used as a reaction would show the addToReaction footer anyway
- Edit does not add missing sockets to an atom


## What is the new behavior?
- Prevent display of the "add X" reaction buttons if the socket used in the reaction is not present in the atom
- Adds every socket that is defined in the useCase but not yet present in an atom when an atom is edited
- Implements a generic socketKeys reset (reset socketUris from atomUri#socketX back to #socketX) -> used for duplicating atoms, up until now we would have to add a case for each new socket we define/use in a useCase. this is no longer the "case" (pun intended)

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
