### PR TITLE
Feat Improve Post (connections-actions, and routing/navigation)

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-actions.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-actions.jsx
@@ -84,6 +84,10 @@ export default function WonAtomActions({
           senderAtom,
           get(ownedConnection, "socketUri")
         );
+        const targetSocketType = atomUtils.getSocketType(
+          targetAtom,
+          get(ownedConnection, "targetSocketUri")
+        );
 
         const isViewOfTargetAtom = get(targetAtom, "uri") === atomUri;
 
@@ -126,7 +130,8 @@ export default function WonAtomActions({
               <div className="atom-actions__info__label">
                 {wonLabelUtils.getSocketActionInfoLabel(
                   senderSocketType,
-                  get(ownedConnection, "state")
+                  get(ownedConnection, "state"),
+                  targetSocketType
                 )}
               </div>
               <div className="atom-actions__info__sender">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-actions.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-actions.jsx
@@ -25,7 +25,7 @@ const ActionType = {
 export default function WonAtomActions({ atom, ownedConnection, className }) {
   const dispatch = useDispatch();
   const atomUri = get(atom, "uri");
-  const atomType = atomUtils.generateTypeLabel(atom);
+  const atomType = atomUtils.generateTypeLabel(atom, "Atom");
 
   const isOwned = useSelector(generalSelectors.isAtomOwned(atomUri));
 
@@ -115,9 +115,9 @@ export default function WonAtomActions({ atom, ownedConnection, className }) {
           <React.Fragment>
             <div className="atom-actions__infolabel">
               {wonLabelUtils.getSocketActionInfoLabel(
-                atomType,
                 toSocketType,
-                get(ownedConnection, "state")
+                get(ownedConnection, "state"),
+                atomType
               )}
             </div>
             <WonAtomHeader

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
@@ -40,6 +40,7 @@ export default function WonAtomContent({
   visibleTab,
   setVisibleTab,
   relevantConnectionsMap,
+  storedAtoms,
   showAddPicker,
   toggleAddPicker,
 }) {
@@ -48,8 +49,6 @@ export default function WonAtomContent({
   const atomUri = get(atom, "uri");
   const { connectionUri } = getQueryParams(history.location);
   const isOwned = useSelector(generalSelectors.isAtomOwned(atomUri));
-
-  const storedAtoms = useSelector(generalSelectors.getAtoms);
 
   const process = useSelector(generalSelectors.getProcessState);
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
@@ -100,7 +100,7 @@ export default function WonAtomContentSocket({
             }
             targetAtom={get(storedAtoms, get(conn, "targetAtomUri"))}
             isOwned={isAtomOwned}
-            flip={get(conn, "targetSocketUri") === socketUri}
+            flip={flip}
           />
         </React.Fragment>
       );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -84,49 +84,10 @@ export default function WonAtomHeaderBig({
         extractAtomUriFromConnectionUri(get(ownedConnection, "uri"))
       );
 
-      const targetSocketType = atomUtils.getSocketType(
-        targetAtom,
-        get(ownedConnection, "targetSocketUri")
-      );
       const senderSocketType = atomUtils.getSocketType(
         senderAtom,
         get(ownedConnection, "socketUri")
       );
-
-      const isTargetAtomDisplayed = get(senderAtom, "uri") === atomUri;
-
-      const generateAtomIcon = displayAtom => {
-        return ownedConnection && !isInactive ? (
-          <div className="won-toggle-actions__button__infoicon">
-            <WonAtomIcon atom={displayAtom} />
-          </div>
-        ) : (
-          undefined
-        );
-      };
-
-      const generateButtonLabel = () => {
-        if (isInactive) {
-          return (
-            <span className="won-toggle-actions__button__label">
-              Atom Inactive
-            </span>
-          );
-        }
-
-        const toSocketType = isTargetAtomDisplayed
-          ? targetSocketType
-          : senderSocketType;
-
-        return (
-          <span className="won-toggle-actions__button__label">
-            {wonLabelUtils.getSocketActionInfoLabel(
-              toSocketType,
-              connectionState
-            )}
-          </span>
-        );
-      };
 
       return (
         <won-toggle-actions>
@@ -139,9 +100,26 @@ export default function WonAtomHeaderBig({
                 : " won-toggle-actions__button--collapsed ")
             }
           >
-            {generateAtomIcon(isTargetAtomDisplayed ? senderAtom : targetAtom)}
-            {generateButtonLabel()}
-            {generateAtomIcon(isTargetAtomDisplayed ? targetAtom : senderAtom)}
+            {isInactive ? (
+              <span className="won-toggle-actions__button__label">
+                Atom Inactive
+              </span>
+            ) : (
+              <React.Fragment>
+                <div className="won-toggle-actions__button__infoicon">
+                  <WonAtomIcon atom={targetAtom} />
+                </div>
+                <span className="won-toggle-actions__button__label">
+                  {wonLabelUtils.getSocketActionInfoLabel(
+                    senderSocketType,
+                    connectionState
+                  )}
+                </span>
+                <div className="won-toggle-actions__button__infoicon">
+                  <WonAtomIcon atom={senderAtom} />
+                </div>
+              </React.Fragment>
+            )}
             <svg className="won-toggle-actions__button__carret">
               <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
             </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -27,7 +27,6 @@ export default function WonAtomHeaderBig({
   toggleActions,
 }) {
   const atomUri = get(atom, "uri");
-  const atomType = atomUtils.generateTypeLabel(atom);
   const personaUri = atomUtils.getHeldByUri(atom);
   const storedAtoms = useSelector(generalSelectors.getAtoms);
   const persona = get(storedAtoms, personaUri);
@@ -96,20 +95,13 @@ export default function WonAtomHeaderBig({
 
       const isTargetAtomDisplayed = get(senderAtom, "uri") === atomUri;
 
-      const generateAtomIcon = () => {
-        let icon;
-        if (ownedConnection && !isInactive) {
-          icon = (
-            <WonAtomIcon
-              atom={isTargetAtomDisplayed ? targetAtom : senderAtom}
-            />
-          );
-        }
-
-        return (
-          icon && (
-            <div className="won-toggle-actions__button__infoicon">{icon}</div>
-          )
+      const generateAtomIcon = displayAtom => {
+        return ownedConnection && !isInactive ? (
+          <div className="won-toggle-actions__button__infoicon">
+            <WonAtomIcon atom={displayAtom} />
+          </div>
+        ) : (
+          undefined
         );
       };
 
@@ -129,7 +121,6 @@ export default function WonAtomHeaderBig({
         return (
           <span className="won-toggle-actions__button__label">
             {wonLabelUtils.getSocketActionInfoLabel(
-              atomType,
               toSocketType,
               connectionState
             )}
@@ -148,8 +139,9 @@ export default function WonAtomHeaderBig({
                 : " won-toggle-actions__button--collapsed ")
             }
           >
+            {generateAtomIcon(isTargetAtomDisplayed ? senderAtom : targetAtom)}
             {generateButtonLabel()}
-            {generateAtomIcon()}
+            {generateAtomIcon(isTargetAtomDisplayed ? targetAtom : senderAtom)}
             <svg className="won-toggle-actions__button__carret">
               <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
             </svg>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -88,6 +88,10 @@ export default function WonAtomHeaderBig({
         senderAtom,
         get(ownedConnection, "socketUri")
       );
+      const targetSocketType = atomUtils.getSocketType(
+        targetAtom,
+        get(ownedConnection, "targetSocketUri")
+      );
 
       return (
         <won-toggle-actions>
@@ -112,7 +116,8 @@ export default function WonAtomHeaderBig({
                 <span className="won-toggle-actions__button__label">
                   {wonLabelUtils.getSocketActionInfoLabel(
                     senderSocketType,
-                    connectionState
+                    connectionState,
+                    targetSocketType
                   )}
                 </span>
                 <div className="won-toggle-actions__button__infoicon">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
@@ -22,6 +22,7 @@ export default function WonAtomInfo({
   const atomUri = get(atom, "uri");
   const connectionUri = get(ownedConnection, "uri");
   const processState = useSelector(generalSelectors.getProcessState);
+  const storedAtoms = useSelector(generalSelectors.getAtoms);
 
   const atomLoading =
     !atom || processUtils.isAtomLoading(processState, atomUri);
@@ -71,7 +72,11 @@ export default function WonAtomInfo({
         toggleActions={toggleActions}
       />
       {showActions ? (
-        <WonAtomActions atom={atom} ownedConnection={ownedConnection} />
+        <WonAtomActions
+          atom={atom}
+          ownedConnection={ownedConnection}
+          storedAtoms={storedAtoms}
+        />
       ) : (
         undefined
       )}
@@ -89,6 +94,7 @@ export default function WonAtomInfo({
         toggleAddPicker={toggleAddPicker}
         showAddPicker={showAddPicker}
         setVisibleTab={setVisibleTab}
+        storedAtoms={storedAtoms}
       />
     </won-atom-info>
   );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import { get } from "../utils.js";
 import WonAtomHeaderBig from "./atom-header-big.jsx";
 import WonAtomMenu from "./atom-menu.jsx";
@@ -12,6 +13,7 @@ import * as processUtils from "../redux/utils/process-utils";
 import * as connectionUtils from "../redux/utils/connection-utils";
 
 import "~/style/_atom-info.scss";
+import { generateLink } from "../utils";
 
 export default function WonAtomInfo({
   atom,
@@ -19,6 +21,7 @@ export default function WonAtomInfo({
   className,
   initialTab = "DETAIL",
 }) {
+  const history = useHistory();
   const atomUri = get(atom, "uri");
   const connectionUri = get(ownedConnection, "uri");
   const processState = useSelector(generalSelectors.getProcessState);
@@ -59,6 +62,16 @@ export default function WonAtomInfo({
     generalSelectors.getConnectionsOfAtomWithOwnedTargetConnections(atomUri)
   );
 
+  /*FIXME: This is a quick(ish) workaround that adds the tabname
+    to the route for all pages but /inventory -> that way navigating
+    from a specific atom within a socket, will not result in
+    browserBack showing the detail page but the tab that was previously selected */
+  const changeTab =
+    history.location.pathname !== "/inventory"
+      ? tabName =>
+          history.replace(generateLink(history.location, { tab: tabName }))
+      : setVisibleTab;
+
   return (
     <won-atom-info
       class={
@@ -83,7 +96,7 @@ export default function WonAtomInfo({
       <WonAtomMenu
         atom={atom}
         visibleTab={visibleTab}
-        setVisibleTab={setVisibleTab}
+        setVisibleTab={changeTab}
         toggleAddPicker={toggleAddPicker}
         relevantConnectionsMap={relevantConnectionsMap}
       />
@@ -93,7 +106,7 @@ export default function WonAtomInfo({
         relevantConnectionsMap={relevantConnectionsMap}
         toggleAddPicker={toggleAddPicker}
         showAddPicker={showAddPicker}
-        setVisibleTab={setVisibleTab}
+        setVisibleTab={changeTab}
         storedAtoms={storedAtoms}
       />
     </won-atom-info>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -192,7 +192,10 @@ export default function WonSocketAddAtom({
             });
           } else if (isAddToAtomOwned && !isSelectedAtomOwned) {
             connectFunctions.push({
-              label: `As ${wonLabelUtils.getSocketItemLabel(socketType)}`,
+              label: `As ${wonLabelUtils.getSocketItemLabel(
+                addToSocketType,
+                socketType
+              )}`,
               func: actionCreators.atoms__connectSockets(
                 addToAtomSocketUri,
                 selectedAtomSocketUri
@@ -200,7 +203,10 @@ export default function WonSocketAddAtom({
             });
           } else if (!isAddToAtomOwned && isSelectedAtomOwned) {
             connectFunctions.push({
-              label: `As ${wonLabelUtils.getSocketItemLabel(socketType)}`,
+              label: `As ${wonLabelUtils.getSocketItemLabel(
+                addToSocketType,
+                socketType
+              )}`,
               func: actionCreators.atoms__connectSockets(
                 selectedAtomSocketUri,
                 addToAtomSocketUri
@@ -420,15 +426,23 @@ export default function WonSocketAddAtom({
               <div className="wsaa__content__create__right__topline">
                 <div className="wsaa__content__create__right__topline__notitle">
                   {isAddToAtomOwned
-                    ? `Add New ${wonLabelUtils.getSocketItemLabel(socketType)}`
+                    ? `Add New ${wonLabelUtils.getSocketItemLabel(
+                        addToSocketType,
+                        socketType
+                      )}`
                     : `Connect New ${wonLabelUtils.getSocketItemLabel(
+                        addToSocketType,
                         socketType
                       )}`}
                 </div>
               </div>
               <div className="wsaa__content__create__right__subtitle">
                 <span className="wsaa__content__create__right__subtitle__type">
-                  <span>{useCaseUtils.getUseCaseLabel(ucIdentifier)}</span>
+                  <span>
+                    {ucIdentifier !== "*"
+                      ? useCaseUtils.getUseCaseLabel(ucIdentifier)
+                      : "Pick a UseCase"}
+                  </span>
                 </span>
               </div>
             </div>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-button.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-button.jsx
@@ -8,7 +8,7 @@ import ico36_plus from "~/images/won-icons/ico36_plus.svg";
 
 export default function WonSocketAddButton({
   senderReactions,
-  /*targetSocketType,*/
+  targetSocketType,
   isAtomOwned,
   onClick,
   className,
@@ -17,13 +17,19 @@ export default function WonSocketAddButton({
     return isAtomOwned
       ? `Add ${
           senderReactions
-            ? wonLabelUtils.getSocketItemLabels(senderReactions.keys())
-            : "Chat"
+            ? wonLabelUtils.getSocketItemLabels(
+                targetSocketType,
+                senderReactions.keys()
+              )
+            : "Atom"
         }`
       : `Connect ${
           senderReactions
-            ? wonLabelUtils.getSocketItemLabels(senderReactions.keys())
-            : "Chat"
+            ? wonLabelUtils.getSocketItemLabels(
+                targetSocketType,
+                senderReactions.keys()
+              )
+            : "Atom"
         }`;
   }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-items/generic-item.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-items/generic-item.jsx
@@ -89,9 +89,7 @@ export default function WonGenericItem({
             toLink={generateLink(
               history.location,
               {
-                postUri: flip
-                  ? get(atom, "uri")
-                  : get(connection, "targetAtomUri"),
+                postUri: flip ? get(atom, "uri") : get(targetAtom, "uri"),
                 connectionUri: get(connection, "uri"),
                 tab: undefined,
               },

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/map.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/map.jsx
@@ -66,7 +66,6 @@ export default function PageMap() {
     generalSelectors
       .getWhatsAroundAtoms(state)
       .filter(metaAtom => atomUtils.isActive(metaAtom))
-      .filter(metaAtom => debugModeEnabled || !atomUtils.isSearchAtom(metaAtom))
       .filter(
         metaAtom => debugModeEnabled || !atomUtils.isInvisibleAtom(metaAtom)
       )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
@@ -35,7 +35,6 @@ export default function PageOverview() {
   const accountState = useSelector(generalSelectors.getAccountState);
   const whatsNewAtoms = whatsNewAtomsUnfiltered
     .filter(metaAtom => atomUtils.isActive(metaAtom))
-    .filter(metaAtom => debugModeEnabled || !atomUtils.isSearchAtom(metaAtom))
     .filter(
       metaAtom => debugModeEnabled || !atomUtils.isInvisibleAtom(metaAtom)
     )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -337,18 +337,6 @@ export function hasUnreadBuddyRequests(atom) {
 }
 
 /**
- * Determines if a given atom is a Search-Atom (see draft in create-search.js)
- * @param atom
- * @returns {*|boolean}
- */
-export function isSearchAtom(atom) {
-  return (
-    getIn(atom, ["content", "type"]) &&
-    getIn(atom, ["content", "type"]).has("demo:PureSearch")
-  );
-}
-
-/**
  * Generates an array that contains all atom flags, using a human readable label if available.
  */
 export function generateFullFlagLabels(atomImm) {
@@ -389,13 +377,8 @@ export function generateTypeLabel(atomImm, defaultType) {
 
   if (useCaseLabel) {
     return useCaseLabel;
-  } else {
-    if (isSearchAtom(atomImm)) {
-      return "Search";
-    }
-
-    return defaultType ? defaultType : "";
   }
+  return defaultType ? defaultType : "";
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -382,7 +382,7 @@ export function generateFullSocketLabels(atomImm) {
  * Retrieves the Label of the used useCase as an atomType, if no usecase is specified we check if atom is a searchAtom
  * @param {*} atomImm the atom as saved in the state
  */
-export function generateTypeLabel(atomImm) {
+export function generateTypeLabel(atomImm, defaultType) {
   const useCaseLabel = useCaseUtils.getUseCaseLabel(
     getMatchedUseCaseIdentifier(atomImm)
   );
@@ -394,7 +394,7 @@ export function generateTypeLabel(atomImm) {
       return "Search";
     }
 
-    return "";
+    return defaultType ? defaultType : "";
   }
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -109,21 +109,35 @@ export function getSocketTabLabel(socketType) {
   return labels.socketTabs[socketType] || socketType;
 }
 
-export function getSocketItemLabels(socketTypes) {
+export function getSocketItemLabels(targetSocketType, socketTypes) {
   if (!socketTypes) {
     return undefined;
   }
 
   const socketTypeLabels = [];
   for (const socketType of socketTypes) {
-    socketTypeLabels.push(labels.socketItem[socketType] || socketType);
+    socketTypeLabels.push(getSocketItemLabel(targetSocketType, socketType));
   }
 
   return socketTypeLabels.join("/");
 }
 
-export function getSocketItemLabel(socketType) {
-  return labels.socketItem[socketType] || socketType;
+export function getSocketItemLabel(targetSocketType, socketType) {
+  if (
+    (targetSocketType === vocab.CHAT.ChatSocketCompacted ||
+      targetSocketType === vocab.GROUP.GroupSocketCompacted) &&
+    socketType === vocab.GROUP.GroupSocketCompacted
+  ) {
+    return "Group";
+  } else if (
+    targetSocketType === vocab.GROUP.GroupSocketCompacted &&
+    (socketType === vocab.CHAT.ChatSocketCompacted ||
+      socketType === vocab.GROUP.GroupSocketCompacted)
+  ) {
+    return "Group Member";
+  } else {
+    return labels.socketItem[socketType] || socketType;
+  }
 }
 
 export function getSocketItemsLabel(socketType) {
@@ -131,13 +145,12 @@ export function getSocketItemsLabel(socketType) {
 }
 
 export function getSocketActionInfoLabel(
-  atomType,
   socketType,
-  connectionState
+  connectionState,
+  atomType
 ) {
   //TODO: IMPL BETTER
   let infoLabel = "";
-  const atomTypeLabel = atomType.length > 0 ? atomType : "Atom";
 
   switch (connectionState) {
     case vocab.WON.Connected:
@@ -160,7 +173,14 @@ export function getSocketActionInfoLabel(
       break;
   }
 
-  return `${atomTypeLabel} ${infoLabel} ${getSocketItemsLabel(socketType)} of`;
+  if (atomType && atomType.length > 0) {
+    const atomTypeLabel = atomType;
+    return `${atomTypeLabel} ${infoLabel} ${getSocketItemsLabel(
+      socketType
+    )} of`;
+  } else {
+    return `${infoLabel} ${getSocketItemsLabel(socketType)} of`;
+  }
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -144,31 +144,35 @@ export function getSocketItemsLabel(socketType) {
   return labels.socketItems[socketType] || socketType;
 }
 
-export function getSocketActionInfoLabel(socketType, connectionState) {
+export function getSocketActionInfoLabel(
+  socketType,
+  connectionState,
+  targetSocketType
+) {
   let infoLabel = "";
 
   switch (connectionState) {
     case vocab.WON.Connected:
-      infoLabel = "already added to";
+      infoLabel = `${getSocketItemLabel(socketType, targetSocketType)} of`;
       break;
     case vocab.WON.RequestSent:
-      infoLabel = "was requested to join";
+      infoLabel = `was requested to join ${getSocketItemsLabel(socketType)}`;
       break;
     case vocab.WON.RequestReceived:
-      infoLabel = "requests to join";
+      infoLabel = `requests to join ${getSocketItemsLabel(socketType)}`;
       break;
     case vocab.WON.Closed:
-      infoLabel = ` was removed from `;
+      infoLabel = `was removed from ${getSocketItemsLabel(socketType)}`;
       break;
     case vocab.WON.Suggested:
-      infoLabel = ` suggested as `;
+      infoLabel = `suggested for ${getSocketItemsLabel(socketType)}`;
       break;
     default:
       infoLabel = " <--> ";
       break;
   }
 
-  return `${infoLabel} ${getSocketItemsLabel(socketType)} of`;
+  return infoLabel;
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -144,12 +144,7 @@ export function getSocketItemsLabel(socketType) {
   return labels.socketItems[socketType] || socketType;
 }
 
-export function getSocketActionInfoLabel(
-  socketType,
-  connectionState,
-  atomType
-) {
-  //TODO: IMPL BETTER
+export function getSocketActionInfoLabel(socketType, connectionState) {
   let infoLabel = "";
 
   switch (connectionState) {
@@ -157,7 +152,7 @@ export function getSocketActionInfoLabel(
       infoLabel = "already added to";
       break;
     case vocab.WON.RequestSent:
-      infoLabel = "requested to join";
+      infoLabel = "was requested to join";
       break;
     case vocab.WON.RequestReceived:
       infoLabel = "requests to join";
@@ -173,14 +168,7 @@ export function getSocketActionInfoLabel(
       break;
   }
 
-  if (atomType && atomType.length > 0) {
-    const atomTypeLabel = atomType;
-    return `${atomTypeLabel} ${infoLabel} ${getSocketItemsLabel(
-      socketType
-    )} of`;
-  } else {
-    return `${infoLabel} ${getSocketItemsLabel(socketType)} of`;
-  }
+  return `${infoLabel} ${getSocketItemsLabel(socketType)} of`;
 }
 
 /**

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -156,16 +156,16 @@ export function getSocketActionInfoLabel(
       infoLabel = `${getSocketItemLabel(socketType, targetSocketType)} of`;
       break;
     case vocab.WON.RequestSent:
-      infoLabel = `was requested to join ${getSocketItemsLabel(socketType)}`;
+      infoLabel = `was requested to join ${getSocketItemsLabel(socketType)} of`;
       break;
     case vocab.WON.RequestReceived:
-      infoLabel = `requests to join ${getSocketItemsLabel(socketType)}`;
+      infoLabel = `requests to join ${getSocketItemsLabel(socketType)} of`;
       break;
     case vocab.WON.Closed:
-      infoLabel = `was removed from ${getSocketItemsLabel(socketType)}`;
+      infoLabel = `was removed from ${getSocketItemsLabel(socketType)} of`;
       break;
     case vocab.WON.Suggested:
-      infoLabel = `suggested for ${getSocketItemsLabel(socketType)}`;
+      infoLabel = `suggested for ${getSocketItemsLabel(socketType)} of`;
       break;
     default:
       infoLabel = " <--> ";

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -105,7 +105,7 @@ export const cyclingPlan = {
 
 export const cyclingInterest = {
   identifier: "cyclingInterest",
-  label: "Add Cycling Interest",
+  label: "Interest in Cycling",
   icon: ico36_uc_cycling_cropped,
   draft: {
     ...mergeInEmptyDraft({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
@@ -103,7 +103,7 @@ export const lunchPlan = {
 
 export const lunchInterest = {
   identifier: "lunchInterest",
-  label: "Add Lunch Interest",
+  label: "Interest in Lunch",
   icon: ico36_uc_meal_half,
   draft: {
     ...mergeInEmptyDraft({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -48,7 +48,7 @@ export const pokemonGoRaid = {
 
 export const pokemonInterest = {
   identifier: "pokemonInterest",
-  label: "Add Interest in Pokémon Go",
+  label: "Interest in Pokémon Go",
   icon: ico36_pokeball, //TODO: Better Icon
   draft: {
     ...mergeInEmptyDraft({

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-actions.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-actions.scss
@@ -1,14 +1,67 @@
 @import "won-config";
 @import "sizing-utils";
 @import "animate";
+@import "square-image";
 
 won-atom-actions {
   display: grid;
-  grid-gap: 0.5rem;
   align-items: center;
 
-  .atom-actions__infolabel {
-    text-align: left;
+  .atom-actions__info {
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-areas: "target label sender";
+    grid-template-columns: min-content max-content 1fr;
+    align-items: center;
+    padding: 0.5rem;
+    grid-gap: 0.5rem;
+
+    @media (max-width: $responsivenessBreakPointLarge) {
+      &--targetVisible {
+        grid-template-areas: "target label" "sender sender";
+        grid-template-columns: min-content 1fr;
+      }
+
+      &--senderVisible {
+        grid-template-areas: "target target" "label sender";
+        grid-template-columns: min-content 1fr;
+      }
+    }
+
+    .atom-actions__info__target {
+      grid-area: target;
+    }
+
+    .atom-actions__info__label {
+      grid-area: label;
+      text-align: left;
+    }
+
+    .atom-actions__info__sender {
+      grid-area: sender;
+    }
+
+    .atom-actions__info__target,
+    .atom-actions__info__sender {
+      @include square-image($postIconSize);
+
+      > won-atom-icon {
+        @media (max-width: $responsivenessBreakPointLarge) {
+          padding-left: 0.5rem;
+        }
+      }
+
+      > won-atom-header {
+        background: $won-light-gray;
+        border: $thinGrayBorder;
+        padding: 0.5rem;
+
+        @media (min-width: $responsivenessBreakPointLarge) {
+          min-width: 16rem;
+          max-width: 20rem;
+        }
+      }
+    }
   }
 
   won-socket-actions,
@@ -18,17 +71,12 @@ won-atom-actions {
     grid-auto-flow: column;
   }
 
-  > won-atom-header {
-    background: $won-light-gray;
-    border: $thinGrayBorder;
-    padding: 0.5rem;
+  @media (min-width: $responsivenessBreakPointLarge) {
+    grid-auto-flow: column;
+    grid-template-columns: 1fr min-content;
   }
 
-  @media (min-width: $maxContentWidth) {
-    grid-auto-flow: column;
-    grid-template-columns: 1fr minmax(16rem, 1fr) min-content;
-  }
-  @media (max-width: $maxContentWidth) {
+  @media (max-width: $responsivenessBreakPointLarge) {
     grid-auto-flow: row;
   }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
@@ -132,10 +132,6 @@ won-atom-header-big {
     font-weight: 300;
     text-overflow: ellipsis;
     overflow: hidden;
-
-    @media (max-width: $responsivenessBreakPoint) {
-      font-size: $normalFontSize;
-    }
   }
 
   > .ahb__info {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
@@ -24,8 +24,6 @@ won-atom-info {
   }
   > won-atom-actions {
     grid-area: actions;
-    display: grid;
-    grid-gap: 0.5rem;
     padding: 0.5rem;
     box-sizing: border-box;
     background: $won-secondary-color;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_won-config.scss
@@ -69,3 +69,5 @@ $maxContentWidth: 70rem;
 $minContentPadding: 1rem;
 
 $responsivenessBreakPoint: $maxContentWidth / 2;
+
+$responsivenessBreakPointLarge: 45rem;

--- a/webofneeds/won-vocab/src/main/resources/ontology/ext/won-ext-demo.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/ext/won-ext-demo.ttl
@@ -74,11 +74,6 @@ vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
 #    Classes
 #################################################################
 
-### https://w3id.org/won/ext/demo#PureSearch
-:PureSearch rdf:type owl:Class; 
-	  rdfs:comment "Class for Atoms that are just searches (defining a search String via match:searchString)."@en ;
-	  rdfs:label "PureSearch" .
-
 ###  https://w3id.org/won/ext/demo#AfterParty
 :AfterParty rdf:type owl:Class ;
             rdfs:comment "Class for describing parties after some event."@en ;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- Currently when navigating from an atom to another atom by clicking it in the specific socket tab, a browser back will cause the tab of the original atom to be reset to the detail page


## What is the new behavior?
- Keep selected tab of previous post selected on Browser back
- Update atom-actions (connection actions) of an atom
- Change Interest UseCase Labels

## Does this introduce a breaking change?

- [ ] Yes
- [X] No