### PR TITLE
Fix rematching for deleted atoms

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataFetchingException.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataFetchingException.java
@@ -2,10 +2,12 @@ package won.protocol.rest;
 
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 public class LinkedDataFetchingException extends RuntimeException {
     // The URI of the resource that could not be fetched
     private URI resourceUri;
+    private Optional<Integer> statusCode = Optional.empty();
 
     public LinkedDataFetchingException(URI resourceUri) {
         this(resourceUri, MessageFormat.format("Error fetching linked data for {0}", resourceUri), null);
@@ -24,7 +26,42 @@ public class LinkedDataFetchingException extends RuntimeException {
         this(resourceUri, MessageFormat.format("Error fetching linked data for {0}", resourceUri), cause);
     }
 
+    public LinkedDataFetchingException(URI resourceUri, int statusCode) {
+        this.resourceUri = resourceUri;
+        this.statusCode = Optional.of(statusCode);
+    }
+
+    public LinkedDataFetchingException(String message, URI resourceUri, int statusCode) {
+        super(message);
+        this.resourceUri = resourceUri;
+        this.statusCode = Optional.of(statusCode);
+    }
+
+    public LinkedDataFetchingException(String message, Throwable cause, URI resourceUri,
+                    int statusCode) {
+        super(message, cause);
+        this.resourceUri = resourceUri;
+        this.statusCode = Optional.of(statusCode);
+    }
+
+    public LinkedDataFetchingException(Throwable cause, URI resourceUri, int statusCode) {
+        super(cause);
+        this.resourceUri = resourceUri;
+        this.statusCode = Optional.of(statusCode);
+    }
+
+    public LinkedDataFetchingException(String message, Throwable cause, boolean enableSuppression,
+                    boolean writableStackTrace, URI resourceUri, int statusCode) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.resourceUri = resourceUri;
+        this.statusCode = Optional.of(statusCode);
+    }
+
     public URI getResourceUri() {
         return resourceUri;
+    }
+
+    public Optional<Integer> getStatusCode() {
+        return statusCode;
     }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -121,16 +121,16 @@ public abstract class LinkedDataRestClient {
                 return new DatasetResponseWithStatusCodeAndHeaders(dataset, 200, headers);
             }
             if (e instanceof HttpClientErrorException) {
-                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
+                throw new LinkedDataFetchingException(MessageFormat.format(
                                 "Caught a HttpClientErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpClientErrorException) e).getResponseBodyAsString()),
-                                e);
+                                e, resourceURI, ((HttpClientErrorException) e).getRawStatusCode());
             }
             if (e instanceof HttpServerErrorException) {
-                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
+                throw new LinkedDataFetchingException(MessageFormat.format(
                                 "Caught a HttpServerErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpServerErrorException) e).getResponseBodyAsString()),
-                                e);
+                                e, resourceURI, ((HttpServerErrorException) e).getRawStatusCode());
             }
             throw new LinkedDataFetchingException(resourceURI,
                             MessageFormat.format("Caught a clientHandler exception, "

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSourceBase.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/LinkedDataSourceBase.java
@@ -116,8 +116,10 @@ public class LinkedDataSourceBase implements LinkedDataSource {
                 logger.debug("fetched resource {}:", resource);
                 RDFDataMgr.write(System.out, dataset, Lang.TRIG);
             }
+        } catch (LinkedDataFetchingException e) {
+            throw e;
         } catch (Exception e) {
-            logger.debug(String.format("Couldn't fetch resource %s", resource), e);
+            logger.info(String.format("Couldn't fetch resource %s", resource), e);
         }
         return dataset;
     }
@@ -136,6 +138,8 @@ public class LinkedDataSourceBase implements LinkedDataSource {
                 logger.debug("fetched resource {} with requesterWebId {}:", resource, requesterWebID);
                 RDFDataMgr.write(System.out, dataset, Lang.TRIG);
             }
+        } catch (LinkedDataFetchingException e) {
+            throw e;
         } catch (Exception e) {
             logger.debug(String.format("Couldn't fetch resource %s", resource), e);
         }


### PR DESCRIPTION
With this fix, deleted atoms are removed from the rematch index, leading to fewer requests to the node during rematching. The LinkedDataSource now throws the LinkedDataFetchingException on instead of swallowing it, so clients can use the exception in their error handling logic.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The matchers keep fetching deleted atom data.  Over time, many atoms get deleted -> many spurious fetches.

- Fixes: N/A


## What is the new behavior?
Deleted atoms are removed from rematch index

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The LinkedDataSource throws the LinkedDataFetchingException instead of swallowing it, so clients might break now. 
