### PR TITLE
Added UseCase for Generic Interest/Generic Plan

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/wikidata-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/wikidata-viewer.jsx
@@ -18,7 +18,11 @@ import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
 
 export default function WikiDataViewer({ content, detail, className }) {
   const dispatch = useDispatch();
-  const entityUri = content && content.replace(/\/$/, "");
+  //FIXME: Workaround for multiple dataUris in state
+  const entityUri =
+    content && Immutable.List.isList(content)
+      ? content.first().replace(/\/$/, "")
+      : content.replace(/\/$/, "");
   const wikiDataContent = useSelector(
     generalSelectors.getExternalData(entityUri)
   );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -53,7 +53,7 @@ export default function WonSocketAddAtom({
         !(isAddToAtomOwned && get(reaction, "refuseOwned"))
     ),
     "useCaseIdentifiers"
-  );
+  ).filter(ucIdentifier => ucIdentifier !== "persona");
   const allowAdHoc =
     !!adHocUseCaseIdentifiers && adHocUseCaseIdentifiers.size === 1;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -53,9 +53,12 @@ export default function WonSocketAddAtom({
         !(isAddToAtomOwned && get(reaction, "refuseOwned"))
     ),
     "useCaseIdentifiers"
-  ).filter(ucIdentifier => ucIdentifier !== "persona" || ucIdentifier !== "*");
+  );
   const allowAdHoc =
-    !!adHocUseCaseIdentifiers && adHocUseCaseIdentifiers.size === 1;
+    !!adHocUseCaseIdentifiers &&
+    adHocUseCaseIdentifiers.filter(
+      ucIdentifier => ucIdentifier !== "persona" && ucIdentifier !== "*"
+    ).size === 1;
 
   //If the addToAtom is Owned, we preselect the holderUri (if present) to be used as the holder of the new atom to establish a connection with
   const addHolderUri = isAddToAtomOwned

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -53,7 +53,7 @@ export default function WonSocketAddAtom({
         !(isAddToAtomOwned && get(reaction, "refuseOwned"))
     ),
     "useCaseIdentifiers"
-  ).filter(ucIdentifier => ucIdentifier !== "persona");
+  ).filter(ucIdentifier => ucIdentifier !== "persona" || ucIdentifier !== "*");
   const allowAdHoc =
     !!adHocUseCaseIdentifiers && adHocUseCaseIdentifiers.size === 1;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
@@ -113,6 +113,8 @@ export function parseMetaAtom(metaAtom) {
           .replace(vocab.DEMO.baseUri, vocab.DEMO.prefix + ":")
           .replace(vocab.BOT.baseUri, vocab.BOT.prefix + ":")
           .replace(vocab.WONMATCH.baseUri, vocab.WONMATCH.prefix + ":")
+          .replace(vocab.VALUEFLOWS.baseUri, vocab.VALUEFLOWS.prefix + ":")
+          .replace(vocab.WXVALUEFLOWS.baseUri, vocab.WXVALUEFLOWS.prefix + ":")
           .replace("http://schema.org/", "s:")
       )
     );
