### PR TITLE
Feat  "smart" fetch

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/WonOwnerMailSender.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class WonOwnerMailSender {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String OWNER_TARGET_ATOM_LINK = "/#!/post?postUri=";
-    private static final String OWNER_CONNECTION_LINK = "/#!/connections?connectionUri=%s";
+    private static final String OWNER_CONNECTION_LINK = "/#!/connections?postUri=%s&connectionUri=%s";
     private static final String OWNER_LOCAL_ATOM_LINK = "/#!/post?postUri=";
     private static final String OWNER_VERIFICATION_LINK = "/#!/inventory?token=";
     private static final String OWNER_ANONYMOUS_LINK = "/#!/inventory?privateId=";
@@ -136,8 +136,8 @@ public class WonOwnerMailSender {
             velocityContext.put("linkLocalAtom", linkLocalAtom);
             velocityContext.put("localAtomTitle", localAtomTitle);
         }
-        if (localConnection != null) {
-            String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK, localConnection);
+        if (localConnection != null && localAtom != null) {
+            String linkConnection = ownerAppLink + String.format(OWNER_CONNECTION_LINK, localAtom, localConnection);
             velocityContext.put("linkConnection", linkConnection);
         }
         if (textMsg != null) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/account-actions.js
@@ -102,7 +102,7 @@ export function accountLogin(credentials) {
         })
       )
       .then(() => dispatch({ type: actionTypes.upgradeHttpSession }))