@@ -143,6 +145,7 @@ export function parseMetaAtom(metaAtom) {
         .replace(vocab.BUDDY.baseUri, vocab.BUDDY.prefix + ":")
         .replace(vocab.BOT.baseUri, vocab.BOT.prefix + ":")
         .replace(vocab.WXSCHEMA.baseUri, vocab.WXSCHEMA.prefix + ":")
+        .replace(vocab.WXVALUEFLOWS.baseUri, vocab.WXVALUEFLOWS.prefix + ":")
     );
 
   const extractStateFromMeta = state => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -63,11 +63,6 @@ export const getOwnedAtomUris = createSelector(getAccountState, account =>
 export const getAtom = atomUri =>
   createSelector(getAtoms, atoms => get(atoms, atomUri));
 
-export const getExternalData = externalDataUri =>
-  createSelector(getExternalDataState, externalData =>
-    get(externalData, externalDataUri)
-  );
-
 export const getOwnedConnection = connectionUri =>
   createSelector(getOwnedConnections, conns => get(conns, connectionUri));
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/service/jsonld-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/service/jsonld-utils.js
@@ -413,6 +413,9 @@ function parseJsonldLeaf(val, type) {
     case "xsd:ID": {
       const id = get(val, "@id");
       if (!id) {
+        const value = get(val, "@value");
+        if (value) return value;
+
         throwErr(`Could not parse \`${val}\` to an id.`);
       }
       return id;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
@@ -112,7 +112,8 @@ export function findUseCaseByAtom(atomImm) {
     if (
       matchingUseCases.size > 1 &&
       contentTypes &&
-      contentTypes.includes("s:PlanAction")
+      (contentTypes.includes("s:PlanAction") ||
+        contentTypes.includes("demo:Interest"))
     ) {
       const eventObjectMatchingUseCases = matchingUseCases.filter(useCase => {
         const draftEventObject = getIn(useCase, [

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
@@ -114,7 +114,7 @@ export function findUseCaseByAtom(atomImm) {
       contentTypes &&
       contentTypes.includes("s:PlanAction")
     ) {
-      matchingUseCases = matchingUseCases.filter(useCase => {
+      const eventObjectMatchingUseCases = matchingUseCases.filter(useCase => {
         const draftEventObject = getIn(useCase, [
           "draft",
           "content",
@@ -133,6 +133,16 @@ export function findUseCaseByAtom(atomImm) {
         }
         return atomEventObject && atomEventObject.includes(draftEventObject);
       });
+
+      //If there is no matching eventObject UseCase we just take the generic one
+      if (eventObjectMatchingUseCases.size !== 0) {
+        matchingUseCases = eventObjectMatchingUseCases;
+      } else {
+        matchingUseCases = matchingUseCases.filter(
+          useCase =>
+            !getIn(useCase, ["draft", "content", "eventObjectAboutUris"])
+        );
+      }
     }
 
     if (matchingUseCases.size > 1) {
@@ -147,7 +157,7 @@ export function findUseCaseByAtom(atomImm) {
       seeksTypes &&
       seeksTypes.includes("s:PlanAction")
     ) {
-      matchingUseCases = matchingUseCases.filter(useCase => {
+      const eventObjectMatchingUseCases = matchingUseCases.filter(useCase => {
         const draftEventObject = getIn(useCase, [
           "draft",
           "seeks",
@@ -168,6 +178,15 @@ export function findUseCaseByAtom(atomImm) {
         }
         return atomEventObject && atomEventObject.includes(draftEventObject);
       });
+
+      //If there is no matching eventObject UseCase we just take the generic one
+      if (eventObjectMatchingUseCases.size !== 0) {
+        matchingUseCases = eventObjectMatchingUseCases;
+      } else {
+        matchingUseCases = matchingUseCases.filter(
+          useCase => !getIn(useCase, ["draft", "seeks", "eventObjectAboutUris"])
+        );
+      }
     }
 
     if (matchingUseCases.size > 1) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -22,6 +22,8 @@ import ico36_search from "../../images/won-icons/ico36_search.svg";
 import ico36_detail_description from "../../images/won-icons/ico36_detail_description.svg";
 import ico36_detail_tags from "../../images/won-icons/ico36_detail_tags.svg";
 import ico36_detail_media from "../../images/won-icons/ico36_detail_media.svg";
+import WikiDataViewer from "~/app/components/details/viewer/wikidata-viewer";
+import WikiDataPicker from "~/app/components/details/picker/wikidata-picker";
 
 export const title = {
   identifier: "title",
@@ -547,6 +549,8 @@ export const eventObjectAboutUris = {
       };
     }
   },
+  component: WikiDataPicker,
+  viewerComponent: WikiDataViewer,
   parseFromRDF: function(jsonLDImm) {
     const types = get(jsonLDImm, "@type");
     if (

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/basic.js
@@ -554,8 +554,9 @@ export const eventObjectAboutUris = {
   parseFromRDF: function(jsonLDImm) {
     const types = get(jsonLDImm, "@type");
     if (
-      (Immutable.List.isList(types) && types.includes("s:PlanAction")) ||
-      types === "s:PlanAction"
+      (Immutable.List.isList(types) &&
+        (types.includes("s:PlanAction") || types.includes("demo:Interest"))) ||
+      (types === "s:PlanAction" || types === "demo:Interest")
     ) {
       const planObjs = get(jsonLDImm, "s:object");
       let plns = [];

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/details/extended.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/details/extended.js
@@ -5,6 +5,7 @@ import WikiDataViewer from "../../app/components/details/viewer/wikidata-viewer"
 import * as jsonLdUtils from "../../app/service/jsonld-utils";
 import ico36_detail_title from "../../images/won-icons/ico36_detail_title.svg";
 import ico36_detail_person from "../../images/won-icons/ico36_detail_person.svg";
+import { is } from "~/app/utils";
 
 export const isbn = {
   identifier: "isbn",
@@ -72,17 +73,27 @@ export const classifiedAs = {
   component: WikiDataPicker,
   viewerComponent: WikiDataViewer,
   parseToRDF: function({ value }) {
-    if (value) {
+    if (!value) {
+      return;
+    } else if (is("Array", value)) {
+      const classifiedAsObjects = value.map(item => {
+        return {
+          "@type": "xsd:ID",
+          "@value": item,
+        };
+      });
+      return { "vf:classifiedAs": classifiedAsObjects };
+    } else {
       return {
         "vf:classifiedAs": {
-          "@id": value,
+          "@type": "xsd:ID",
+          "@value": value,
         },
       };
     }
-    return undefined;
   },
   parseFromRDF: function(jsonLDImm) {
-    return jsonLdUtils.parseFrom(jsonLDImm, ["vf:classifiedAs"], "xsd:ID");
+    return jsonLdUtils.parseListFrom(jsonLDImm, ["vf:classifiedAs"], "xsd:ID");
   },
   generateHumanReadable: function({ value, includeLabel }) {
     //TODO: Implement

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecase-definitions.js
@@ -10,6 +10,7 @@ import { personalMobilityGroup } from "./usecases/group-personal-mobility";
 import { interestsGroup } from "./usecases/group-interests";
 // import { customUseCase } from "./usecases/uc-custom.js";
 
+import { genericPlan } from "./usecases/uc-interest.js";
 import { lunchPlan } from "./usecases/uc-lunch.js";
 import { cyclingPlan } from "./usecases/uc-cycling.js";
 import { pokemonGoRaid } from "./usecases/uc-pokemon.js";
@@ -75,6 +76,7 @@ const useCaseGroups = {
 // add useCases here that should not be visible in the grouped useCases (will be hidden and only accessible through reactions
 export const hiddenUseCases = {
   pokemonGoRaid: pokemonGoRaid,
+  genericPlan: genericPlan,
   lunchPlan: lunchPlan,
   cyclingPlan: cyclingPlan,
   persona: persona,

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-interests.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/group-interests.js
@@ -1,5 +1,6 @@
 import { cyclingInterest } from "./uc-cycling.js";
 import { lunchInterest } from "./uc-lunch.js";
+import { genericInterest } from "./uc-interest.js";
 import { pokemonInterest } from "./uc-pokemon.js";
 
 import ico36_detail_interests from "../../images/won-icons/ico36_detail_interests.svg";
@@ -12,5 +13,6 @@ export const interestsGroup = {
     lunchInterest: lunchInterest,
     cyclingInterest: cyclingInterest,
     pokemonInterest: pokemonInterest,
+    genericInterest: genericInterest,
   },
 };

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-band-search.js
@@ -40,7 +40,7 @@ export const bandSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["musicianSearch", "persona"],
+        useCaseIdentifiers: ["musicianSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-offer.js
@@ -28,7 +28,7 @@ export const booksOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["booksSearch", "persona"],
+        useCaseIdentifiers: ["booksSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-books-search.js
@@ -28,7 +28,7 @@ export const booksSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["booksOffer", "persona"],
+        useCaseIdentifiers: ["booksOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-complain.js
@@ -32,7 +32,7 @@ export const complain = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["handleComplaint", "persona"],
+        useCaseIdentifiers: ["handleComplaint"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-offer.js
@@ -30,7 +30,7 @@ export const consortiumOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["consortiumSearch", "persona"],
+        useCaseIdentifiers: ["consortiumSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-consortium-search.js
@@ -30,7 +30,7 @@ export const consortiumSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["consortiumOffer", "persona"],
+        useCaseIdentifiers: ["consortiumOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -23,7 +23,7 @@ export const cyclingPlan = {
       content: {
         type: ["s:PlanAction"],
         title: "Let's go for a bike ride!",
-        eventObjectAboutUris: "http://dbpedia.org/resource/Cycling",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q53121",
         sockets: {
           "#groupSocket": vocab.GROUP.GroupSocketCompacted,
           "#holdableSocket": vocab.HOLD.HoldableSocketCompacted,
@@ -90,7 +90,7 @@ export const cyclingPlan = {
         `${resultName} match:seeks ?seeks .`,
         `?seeks rdf:type s:PlanAction.`,
         `?seeks s:object ?planObject.`,
-        `?planObject s:about <http://dbpedia.org/resource/Cycling>.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q53121>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         `BIND( (
           COALESCE(?location_geoScore, 0) 
@@ -116,7 +116,7 @@ export const cyclingInterest = {
       },
       seeks: {
         type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://dbpedia.org/resource/Cycling",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q53121",
       },
     }),
   },
@@ -175,7 +175,7 @@ export const cyclingInterest = {
         `${resultName} rdf:type s:PlanAction.`,
         `${resultName} s:object ?planObject.`,
         `${resultName} hold:heldBy ?holder.`,
-        `?planObject s:about <http://dbpedia.org/resource/Cycling>.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q53121>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         // calculate average of scores; can be weighed if necessary
         `BIND( (

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -37,7 +37,7 @@ export const cyclingPlan = {
     ...defaultReactions,
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["cyclingInterest", "persona"],
+        useCaseIdentifiers: ["cyclingInterest"],
       },
       [vocab.GROUP.GroupSocketCompacted]: {
         useCaseIdentifiers: ["cyclingPlan"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-cycling.js
@@ -87,9 +87,7 @@ export const cyclingPlan = {
       subQueries: subQueries,
       where: [
         `${resultName} rdf:type demo:Interest.`,
-        `${resultName} match:seeks ?seeks .`,
-        `?seeks rdf:type s:PlanAction.`,
-        `?seeks s:object ?planObject.`,
+        `${resultName} s:object ?planObject.`,
         `?planObject s:about <http://www.wikidata.org/entity/Q53121>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         `BIND( (
@@ -112,12 +110,10 @@ export const cyclingInterest = {
     ...mergeInEmptyDraft({
       content: {
         type: ["demo:Interest"],
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q53121",
         title: "I am interested in cycling!",
       },
-      seeks: {
-        type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://www.wikidata.org/entity/Q53121",
-      },
+      seeks: {},
     }),
   },
   reactions: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-offer.js
@@ -28,7 +28,7 @@ export const goodsOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsServiceSearch", "persona"],
+        useCaseIdentifiers: ["goodsServiceSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-service-search.js
@@ -37,7 +37,7 @@ export const goodsServiceSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["serviceOffer", "goodsOffer", "persona"],
+        useCaseIdentifiers: ["serviceOffer", "goodsOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
@@ -19,7 +19,7 @@ export const goodsTransportOffer = {
     ...mergeInEmptyDraft({
       content: {
         title: "Transportation offer",
-        type: ["http://dbpedia.org/resource/Transport"],
+        type: ["http://www.wikidata.org/entity/Q7590"],
       },
     }),
   },
@@ -57,7 +57,7 @@ export const goodsTransportOffer = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Cargo>.`,
+          `${resultName} a <http://www.wikidata.org/entity/Q319224>.`,
           `${resultName} match:seeks ?seeks.`,
           "?seeks con:travelAction/s:fromLocation ?fromLocation.",
           "?seeks con:travelAction/s:toLocation ?toLocation.",
@@ -94,7 +94,7 @@ export const goodsTransportOffer = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Cargo>.`,
+          `${resultName} a <http://www.wikidata.org/entity/Q319224>.`,
         ],
       };
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-offer.js
@@ -27,7 +27,7 @@ export const goodsTransportOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsTransportSearch", "persona"],
+        useCaseIdentifiers: ["goodsTransportSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
@@ -31,7 +31,7 @@ export const goodsTransportSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsTransportOffer", "persona"],
+        useCaseIdentifiers: ["goodsTransportOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-goods-transport-search.js
@@ -23,7 +23,7 @@ export const goodsTransportSearch = {
     ...mergeInEmptyDraft({
       content: {
         title: "Want to send something",
-        type: ["http://dbpedia.org/resource/Cargo"],
+        type: ["http://www.wikidata.org/entity/Q319224"],
       },
     }),
   },
@@ -301,7 +301,7 @@ export const goodsTransportSearch = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Transport>. `,
+          `${resultName} a <http://www.wikidata.org/entity/Q7590>. `,
           `${resultName} (won:location|s:location) ?location.`,
           "?location s:geo ?location_geo.",
           "?location_geo s:latitude ?location_lat;",
@@ -335,7 +335,7 @@ export const goodsTransportSearch = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Transport>.`,
+          `${resultName} a <http://www.wikidata.org/entity/Q7590>.`,
           `${resultName} (won:location|s:location) ?location.`,
           "?location s:geo ?location_geo.",
           "?location_geo s:latitude ?location_lat;",
@@ -361,7 +361,7 @@ export const goodsTransportSearch = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Transport>.`,
+          `${resultName} a <http://www.wikidata.org/entity/Q7590>.`,
           `${resultName} (won:location|s:location) ?location.`,
           "?location s:geo ?location_geo.",
           "?location_geo s:latitude ?location_lat;",
@@ -384,7 +384,7 @@ export const goodsTransportSearch = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `${resultName} a <http://dbpedia.org/resource/Transport>. `,
+          `${resultName} a <http://www.wikidata.org/entity/Q7590>. `,
         ],
       };
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-handle-complaint.js
@@ -32,7 +32,7 @@ export const handleComplaint = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["complain", "persona"],
+        useCaseIdentifiers: ["complain"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
@@ -1,0 +1,100 @@
+import {
+  details,
+  mergeInEmptyDraft,
+  defaultReactions,
+} from "../detail-definitions.js";
+// import {
+//   vicinityScoreSubQuery,
+//   sparqlQuery,
+// } from "../../app/sparql-builder-utils.js";
+// import { getIn } from "../../app/utils.js";
+// import won from "../../app/service/won.js";
+import vocab from "../../app/service/vocab.js";
+import ico36_uc_question from "~/images/won-icons/ico36_uc_question.svg";
+
+export const genericInterest = {
+  identifier: "genericInterest",
+  label: "Interest",
+  icon: ico36_uc_question, //TODO: Find generic interest Icon
+  draft: {
+    ...mergeInEmptyDraft({
+      content: {
+        type: ["demo:Interest"],
+      },
+      seeks: {
+        type: ["s:PlanAction"],
+      },
+    }),
+  },
+  reactions: {
+    ...defaultReactions,
+    [vocab.CHAT.ChatSocketCompacted]: {
+      [vocab.GROUP.GroupSocketCompacted]: {
+        useCaseIdentifiers: ["genericPlan"],
+      },
+    },
+  },
+  details: {
+    title: { ...details.title },
+    description: { ...details.description },
+    location: {
+      ...details.location,
+      mandatory: true,
+    },
+  },
+  seeksDetails: {
+    eventObjectAboutUris: {
+      ...details.eventObjectAboutUris,
+      mandatory: true,
+    },
+  },
+  //TODO: Fix Query,
+  /*generateQuery: (draft, resultName) => {
+    const vicinityScoreSQ = vicinityScoreSubQuery({
+      resultName: resultName,
+      bindScoreAs: "?location_geoScore",
+      pathToGeoCoords: "s:location/s:geo",
+      prefixesInPath: {
+        s: won.defaultContext["s"],
+        won: won.defaultContext["won"],
+        con: won.defaultContext["con"],
+      },
+      geoCoordinates: getIn(draft, ["content", "location"]),
+    });
+
+    const subQueries = [vicinityScoreSQ]
+      .filter(sq => sq) // filter out non-existing details (the SQs should be `undefined` for them)
+      .map(sq => ({
+        query: sq,
+        optional: true, // so counterparts without that detail don't get filtered out (just assigned a score of 0 via `coalesce`)
+      }));
+
+    const query = sparqlQuery({
+      prefixes: {
+        won: won.defaultContext["won"],
+        rdf: won.defaultContext["rdf"],
+        buddy: won.defaultContext["buddy"],
+        hold: won.defaultContext["hold"],
+        s: won.defaultContext["s"],
+      },
+      distinct: true,
+      variables: [resultName, "?score"],
+      subQueries: subQueries,
+      where: [
+        `${resultName} rdf:type won:Atom.`,
+        `${resultName} rdf:type s:PlanAction.`,
+        `${resultName} s:object ?planObject.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
+        `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
+        // calculate average of scores; can be weighed if necessary
+        `BIND( (
+          COALESCE(?location_geoScore, 0)
+        ) / 5  as ?score)`,
+        // `FILTER(?score > 0)`, // not necessary atm to filter; there are parts of -postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
+      ],
+      orderBy: [{ order: "DESC", variable: "?score" }],
+    });
+
+    return query;
+  },*/
+};

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
@@ -86,9 +86,7 @@ export const genericPlan = {
       subQueries: subQueries,
       where: [
         `${resultName} rdf:type demo:Interest.`,
-        `${resultName} match:seeks ?seeks .`,
-        `?seeks rdf:type s:PlanAction.`,
-        `?seeks s:object ?planObject.`,
+        `${resultName} s:object ?planObject.`,
         `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         `BIND( ( 
@@ -112,9 +110,7 @@ export const genericInterest = {
       content: {
         type: ["demo:Interest"],
       },
-      seeks: {
-        type: ["s:PlanAction"],
-      },
+      seeks: {},
     }),
   },
   reactions: {
@@ -128,17 +124,16 @@ export const genericInterest = {
   details: {
     title: { ...details.title },
     description: { ...details.description },
+    eventObjectAboutUris: {
+      ...details.eventObjectAboutUris,
+      mandatory: true,
+    },
     location: {
       ...details.location,
       mandatory: true,
     },
   },
-  seeksDetails: {
-    eventObjectAboutUris: {
-      ...details.eventObjectAboutUris,
-      mandatory: true,
-    },
-  },
+  seeksDetails: {},
   //TODO: Fix Query,
   /*generateQuery: (draft, resultName) => {
     const vicinityScoreSQ = vicinityScoreSubQuery({

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
@@ -35,7 +35,7 @@ export const genericPlan = {
     ...defaultReactions,
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["genericInterest", "persona"],
+        useCaseIdentifiers: ["genericInterest"],
       },
       [vocab.GROUP.GroupSocketCompacted]: {
         useCaseIdentifiers: ["genericPlan"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-interest.js
@@ -11,6 +11,97 @@ import {
 // import won from "../../app/service/won.js";
 import vocab from "../../app/service/vocab.js";
 import ico36_uc_question from "~/images/won-icons/ico36_uc_question.svg";
+import * as jsonLdUtils from "~/app/service/jsonld-utils";
+
+export const genericPlan = {
+  identifier: "genericPlan",
+  label: "Plan",
+  icon: ico36_uc_question,
+  doNotMatchAfter: jsonLdUtils.findLatestIntervallEndInJsonLdOrNowAndAddMillis,
+  draft: {
+    ...mergeInEmptyDraft({
+      content: {
+        type: ["s:PlanAction"],
+        sockets: {
+          "#groupSocket": vocab.GROUP.GroupSocketCompacted,
+          "#holdableSocket": vocab.HOLD.HoldableSocketCompacted,
+          "#sReviewSocket": vocab.WXSCHEMA.ReviewSocketCompacted,
+        },
+      },
+      seeks: {},
+    }),
+  },
+  reactions: {
+    ...defaultReactions,
+    [vocab.GROUP.GroupSocketCompacted]: {
+      [vocab.CHAT.ChatSocketCompacted]: {
+        useCaseIdentifiers: ["genericInterest", "persona"],
+      },
+      [vocab.GROUP.GroupSocketCompacted]: {
+        useCaseIdentifiers: ["genericPlan"],
+      },
+    },
+  },
+  details: {
+    title: { ...details.title },
+    eventObjectAboutUris: { ...details.eventObjectAboutUris, mandatory: true },
+    description: { ...details.description },
+    location: { ...details.location, mandatory: true },
+    fromDatetime: { ...details.fromDatetime },
+  },
+  seeksDetails: {},
+
+  /*generateQuery: (draft, resultName) => {
+    const vicinityScoreSQ = vicinityScoreSubQuery({
+      resultName: resultName,
+      bindScoreAs: "?location_geoScore",
+      pathToGeoCoords: "s:location/s:geo",
+      prefixesInPath: {
+        s: won.defaultContext["s"],
+        won: won.defaultContext["won"],
+        con: won.defaultContext["con"],
+      },
+      geoCoordinates: getIn(draft, ["content", "location"]),
+    });
+
+    const subQueries = [vicinityScoreSQ]
+      .filter(sq => sq) // filter out non-existing details (the SQs should be `undefined` for them)
+      .map(sq => ({
+        query: sq,
+        optional: true, // so counterparts without that detail don't get filtered out (just assigned a score of 0 via `coalesce`)
+      }));
+
+    const query = sparqlQuery({
+      prefixes: {
+        won: won.defaultContext["won"],
+        rdf: won.defaultContext["rdf"],
+        buddy: won.defaultContext["buddy"],
+        hold: won.defaultContext["hold"],
+        s: won.defaultContext["s"],
+        match: won.defaultContext["match"],
+        demo: won.defaultContext["demo"],
+      },
+      distinct: true,
+      variables: [resultName, "?score"],
+      subQueries: subQueries,
+      where: [
+        `${resultName} rdf:type demo:Interest.`,
+        `${resultName} match:seeks ?seeks .`,
+        `?seeks rdf:type s:PlanAction.`,
+        `?seeks s:object ?planObject.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
+        `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
+        `BIND( ( 
+          COALESCE(?location_geoScore, 0) 
+        ) / 5  as ?score)`,
+        // `FILTER(?score > 0)`, // not necessary atm to filter; there are parts of -postings we can't match yet (e.g. NLP on description). also content's sparse anyway.
+      ],
+      orderBy: [{ order: "DESC", variable: "?score" }],
+    });
+
+    return query;
+  },*/
+};
 
 export const genericInterest = {
   identifier: "genericInterest",

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-offer.js
@@ -41,7 +41,7 @@ export const jobOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["jobSearch", "persona"],
+        useCaseIdentifiers: ["jobSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-job-search.js
@@ -43,7 +43,7 @@ export const jobSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["jobOffer", "persona"],
+        useCaseIdentifiers: ["jobOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
@@ -23,7 +23,7 @@ export const lunchPlan = {
       content: {
         type: ["s:PlanAction"],
         title: "Let's go get lunch!",
-        eventObjectAboutUris: "http://dbpedia.org/resource/Lunch",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q12896105",
         sockets: {
           "#groupSocket": vocab.GROUP.GroupSocketCompacted,
           "#holdableSocket": vocab.HOLD.HoldableSocketCompacted,
@@ -88,7 +88,7 @@ export const lunchPlan = {
         `${resultName} match:seeks ?seeks .`,
         `?seeks rdf:type s:PlanAction.`,
         `?seeks s:object ?planObject.`,
-        `?planObject s:about <http://dbpedia.org/resource/Lunch>.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         `BIND( ( 
           COALESCE(?location_geoScore, 0) 
@@ -114,7 +114,7 @@ export const lunchInterest = {
       },
       seeks: {
         type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://dbpedia.org/resource/Lunch",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q12896105",
       },
     }),
   },
@@ -169,7 +169,7 @@ export const lunchInterest = {
         `${resultName} rdf:type won:Atom.`,
         `${resultName} rdf:type s:PlanAction.`,
         `${resultName} s:object ?planObject.`,
-        `?planObject s:about <http://dbpedia.org/resource/Lunch>.`,
+        `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         // calculate average of scores; can be weighed if necessary
         `BIND( (

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
@@ -37,7 +37,7 @@ export const lunchPlan = {
     ...defaultReactions,
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["lunchInterest", "persona"],
+        useCaseIdentifiers: ["lunchInterest"],
       },
       [vocab.GROUP.GroupSocketCompacted]: { useCaseIdentifiers: ["lunchPlan"] },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-lunch.js
@@ -85,9 +85,7 @@ export const lunchPlan = {
       subQueries: subQueries,
       where: [
         `${resultName} rdf:type demo:Interest.`,
-        `${resultName} match:seeks ?seeks .`,
-        `?seeks rdf:type s:PlanAction.`,
-        `?seeks s:object ?planObject.`,
+        `${resultName} s:object ?planObject.`,
         `?planObject s:about <http://www.wikidata.org/entity/Q12896105>.`,
         `?thisAtom hold:heldBy/buddy:buddy/hold:holds ${resultName}.`,
         `BIND( ( 
@@ -110,12 +108,10 @@ export const lunchInterest = {
     ...mergeInEmptyDraft({
       content: {
         type: ["demo:Interest"],
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q12896105",
         title: "I am interested in meeting up for lunch!",
       },
-      seeks: {
-        type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://www.wikidata.org/entity/Q12896105",
-      },
+      seeks: {},
     }),
   },
   reactions: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-musician-search.js
@@ -40,7 +40,7 @@ export const musicianSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["bandSearch", "persona"],
+        useCaseIdentifiers: ["bandSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
@@ -74,7 +74,7 @@ export const personalTransportSearch = {
             ${resultName} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> won:Atom.
             {
               { 
-                ${resultName} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/resource/Ridesharing>.
+                ${resultName} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q16804155>.
                 OPTIONAL { 
                   ${resultName} (con:travelAction/s:fromLocation) ?fromLocation.
                   ?fromLocation s:geo ?fromLocation_geo.
@@ -152,7 +152,7 @@ export const personalTransportSearch = {
           `${resultName} a won:Atom.
           {
             {
-              ${resultName} a <http://dbpedia.org/resource/Ridesharing> ;
+              ${resultName} a <http://www.wikidata.org/entity/Q16804155> ;
                             (con:travelAction/s:fromLocation) ?location.
             } 
             union 
@@ -188,7 +188,7 @@ export const personalTransportSearch = {
           `${resultName} a won:Atom.
           {
             {
-              ${resultName} a <http://dbpedia.org/resource/Ridesharing> ;
+              ${resultName} a <http://www.wikidata.org/entity/Q16804155> ;
                             (con:travelAction/s:toLocation) ?location.
             } 
             union 
@@ -219,7 +219,7 @@ export const personalTransportSearch = {
         },
         operations: [
           `${resultName} a won:Atom.`,
-          `{{${resultName} a <http://dbpedia.org/resource/Ridesharing>} union {${resultName} a s:TaxiService}}`,
+          `{{${resultName} a <http://www.wikidata.org/entity/Q16804155>} union {${resultName} a s:TaxiService}}`,
         ],
       };
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-personal-transport-search.js
@@ -30,7 +30,7 @@ export const personalTransportSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["taxiOffer", "rideShareOffer", "persona"],
+        useCaseIdentifiers: ["taxiOffer", "rideShareOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-offer.js
@@ -30,7 +30,7 @@ export const phdOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["phdSearch", "persona"],
+        useCaseIdentifiers: ["phdSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-phd-search.js
@@ -33,7 +33,7 @@ export const phdSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["phdOffer", "persona"],
+        useCaseIdentifiers: ["phdOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -17,7 +17,7 @@ export const pokemonGoRaid = {
     ...mergeInEmptyDraft({
       content: {
         type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://dbpedia.org/resource/Pokemon_Go",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q20966579",
         sockets: {
           "#groupSocket": vocab.GROUP.GroupSocketCompacted,
           "#holdableSocket": vocab.HOLD.HoldableSocketCompacted,
@@ -58,7 +58,7 @@ export const pokemonInterest = {
       },
       seeks: {
         type: ["s:PlanAction"],
-        eventObjectAboutUris: "http://dbpedia.org/resource/Pokemon_Go",
+        eventObjectAboutUris: "http://www.wikidata.org/entity/Q20966579",
       },
     }),
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -55,11 +55,9 @@ export const pokemonInterest = {
     ...mergeInEmptyDraft({
       content: {
         type: ["demo:Interest"],
-      },
-      seeks: {
-        type: ["s:PlanAction"],
         eventObjectAboutUris: "http://www.wikidata.org/entity/Q20966579",
       },
+      seeks: {},
     }),
   },
   reactions: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-pokemon.js
@@ -31,7 +31,7 @@ export const pokemonGoRaid = {
     ...defaultReactions,
     [vocab.GROUP.GroupSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["pokemonInterest", "persona"],
+        useCaseIdentifiers: ["pokemonInterest"],
       },
       [vocab.GROUP.GroupSocketCompacted]: {
         useCaseIdentifiers: ["pokemonGoRaid"],

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-offer.js
@@ -30,7 +30,7 @@ export const postdocOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["postdocSearch", "persona"],
+        useCaseIdentifiers: ["postdocSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-postdoc-search.js
@@ -33,7 +33,7 @@ export const postdocSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["postdocOffer", "persona"],
+        useCaseIdentifiers: ["postdocOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-offer.js
@@ -44,7 +44,7 @@ export const rehearsalRoomOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rehearsalRoomSearch", "persona"],
+        useCaseIdentifiers: ["rehearsalRoomSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rehearsal-room-search.js
@@ -44,7 +44,7 @@ export const rehearsalRoomSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rehearsalRoomOffer", "persona"],
+        useCaseIdentifiers: ["rehearsalRoomOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-offer.js
@@ -47,7 +47,7 @@ export const rentRealEstateOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rentRealEstateSearch", "persona"],
+        useCaseIdentifiers: ["rentRealEstateSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rent-real-estate-search.js
@@ -47,7 +47,7 @@ export const rentRealEstateSearch = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["rentRealEstateOffer", "persona"],
+        useCaseIdentifiers: ["rentRealEstateOffer"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
@@ -26,7 +26,7 @@ export const rideShareOffer = {
     ...mergeInEmptyDraft({
       content: {
         title: "Share a Ride",
-        type: ["http://dbpedia.org/resource/Ridesharing"],
+        type: ["http://www.wikidata.org/entity/Q16804155"],
       },
     }),
   },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-rideshare-offer.js
@@ -34,7 +34,7 @@ export const rideShareOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["personalTransportSearch", "persona"],
+        useCaseIdentifiers: ["personalTransportSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-service-offer.js
@@ -25,7 +25,7 @@ export const serviceOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["goodsServiceSearch", "persona"],
+        useCaseIdentifiers: ["goodsServiceSearch"],
         refuseOwned: true,
       },
     },

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-taxi-offer.js
@@ -27,7 +27,7 @@ export const taxiOffer = {
     ...defaultReactions,
     [vocab.CHAT.ChatSocketCompacted]: {
       [vocab.CHAT.ChatSocketCompacted]: {
-        useCaseIdentifiers: ["personalTransportSearch", "persona"],
+        useCaseIdentifiers: ["personalTransportSearch"],
         refuseOwned: true,
       },
     },


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently we can only show interest in Pokemon Go, Cycling And Lunch

## What is the new behavior?
- Added a new UseCase for a generic interest (interest in is picked from wikidata uris)
- Adapted the existing UseCases to use wikidata uris instead of fixed dbpedia uris
- Adapted Adhoc connect (create a corresponding atom based on the useCase defined in the reactions)
- Add eventObjectAboutUris within create-atom, and connectAdHoc for PlanAction and demo:Interest atoms

## Does this introduce a breaking change?

- [ ] Yes
- [X] No