-      .then(() => stateStore.fetchOwnedData(dispatch, getState))
+      .then(() => stateStore.fetchOwnedMetaData(dispatch, getState))
       .then(() => dispatch({ type: actionTypes.account.loginFinished }))
       .catch(error =>
         error.response.json().then(loginError => {
@@ -321,7 +321,7 @@ export const reconnect = () => (dispatch, getState) => {
     .then(() => {
       dispatch({ type: actionTypes.reconnect.success });
 
-      return stateStore.fetchOwnedData(dispatch, getState);
+      return stateStore.fetchOwnedMetaData(dispatch, getState);
     })
     .catch(e => {
       if (e.status >= 400 && e.status < 500) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/load-action.js
@@ -25,7 +25,7 @@ export const pageLoadAction = () => (dispatch, getState) => {
 function loadingWhileSignedIn(dispatch, getState) {
   // reset websocket to make sure it's using the logged-in session
   dispatch(actionCreators.reconnect__start());
-  return stateStore.fetchOwnedData(dispatch, getState);
+  return stateStore.fetchOwnedMetaData(dispatch, getState);
 }
 
 export const fetchWhatsNew = createdAfterDate => (dispatch, getState) => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/messages-actions.js
@@ -52,7 +52,7 @@ export function failedCloseAtom(event) {
     const atomUri = event.getAtom();
 
     stateStore
-      .fetchDataForOwnedAtoms([atomUri], dispatch, getState)
+      .fetchAtomAndDispatch(atomUri, dispatch, getState)
       .then(() => dispatch({ type: actionTypes.messages.closeAtom.failed }));
   };
 }
@@ -62,7 +62,7 @@ export function failedReopenAtom(event) {
     const atomUri = event.getAtom();
 
     stateStore
-      .fetchDataForOwnedAtoms([atomUri], dispatch, getState)
+      .fetchAtomAndDispatch(atomUri, dispatch, getState)
       .then(() => dispatch({ type: actionTypes.messages.reopenAtom.failed }));
   };
 }
@@ -157,7 +157,7 @@ export function successfulEdit(event) {
       );
     } else {
       stateStore
-        .fetchDataForOwnedAtoms([atomURI], dispatch, getState, true)
+        .fetchAtomAndDispatch(atomURI, dispatch, getState, true)
         .then(() => {
           dispatch(
             actionCreators.atoms__editSuccessful({

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/app.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/app.js
@@ -12,6 +12,7 @@ import "../style/won.scss";
 
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import { applyMiddleware, createStore } from "redux";
 import { composeWithDevTools } from "redux-devtools-extension";
 import * as generalSelectors from "./redux/selectors/general-selectors.js";
@@ -50,6 +51,7 @@ import { getQueryParams } from "./utils.js";
 import * as accountUtils from "./redux/utils/account-utils.js";
 import * as processUtils from "./redux/utils/process-utils.js";
 import { runPushAgent } from "./push-agent";
+import ico_loading_anim from "~/images/won-icons/ico_loading_anim.svg";
 
 window.won = won;
 
@@ -97,11 +99,10 @@ store.dispatch(actionCreators.initialPageLoad());
 //app.run(["$ngRedux", $ngRedux => $ngRedux.dispatch(actionCreators.tick())]);
 store.dispatch(actionCreators.tick());
 
-function AppRoutes() {
+function AppRoutes({ processState }) {
   const dispatch = useDispatch();
   const location = useLocation();
   const accountState = useSelector(generalSelectors.getAccountState);
-  const processState = useSelector(generalSelectors.getProcessState);
 
   const isLoggedIn = accountUtils.isLoggedIn(accountState);
   const hasLoginError = !!accountUtils.getLoginError(accountState);
@@ -166,12 +167,32 @@ function AppRoutes() {
     </Switch>
   );
 }
+AppRoutes.propTypes = { processState: PropTypes.object.isRequired };
+
+function App() {
+  const processState = useSelector(generalSelectors.getProcessState);
+
+  if (processUtils.isProcessingInitialLoad(processState)) {
+    return (
+      <main className="ownerloading">
+        <svg className="ownerloading__spinner hspinner">
+          <use xlinkHref={ico_loading_anim} href={ico_loading_anim} />
+        </svg>
+        <span className="ownerloading__label">Gathering your Atoms...</span>
+      </main>
+    );
+  } else {
+    return (
+      <HashRouter hashType="hashbang">
+        <AppRoutes processState={processState} />
+      </HashRouter>
+    );
+  }
+}
 
 ReactDOM.render(
   <Provider store={store}>
-    <HashRouter hashType="hashbang">
-      <AppRoutes />
-    </HashRouter>
+    <App />
   </Provider>,
   document.getElementById("root")
 );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
@@ -156,9 +156,11 @@ export default function WonAtomContent({
         );
 
         // Filter out singleConnectSocketReactions
-        const filteredReactions = reactions.filter(
-          connectionUtils.filterSingleConnectedSocketCapacityFilter
-        );
+        const filteredReactions =
+          reactions &&
+          reactions.filter(
+            connectionUtils.filterSingleConnectedSocketCapacityFilter
+          );
 
         visibleTabFragment = (
           <React.Fragment>

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -3,159 +3,240 @@
  */
 import React from "react";
 import PropTypes from "prop-types";
-import { useSelector } from "react-redux";
+import { actionCreators } from "~/app/actions/actions";
+import { useDispatch, useSelector } from "react-redux";
 
-import "~/style/_atom-header-big.scss";
+import * as generalSelectors from "../redux/selectors/general-selectors";
 import * as atomUtils from "../redux/utils/atom-utils";
 import * as wonLabelUtils from "../won-label-utils.js";
 import * as accountUtils from "../redux/utils/account-utils";
-import { get } from "../utils.js";
+import { get, extractAtomUriFromConnectionUri } from "../utils.js";
 
 import WonAtomContextDropdown from "../components/atom-context-dropdown.jsx";
 import WonAtomIcon from "../components/atom-icon.jsx";
 import WonShareDropdown from "../components/share-dropdown.jsx";
 import WonAddBuddy from "../components/add-buddy.jsx";
-import * as generalSelectors from "../redux/selectors/general-selectors";
 
 import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
-import { extractAtomUriFromConnectionUri } from "../utils";
+import "~/style/_atom-header-big.scss";
+import * as processUtils from "~/app/redux/utils/process-utils";
+import VisibilitySensor from "react-visibility-sensor";
 
 export default function WonAtomHeaderBig({
+  atomUri,
   atom,
   ownedConnection,
   showActions,
   toggleActions,
 }) {
-  const atomUri = get(atom, "uri");
-  const personaUri = atomUtils.getHeldByUri(atom);
+  const dispatch = useDispatch();
   const storedAtoms = useSelector(generalSelectors.getAtoms);
-  const persona = get(storedAtoms, personaUri);
-  const personaName =
-    atomUtils.hasHoldableSocket(atom) && !atomUtils.hasGroupSocket(atom)
-      ? atomUtils.getTitle(persona, externalDataState) ||
-        get(atom, "fakePersonaName")
-      : undefined;
   const accountState = useSelector(generalSelectors.getAccountState);
+  const processState = useSelector(generalSelectors.getProcessState);
   const ownedAtomsWithBuddySocket = useSelector(
     generalSelectors.getOwnedAtomsWithBuddySocket
   );
+  const atomLoading =
+    !atom || processUtils.isAtomLoading(processState, atomUri);
+  const atomToLoad = !atom || processUtils.isAtomToLoad(processState, atomUri);
+  const atomFailedToLoad =
+    atom && processUtils.hasAtomFailedToLoad(processState, atomUri);
   const externalDataState = useSelector(generalSelectors.getExternalDataState);
-  const hasOwnedAtomsWithBuddySocket =
-    ownedAtomsWithBuddySocket &&
-    ownedAtomsWithBuddySocket
-      .filter(atom => atomUtils.isActive(atom))
-      .filter(atom => get(atom, "uri") !== atomUri).size > 0;
 
-  const isGroupChatEnabled = atomUtils.hasGroupSocket(atom);
-  const isChatEnabled = atomUtils.hasChatSocket(atom);
-  const showAddBuddyElement =
-    atomUtils.hasBuddySocket(atom) &&
-    hasOwnedAtomsWithBuddySocket &&
-    !accountUtils.isAtomOwned(accountState, atomUri);
+  let contentElement;
 
-  const title = atomUtils.getTitle(atom, externalDataState);
+  if (atomLoading || atomToLoad || !atom) {
+    const onChange = isVisible => {
+      console.debug("is visible...", isVisible);
+      if (isVisible) {
+        ensureAtomIsLoaded();
+      }
+    };
 
-  const titleElement = title ? (
-    <h1 className="ahb__title">{title}</h1>
-  ) : (
-    <h1 className="ahb__title ahb__title--notitle">No Title</h1>
-  );
+    const ensureAtomIsLoaded = () => {
+      console.debug("ensureAtomIsLoaded...");
+      if (atomUri && (!atom || (atomToLoad && !atomLoading))) {
+        console.debug("fetch atomUri, ", atomUri);
+        dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
+      } else {
+        console.debug(
+          "fetch omitted atomUri, ",
+          atomUri,
+          atomToLoad,
+          atomLoading,
+          atom
+        );
+      }
+    };
 
-  const personaNameElement = personaName && (
-    <span className="ahb__info__persona">{personaName}</span>
-  );
+    //Loading View
+    contentElement = (
+      <React.Fragment>
+        <VisibilitySensor
+          onChange={onChange}
+          intervalDelay={200}
+          partialVisibility={true}
+          offset={{ top: -300, bottom: -300 }}
+        >
+          <div className="ahb__icon__skeleton" />
+        </VisibilitySensor>
+        <div className="ahb__title" />
+        <div className="ahb__info" />
+      </React.Fragment>
+    );
+  } else if (atomFailedToLoad) {
+    //FailedToLoad View
+    contentElement = (
+      <React.Fragment>
+        <div className="ahb__icon__skeleton" />
+        <div className="ahb__title" />
+        <div className="ahb__info" />
+      </React.Fragment>
+    );
+  } else {
+    //Normal View
+    const hasOwnedAtomsWithBuddySocket =
+      ownedAtomsWithBuddySocket &&
+      ownedAtomsWithBuddySocket
+        .filter(atom => atomUtils.isActive(atom))
+        .filter(atom => get(atom, "uri") !== atomUri).size > 0;
 
-  const groupChatElement = isGroupChatEnabled && (
-    <span className="ahb__info__groupchat">
-      {"Group Chat" + (isChatEnabled ? " enabled" : "")}
-    </span>
-  );
+    const showAddBuddyElement =
+      atomUtils.hasBuddySocket(atom) &&
+      hasOwnedAtomsWithBuddySocket &&
+      !accountUtils.isAtomOwned(accountState, atomUri);
 
-  const buddyActionElement = showAddBuddyElement && <WonAddBuddy atom={atom} />;
+    const generateAtomActionButton = () => {
+      const isInactive = atomUtils.isInactive(atom);
+      if (ownedConnection || isInactive) {
+        const connectionState = get(ownedConnection, "state");
+        const targetAtom = get(
+          storedAtoms,
+          get(ownedConnection, "targetAtomUri")
+        );
+        const senderAtom = get(
+          storedAtoms,
+          extractAtomUriFromConnectionUri(get(ownedConnection, "uri"))
+        );
 
-  const generateAtomActionButton = () => {
-    const isInactive = atomUtils.isInactive(atom);
-    if (ownedConnection || isInactive) {
-      const connectionState = get(ownedConnection, "state");
-      const targetAtom = get(
-        storedAtoms,
-        get(ownedConnection, "targetAtomUri")
-      );
-      const senderAtom = get(
-        storedAtoms,
-        extractAtomUriFromConnectionUri(get(ownedConnection, "uri"))
-      );
+        const senderSocketType = atomUtils.getSocketType(
+          senderAtom,
+          get(ownedConnection, "socketUri")
+        );
+        const targetSocketType = atomUtils.getSocketType(
+          targetAtom,
+          get(ownedConnection, "targetSocketUri")
+        );
 
-      const senderSocketType = atomUtils.getSocketType(
-        senderAtom,
-        get(ownedConnection, "socketUri")
-      );
-      const targetSocketType = atomUtils.getSocketType(
-        targetAtom,
-        get(ownedConnection, "targetSocketUri")
-      );
-
-      return (
-        <won-toggle-actions>
-          <button
-            onClick={() => toggleActions(!showActions)}
-            className={
-              "won-toggle-actions__button " +
-              (showActions
-                ? " won-toggle-actions__button--expanded "
-                : " won-toggle-actions__button--collapsed ")
-            }
-          >
-            {isInactive ? (
-              <span className="won-toggle-actions__button__label">
-                Atom Inactive
-              </span>
-            ) : (
-              <React.Fragment>
-                <div className="won-toggle-actions__button__infoicon">
-                  <WonAtomIcon atom={targetAtom} />
-                </div>
+        return (
+          <won-toggle-actions>
+            <button
+              onClick={() => toggleActions(!showActions)}
+              className={
+                "won-toggle-actions__button " +
+                (showActions
+                  ? " won-toggle-actions__button--expanded "
+                  : " won-toggle-actions__button--collapsed ")
+              }
+            >
+              {isInactive ? (
                 <span className="won-toggle-actions__button__label">
-                  {wonLabelUtils.getSocketActionInfoLabel(
-                    senderSocketType,
-                    connectionState,
-                    targetSocketType
-                  )}
+                  Atom Inactive
                 </span>
-                <div className="won-toggle-actions__button__infoicon">
-                  <WonAtomIcon atom={senderAtom} />
-                </div>
-              </React.Fragment>
-            )}
-            <svg className="won-toggle-actions__button__carret">
-              <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
-            </svg>
-          </button>
-        </won-toggle-actions>
-      );
-    }
-  };
+              ) : (
+                <React.Fragment>
+                  <div className="won-toggle-actions__button__infoicon">
+                    <WonAtomIcon atom={targetAtom} />
+                  </div>
+                  <span className="won-toggle-actions__button__label">
+                    {wonLabelUtils.getSocketActionInfoLabel(
+                      senderSocketType,
+                      connectionState,
+                      targetSocketType
+                    )}
+                  </span>
+                  <div className="won-toggle-actions__button__infoicon">
+                    <WonAtomIcon atom={senderAtom} />
+                  </div>
+                </React.Fragment>
+              )}
+              <svg className="won-toggle-actions__button__carret">
+                <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
+              </svg>
+            </button>
+          </won-toggle-actions>
+        );
+      }
+    };
+
+    const buddyActionElement = showAddBuddyElement && (
+      <WonAddBuddy atom={atom} />
+    );
+
+    const title = atomUtils.getTitle(atom, externalDataState);
+
+    const titleElement = title ? (
+      <h1 className="ahb__title">{title}</h1>
+    ) : (
+      <h1 className="ahb__title ahb__title--notitle">No Title</h1>
+    );
+
+    const personaUri = atomUtils.getHeldByUri(atom);
+    const persona = get(storedAtoms, personaUri);
+    const personaName =
+      atomUtils.hasHoldableSocket(atom) && !atomUtils.hasGroupSocket(atom)
+        ? atomUtils.getTitle(persona, externalDataState) ||
+          get(atom, "fakePersonaName")
+        : undefined;
+
+    const personaNameElement = personaName && (
+      <span className="ahb__info__persona">{personaName}</span>
+    );
+
+    const isGroupChatEnabled = atomUtils.hasGroupSocket(atom);
+    const isChatEnabled = atomUtils.hasChatSocket(atom);
+
+    const groupChatElement = isGroupChatEnabled && (
+      <span className="ahb__info__groupchat">
+        {"Group Chat" + (isChatEnabled ? " enabled" : "")}
+      </span>
+    );
+
+    contentElement = (
+      <React.Fragment>
+        <WonAtomIcon atom={atom} />
+        {titleElement}
+        {(groupChatElement || personaNameElement) && (
+          <div className="ahb__info">
+            {groupChatElement}
+            {personaNameElement}
+          </div>
+        )}
+        {buddyActionElement}
+        {generateAtomActionButton()}
+        <WonShareDropdown atom={atom} />
+        <WonAtomContextDropdown atom={atom} />
+      </React.Fragment>
+    );
+  }
 
   return (
     <won-atom-header-big
-      class={showActions ? "won-atom-header-big--actions-expanded" : ""}
+      class={
+        showActions
+          ? " won-atom-header-big--actions-expanded "
+          : "" +
+            (atomFailedToLoad ? " won-failed-to-load " : "") +
+            (atomLoading ? " won-is-loading " : "") +
+            (atomToLoad ? " won-to-load " : "")
+      }
     >
-      <WonAtomIcon atom={atom} />
-      {titleElement}
-      {(groupChatElement || personaNameElement) && (
-        <div className="ahb__info">
-          {groupChatElement}
-          {personaNameElement}
-        </div>
-      )}
-      {buddyActionElement}
-      {generateAtomActionButton()}
-      <WonShareDropdown atom={atom} />
-      <WonAtomContextDropdown atom={atom} />
+      {contentElement}
     </won-atom-header-big>
   );
 }
 WonAtomHeaderBig.propTypes = {
+  atomUri: PropTypes.string.isRequired,
   atom: PropTypes.object,
   ownedConnection: PropTypes.object,
   showActions: PropTypes.bool.isRequired,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
@@ -71,14 +71,21 @@ export default function WonAtomHeader({
 
     atomHeaderIcon = <div className="ph__icon__skeleton" />;
     atomHeaderContent = (
-      <div className="ph__right">
-        <div className="ph__right__topline">
-          <div className="ph__right__topline__title" />
+      <VisibilitySensor
+        onChange={onChange}
+        intervalDelay={200}
+        partialVisibility={true}
+        offset={{ top: -300, bottom: -300 }}
+      >
+        <div className="ph__right">
+          <div className="ph__right__topline">
+            <div className="ph__right__topline__title" />
+          </div>
+          <div className="ph__right__subtitle">
+            <span className="ph__right__subtitle__type" />
+          </div>
         </div>
-        <div className="ph__right__subtitle">
-          <span className="ph__right__subtitle__type" />
-        </div>
-      </div>
+      </VisibilitySensor>
     );
   } else if (get(atom, "isBeingCreated")) {
     //In Creation View
@@ -171,14 +178,7 @@ export default function WonAtomHeader({
       to={toLink}
     >
       {atomHeaderIcon}
-      <VisibilitySensor
-        onChange={onChange}
-        intervalDelay={200}
-        partialVisibility={true}
-        offset={{ top: -300, bottom: -300 }}
-      >
-        {atomHeaderContent}
-      </VisibilitySensor>
+      {atomHeaderContent}
     </Link>
   ) : (
     <won-atom-header
@@ -191,14 +191,7 @@ export default function WonAtomHeader({
       onClick={onClick}
     >
       {atomHeaderIcon}
-      <VisibilitySensor
-        onChange={onChange}
-        intervalDelay={200}
-        partialVisibility={true}
-        offset={{ top: -300, bottom: -300 }}
-      >
-        {atomHeaderContent}
-      </VisibilitySensor>
+      {atomHeaderContent}
     </won-atom-header>
   );
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-info.jsx
@@ -35,6 +35,7 @@ export default function WonAtomInfo({
   const atomFailedToLoad =
     atom && processUtils.hasAtomFailedToLoad(processState, atomUri);
   const atomToLoad = !atom || processUtils.isAtomToLoad(processState, atomUri);
+  const initialLoad = processUtils.isProcessingInitialLoad(processState);
 
   const [visibleTab, setVisibleTab] = useState(initialTab);
   const [showAddPicker, toggleAddPicker] = useState(false);
@@ -62,11 +63,11 @@ export default function WonAtomInfo({
               !connectionUtils.isConnected(ownedConnection)))
       );
 
-      if (atomUri && ((atomToLoad && !atomLoading) || !atom)) {
+      if (atomUri && !initialLoad && ((atomToLoad && !atomLoading) || !atom)) {
         dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
       }
     },
-    [atomUri, connectionUri, atomLoading]
+    [atomUri, connectionUri, atomLoading, initialLoad]
   );
 
   const relevantConnectionsMap = useSelector(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
@@ -113,11 +113,10 @@ export default function ChatTextfield({
   );
 
   const processState = useSelector(generalSelectors.getProcessState);
-  const initialLoad = processUtils.isProcessingInitialLoad(processState);
   const ownedPersonas = useSelector(generalSelectors.getOwnedPersonas);
   useEffect(
     () => {
-      if (showPersonas && !initialLoad && ownedPersonas) {
+      if (showPersonas && ownedPersonas) {
         const unloadedPersonas = ownedPersonas.filter(
           (_, atomUri) =>
             processUtils.isAtomToLoad(processState, atomUri) &&
@@ -131,7 +130,7 @@ export default function ChatTextfield({
         }
       }
     },
-    [initialLoad, showPersonas, ownedPersonas]
+    [showPersonas, ownedPersonas]
   );
 
   function updateDetail(name, value, closeOnDelete = false) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { get, getIn } from "../utils.js";
@@ -25,6 +25,7 @@ import ico36_plus_circle from "~/images/won-icons/ico36_plus_circle.svg";
 import ico36_added_circle from "~/images/won-icons/ico36_added_circle.svg";
 import ico36_close_circle from "~/images/won-icons/ico36_close_circle.svg";
 import * as atomUtils from "../redux/utils/atom-utils";
+import * as processUtils from "~/app/redux/utils/process-utils";
 
 export default function ChatTextfield({
   connection,
@@ -109,6 +110,28 @@ export default function ChatTextfield({
 
   const personas = useSelector(state =>
     generalSelectors.getOwnedCondensedPersonaList(state).toJS()
+  );
+
+  const processState = useSelector(generalSelectors.getProcessState);
+  const initialLoad = processUtils.isProcessingInitialLoad(processState);
+  const ownedPersonas = useSelector(generalSelectors.getOwnedPersonas);
+  useEffect(
+    () => {
+      if (showPersonas && !initialLoad && ownedPersonas) {
+        const unloadedPersonas = ownedPersonas.filter(
+          (_, atomUri) =>
+            processUtils.isAtomToLoad(processState, atomUri) &&
+            !processUtils.isAtomLoading(processState, atomUri)
+        );
+        if (unloadedPersonas.size > 0) {
+          console.debug("Fetching unloaded personas...");
+          unloadedPersonas.map((atom, atomUri) => {
+            dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
+          });
+        }
+      }
+    },
+    [initialLoad, showPersonas, ownedPersonas]
   );
 
   function updateDetail(name, value, closeOnDelete = false) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-atom.jsx
@@ -119,11 +119,10 @@ export default function WonCreateAtom({
     generalSelectors.isAtomUsableAsTemplate(get(fromAtom, "uri"))
   );
 
-  const initialLoad = processUtils.isProcessingInitialLoad(processState);
   const ownedPersonas = useSelector(generalSelectors.getOwnedPersonas);
   useEffect(
     () => {
-      if (!initialLoad && ownedPersonas) {
+      if (ownedPersonas) {
         const unloadedPersonas = ownedPersonas.filter(
           (_, atomUri) =>
             processUtils.isAtomToLoad(processState, atomUri) &&
@@ -137,7 +136,7 @@ export default function WonCreateAtom({
         }
       }
     },
-    [initialLoad, ownedPersonas]
+    [ownedPersonas]
   );
 
   const personas = useSelector(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/create-atom.jsx
@@ -1,7 +1,7 @@
 /**
  * Created by quasarchimaere on 30.07.2019.
  */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import { get, generateLink } from "../utils.js";
@@ -118,6 +118,28 @@ export default function WonCreateAtom({
   const isFromAtomUsableAsTemplate = useSelector(
     generalSelectors.isAtomUsableAsTemplate(get(fromAtom, "uri"))
   );
+
+  const initialLoad = processUtils.isProcessingInitialLoad(processState);
+  const ownedPersonas = useSelector(generalSelectors.getOwnedPersonas);
+  useEffect(
+    () => {
+      if (!initialLoad && ownedPersonas) {
+        const unloadedPersonas = ownedPersonas.filter(
+          (_, atomUri) =>
+            processUtils.isAtomToLoad(processState, atomUri) &&
+            !processUtils.isAtomLoading(processState, atomUri)
+        );
+        if (unloadedPersonas.size > 0) {
+          console.debug("Fetching unloaded personas...");
+          unloadedPersonas.map((atom, atomUri) => {
+            dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
+          });
+        }
+      }
+    },
+    [initialLoad, ownedPersonas]
+  );
+
   const personas = useSelector(
     generalSelectors.getOwnedCondensedPersonaList
   ).toJS();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/connections.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/connections.jsx
@@ -43,7 +43,6 @@ export default function PageConnections() {
   const atomUri =
     get(atom, "uri") || extractAtomUriFromConnectionUri(selectedConnectionUri);
   const atomLoading = processUtils.isAtomLoading(processState, atomUri);
-  const initialLoad = processUtils.isProcessingInitialLoad(processState);
 
   const selectedConnection = getIn(atom, [
     "connections",
@@ -55,7 +54,7 @@ export default function PageConnections() {
 
   useEffect(
     () => {
-      if (atomUri && !initialLoad && (!atomLoading || !atom)) {
+      if (atomUri && (!atomLoading || !atom)) {
         console.debug(
           "Fetching unloaded atom:",
           atomUri,
@@ -64,15 +63,8 @@ export default function PageConnections() {
         );
         dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
       }
-    },
-    [selectedConnectionUri, atom, atomLoading, initialLoad]
-  );
 
-  const ownedAtoms = useSelector(generalSelectors.getOwnedAtoms);
-
-  useEffect(
-    () => {
-      if (!atomUriInRoute && !initialLoad && ownedAtoms) {
+      if (!atomUriInRoute && ownedAtoms) {
         const unloadedAtoms = ownedAtoms.filter(
           (_, atomUri) =>
             processUtils.isAtomToLoad(processState, atomUri) &&
@@ -87,8 +79,10 @@ export default function PageConnections() {
         }
       }
     },
-    [selectedConnectionUri, atom, atomLoading, initialLoad, ownedAtoms]
+    [selectedConnectionUri, atom, atomLoading, ownedAtoms]
   );
+
+  const ownedAtoms = useSelector(generalSelectors.getOwnedAtoms);
 
   const isSelectedConnectionGroupChat =
     selectedConnection &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/connections.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/connections.jsx
@@ -56,10 +56,38 @@ export default function PageConnections() {
   useEffect(
     () => {
       if (atomUri && !initialLoad && (!atomLoading || !atom)) {
+        console.debug(
+          "Fetching unloaded atom:",
+          atomUri,
+          " for connection: ",
+          selectedConnectionUri
+        );
         dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
       }
     },
     [selectedConnectionUri, atom, atomLoading, initialLoad]
+  );
+
+  const ownedAtoms = useSelector(generalSelectors.getOwnedAtoms);
+
+  useEffect(
+    () => {
+      if (!atomUriInRoute && !initialLoad && ownedAtoms) {
+        const unloadedAtoms = ownedAtoms.filter(
+          (_, atomUri) =>
+            processUtils.isAtomToLoad(processState, atomUri) &&
+            !processUtils.isAtomLoading(processState, atomUri)
+        );
+
+        if (unloadedAtoms.size > 0) {
+          console.debug("Fetching unloaded atoms...");
+          unloadedAtoms.map((atom, atomUri) => {
+            dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
+          });
+        }
+      }
+    },
+    [selectedConnectionUri, atom, atomLoading, initialLoad, ownedAtoms]
   );
 
   const isSelectedConnectionGroupChat =
@@ -135,6 +163,8 @@ export default function PageConnections() {
       </React.Fragment>
     );
   } else {
+    // TODO: FETCH ALL ATOMS TO DETERMINE IF NO CHATS ARE ACTUALLY TRUE
+
     contentElements = (
       <main className="overview__nochats">
         <div className="overview__nochats__empty">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
@@ -57,15 +57,27 @@ export default function PageCreate() {
     ? processUtils.hasAtomFailedToLoad(processState, fromAtomUri)
     : false;
 
-  useEffect(() => {
-    if (
-      fromAtomUri &&
-      (!fromAtom ||
-        (isFromAtomToLoad && !isFromAtomLoading && !hasFromAtomFailedToLoad))
-    ) {
-      dispatch(actionCreators.atoms__fetchUnloadedAtom(fromAtomUri));
-    }
-  });
+  const initialLoad = processUtils.isProcessingInitialLoad(processState);
+
+  useEffect(
+    () => {
+      if (
+        fromAtomUri &&
+        (!fromAtom ||
+          (isFromAtomToLoad && !isFromAtomLoading && !hasFromAtomFailedToLoad))
+      ) {
+        dispatch(actionCreators.atoms__fetchUnloadedAtom(fromAtomUri));
+      }
+    },
+    [
+      initialLoad,
+      fromAtom,
+      isFromAtomLoading,
+      isFromAtomToLoad,
+      hasFromAtomFailedToLoad,
+      initialLoad,
+    ]
+  );
 
   let contentElement;
   let showUseCaseGroup = !useCase && !!useCaseGroup;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/create.jsx
@@ -57,8 +57,6 @@ export default function PageCreate() {
     ? processUtils.hasAtomFailedToLoad(processState, fromAtomUri)
     : false;
 
-  const initialLoad = processUtils.isProcessingInitialLoad(processState);
-
   useEffect(
     () => {
       if (
@@ -69,14 +67,7 @@ export default function PageCreate() {
         dispatch(actionCreators.atoms__fetchUnloadedAtom(fromAtomUri));
       }
     },
-    [
-      initialLoad,
-      fromAtom,
-      isFromAtomLoading,
-      isFromAtomToLoad,
-      hasFromAtomFailedToLoad,
-      initialLoad,
-    ]
+    [fromAtom, isFromAtomLoading, isFromAtomToLoad, hasFromAtomFailedToLoad]
   );
 
   let contentElement;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/inventory.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/inventory.jsx
@@ -5,7 +5,6 @@ import * as generalSelectors from "../../redux/selectors/general-selectors.js";
 import { get, sortByDate } from "../../utils.js";
 import * as accountUtils from "../../redux/utils/account-utils.js";
 import * as viewSelectors from "../../redux/selectors/view-selectors.js";
-import * as processUtils from "../../redux/utils/process-utils.js";
 import * as atomUtils from "../../redux/utils/atom-utils.js";
 import * as viewUtils from "../../redux/utils/view-utils.js";
 import WonModalDialog from "../../components/modal-dialog.jsx";
@@ -18,7 +17,6 @@ import WonFooter from "../../components/footer.jsx";
 import WonHowTo from "../../components/howto.jsx";
 import WonAtomCardGrid from "../../components/atom-card-grid.jsx";
 
-import ico_loading_anim from "~/images/won-icons/ico_loading_anim.svg";
 import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
 
 import "~/style/_inventory.scss";
@@ -53,9 +51,7 @@ export default function PageInventory() {
 
   const theme = useSelector(generalSelectors.getTheme);
   const accountState = useSelector(generalSelectors.getAccountState);
-  const process = useSelector(generalSelectors.getProcessState);
 
-  const isInitialLoadInProgress = processUtils.isProcessingInitialLoad(process);
   const isLoggedIn = accountUtils.isLoggedIn(accountState);
   const welcomeTemplateHtml = get(theme, "welcomeTemplate");
   const additionalLogos =
@@ -92,86 +88,76 @@ export default function PageInventory() {
       {showSlideIns && <WonSlideIn />}
 
       {isLoggedIn ? (
-        isInitialLoadInProgress ? (
-          <main className="ownerloading">
-            <svg className="ownerloading__spinner hspinner">
-              <use xlinkHref={ico_loading_anim} href={ico_loading_anim} />
-            </svg>
-            <span className="ownerloading__label">Gathering your Atoms...</span>
-          </main>
-        ) : (
-          <main className="ownerinventory">
-            {hasOwnedActivePersonas && (
-              <div className="ownerinventory__personas">
-                {sortedOwnedActivePersonas.map((persona, index) => (
-                  <WonAtomInfo
-                    key={get(persona, "uri") + "-" + index}
-                    className="ownerinventory__personas__persona"
-                    atom={persona}
-                    initialTab={vocab.HOLD.HolderSocketCompacted}
-                  />
-                ))}
-              </div>
-            )}
-            <div className="ownerinventory__header">
+        <main className="ownerinventory">
+          {hasOwnedActivePersonas && (
+            <div className="ownerinventory__personas">
+              {sortedOwnedActivePersonas.map((persona, index) => (
+                <WonAtomInfo
+                  key={get(persona, "uri") + "-" + index}
+                  className="ownerinventory__personas__persona"
+                  atomUri={get(persona, "uri")}
+                  atom={persona}
+                  initialTab={vocab.HOLD.HolderSocketCompacted}
+                />
+              ))}
+            </div>
+          )}
+          <div className="ownerinventory__header">
+            <div className="ownerinventory__header__title">
+              Unassigned
+              {hasOwnedUnassignedAtomUris && (
+                <span className="ownerinventory__header__title__count">
+                  {"(" + unassignedAtomSize + ")"}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="ownerinventory__content">
+            <WonAtomCardGrid
+              atoms={sortedOwnedUnassignedActivePosts}
+              currentLocation={currentLocation}
+              showIndicators={true}
+              showHolder={true}
+              showCreate={true}
+              showCreatePersona={true}
+            />
+          </div>
+          {hasOwnedInactiveAtomUris && (
+            <div
+              className="ownerinventory__header clickable"
+              onClick={() => dispatch(actionCreators.view__toggleClosedAtoms())}
+            >
               <div className="ownerinventory__header__title">
-                Unassigned
-                {hasOwnedUnassignedAtomUris && (
-                  <span className="ownerinventory__header__title__count">
-                    {"(" + unassignedAtomSize + ")"}
-                  </span>
-                )}
+                Archived
+                <span className="ownerinventory__header__title__count">
+                  {"(" + inactiveAtomUriSize + ")"}
+                </span>
               </div>
-            </div>
-            <div className="ownerinventory__content">
-              <WonAtomCardGrid
-                atoms={sortedOwnedUnassignedActivePosts}
-                currentLocation={currentLocation}
-                showIndicators={true}
-                showHolder={true}
-                showCreate={true}
-                showCreatePersona={true}
-              />
-            </div>
-            {hasOwnedInactiveAtomUris && (
-              <div
-                className="ownerinventory__header clickable"
-                onClick={() =>
-                  dispatch(actionCreators.view__toggleClosedAtoms())
+              <svg
+                className={
+                  "ownerinventory__header__carret " +
+                  (showClosedAtoms
+                    ? "ownerinventory__header__carret--expanded"
+                    : "ownerinventory__header__carret--collapsed")
                 }
               >
-                <div className="ownerinventory__header__title">
-                  Archived
-                  <span className="ownerinventory__header__title__count">
-                    {"(" + inactiveAtomUriSize + ")"}
-                  </span>
-                </div>
-                <svg
-                  className={
-                    "ownerinventory__header__carret " +
-                    (showClosedAtoms
-                      ? "ownerinventory__header__carret--expanded"
-                      : "ownerinventory__header__carret--collapsed")
-                  }
-                >
-                  <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
-                </svg>
+                <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
+              </svg>
+            </div>
+          )}
+          {showClosedAtoms &&
+            hasOwnedInactiveAtomUris && (
+              <div className="ownerinventory__content">
+                <WonAtomCardGrid
+                  atoms={sortedOwnedInactiveAtoms}
+                  currentLocation={currentLocation}
+                  showIndicators={false}
+                  showHolder={false}
+                  showCreate={false}
+                />
               </div>
             )}
-            {showClosedAtoms &&
-              hasOwnedInactiveAtomUris && (
-                <div className="ownerinventory__content">
-                  <WonAtomCardGrid
-                    atoms={sortedOwnedInactiveAtoms}
-                    currentLocation={currentLocation}
-                    showIndicators={false}
-                    showHolder={false}
-                    showCreate={false}
-                  />
-                </div>
-              )}
-          </main>
-        )
+        </main>
       ) : (
         <main className="ownerwelcome">
           <div

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
@@ -1,11 +1,9 @@
-import React, { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { actionCreators } from "../../actions/actions.js";
+import React from "react";
+import { useSelector } from "react-redux";
 import { getQueryParams } from "../../utils.js";
 import * as atomUtils from "../../redux/utils/atom-utils.js";
 import * as accountUtils from "../../redux/utils/account-utils.js";
 import * as viewSelectors from "../../redux/selectors/view-selectors.js";
-import * as processUtils from "../../redux/utils/process-utils.js";
 import WonModalDialog from "../../components/modal-dialog.jsx";
 import WonAtomInfo from "../../components/atom-info.jsx";
 import WonTopnav from "../../components/topnav.jsx";
@@ -15,14 +13,11 @@ import WonSlideIn from "../../components/slide-in.jsx";
 import WonFooter from "../../components/footer.jsx";
 
 import "~/style/_post.scss";
-import ico_loading_anim from "~/images/won-icons/ico_loading_anim.svg";
-import ico16_indicator_error from "~/images/won-icons/ico16_indicator_error.svg";
 import { useHistory } from "react-router-dom";
 import * as generalSelectors from "../../redux/selectors/general-selectors";
 
 export default function PagePost() {
   const history = useHistory();
-  const dispatch = useDispatch();
   const { postUri, connectionUri, tab } = getQueryParams(history.location);
   const atomUri = postUri;
   const atom = useSelector(generalSelectors.getAtom(atomUri));
@@ -30,7 +25,6 @@ export default function PagePost() {
     generalSelectors.getOwnedConnection(connectionUri)
   );
 
-  const processState = useSelector(generalSelectors.getProcessState);
   const accountState = useSelector(generalSelectors.getAccountState);
   const externalDataState = useSelector(generalSelectors.getExternalDataState);
 
@@ -38,85 +32,6 @@ export default function PagePost() {
   const atomTitle = atomUtils.getTitle(atom, externalDataState);
   const showSlideIns = useSelector(viewSelectors.showSlideIns(history));
   const showModalDialog = useSelector(viewSelectors.showModalDialog);
-  const atomLoading =
-    !atom || processUtils.isAtomLoading(processState, atomUri);
-  const atomToLoad = !atom || processUtils.isAtomToLoad(processState, atomUri);
-  const atomFailedToLoad =
-    atom && processUtils.hasAtomFailedToLoad(processState, atomUri);
-
-  function tryReload() {
-    if (atomUri && atomFailedToLoad) {
-      dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
-    }
-  }
-
-  useEffect(() => {
-    //THIS IS THE OLD APPROACH I AM NOT SURE IF THEY ARE EQUAL
-    /* componentDidMount() {
-      if ((!atom || (atomToLoad && !atomLoading))) {
-        dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
-      }
-    }
-
-    componentDidUpdate(prevProps) {
-      // Invoke possible fetch if:
-      //    - atomUri is present AND
-      //        - atomUri has changed OR
-      //        - loginStatus has changed to loggedOut
-      if (
-        (atomUri !== prevProps.atomUri || (!isLoggedIn && prevProps.isLoggedIn))
-      ) {
-        if (!atom || (atomToLoad && !atomLoading)) {
-          dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
-        }
-      }
-    } */
-
-    //COMBINED:
-    if (atomUri && ((atomToLoad && !atomLoading) || !atom)) {
-      dispatch(actionCreators.atoms__fetchUnloadedAtom(atomUri));
-    }
-  });
-
-  let atomContentElement;
-
-  if (atomLoading) {
-    atomContentElement = (
-      <div className="pc__loading">
-        <svg className="pc__loading__spinner hspinner">
-          <use xlinkHref={ico_loading_anim} href={ico_loading_anim} />
-        </svg>
-        <span className="pc__loading__label">Loading...</span>
-      </div>
-    );
-  } else if (atomFailedToLoad) {
-    atomContentElement = (
-      <div className="pc__failed">
-        <svg className="pc__failed__icon">
-          <use xlinkHref={ico16_indicator_error} href={ico16_indicator_error} />
-        </svg>
-        <span className="pc__failed__label">
-          Failed To Load - Atom might have been deleted
-        </span>
-        <div className="pc__failed__actions">
-          <button
-            className="pc__failed__actions__button red won-button--outlined thin"
-            onClick={tryReload}
-          >
-            Try Reload
-          </button>
-        </div>
-      </div>
-    );
-  } else if (atom) {
-    atomContentElement = (
-      <WonAtomInfo
-        atom={atom}
-        ownedConnection={ownedConnection}
-        initialTab={tab}
-      />
-    );
-  }
 
   return (
     <section className={!isLoggedIn ? "won-signed-out" : ""}>
@@ -125,7 +40,13 @@ export default function PagePost() {
       {isLoggedIn && <WonMenu />}
       <WonToasts />
       {showSlideIns && <WonSlideIn />}
-      <main className="atomcontent">{atomContentElement}</main>
+      <main className="atomcontent">
+        <WonAtomInfo
+          atom={atom}
+          ownedConnection={ownedConnection}
+          initialTab={tab}
+        />
+      </main>
       <WonFooter />
     </section>
   );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
@@ -44,6 +44,7 @@ export default function PagePost() {
       <main className="atomcontent">
         <WonAtomInfo
           atom={atom}
+          atomUri={atomUri}
           ownedConnection={ownedConnection}
           initialTab={tab}
         />

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/post.jsx
@@ -18,8 +18,9 @@ import * as generalSelectors from "../../redux/selectors/general-selectors";
 
 export default function PagePost() {
   const history = useHistory();
-  const { postUri, connectionUri, tab } = getQueryParams(history.location);
-  const atomUri = postUri;
+  const { postUri: atomUri, connectionUri, tab } = getQueryParams(
+    history.location
+  );
   const atom = useSelector(generalSelectors.getAtom(atomUri));
   const ownedConnection = useSelector(
     generalSelectors.getOwnedConnection(connectionUri)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -471,7 +471,7 @@ export function generateShortFlagLabels(atomImm) {
 }
 
 export function getSockets(atomImm) {
-  return getIn(atomImm, ["content", "sockets"]);
+  return getIn(atomImm, ["content", "sockets"]) || Immutable.Map();
 }
 
 export function getSocketsWithKeysReset(atomImm) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-content.scss
@@ -104,7 +104,7 @@ won-atom-content {
       display: flex;
       justify-content: center;
 
-      > .pc__failed__actions__button {
+      > .atom-failedtoload__actions__button {
       }
     }
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-header-big.scss
@@ -2,6 +2,7 @@
 @import "flex-layout";
 @import "sizing-utils";
 @import "square-image";
+@import "animate";
 
 won-atom-header-big {
   display: grid;
@@ -38,6 +39,42 @@ won-atom-header-big {
       "icon title . . . ."
       "icon info actiontoggle actiontoggle actiontoggle actiontoggle";
     grid-template-columns: min-content 1fr min-content min-content min-content min-content;
+  }
+
+  &.won-failed-to-load,
+  &.won-to-load,
+  &.won-is-loading {
+    pointer-events: none;
+
+    .ahb__info {
+      height: $normalFontSize;
+      width: 5rem;
+      background-color: $won-skeleton-color;
+    }
+
+    .ahb__title {
+      height: $mediumFontSize;
+      width: 7rem;
+      background-color: $won-skeleton-color;
+    }
+
+    .ahb__icon__skeleton {
+      grid-area: icon;
+      background-color: $won-skeleton-color;
+      @media (min-width: $responsivenessBreakPoint) {
+        @include fixed-square(4.7rem);
+        margin: 0 1rem 1rem 0;
+      }
+      @media (max-width: $responsivenessBreakPoint) {
+        @include fixed-square($postIconSize);
+        margin: 0 0.5rem 0.5rem 0;
+      }
+    }
+  }
+
+  &.won-to-load,
+  &.won-is-loading {
+    @include animateOpacityHeartBeat();
   }
 
   > won-atom-icon {

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
@@ -29,43 +29,4 @@ won-atom-info {
     background: $won-secondary-color;
     color: white;
   }
-  &.won-is-loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 0;
-    > .ai__loading__spinner.hspinner {
-      @include fixed-square(5rem);
-    }
-    > .ai__loading__label {
-      color: $won-line-gray;
-      text-align: center;
-    }
-  }
-  &.won-failed-to-load {
-    display: grid;
-    grid-template-areas: "failed_icon failed_label" "failed_actions failed_actions";
-    grid-template-rows: min-content min-content;
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 0.5rem;
-    grid-gap: 0.5rem;
-    > .ai__failed__icon {
-      grid-area: failed_icon;
-      @include fixed-square(5rem);
-      --local-primary: #{$won-primary-color};
-    }
-    > .ai__failed__label {
-      grid-area: failed_label;
-      text-align: center;
-    }
-    > .ai__failed__actions {
-      grid-area: failed_actions;
-      display: flex;
-      justify-content: center;
-      > .ai__failed__actions__button {
-      }
-    }
-  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_atom-info.scss
@@ -29,4 +29,43 @@ won-atom-info {
     background: $won-secondary-color;
     color: white;
   }
+  &.won-is-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 0;
+    > .ai__loading__spinner.hspinner {
+      @include fixed-square(5rem);
+    }
+    > .ai__loading__label {
+      color: $won-line-gray;
+      text-align: center;
+    }
+  }
+  &.won-failed-to-load {
+    display: grid;
+    grid-template-areas: "failed_icon failed_label" "failed_actions failed_actions";
+    grid-template-rows: min-content min-content;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 0.5rem;
+    grid-gap: 0.5rem;
+    > .ai__failed__icon {
+      grid-area: failed_icon;
+      @include fixed-square(5rem);
+      --local-primary: #{$won-primary-color};
+    }
+    > .ai__failed__label {
+      grid-area: failed_label;
+      text-align: center;
+    }
+    > .ai__failed__actions {
+      grid-area: failed_actions;
+      display: flex;
+      justify-content: center;
+      > .ai__failed__actions__button {
+      }
+    }
+  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_inventory.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_inventory.scss
@@ -67,24 +67,6 @@ main.ownerwelcome {
   }
 }
 
-main.ownerloading {
-  grid-column: 1 / -1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 5rem 0;
-
-  > .ownerloading__spinner.hspinner {
-    @include fixed-square(5rem);
-  }
-
-  > .ownerloading__label {
-    color: $won-line-gray;
-    text-align: center;
-  }
-}
-
 main.ownerinventory {
   grid-column: 1 / -1;
   padding: 0;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_post.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_post.scss
@@ -28,47 +28,4 @@ main.atomcontent {
       padding: 0.5rem;
     }
   }
-
-  & > .pc__loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 0;
-
-    > .pc__loading__spinner.hspinner {
-      @include fixed-square(5rem);
-    }
-    > .pc__loading__label {
-      color: $won-line-gray;
-      text-align: center;
-    }
-  }
-
-  & > .pc__failed {
-    display: grid;
-    grid-template-areas: "failed_icon failed_label" "failed_actions failed_actions";
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 0.5rem;
-    grid-gap: 0.5rem;
-
-    > .pc__failed__icon {
-      grid-area: failed_icon;
-      @include fixed-square(5rem);
-      --local-primary: #{$won-primary-color};
-    }
-    > .pc__failed__label {
-      grid-area: failed_label;
-      text-align: center;
-    }
-    > .pc__failed__actions {
-      grid-area: failed_actions;
-      display: flex;
-      justify-content: center;
-
-      > .pc__failed__actions__button {
-      }
-    }
-  }
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/won.scss
@@ -277,3 +277,21 @@ main.settings won-svg-icon {
     @include fixed-square($postIconSize);
   }
 }
+
+main.ownerloading {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 5rem 0;
+
+  > .ownerloading__spinner.hspinner {
+    @include fixed-square(5rem);
+  }
+
+  > .ownerloading__label {
+    color: $won-line-gray;
+    text-align: center;
+  }
+}

--- a/webofneeds/won-owner-webapp/src/main/webapp/sw.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/sw.js
@@ -78,7 +78,7 @@ async function openNotifiedPage(event) {
       ? `${self.registration.scope}#!/post?postUri=${atomUri}` // when deeplink works, change this to `/connections?connectionUri=${connectionUri}` see https://github.com/researchstudio-sat/webofneeds/issues/2985
       : `${
           self.registration.scope
-        }#!/connections?connectionUri=${connectionUri}`;
+        }#!/connections?postUri=${atomUri}&connectionUri=${connectionUri}`;
   console.log(targetUri);
 
   if (urlWindows.length > 0) {


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently the initialLoad (on login, or page load) will fetch all owned Atoms incl. their connections, this is rather slow for Users with alot of owned Atoms


## What is the new behavior?
Initial Load only fetches MetaData now (all owned atomUris incl. their metaInfo eg. atomType state etc)
- Connection View: Fetches all ownedAtoms incl their connections if there is no postUri in the url -> non deep link)
- Chat-Textfield and Create-atom fetches the owned unloaded Personas (so that the personapicker in the publish/send button is present)
- Atom-info fetches an atom if it is not loaded in the state yet (inventory would have not fetched personas otherwise)

Everything else stays the same since the fetch of unloaded atoms was already implemented in most components anyway

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
