### PR TITLE
Implement Modify ServiceAtom, Adapt "What's New"-Page

### DIFF
--- a/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomBehaviour.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomBehaviour.java
@@ -139,7 +139,6 @@ public class ServiceAtomBehaviour extends BotBehaviour {
 
                             private void modifyServiceAtom(ServiceAtomModelWrapper oldServiceAtomModelWrapper) {
                                 final URI atomUri = URI.create(oldServiceAtomModelWrapper.getAtomUri());
-
                                 // Replace placeholder socketUris with existing socketUris
                                 // if socketType was present before modification
                                 Map<String, String> oldServiceAtomSocketsInverse = oldServiceAtomModelWrapper

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomContent.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomContent.java
@@ -1,6 +1,12 @@
 package won.bot.framework.extensions.serviceatom;
 
+import won.protocol.vocabulary.WXCHAT;
+import won.protocol.vocabulary.WXHOLD;
+import won.protocol.vocabulary.WXSCHEMA;
+
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class ServiceAtomContent {
@@ -8,9 +14,22 @@ public class ServiceAtomContent {
     private String description;
     private String termsOfService;
     private Collection<String> tags;
+    private Map<String, String> sockets;
 
     public ServiceAtomContent(String name) {
+        this(name, null);
+    }
+
+    public ServiceAtomContent(String name, Map<String, String> sockets) {
         this.name = name;
+        if (sockets == null) {
+            this.sockets = new HashMap<String, String>();
+            this.sockets.put("#HolderSocket", WXHOLD.HolderSocketString);
+            this.sockets.put("#ChatSocket", WXCHAT.ChatSocketString);
+            this.sockets.put("#sReviewSocket", WXSCHEMA.ReviewSocketString);
+        } else {
+            this.sockets = sockets;
+        }
     }
 
     public String getName() {
@@ -45,6 +64,14 @@ public class ServiceAtomContent {
         this.tags = tags;
     }
 
+    public void setSockets(Map<String, String> sockets) {
+        this.sockets = sockets;
+    }
+
+    public Map<String, String> getSockets() {
+        return sockets;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -52,10 +79,24 @@ public class ServiceAtomContent {
         if (o == null || getClass() != o.getClass())
             return false;
         ServiceAtomContent that = (ServiceAtomContent) o;
+        if (that.sockets != null && sockets != null) {
+            if (that.sockets.size() != sockets.size()) {
+                return false;
+            } else {
+                for (String socketTypeUri : sockets.values()) {
+                    if (!that.sockets.containsValue(socketTypeUri)) {
+                        return false;
+                    }
+                }
+            }
+        } else if (that.sockets != sockets) {
+            return false;
+        }
         return name.equals(that.name) &&
                         Objects.equals(description, that.description) &&
                         Objects.equals(termsOfService, that.termsOfService) &&
-                        Objects.equals(tags, that.tags);
+                        ((tags == null && that.tags == null) || tags != null && tags.containsAll(that.tags)
+                                        && that.tags != null && that.tags.containsAll(tags));
     }
 
     @Override

--- a/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomModelWrapper.java
+++ b/webofneeds/won-bot/src/main/java/won/bot/framework/extensions/serviceatom/ServiceAtomModelWrapper.java
@@ -8,11 +8,12 @@ import won.protocol.util.DefaultAtomModelWrapper;
 import won.protocol.vocabulary.*;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class ServiceAtomModelWrapper extends DefaultAtomModelWrapper {
-    // TODO: ADD MORE SERVICE BOT ATOM CONTENT MAKE SOCKETS CONFIGURABLE
-    private ServiceAtomContent serviceAtomContent;
+    private final ServiceAtomContent serviceAtomContent;
 
     public ServiceAtomModelWrapper(URI atomUri, ServiceAtomContent serviceAtomContent) {
         this(atomUri.toString(), serviceAtomContent);
@@ -25,18 +26,20 @@ public class ServiceAtomModelWrapper extends DefaultAtomModelWrapper {
         // SET RDF STRUCTURE
         Resource atom = this.getAtomModel().createResource(atomUri);
         atom.addProperty(RDF.type, WXBOT.ServiceAtom);
-        this.addSocket("#HolderSocket", WXHOLD.HolderSocketString);
-        this.addSocket("#ChatSocket", WXCHAT.ChatSocketString);
-        this.addSocket("#sReviewSocket", WXSCHEMA.ReviewSocketString);
-        this.setDefaultSocket("#ChatSocket");
+        if (Objects.nonNull(serviceAtomContent.getSockets())) {
+            serviceAtomContent.getSockets().forEach(this::addSocket);
+        }
         if (Objects.nonNull(serviceAtomContent.getName())) {
             this.setName(serviceAtomContent.getName());
         }
         if (Objects.nonNull(serviceAtomContent.getDescription())) {
-            this.setDescription(serviceAtomContent.getDescription());
+            atom.addProperty(SCHEMA.DESCRIPTION, serviceAtomContent.getDescription());
         }
         if (Objects.nonNull(serviceAtomContent.getTermsOfService())) {
             atom.addProperty(SCHEMA.TERMS_OF_SERVICE, serviceAtomContent.getTermsOfService());
+        }
+        if (Objects.nonNull(serviceAtomContent.getTags())) {
+            serviceAtomContent.getTags().forEach(tag -> atom.addProperty(WONCON.tag, tag));
         }
     }
 
@@ -45,6 +48,11 @@ public class ServiceAtomModelWrapper extends DefaultAtomModelWrapper {
         serviceAtomContent = new ServiceAtomContent(this.getSomeName());
         serviceAtomContent.setDescription(this.getSomeDescription());
         serviceAtomContent.setTermsOfService(getSomeContentPropertyStringValue(SCHEMA.TERMS_OF_SERVICE));
+        serviceAtomContent.setTags(this.getTags(this.getAtomContentNode()));
+        Map<String, String> sockets = new HashMap<>();
+        this.getSocketTypeUriMap().forEach(
+                        (socketUri, socketTypeUri) -> sockets.put(socketUri.toString(), socketTypeUri.toString()));
+        serviceAtomContent.setSockets(sockets);
     }
 
     public ServiceAtomContent getServiceAtomContent() {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/AtomModelWrapper.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/AtomModelWrapper.java
@@ -473,6 +473,10 @@ public class AtomModelWrapper {
         socket.addProperty(WON.socketDefinition, socketType);
     }
 
+    /**
+     * @deprecated Default Socket is not used anymore, will be removed soon
+     */
+    @Deprecated
     public void setDefaultSocket(String socketUri) {
         if (socketUri.startsWith("#")) {
             socketUri = getAtomUri() + socketUri;
@@ -484,6 +488,10 @@ public class AtomModelWrapper {
         getAtomContentNode().addProperty(WON.defaultSocket, socket);
     }
 
+    /**
+     * @deprecated Default Socket is not used anymore, will be removed soon
+     */
+    @Deprecated
     public Optional<String> getDefaultSocket() {
         Statement stmt = getAtomContentNode().getProperty(WON.defaultSocket);
         if (stmt == null)

--- a/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/WonRdfUtils.java
@@ -962,6 +962,7 @@ public class WonRdfUtils {
          * @param model
          * @param subject
          * @param returnAnyIfNoDefaultFound
+         * @deprecated Default Socket is not used anymore, will be removed soon
          * @return
          */
         public static Optional<URI> getDefaultSocket(Model model, Resource subject, boolean returnAnyIfNoDefaultFound) {
@@ -992,7 +993,10 @@ public class WonRdfUtils {
          * 
          * @param model
          * @param socketURI
+         * @deprecated will be removed, use
+         * {@link SocketUtils#addSocket(Model, URI, URI)} instead
          */
+        @Deprecated
         public static void addSocket(final Model model, final URI socketURI, final URI socketTypeURI,
                         final boolean isDefaultSocket) {
             Resource baseRes = RdfUtils.getBaseResource(model);
@@ -1007,10 +1011,35 @@ public class WonRdfUtils {
             }
         }
 
+        /**
+         * Adds a triple to the model of the form {@literal <>} won:socket [socketURI].
+         *
+         * @param model
+         * @param socketURI
+         */
+        public static void addSocket(final Model model, final URI socketURI, final URI socketTypeURI) {
+            Resource baseRes = RdfUtils.getBaseResource(model);
+            Resource socket = model.createResource(socketURI.toString());
+            baseRes.addProperty(WON.socket, socket);
+            socket.addProperty(WON.socketDefinition, model.createResource(socketTypeURI.toString()));
+        }
+
+        /**
+         * @deprecated will be removed, use
+         * {@link SocketUtils#addSocket(Dataset, URI, URI)} instead
+         */
+        @Deprecated
         public static void addSocket(final Dataset dataset, final URI socketURI, final URI socketTypeURI,
                         final boolean isDefaultSocket) {
             visit(dataset, model -> {
                 addSocket(model, socketURI, socketTypeURI, isDefaultSocket);
+                return null;
+            });
+        }
+
+        public static void addSocket(final Dataset dataset, final URI socketURI, final URI socketTypeURI) {
+            visit(dataset, model -> {
+                addSocket(model, socketURI, socketTypeURI);
                 return null;
             });
         }

--- a/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/vocabulary/WON.java
@@ -47,6 +47,10 @@ public class WON {
     public static final Property contentGraph = m.createProperty(BASE_URI, "contentGraph");
     public static final Property derivedGraph = m.createProperty(BASE_URI, "derivedGraph");
     public static final Property socket = m.createProperty(BASE_URI, "socket");
+    /**
+     * @deprecated Default Socket is not used anymore, will be removed soon
+     */
+    @Deprecated
     public static final Property defaultSocket = m.createProperty(BASE_URI, "defaultSocket");
     public static final Resource Socket = m.createResource(BASE_URI + "Socket");
     public static final Property compatibleSocketDefinition = m.createProperty(BASE_URI + "compatibleSocketDefinition");

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/connections-actions.js
@@ -620,7 +620,9 @@ export function connectionsRate(connectionUri, rating) {
     const connection = atomUtils.getConnection(ownedAtom, connectionUri);
 
     const theirAtomUri = connectionUtils.getTargetAtomUri(connection);
-    const theirConnectionUri = get(connection, "targetConnectionUri");
+    const theirConnectionUri = connectionUtils.getTargetConnectionUri(
+      connection
+    );
     const theirAtom = generalSelectors.getAtom(theirAtomUri)(state);
 
     won

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card-grid.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card-grid.jsx
@@ -4,7 +4,7 @@
 
 import React from "react";
 import WonAtomCard from "./atom-card.jsx";
-import { getUri, generateLink } from "../utils.js";
+import { generateLink } from "../utils.js";
 import PropTypes from "prop-types";
 
 import ico32_buddy_add from "~/images/won-icons/ico32_buddy_add.svg";
@@ -19,14 +19,14 @@ export default function WonAtomCardGrid({
   showCreatePersona,
   currentLocation,
 }) {
-  //TODO: REFACTOR THIS COMPONENT TO RETRIEVE A atomsImm Map instead of an array
-  const atomCards =
-    atoms &&
-    atoms.map(atom => {
-      return (
+  const atomCardElements = [];
+
+  atoms &&
+    atoms.map((atom, atomUri) => {
+      atomCardElements.push(
         <WonAtomCard
-          key={getUri(atom)}
-          atomUri={getUri(atom)}
+          key={atomUri}
+          atomUri={atomUri}
           atom={atom}
           showHolder={showHolder}
           showIndicators={showIndicators}
@@ -76,12 +76,12 @@ export default function WonAtomCardGrid({
     <React.Fragment>
       {createAtom}
       {createPersonaAtom}
-      {atomCards}
+      {atomCardElements}
     </React.Fragment>
   );
 }
 WonAtomCardGrid.propTypes = {
-  atoms: PropTypes.arrayOf(PropTypes.object).isRequired,
+  atoms: PropTypes.object,
   showHolder: PropTypes.bool,
   showIndicators: PropTypes.bool,
   showCreate: PropTypes.bool,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card.jsx
@@ -2,8 +2,8 @@
  * Created by quasarchimaere on 30.07.2019.
  */
 import React from "react";
-import { get, getIn } from "../utils.js";
 
+import * as atomUtils from "../redux/utils/atom-utils.js";
 import * as processUtils from "../redux/utils/process-utils.js";
 import * as generalSelectors from "../redux/selectors/general-selectors.js";
 import WonOtherCard from "./cards/other-card.jsx";
@@ -25,11 +25,11 @@ export default function WonAtomCard({
 }) {
   const processState = useSelector(generalSelectors.getProcessState);
   const isSkeleton =
-    get(atom, "isBeingCreated") ||
+    atomUtils.isBeingCreated(atom) ||
     processUtils.hasAtomFailedToLoad(processState, atomUri) ||
     processUtils.isAtomFetchNecessary(processState, atomUri, atom);
 
-  const matchedUseCase = getIn(atom, ["matchedUseCase", "identifier"]);
+  const matchedUseCase = atomUtils.getMatchedUseCaseIdentifier(atom);
 
   let cardContent;
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
@@ -131,9 +131,9 @@ export default function WonAtomContent({
 
     switch (visibleTab) {
       case "DETAIL": {
-        const content = get(atom, "content");
+        const content = atomUtils.getContent(atom);
         //TODO it will be possible to have more than one seeks
-        const seeks = get(atom, "seeks");
+        const seeks = atomUtils.getSeeks(atom);
 
         /**
          * This function checks if there is at least one detail present that is displayable

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-chats.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-chats.jsx
@@ -6,7 +6,6 @@ import vocab from "../../service/vocab.js";
 import {
   getUri,
   generateLink,
-  sortByDate,
   filterConnectionsBySearchValue,
   filterAtomsBySearchValue,
 } from "../../utils.js";
@@ -74,29 +73,36 @@ export default function AtomContentChats({
   );
 
   function generateConnectionItems(connections) {
-    const connectionsArray = sortByDate(connections) || [];
+    const connectionElements = [];
+    connections &&
+      connections
+        .toOrderedMap()
+        .sortBy(conn => {
+          const lastUpdateDate = connectionUtils.getLastUpdateDate(conn);
+          return lastUpdateDate && lastUpdateDate.getTime();
+        })
+        .reverse()
+        .map((conn, connUri) => {
+          connectionElements.push(
+            <div className="acc__item" key={connUri}>
+              <WonConnectionSelectionItem
+                connection={conn}
+                toLink={generateLink(
+                  history.location,
+                  {
+                    postUri: getUri(atom),
+                    connectionUri: connUri,
+                  },
+                  "/connections",
+                  false
+                )}
+                flip={!isAtomOwned}
+              />
+            </div>
+          );
+        });
 
-    return connectionsArray.map((conn, index) => {
-      const connUri = getUri(conn);
-
-      return (
-        <div className="acc__item" key={connUri + "-" + index}>
-          <WonConnectionSelectionItem
-            connection={conn}
-            toLink={generateLink(
-              history.location,
-              {
-                postUri: getUri(atom),
-                connectionUri: connUri,
-              },
-              "/connections",
-              false
-            )}
-            flip={!isAtomOwned}
-          />
-        </div>
-      );
-    });
+    return connectionElements;
   }
 
   function generateHeaderItem(label, size, toggleFunction, isExpanded) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-general.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-general.jsx
@@ -4,7 +4,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as generalSelectors from "../../redux/selectors/general-selectors";
-import { get } from "../../utils.js";
 import * as atomUtils from "../../redux/utils/atom-utils.js";
 import { relativeTime } from "../../won-label-utils.js";
 import * as viewUtils from "../../redux/utils/view-utils.js";
@@ -15,8 +14,8 @@ import "~/style/_atom-content-general.scss";
 export default function WonAtomContentGeneral({ atom }) {
   const viewState = useSelector(generalSelectors.getViewState);
 
-  const creationDate = get(atom, "creationDate");
-  const modifiedDate = get(atom, "modifiedDate");
+  const creationDate = atomUtils.getCreationDate(atom);
+  const modifiedDate = atomUtils.getModifiedDate(atom);
 
   const typeLabel = atom && atomUtils.generateTypeLabel(atom);
   const fullFlagLabels = atom && atomUtils.generateFullFlagLabels(atom);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content/atom-content-socket.jsx
@@ -38,6 +38,7 @@ export default function WonAtomContentSocket({
   setVisibleTab,
 }) {
   const accountState = useSelector(generalSelectors.getAccountState);
+  const currentLocation = useSelector(generalSelectors.getCurrentLocation);
   const isAtomOwned = accountUtils.isAtomOwned(accountState, getUri(atom));
 
   const [showRequestReceived, toggleRequestReceived] = useState(false);
@@ -103,6 +104,7 @@ export default function WonAtomContentSocket({
             <ItemComponent
               key={connUri}
               connection={conn}
+              currentLocation={currentLocation}
               atom={
                 flip
                   ? get(storedAtoms, extractAtomUriFromConnectionUri(connUri))

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-editor/branch-detail-input.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-editor/branch-detail-input.jsx
@@ -49,7 +49,6 @@ export default function WonBranchDetailInput({
 
           const detailJS = detailImm.toJS();
           const DetailComponent = detailJS.component;
-          const generateHumanReadable = detailJS.generateHumanReadable;
 
           const detailValueJS =
             draftObjectJS && draftObjectJS[detailIdentifier];
@@ -94,7 +93,7 @@ export default function WonBranchDetailInput({
                 {hasDetailValue &&
                   !isDetailExpanded && (
                     <div className="bdi__detail__items__item__header__content">
-                      {generateHumanReadable({
+                      {detailJS.generateHumanReadable({
                         value: detailValueJS,
                         includeLabel: false,
                       })}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -264,7 +264,7 @@ export default function WonAtomHeaderBig({
     const holderName =
       atomUtils.hasHoldableSocket(atom) && !atomUtils.hasGroupSocket(atom)
         ? atomUtils.getTitle(holderAtom, externalDataState) ||
-          get(atom, "fakePersonaName")
+          atomUtils.getFakePersonaName(atom)
         : undefined;
 
     const holderNameElement = holderName && (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { Link } from "react-router-dom";
-import { get, getUri } from "../utils.js";
+import { getUri } from "../utils.js";
 import { actionCreators } from "../actions/actions.js";
 import { relativeTime } from "../won-label-utils.js";
 import * as generalSelectors from "../redux/selectors/general-selectors.js";
@@ -47,7 +47,7 @@ export default function WonAtomHeader({
   const friendlyTimestamp =
     !hideTimestamp &&
     atom &&
-    relativeTime(globalUpdateTimestamp, get(atom, "lastUpdateDate"));
+    relativeTime(globalUpdateTimestamp, atomUtils.getLastUpdateDate(atom));
 
   const title = atomUtils.getTitle(atom, externalDataState);
 
@@ -107,7 +107,7 @@ export default function WonAtomHeader({
         </div>
       </VisibilitySensor>
     );
-  } else if (get(atom, "isBeingCreated")) {
+  } else if (atomUtils.isBeingCreated(atom)) {
     //In Creation View
     atomHeaderIcon = <WonAtomIcon atom={atom} />;
     atomHeaderContent = (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
@@ -8,7 +8,6 @@ import * as messageUtils from "../redux/utils/message-utils";
 import { rdfTextfieldHelpText } from "../won-label-utils.js";
 import {
   get,
-  getIn,
   getUri,
   generateLink,
   extractAtomUriFromConnectionUri,
@@ -72,7 +71,7 @@ export default function WonAtomMessages({
   const chatMessages =
     messages &&
     messages
-      .filter(msg => !get(msg, "forwardMessage"))
+      .filter(msg => !messageUtils.getForwardMessage(msg))
       .filter(msg => !messageUtils.isAtomHintMessage(msg))
       .filter(msg => !messageUtils.isSocketHintMessage(msg));
 
@@ -82,9 +81,9 @@ export default function WonAtomMessages({
     connectionUri
   );
 
-  const agreementData = get(connection, "agreementData");
-  const agreementDataset = get(connection, "agreementDataset");
-  const petriNetData = get(connection, "petriNetData");
+  const agreementData = connectionUtils.getAgreementData(connection);
+  const agreementDataset = connectionUtils.getAgreementDataset(connection);
+  const petriNetData = connectionUtils.getPetriNetData(connection);
 
   //TODO: calculate this based on the uris in the agreementData and not based on every possible message
   const agreementMessages =
@@ -108,11 +107,11 @@ export default function WonAtomMessages({
   const showChatData =
     connection &&
     !(
-      get(connection, "showAgreementData") ||
-      get(connection, "showPetriNetData")
+      connectionUtils.showAgreementData(connection) ||
+      connectionUtils.showPetriNetData(connection)
     );
 
-  const multiSelectType = get(connection, "multiSelectType");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
 
   const unreadMessageCount = unreadMessages && unreadMessages.size;
   const isProcessingLoadingMessages =
@@ -130,8 +129,8 @@ export default function WonAtomMessages({
       processState,
       connectionUri
     );
-  const showAgreementData = get(connection, "showAgreementData");
-  const showPetriNetData = get(connection, "showPetriNetData");
+  const showAgreementData = connectionUtils.showAgreementData(connection);
+  const showPetriNetData = connectionUtils.showPetriNetData(connection);
   const petriNetDataArray = petriNetData ? petriNetData.toArray() : [];
   const agreementDataLoaded =
     agreementData &&
@@ -352,7 +351,7 @@ export default function WonAtomMessages({
           messageUri: msgUri,
           connectionUri: connectionUri,
           atomUri: senderAtomUri,
-          isSelected: !getIn(msg, ["viewState", "isSelected"]),
+          isSelected: !messageUtils.isMessageSelected(msg),
         })
       );
     }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-messages.jsx
@@ -646,7 +646,6 @@ export default function WonAtomMessages({
               message={msg}
               connection={connection}
               senderAtom={senderAtom}
-              targetAtom={targetAtom}
               processState={processState}
               allAtoms={allAtoms}
               ownedConnections={ownedConnections}
@@ -733,7 +732,6 @@ export default function WonAtomMessages({
             message={msg}
             connection={connection}
             senderAtom={senderAtom}
-            targetAtom={targetAtom}
             processState={processState}
             allAtoms={allAtoms}
             ownedConnections={ownedConnections}
@@ -754,7 +752,6 @@ export default function WonAtomMessages({
             message={msg}
             connection={connection}
             senderAtom={senderAtom}
-            targetAtom={targetAtom}
             processState={processState}
             allAtoms={allAtoms}
             ownedConnections={ownedConnections}
@@ -775,7 +772,6 @@ export default function WonAtomMessages({
             message={msg}
             connection={connection}
             senderAtom={senderAtom}
-            targetAtom={targetAtom}
             processState={processState}
             allAtoms={allAtoms}
             ownedConnections={ownedConnections}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/skeleton-card.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/skeleton-card.jsx
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import VisibilitySensor from "react-visibility-sensor";
 import WonAtomConnectionsIndicator from "../atom-connections-indicator.jsx";
 import * as processUtils from "../../redux/utils/process-utils.js";
-import { get } from "../../utils.js";
+import * as atomUtils from "../../redux/utils/atom-utils.js";
 import { actionCreators } from "../../actions/actions.js";
 import { useDispatch } from "react-redux";
 
@@ -21,7 +21,7 @@ export default function WonSkeletonCard({
 }) {
   const dispatch = useDispatch();
 
-  const atomInCreation = get(atom, "isBeingCreated");
+  const atomInCreation = atomUtils.isBeingCreated(atom);
   const atomFailedToLoad = processUtils.hasAtomFailedToLoad(
     processState,
     atomUri

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/snippets/content-snippet.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/snippets/content-snippet.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { generateLink, get, getIn, getUri } from "~/app/utils";
+import { generateLink, get, getUri } from "~/app/utils";
 import { Link } from "react-router-dom";
 import * as atomUtils from "~/app/redux/utils/atom-utils";
 import WonAtomMap from "~/app/components/atom-map";
@@ -38,11 +38,12 @@ export function generateSwipeableContent(
           );
       });
   };
-  generateWikiDataImages(getIn(atom, ["content", "eventObjectAboutUris"]));
-  generateWikiDataImages(getIn(atom, ["content", "classifiedAs"]));
+  const atomContent = atomUtils.getContent(atom);
+  generateWikiDataImages(get(atomContent, "eventObjectAboutUris"));
+  generateWikiDataImages(get(atomContent, "classifiedAs"));
 
   // Add Pokemon Image if pokemonRaid detail is set
-  const pokemonRaid = getIn(atom, ["content", "pokemonRaid"]);
+  const pokemonRaid = get(atomContent, "pokemonRaid");
   const pokemonId = get(pokemonRaid, "id");
   const pokemon =
     pokemonId &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/snippets/main-snippet.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/snippets/main-snippet.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import { generateLink, get, getUri } from "~/app/utils";
+import { generateLink, getUri } from "~/app/utils";
 import * as atomUtils from "~/app/redux/utils/atom-utils";
 import * as generalSelectors from "~/app/redux/selectors/general-selectors";
 import { relativeTime } from "~/app/won-label-utils";
@@ -20,7 +20,8 @@ export default function WonMainSnippet({ atom, showIcon, externalDataState }) {
     generalSelectors.selectLastUpdateTime
   );
   const friendlyTimestamp =
-    atom && relativeTime(globalLastUpdateTime, get(atom, "lastUpdateDate"));
+    atom &&
+    relativeTime(globalLastUpdateTime, atomUtils.getLastUpdateDate(atom));
 
   function createCardMainSubtitle() {
     const createGroupChatLabel = () => {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
@@ -93,8 +93,8 @@ export default function ChatTextfield({
     selectedDetailIdentifier &&
     get(allMessageDetailsImm, selectedDetailIdentifier);
 
-  const multiSelectType = get(connection, "multiSelectType");
-  const showAgreementData = get(connection, "showAgreementData");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
+  const showAgreementData = connectionUtils.showAgreementData(connection);
   const isChatToGroupConnection = connectionUtils.hasTargetSocketUri(
     connection,
     atomUtils.getGroupSocket(targetAtom)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/chat-textfield.jsx
@@ -659,6 +659,7 @@ export default function ChatTextfield({
       getAdditionalContentKeysArray().map((key, index) => {
         const usedDetailImm = get(allMessageDetailsImm, key);
         const usedDetail = usedDetailImm && usedDetailImm.toJS();
+        const usedDetailIcon = get(usedDetail, "icon");
 
         const humanReadableDetail =
           usedDetail &&
@@ -682,10 +683,7 @@ export default function ChatTextfield({
                 )
               }
             >
-              <use
-                xlinkHref={get(usedDetailImm, "icon")}
-                href={get(usedDetailImm, "icon")}
-              />
+              <use xlinkHref={usedDetailIcon} href={usedDetailIcon} />
             </svg>
             <span
               className="cts__additionalcontent__list__item__label clickable"

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-agreement-details.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-agreement-details.jsx
@@ -6,12 +6,12 @@ import * as N3 from "n3";
 import { usePrevious } from "../cstm-react-utils.js";
 import PropTypes from "prop-types";
 import won from "../service/won";
-import { get } from "../utils.js";
+import * as connectionUtils from "../redux/utils/connection-utils.js";
 
 import "../../style/_connection-agreement-details.scss";
 
 export default function WonConnectionAgreementDetails({ connection }) {
-  const lastAgreementDataset = get(connection, "agreementDataset");
+  const lastAgreementDataset = connectionUtils.getAgreementDataset(connection);
   const previousAgreementDataset =
     lastAgreementDataset &&
     usePrevious(lastAgreementDataset, useRef, useEffect);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-context-dropdown.jsx
@@ -58,8 +58,8 @@ export default function WonConnectionContextDropdown({
     connection,
     atomUtils.getGroupSocket(targetAtom)
   );
-  const showAgreementData = get(connection, "showAgreementData");
-  const showPetriNetData = get(connection, "showPetriNetData");
+  const showAgreementData = connectionUtils.showAgreementData(connection);
+  const showPetriNetData = connectionUtils.showPetriNetData(connection);
   const isClosed = connectionUtils.isClosed(connection);
   const isConnected = connectionUtils.isConnected(connection);
   const isSentRequest = connectionUtils.isRequestSent(connection);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/connection-header.jsx
@@ -270,7 +270,10 @@ export default function WonConnectionHeader({
       if (!hideTimestamp) {
         const friendlyTimestamp =
           connection &&
-          relativeTime(globalLastUpdateTime, get(connection, "lastUpdateDate"));
+          relativeTime(
+            globalLastUpdateTime,
+            connectionUtils.getLastUpdateDate(connection)
+          );
         timeStampElement = friendlyTimestamp ? (
           <div className="ch__right__subtitle__date">{friendlyTimestamp}</div>
         ) : (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/picker/suggest-atom-picker.jsx
@@ -23,7 +23,7 @@ const mapStateToProps = (state, ownProps) => {
   const hasAtLeastOneAllowedSocket = (atom, allowedSockets) => {
     if (allowedSockets) {
       const allowedSocketsImm = Immutable.fromJS(allowedSockets);
-      const atomSocketsImm = getIn(atom, ["content", "sockets"]);
+      const atomSocketsImm = atomUtils.getSockets(atom);
 
       return (
         atomSocketsImm &&

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/amount-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/amount-viewer.jsx
@@ -3,33 +3,31 @@ import React from "react";
 import "~/style/_price-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonAmountViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="pricev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonAmountViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="pricev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="pricev__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="pricev__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-price-viewer class={this.props.className}>
-        <div className="pricev__header">
-          {icon}
-          {label}
-        </div>
-        <div className="pricev__content">
-          {this.props.detail.generateHumanReadable({
-            value: this.props.content.toJS(),
-            includeLabel: false,
-          })}
-        </div>
-      </won-price-viewer>
-    );
-  }
+  return (
+    <won-price-viewer class={className}>
+      <div className="pricev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="pricev__content">
+        {detail.generateHumanReadable({
+          value: content.toJS(),
+          includeLabel: false,
+        })}
+      </div>
+    </won-price-viewer>
+  );
 }
 WonAmountViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/datetime-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/datetime-viewer.jsx
@@ -3,32 +3,28 @@ import React from "react";
 import "~/style/_datetime-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonDateTimeViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="datetimev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonDateTimeViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="datetimev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="datetimev__header__label">
-        {this.props.detail.label}
-      </span>
-    );
+  const label = detail.icon && (
+    <span className="datetimev__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-datetime-viewer class={this.props.className}>
-        <div className="datetimev__header">
-          {icon}
-          {label}
-        </div>
-        <div className="datetimev__content">
-          {this.props.content && this.props.content.toLocaleString()}
-        </div>
-      </won-datetime-viewer>
-    );
-  }
+  return (
+    <won-datetime-viewer class={className}>
+      <div className="datetimev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="datetimev__content">
+        {content && content.toLocaleString()}
+      </div>
+    </won-datetime-viewer>
+  );
 }
 WonDateTimeViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/dropdown-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/dropdown-viewer.jsx
@@ -3,30 +3,26 @@ import React from "react";
 import "~/style/_dropdown-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonDropdownViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="dropdownv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonDropdownViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="dropdownv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="dropdownv__header__label">
-        {this.props.detail.label}
-      </span>
-    );
+  const label = detail.icon && (
+    <span className="dropdownv__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-dropdown-viewer class={this.props.className}>
-        <div className="dropdownv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="dropdownv__content">{this.props.content}</div>
-      </won-dropdown-viewer>
-    );
-  }
+  return (
+    <won-dropdown-viewer class={className}>
+      <div className="dropdownv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="dropdownv__content">{content}</div>
+    </won-dropdown-viewer>
+  );
 }
 WonDropdownViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/file-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/file-viewer.jsx
@@ -5,77 +5,57 @@ import "~/style/_file-viewer.scss";
 import ico36_uc_transport_demand from "~/images/won-icons/ico36_uc_transport_demand.svg";
 import PropTypes from "prop-types";
 
-export default class WonFileViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="filev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonFileViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="filev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="filev__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="filev__header__label">{detail.label}</span>
+  );
 
-    const filesArray = this.props.content && this.props.content.toArray();
+  const filesArray = content && content.toArray();
 
-    const files =
-      filesArray &&
-      filesArray.map((file, index) => {
-        return (
-          <div className="filev__content__item" key={index}>
-            <a
-              className="filev__content__item__inner"
-              href={
-                "data:" +
-                get(file, "encodingFormat") +
-                ";base64," +
-                get(file, "encoding")
-              }
-              download={get(file, "name")}
-            >
-              <svg className="filev__content__item__inner__typeicon">
-                <use
-                  xlinkHref={ico36_uc_transport_demand}
-                  href={ico36_uc_transport_demand}
-                />
-              </svg>
-              <div className="filev__content__item__inner__label">
-                {get(file, "name")}
-              </div>
-            </a>
-          </div>
-        );
-      });
-
-    return (
-      <won-file-viewer class={this.props.className}>
-        <div className="filev__header">
-          {icon}
-          {label}
+  const files =
+    filesArray &&
+    filesArray.map((file, index) => {
+      return (
+        <div className="filev__content__item" key={index}>
+          <a
+            className="filev__content__item__inner"
+            href={
+              "data:" +
+              get(file, "encodingFormat") +
+              ";base64," +
+              get(file, "encoding")
+            }
+            download={get(file, "name")}
+          >
+            <svg className="filev__content__item__inner__typeicon">
+              <use
+                xlinkHref={ico36_uc_transport_demand}
+                href={ico36_uc_transport_demand}
+              />
+            </svg>
+            <div className="filev__content__item__inner__label">
+              {get(file, "name")}
+            </div>
+          </a>
         </div>
-        <div className="filev__content">{files}</div>
-      </won-file-viewer>
-    );
-  }
+      );
+    });
 
-  isImage(file) {
-    return file && /^image\//.test(file.get("encodingFormat"));
-  }
-
-  openImageInNewTab(file) {
-    if (file) {
-      let image = new Image();
-      image.src =
-        "data:" +
-        get(file, "encodingFormat") +
-        ";base64," +
-        get(file, "encoding");
-
-      let w = window.open("");
-      w.document.write(image.outerHTML);
-    }
-  }
+  return (
+    <won-file-viewer class={className}>
+      <div className="filev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="filev__content">{files}</div>
+    </won-file-viewer>
+  );
 }
 WonFileViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/image-viewer.jsx
@@ -1,104 +1,31 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { get } from "../../../utils.js";
 import "~/style/_image-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonImageViewer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedIndex: 0,
-    };
-  }
+export default function WonImageViewer({ detail, content, className }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="imagev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+  const icon = detail.icon && (
+    <svg className="imagev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="imagev__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="imagev__header__label">{detail.label}</span>
+  );
 
-    const imagesArray = this.props.content && this.props.content.toArray();
-
-    const thumbNails =
-      imagesArray &&
-      imagesArray.map((file, index) => {
-        if (this.isImage(file)) {
-          return (
-            <div
-              className={
-                "imagev__content__thumbnails__thumbnail " +
-                (this.state.selectedIndex == index
-                  ? "imagev__content__thumbnails__thumbnail--selected"
-                  : "")
-              }
-              key={index}
-            >
-              <img
-                className="imagev__content__thumbnails__thumbnail__image"
-                onClick={() => this.changeSelectedIndex(index)}
-                alt={get(file, "name")}
-                src={
-                  "data:" +
-                  get(file, "encodingFormat") +
-                  ";base64," +
-                  get(file, "encoding")
-                }
-              />
-            </div>
-          );
-        }
-      });
-
-    return (
-      <won-image-viewer class={this.props.className}>
-        <div className="imagev__header">
-          {icon}
-          {label}
-        </div>
-        <div className="imagev__content">
-          <div className="imagev__content__selected">
-            <img
-              className="imagev__content__selected__image"
-              onClick={() => this.openImageInNewTab(this.getSelectedImage())}
-              alt={this.getSelectedImage().get("name")}
-              src={
-                "data:" +
-                this.getSelectedImage().get("encodingFormat") +
-                ";base64," +
-                this.getSelectedImage().get("encoding")
-              }
-            />
-          </div>
-          {this.props.content.size > 1 && (
-            <div className="imagev__content__thumbnails">{thumbNails}</div>
-          )}
-        </div>
-      </won-image-viewer>
-    );
-  }
-
-  isImage(file) {
+  function isImage(file) {
     return file && /^image\//.test(file.get("encodingFormat"));
   }
 
-  changeSelectedIndex(index) {
-    this.setState({ selectedIndex: index });
+  function getSelectedImage() {
+    return content && content.toArray()[selectedIndex];
   }
 
-  getSelectedImage() {
-    return (
-      this.props.content &&
-      this.props.content.toArray()[this.state.selectedIndex]
-    );
-  }
-
-  openImageInNewTab(file) {
+  function openImageInNewTab(file) {
     if (file) {
       let image = new Image();
       image.src =
@@ -111,6 +38,65 @@ export default class WonImageViewer extends React.Component {
       w.document.write(image.outerHTML);
     }
   }
+
+  const imagesArray = content && content.toArray();
+
+  const thumbNails =
+    imagesArray &&
+    imagesArray.map((file, index) => {
+      if (isImage(file)) {
+        return (
+          <div
+            className={
+              "imagev__content__thumbnails__thumbnail " +
+              (selectedIndex == index
+                ? "imagev__content__thumbnails__thumbnail--selected"
+                : "")
+            }
+            key={index}
+          >
+            <img
+              className="imagev__content__thumbnails__thumbnail__image"
+              onClick={() => setSelectedIndex(index)}
+              alt={get(file, "name")}
+              src={
+                "data:" +
+                get(file, "encodingFormat") +
+                ";base64," +
+                get(file, "encoding")
+              }
+            />
+          </div>
+        );
+      }
+    });
+
+  return (
+    <won-image-viewer class={className}>
+      <div className="imagev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="imagev__content">
+        <div className="imagev__content__selected">
+          <img
+            className="imagev__content__selected__image"
+            onClick={() => openImageInNewTab(getSelectedImage())}
+            alt={getSelectedImage().get("name")}
+            src={
+              "data:" +
+              getSelectedImage().get("encodingFormat") +
+              ";base64," +
+              getSelectedImage().get("encoding")
+            }
+          />
+        </div>
+        {content.size > 1 && (
+          <div className="imagev__content__thumbnails">{thumbNails}</div>
+        )}
+      </div>
+    </won-image-viewer>
+  );
 }
 WonImageViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/location-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/location-viewer.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import "~/style/_location-viewer.scss";
 import ico_filter_map from "~/images/won-icons/ico-filter_map.svg";
@@ -8,74 +8,63 @@ import WonAtomMap from "../../atom-map.jsx";
 
 import PropTypes from "prop-types";
 
-export default class WonLocationViewer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      locationExpanded: false,
-    };
-  }
+export default function WonLocationViewer({ detail, content, className }) {
+  const [locationExpanded, toggleLocationExpanded] = useState(false);
 
-  toggleLocation() {
-    this.setState({ locationExpanded: !this.state.locationExpanded });
-  }
+  const icon = detail.icon && (
+    <svg className="lv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="lv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
+  const label = detail.icon && (
+    <span className="lv__header__label">{detail.label}</span>
+  );
+
+  const address = get(content, "address");
+  const addressElement = address ? (
+    <div
+      className="lv__content__text clickable"
+      onClick={() => toggleLocationExpanded(!locationExpanded)}
+    >
+      {address}
+      <svg className="lv__content__text__carret">
+        <use xlinkHref={ico_filter_map} href={ico_filter_map} />
       </svg>
-    );
-
-    const label = this.props.detail.icon && (
-      <span className="lv__header__label">{this.props.detail.label}</span>
-    );
-
-    const address = get(this.props.content, "address");
-    const addressElement = address ? (
-      <div
-        className="lv__content__text clickable"
-        onClick={this.toggleLocation.bind(this)}
+      <svg
+        className={
+          "lv__content__text__carret " +
+          (locationExpanded
+            ? " lv__content__text__carret--expanded "
+            : " lv__content__text__carret--collapsed ")
+        }
       >
-        {address}
-        <svg className="lv__content__text__carret">
-          <use xlinkHref={ico_filter_map} href={ico_filter_map} />
-        </svg>
-        <svg
-          className={
-            "lv__content__text__carret " +
-            (this.state.locationExpanded
-              ? " lv__content__text__carret--expanded "
-              : " lv__content__text__carret--collapsed ")
-          }
-        >
-          <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
-        </svg>
-      </div>
+        <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
+      </svg>
+    </div>
+  ) : (
+    undefined
+  );
+
+  const map =
+    content && locationExpanded ? (
+      <WonAtomMap locations={[content]} />
     ) : (
       undefined
     );
 
-    const map =
-      this.props.content && this.state.locationExpanded ? (
-        <WonAtomMap locations={[this.props.content]} />
-      ) : (
-        undefined
-      );
-
-    return (
-      <won-location-viewer class={this.props.className}>
-        <div className="lv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="lv__content">
-          {addressElement}
-          {map}
-        </div>
-      </won-location-viewer>
-    );
-  }
+  return (
+    <won-location-viewer class={className}>
+      <div className="lv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="lv__content">
+        {addressElement}
+        {map}
+      </div>
+    </won-location-viewer>
+  );
 }
 WonLocationViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/number-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/number-viewer.jsx
@@ -3,28 +3,26 @@ import React from "react";
 import "~/style/_number-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonNumberViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="numberv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonNumberViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="numberv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="numberv__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="numberv__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-number-viewer class={this.props.className}>
-        <div className="numberv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="numberv__content">{this.props.content}</div>
-      </won-number-viewer>
-    );
-  }
+  return (
+    <won-number-viewer class={className}>
+      <div className="numberv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="numberv__content">{content}</div>
+    </won-number-viewer>
+  );
 }
 WonNumberViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/paypal-payment-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/paypal-payment-viewer.jsx
@@ -4,60 +4,56 @@ import { get } from "../../../utils.js";
 import "~/style/_paypalpayment-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonPaypalPaymentViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="paypalpaymentv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonPaypalPaymentViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="paypalpaymentv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="paypalpaymentv__header__label">
-        {this.props.detail.label}
-      </span>
-    );
+  const label = detail.icon && (
+    <span className="paypalpaymentv__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-paypal-payment-viewer class={this.props.className}>
-        <div className="paypalpaymentv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="paypalpaymentv__content">
-          <div className="paypalpaymentv__content__label">
-            {this.props.detail.amountLabel}
-          </div>
-          <div className="paypalpaymentv__content__price">
-            {this.getPriceWithCurrency()}
-          </div>
-          <div className="paypalpaymentv__content__label">
-            {this.props.detail.receiverLabel}
-          </div>
-          <div className="paypalpaymentv__content__receiver">
-            {get(this.props.content, "receiver")}
-          </div>
-        </div>
-      </won-paypal-payment-viewer>
-    );
-  }
-
-  getPriceWithCurrency() {
-    if (this.props.content && this.props.detail) {
+  function getPriceWithCurrency() {
+    if (content && detail) {
       let currencyLabel = undefined;
 
-      this.props.detail.currency &&
-        this.props.detail.currency.forEach(curr => {
-          if (curr.value === get(this.props.content, "currency")) {
+      detail.currency &&
+        detail.currency.forEach(curr => {
+          if (curr.value === get(content, "currency")) {
             currencyLabel = curr.label;
           }
         });
-      currencyLabel = currencyLabel || this.content.get("currency");
+      currencyLabel = currencyLabel || content.get("currency");
 
-      return get(this.props.content, "amount") + currencyLabel;
+      return get(content, "amount") + currencyLabel;
     }
     return undefined;
   }
+
+  return (
+    <won-paypal-payment-viewer class={className}>
+      <div className="paypalpaymentv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="paypalpaymentv__content">
+        <div className="paypalpaymentv__content__label">
+          {detail.amountLabel}
+        </div>
+        <div className="paypalpaymentv__content__price">
+          {getPriceWithCurrency()}
+        </div>
+        <div className="paypalpaymentv__content__label">
+          {detail.receiverLabel}
+        </div>
+        <div className="paypalpaymentv__content__receiver">
+          {get(content, "receiver")}
+        </div>
+      </div>
+    </won-paypal-payment-viewer>
+  );
 }
 WonPaypalPaymentViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/person-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/person-viewer.jsx
@@ -4,69 +4,59 @@ import "~/style/_person-viewer.scss";
 import { get } from "../../../utils.js";
 import PropTypes from "prop-types";
 
-export default class WonPersonViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="pv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonPersonViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="pv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="pv__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="pv__header__label">{detail.label}</span>
+  );
 
-    const title = get(this.props.content, "title") && (
-      <React.Fragment>
-        <div className="pv__content__label">Title</div>
-        <div className="pv__content__value">
-          {this.props.content.get("title")}
-        </div>
-      </React.Fragment>
-    );
+  const title = get(content, "title") && (
+    <React.Fragment>
+      <div className="pv__content__label">Title</div>
+      <div className="pv__content__value">{get(content, "title")}</div>
+    </React.Fragment>
+  );
 
-    const name = get(this.props.content, "name") && (
-      <React.Fragment>
-        <div className="pv__content__label">Name</div>
-        <div className="pv__content__value">
-          {this.props.content.get("name")}
-        </div>
-      </React.Fragment>
-    );
+  const name = get(content, "name") && (
+    <React.Fragment>
+      <div className="pv__content__label">Name</div>
+      <div className="pv__content__value">{get(content, "name")}</div>
+    </React.Fragment>
+  );
 
-    const position = get(this.props.content, "position") && (
-      <React.Fragment>
-        <div className="pv__content__label">Position</div>
-        <div className="pv__content__value">
-          {this.props.content.get("position")}
-        </div>
-      </React.Fragment>
-    );
+  const position = get(content, "position") && (
+    <React.Fragment>
+      <div className="pv__content__label">Position</div>
+      <div className="pv__content__value">{get(content, "position")}</div>
+    </React.Fragment>
+  );
 
-    const company = get(this.props.content, "company") && (
-      <React.Fragment>
-        <div className="pv__content__label">Company</div>
-        <div className="pv__content__value">
-          {this.props.content.get("company")}
-        </div>
-      </React.Fragment>
-    );
+  const company = get(content, "company") && (
+    <React.Fragment>
+      <div className="pv__content__label">Company</div>
+      <div className="pv__content__value">{get(content, "company")}</div>
+    </React.Fragment>
+  );
 
-    return (
-      <won-person-viewer class={this.props.className}>
-        <div className="pv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="pv__content">
-          {title}
-          {name}
-          {position}
-          {company}
-        </div>
-      </won-person-viewer>
-    );
-  }
+  return (
+    <won-person-viewer class={className}>
+      <div className="pv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="pv__content">
+        {title}
+        {name}
+        {position}
+        {company}
+      </div>
+    </won-person-viewer>
+  );
 }
 WonPersonViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinet-viewer.jsx
@@ -6,63 +6,54 @@ import PropTypes from "prop-types";
 import WonPetrinetState from "../../petrinet-state";
 import { get } from "../../../utils.js";
 
-export default class WonPetrinetViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="petrinetv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
+export default function WonPetrinetViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="petrinetv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
+
+  const label = detail.icon && (
+    <span className="petrinetv__header__label">{detail.label}</span>
+  );
+
+  const petrinetStateElement = get(content, "processURI") && (
+    <WonPetrinetState
+      className="petrinetv__content__state"
+      processUri={get(content, "processURI")}
+    />
+  );
+
+  const petrinetDownloadElement = content && (
+    <a
+      className="petrinetv__content__download"
+      href={"data:" + get(content, "type") + ";base64," + get(content, "data")}
+      download={get(content, "name")}
+    >
+      <svg className="petrinetv__content__download__typeicon">
+        <use
+          xlinkHref={ico36_uc_transport_demand}
+          href={ico36_uc_transport_demand}
+        />
       </svg>
-    );
+      <div className="petrinetv__content__download__label clickable">
+        {"Download '" + get(content, "name") + "'"}
+      </div>
+    </a>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="petrinetv__header__label">
-        {this.props.detail.label}
-      </span>
-    );
-
-    const petrinetStateElement = get(this.props.content, "processURI") && (
-      <WonPetrinetState
-        className="petrinetv__content__state"
-        processUri={get(this.props.content, "processURI")}
-      />
-    );
-
-    const petrinetDownloadElement = this.props.content && (
-      <a
-        className="petrinetv__content__download"
-        href={
-          "data:" +
-          get(this.props.content, "type") +
-          ";base64," +
-          get(this.props.content, "data")
-        }
-        download={get(this.props.content, "name")}
-      >
-        <svg className="petrinetv__content__download__typeicon">
-          <use
-            xlinkHref={ico36_uc_transport_demand}
-            href={ico36_uc_transport_demand}
-          />
-        </svg>
-        <div className="petrinetv__content__download__label clickable">
-          {"Download '" + get(this.props.content, "name") + "'"}
-        </div>
-      </a>
-    );
-
-    return (
-      <won-petrinet-viewer class={this.props.className}>
-        <div className="petrinetv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="petrinetv__content">
-          {petrinetStateElement}
-          {petrinetDownloadElement}
-        </div>
-      </won-petrinet-viewer>
-    );
-  }
+  return (
+    <won-petrinet-viewer class={className}>
+      <div className="petrinetv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="petrinetv__content">
+        {petrinetStateElement}
+        {petrinetDownloadElement}
+      </div>
+    </won-petrinet-viewer>
+  );
 }
 WonPetrinetViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinettransition-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/petrinettransition-viewer.jsx
@@ -3,35 +3,35 @@ import React from "react";
 import "~/style/_petrinettransition-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonPetrinetTransitionViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="petrinettransitionv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonPetrinetTransitionViewer({
+  detail,
+  content,
+  className,
+}) {
+  const icon = detail.icon && (
+    <svg className="petrinettransitionv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="petrinettransitionv__header__label">
-        {this.props.detail.label}
-      </span>
-    );
+  const label = detail.icon && (
+    <span className="petrinettransitionv__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-petrinettransition-viewer class={this.props.className}>
-        <div className="petrinettransitionv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="petrinettransitionv__content">
-          {this.props.detail.generateHumanReadable({
-            value: this.props.content.toJS(),
-            includeLabel: false,
-          })}
-        </div>
-      </won-petrinettransition-viewer>
-    );
-  }
+  return (
+    <won-petrinettransition-viewer class={className}>
+      <div className="petrinettransitionv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="petrinettransitionv__content">
+        {detail.generateHumanReadable({
+          value: content.toJS(),
+          includeLabel: false,
+        })}
+      </div>
+    </won-petrinettransition-viewer>
+  );
 }
 WonPetrinetTransitionViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/pokemon-gym-viewer.jsx
@@ -4,31 +4,29 @@ import "~/style/_pokemon-gym-viewer.scss";
 import { get } from "../../../utils.js";
 import PropTypes from "prop-types";
 
-export default class PokemonGymViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="pgv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function PokemonGymViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="pgv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="pgv__header__label">{this.props.detail.label}</span>
-    );
-    const exGym = get(this.props.content, "ex") && (
-      <div className="pgv__content__ex">This is an Ex Gym!</div>
-    );
+  const label = detail.icon && (
+    <span className="pgv__header__label">{detail.label}</span>
+  );
+  const exGym = get(content, "ex") && (
+    <div className="pgv__content__ex">This is an Ex Gym!</div>
+  );
 
-    return (
-      <pokemon-gym-viewer class={this.props.className}>
-        <div className="pgv__header">
-          {icon}
-          {label}
-        </div>
-        {exGym}
-      </pokemon-gym-viewer>
-    );
-  }
+  return (
+    <pokemon-gym-viewer class={className}>
+      <div className="pgv__header">
+        {icon}
+        {label}
+      </div>
+      {exGym}
+    </pokemon-gym-viewer>
+  );
 }
 PokemonGymViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/price-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/price-viewer.jsx
@@ -3,33 +3,31 @@ import React from "react";
 import "~/style/_price-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonPriceViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="pricev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonPriceViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="pricev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="pricev__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="pricev__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-price-viewer class={this.props.className}>
-        <div className="pricev__header">
-          {icon}
-          {label}
-        </div>
-        <div className="pricev__content">
-          {this.props.detail.generateHumanReadable({
-            value: this.props.content.toJS(),
-            includeLabel: false,
-          })}
-        </div>
-      </won-price-viewer>
-    );
-  }
+  return (
+    <won-price-viewer class={className}>
+      <div className="pricev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="pricev__content">
+        {detail.generateHumanReadable({
+          value: content.toJS(),
+          includeLabel: false,
+        })}
+      </div>
+    </won-price-viewer>
+  );
 }
 WonPriceViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/range-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/range-viewer.jsx
@@ -3,33 +3,31 @@ import React from "react";
 import "~/style/_range-viewer.scss";
 import PropTypes from "prop-types";
 
-export default class WonRangeViewer extends React.Component {
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="rangev__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+export default function WonRangeViewer({ detail, content, className }) {
+  const icon = detail.icon && (
+    <svg className="rangev__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="rangev__header__label">{this.props.detail.label}</span>
-    );
+  const label = detail.icon && (
+    <span className="rangev__header__label">{detail.label}</span>
+  );
 
-    return (
-      <won-range-viewer class={this.props.className}>
-        <div className="rangev__header">
-          {icon}
-          {label}
-        </div>
-        <div className="rangev__content">
-          {this.props.detail.generateHumanReadable({
-            value: this.props.content.toJS(),
-            includeLabel: false,
-          })}
-        </div>
-      </won-range-viewer>
-    );
-  }
+  return (
+    <won-range-viewer class={className}>
+      <div className="rangev__header">
+        {icon}
+        {label}
+      </div>
+      <div className="rangev__content">
+        {detail.generateHumanReadable({
+          value: content.toJS(),
+          includeLabel: false,
+        })}
+      </div>
+    </won-range-viewer>
+  );
 }
 WonRangeViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/travel-action-viewer.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/details/viewer/travel-action-viewer.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import "~/style/_travel-action-viewer.scss";
 import ico_filter_map from "~/images/won-icons/ico-filter_map.svg";
@@ -7,102 +7,87 @@ import PropTypes from "prop-types";
 import { get } from "../../../utils.js";
 import WonAtomMap from "../../atom-map";
 
-export default class WonTravelActionViewer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      locationExpanded: false,
-    };
-  }
+export default function WonTravelActionViewer({ detail, content, className }) {
+  const [locationExpanded, toggleLocationExpanded] = useState(false);
 
-  toggleLocation() {
-    this.setState({ locationExpanded: !this.state.locationExpanded });
-  }
+  const icon = detail.icon && (
+    <svg className="rv__header__icon">
+      <use xlinkHref={detail.icon} href={detail.icon} />
+    </svg>
+  );
 
-  render() {
-    const icon = this.props.detail.icon && (
-      <svg className="rv__header__icon">
-        <use xlinkHref={this.props.detail.icon} href={this.props.detail.icon} />
-      </svg>
-    );
+  const label = detail.icon && (
+    <span className="rv__header__label">{detail.label}</span>
+  );
 
-    const label = this.props.detail.icon && (
-      <span className="rv__header__label">{this.props.detail.label}</span>
-    );
-
-    const fromAddress = get(this.props.content, "fromAddress");
-    const toAddress = get(this.props.content, "toAddress");
-    const addressElement =
-      fromAddress || toAddress ? (
-        <div
-          className="rv__content__text clickable"
-          onClick={() => this.toggleLocation()}
+  const fromAddress = get(content, "fromAddress");
+  const toAddress = get(content, "toAddress");
+  const addressElement =
+    fromAddress || toAddress ? (
+      <div
+        className="rv__content__text clickable"
+        onClick={() => toggleLocationExpanded(!locationExpanded)}
+      >
+        <div>
+          {fromAddress ? (
+            <span>
+              <strong>From: </strong>
+              {fromAddress}
+            </span>
+          ) : (
+            undefined
+          )}
+          <br />
+          {toAddress ? (
+            <span>
+              <strong>To: </strong>
+              {toAddress}
+            </span>
+          ) : (
+            undefined
+          )}
+        </div>
+        <svg className="rv__content__text__carret">
+          <use xlinkHref={ico_filter_map} href={ico_filter_map} />
+        </svg>
+        <svg
+          className={
+            "rv__content__text__carret " +
+            (locationExpanded
+              ? " rv__content__text__carret--expanded "
+              : " rv__content__text__carret--collapsed ")
+          }
         >
-          <div>
-            {fromAddress ? (
-              <span>
-                <strong>From: </strong>
-                {fromAddress}
-              </span>
-            ) : (
-              undefined
-            )}
-            <br />
-            {toAddress ? (
-              <span>
-                <strong>To: </strong>
-                {toAddress}
-              </span>
-            ) : (
-              undefined
-            )}
-          </div>
-          <svg className="rv__content__text__carret">
-            <use xlinkHref={ico_filter_map} href={ico_filter_map} />
-          </svg>
-          <svg
-            className={
-              "rv__content__text__carret " +
-              (this.state.locationExpanded
-                ? " rv__content__text__carret--expanded "
-                : " rv__content__text__carret--collapsed ")
-            }
-          >
-            <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
-          </svg>
-        </div>
-      ) : (
-        undefined
-      );
-
-    const map =
-      this.props.content &&
-      this.state.locationExpanded &&
-      (get(this.props.content, "fromLocation") ||
-        get(this.props.content, "toLocation")) ? (
-        <WonAtomMap
-          locations={[
-            get(this.props.content, "fromLocation"),
-            get(this.props.content, "toLocation"),
-          ]}
-        />
-      ) : (
-        undefined
-      );
-
-    return (
-      <won-travel-action-viewer class={this.props.className}>
-        <div className="rv__header">
-          {icon}
-          {label}
-        </div>
-        <div className="rv__content">
-          {addressElement}
-          {map}
-        </div>
-      </won-travel-action-viewer>
+          <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
+        </svg>
+      </div>
+    ) : (
+      undefined
     );
-  }
+
+  const map =
+    content &&
+    locationExpanded &&
+    (get(content, "fromLocation") || get(content, "toLocation")) ? (
+      <WonAtomMap
+        locations={[get(content, "fromLocation"), get(content, "toLocation")]}
+      />
+    ) : (
+      undefined
+    );
+
+  return (
+    <won-travel-action-viewer class={className}>
+      <div className="rv__header">
+        {icon}
+        {label}
+      </div>
+      <div className="rv__content">
+        {addressElement}
+        {map}
+      </div>
+    </won-travel-action-viewer>
+  );
 }
 WonTravelActionViewer.propTypes = {
   detail: PropTypes.object,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
@@ -338,7 +338,6 @@ export default function WonGroupAtomMessages({
             message={msg}
             connection={connection}
             senderAtom={senderAtom}
-            targetAtom={targetAtom}
             processState={processState}
             allAtoms={allAtoms}
             ownedConnections={ownedConnections}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/group-atom-messages.jsx
@@ -342,7 +342,7 @@ export default function WonGroupAtomMessages({
             processState={processState}
             allAtoms={allAtoms}
             ownedConnections={ownedConnections}
-            originatorAtom={get(allAtoms, get(msg, "originatorUri"))}
+            originatorAtom={get(allAtoms, messageUtils.getOriginatorUri(msg))}
             shouldShowRdf={shouldShowRdf}
             groupChatMessage={true}
           />

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/combined-message-content.jsx
@@ -31,15 +31,15 @@ export default function WonCombinedMessageContent({
   onClick,
 }) {
   const history = useHistory();
-  const messageType = get(message, "messageType");
-  const injectInto = get(message, "injectInto");
+  const messageType = messageUtils.getType(message);
+  const injectInto = messageUtils.getInjectInto(message);
 
-  const hasReferences = get(message, "hasReferences");
+  const hasReferences = messageUtils.hasReferences(message);
   const referencesProposes = messageUtils.getProposesReferences(message);
   const referencesClaims = messageUtils.getClaimsReferences(message);
   const externalDataState = useSelector(generalSelectors.getExternalDataState);
 
-  const originatorUri = get(message, "originatorUri");
+  const originatorUri = messageUtils.getOriginatorUri(message);
   /*Extract persona name from message:
 
    either within the atom of the originatorUri-atom (in group-chat-messages)
@@ -48,7 +48,7 @@ export default function WonCombinedMessageContent({
    */
   let personaName = undefined;
 
-  if (!get(message, "outgoingMessage")) {
+  if (messageUtils.isIncomingMessage(message)) {
     const relevantAtomUri = groupChatMessage
       ? originatorUri
       : connectionUtils.getTargetAtomUri(connection);
@@ -63,12 +63,12 @@ export default function WonCombinedMessageContent({
       : get(relevantAtom, "fakePersonaName");
   }
 
-  const multiSelectType = get(connection, "multiSelectType");
-  const hasContent = get(message, "hasContent");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
+  const hasContent = messageUtils.hasContent(message);
   const hasNotBeenLoaded = !message;
   const hasClaims = referencesClaims && referencesClaims.size > 0;
   const hasProposes = referencesProposes && referencesProposes.size > 0;
-  const agreementData = get(connection, "agreementData");
+  const agreementData = connectionUtils.getAgreementData(connection);
   const isInjectIntoMessage = injectInto && injectInto.size > 0; //contains the targetConnectionUris
 
   const injectIntoArray = injectInto && Array.from(injectInto.toSet());
@@ -140,7 +140,7 @@ export default function WonCombinedMessageContent({
       return (
         ownedConnections &&
         !!ownedConnections.find(
-          conn => get(conn, "targetConnectionUri") === connectionUri
+          conn => connectionUtils.getTargetConnectionUri(conn) === connectionUri
         )
       );
     }
@@ -156,7 +156,7 @@ export default function WonCombinedMessageContent({
       connection =
         ownedConnections &&
         ownedConnections.find(
-          conn => get(conn, "targetConnectionUri") === connectionUri
+          conn => connectionUtils.getTargetConnectionUri(conn) === connectionUri
         );
 
       if (connection) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Immutable from "immutable";
 import PropTypes from "prop-types";
-import { get, getUri } from "../../utils.js";
+import { getUri } from "../../utils.js";
 import { actionCreators } from "../../actions/actions.js";
 import { useDispatch } from "react-redux";
 
@@ -11,7 +11,7 @@ import * as connectionUtils from "../../redux/utils/connection-utils.js";
 
 export default function WonConnectionMessageActions({ message, connection }) {
   const dispatch = useDispatch();
-  const multiSelectType = get(connection, "multiSelectType");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
   const isProposed = messageUtils.isMessageProposed(connection, message);
   const isCancellationPending = messageUtils.isMessageCancellationPending(
     connection,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-actions.jsx
@@ -11,8 +11,7 @@ import * as connectionUtils from "../../redux/utils/connection-utils.js";
 
 export default function WonConnectionMessageActions({ message, connection }) {
   const dispatch = useDispatch();
-  const multiSelectType = connectionUtils.getMultiSelectType(connection);
-  const isProposed = messageUtils.isMessageProposed(connection, message);
+  const multiSelectType = !!connectionUtils.getMultiSelectType(connection);
   const isCancellationPending = messageUtils.isMessageCancellationPending(
     connection,
     message
@@ -66,7 +65,9 @@ export default function WonConnectionMessageActions({ message, connection }) {
     <won-connection-message-actions>
       {isProposable
         ? generateButton(
-            isProposed ? "Propose (again)" : "Propose",
+            messageUtils.isMessageProposed(connection, message)
+              ? "Propose (again)"
+              : "Propose",
             "proposes",
             "black",
             multiSelectType

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-status.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-status.jsx
@@ -4,7 +4,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { relativeTime } from "../../won-label-utils.js";
-import { get } from "../../utils.js";
 import { useSelector } from "react-redux";
 import { selectLastUpdateTime } from "../../redux/selectors/general-selectors.js";
 import * as messageUtils from "../../redux/utils/message-utils.js";
@@ -16,7 +15,7 @@ import ico36_added_circle from "~/images/won-icons/ico36_added_circle.svg";
 export default function WonConnectionMessageStatus({ message }) {
   const lastUpdateTime = useSelector(selectLastUpdateTime);
 
-  const isOutgoingMessage = get(message, "outgoingMessage");
+  const isOutgoingMessage = messageUtils.isOutgoingMessage(message);
   const isFailedToSend = messageUtils.hasFailedToSend(message);
   const isReceivedByOwn = messageUtils.isReceivedByOwn(message);
   const isReceivedByRemote = messageUtils.isReceivedByRemote(message);
@@ -72,7 +71,7 @@ export default function WonConnectionMessageStatus({ message }) {
   ) {
     timeStampLabel = (
       <div className="msgstatus__time">
-        {relativeTime(lastUpdateTime, get(message, "date"))}
+        {relativeTime(lastUpdateTime, messageUtils.getDate(message))}
       </div>
     );
   }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-status.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message-status.jsx
@@ -16,14 +16,13 @@ export default function WonConnectionMessageStatus({ message }) {
   const lastUpdateTime = useSelector(selectLastUpdateTime);
 
   const isOutgoingMessage = messageUtils.isOutgoingMessage(message);
-  const isFailedToSend = messageUtils.hasFailedToSend(message);
-  const isReceivedByOwn = messageUtils.isReceivedByOwn(message);
-  const isReceivedByRemote = messageUtils.isReceivedByRemote(message);
-
-  let statusIcons;
 
   if (isOutgoingMessage) {
+    const isFailedToSend = messageUtils.hasFailedToSend(message);
+
     let icons;
+    let label;
+
     if (isFailedToSend) {
       icons = (
         <svg
@@ -36,7 +35,11 @@ export default function WonConnectionMessageStatus({ message }) {
           />
         </svg>
       );
+      label = <div className="msgstatus__time--failure">Sending failed</div>;
     } else {
+      const isReceivedByOwn = messageUtils.isReceivedByOwn(message);
+      const isReceivedByRemote = messageUtils.isReceivedByRemote(message);
+
       icons = (
         <React.Fragment>
           <svg
@@ -56,50 +59,32 @@ export default function WonConnectionMessageStatus({ message }) {
           </svg>
         </React.Fragment>
       );
+
+      label =
+        isReceivedByRemote && isReceivedByOwn ? (
+          <div className="msgstatus__time">
+            {relativeTime(lastUpdateTime, messageUtils.getDate(message))}
+          </div>
+        ) : (
+          <div className="msgstatus__time--pending">Sending&nbsp;&hellip;</div>
+        );
     }
 
-    statusIcons = <div className="msgstatus__icons">{icons}</div>;
-  }
-
-  let timeStampLabel;
-  let failedLabel;
-  let sendingLabel;
-
-  if (
-    !isOutgoingMessage ||
-    (!isFailedToSend && (isReceivedByRemote && isReceivedByOwn))
-  ) {
-    timeStampLabel = (
-      <div className="msgstatus__time">
-        {relativeTime(lastUpdateTime, messageUtils.getDate(message))}
-      </div>
+    return (
+      <won-connection-message-status>
+        <div className="msgstatus__icons">{icons}</div>
+        {label}
+      </won-connection-message-status>
+    );
+  } else {
+    return (
+      <won-connection-message-status>
+        <div className="msgstatus__time">
+          {relativeTime(lastUpdateTime, messageUtils.getDate(message))}
+        </div>
+      </won-connection-message-status>
     );
   }
-
-  if (
-    isOutgoingMessage &&
-    !isFailedToSend &&
-    (!isReceivedByRemote || !isReceivedByOwn)
-  ) {
-    sendingLabel = (
-      <div className="msgstatus__time--pending">Sending&nbsp;&hellip;</div>
-    );
-  }
-
-  if (isOutgoingMessage && isFailedToSend) {
-    failedLabel = (
-      <div className="msgstatus__time--failure">Sending failed</div>
-    );
-  }
-
-  return (
-    <won-connection-message-status>
-      {statusIcons}
-      {timeStampLabel}
-      {sendingLabel}
-      {failedLabel}
-    </won-connection-message-status>
-  );
 }
 WonConnectionMessageStatus.propTypes = {
   message: PropTypes.object.isRequired,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.jsx
@@ -5,7 +5,7 @@ import * as atomUtils from "../../redux/utils/atom-utils.js";
 import * as messageUtils from "../../redux/utils/message-utils.js";
 import * as connectionUtils from "../../redux/utils/connection-utils.js";
 import * as processUtils from "../../redux/utils/process-utils.js";
-import { get, getUri, getIn, generateLink } from "../../utils.js";
+import { get, getUri, generateLink } from "../../utils.js";
 import { actionCreators } from "../../actions/actions.js";
 import { useDispatch } from "react-redux";
 import { ownerBaseUrl } from "~/config/default.js";
@@ -257,7 +257,7 @@ export default function WonConnectionMessage({
 
   function showMessageAlways() {
     if (message) {
-      return getIn(message, ["content", "text"])
+      return messageUtils.hasText(message)
         ? true
         : !hasReferences ||
             shouldShowRdf ||

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/connection-message.jsx
@@ -44,17 +44,19 @@ export default function WonConnectionMessage({
   const connectionUri = getUri(connection);
 
   let rdfLinkURL;
+  const isSent = messageUtils.isOutgoingMessage(message);
+
   if (shouldShowRdf && ownerBaseUrl && senderAtom && message) {
     rdfLinkURL = urljoin(
       ownerBaseUrl,
       "/rest/linked-data/",
       `?requester=${encodeURIComponent(getUri(senderAtom))}`,
       `&uri=${encodeURIComponent(getUri(message))}`,
-      get(message, "outgoingMessage") ? "&deep=true" : ""
+      isSent ? "&deep=true" : ""
     );
   }
-  const isSent = get(message, "outgoingMessage");
-  const isReceived = !get(message, "outgoingMessage");
+
+  const isReceived = messageUtils.isIncomingMessage(message);
   const isFailedToSend = messageUtils.hasFailedToSend(message);
   const isReceivedByOwn = messageUtils.isReceivedByOwn(message);
   const isReceivedByRemote = messageUtils.isReceivedByRemote(message);
@@ -70,18 +72,18 @@ export default function WonConnectionMessage({
     (!(isReceivedByOwn && isReceivedByRemote) &&
       (isReceivedByOwn || isReceivedByRemote));
 
-  const injectInto = get(message, "injectInto");
+  const injectInto = messageUtils.getInjectInto(message);
 
-  const originatorUri = get(message, "originatorUri");
+  const originatorUri = messageUtils.getOriginatorUri(message);
 
   const isConnectionMessage = messageUtils.isConnectionMessage(message);
   const isChangeNotificationMessage = messageUtils.isChangeNotificationMessage(
     message
   );
-  const isSelected = getIn(message, ["viewState", "isSelected"]);
-  const isCollapsed = getIn(message, ["viewState", "isCollapsed"]);
-  const showActions = getIn(message, ["viewState", "showActions"]);
-  const multiSelectType = get(connection, "multiSelectType");
+  const isSelected = messageUtils.isMessageSelected(message);
+  const isCollapsed = messageUtils.isCollapsed(message);
+  const showActions = messageUtils.showActions(message);
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
   const isParsable = messageUtils.isParsable(message);
   const isClaimed = messageUtils.isMessageClaimed(connection, message);
   const isProposed = messageUtils.isMessageProposed(connection, message);
@@ -114,8 +116,8 @@ export default function WonConnectionMessage({
   const isAcceptable = messageUtils.isMessageAcceptable(connection, message);
   const isUnread = messageUtils.isMessageUnread(message);
   const isInjectIntoMessage = injectInto && injectInto.size > 0;
-  const isFromSystem = get(message, "systemMessage");
-  const hasReferences = get(message, "hasReferences");
+  const isFromSystem = messageUtils.isSystemMessage(message);
+  const hasReferences = messageUtils.hasReferences(message);
 
   const originatorHolderUri =
     groupChatMessage && atomUtils.getHeldByUri(originatorAtom);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactMarkdown from "react-markdown";
 import { get } from "../../utils.js";
+import { noParsableContentPlaceholder } from "~/app/won-label-utils.js";
 import * as messageUtils from "../../redux/utils/message-utils.js";
 import * as usecaseUtils from "../../usecase-utils.js";
 
@@ -12,18 +13,12 @@ import "~/style/_message-content.scss";
 import "~/style/_won-markdown.scss";
 import vocab from "../../service/vocab.js";
 
-const noParsableContentPlaceholder =
-  "«This message couldn't be displayed as it didn't contain," +
-  "any parsable content! " +
-  'Click on the "Show raw RDF data"-button in ' +
-  'the footer of the page to see the "raw" message-data.»';
-
 export default function WonMessageContent({ message }) {
-  const content = get(message, "content");
+  const content = messageUtils.getContent(message);
   const matchScore = get(content, "matchScore");
   const text = get(content, "text");
 
-  const messageType = get(message, "messageType");
+  const messageType = messageUtils.getType(message);
   const matchScorePercentage = matchScore && matchScore * 100;
 
   if (message) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/message-content.jsx
@@ -14,14 +14,14 @@ import "~/style/_won-markdown.scss";
 import vocab from "../../service/vocab.js";
 
 export default function WonMessageContent({ message }) {
-  const content = messageUtils.getContent(message);
-  const matchScore = get(content, "matchScore");
-  const text = get(content, "text");
-
-  const messageType = messageUtils.getType(message);
-  const matchScorePercentage = matchScore && matchScore * 100;
-
   if (message) {
+    const content = messageUtils.getContent(message);
+    const matchScore = get(content, "matchScore");
+    const text = get(content, "text");
+
+    const messageType = messageUtils.getType(message);
+    const matchScorePercentage = matchScore && matchScore * 100;
+
     const markdownText = text ? (
       <ReactMarkdown
         className="msg__text markdown"
@@ -31,7 +31,7 @@ export default function WonMessageContent({ message }) {
     ) : (
       undefined
     );
-    const matchScore = matchScore ? (
+    const matchScoreElement = matchScore ? (
       <div className="msg__matchScore">MatchScore: {matchScorePercentage}%</div>
     ) : (
       undefined
@@ -79,7 +79,7 @@ export default function WonMessageContent({ message }) {
       <won-message-content>
         {markdownText}
         {contentDetailsArray}
-        {matchScore}
+        {matchScoreElement}
         {noParsableContent}
       </won-message-content>
     );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/messages/referenced-message-content.jsx
@@ -6,7 +6,7 @@ import { actionCreators } from "../../actions/actions.js";
 import { useDispatch } from "react-redux";
 
 import PropTypes from "prop-types";
-import { get, getIn, getUri } from "../../utils.js";
+import { get, getUri } from "../../utils.js";
 import * as connectionUtils from "../../redux/utils/connection-utils.js";
 import * as messageUtils from "../../redux/utils/message-utils.js";
 import * as ownerApi from "../../api/owner-api";
@@ -25,14 +25,11 @@ export default function WonReferencedMessageContent({
   originatorAtom,
 }) {
   const dispatch = useDispatch();
-  const expandedReferences = getIn(message, [
-    "viewState",
-    "expandedReferences",
-  ]);
+  const expandedReferences = messageUtils.getExpandedReferences(message);
 
   const references = messageUtils.getReferences(message);
   const senderAtomUri = getUri(senderAtom);
-  const multiSelectType = get(connection, "multiSelectType");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
 
   function toggleReferenceExpansion(reference) {
     if (message && !multiSelectType) {
@@ -151,7 +148,9 @@ export default function WonReferencedMessageContent({
   return (
     <won-referenced-message-content
       class={
-        !message || get(message, "hasContent") ? "won-has-non-ref-content" : ""
+        !message || messageUtils.hasContent(message)
+          ? "won-has-non-ref-content"
+          : ""
       }
     >
       {generateMessageElementFragment("Claiming", "claims")}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/petrinet-state.jsx
@@ -28,7 +28,7 @@ export default function WonPetrinetState({ processUri, className }) {
   const processState = useSelector(generalSelectors.getProcessState);
   const connection = atomUtils.getConnection(atom, connectionUri);
 
-  const petriNetData = get(connection, "petriNetData");
+  const petriNetData = connectionUtils.getPetriNetData(connection);
 
   const process = processUri && get(petriNetData, processUri);
 
@@ -54,7 +54,7 @@ export default function WonPetrinetState({ processUri, className }) {
     ? enabledTransitions.size
     : 0;
 
-  const multiSelectType = get(connection, "multiSelectType");
+  const multiSelectType = connectionUtils.getMultiSelectType(connection);
   const hasEnabledTransitions = enabledTransitionsSize > 0;
   const hasMarkedPlaces = markedPlacesSize > 0;
   const enabledTransitionsArray =

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/map.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/map.jsx
@@ -86,12 +86,10 @@ export default function PageMap() {
         }
         return false;
       })
+      .toOrderedMap()
+      .sortBy(metaAtom => atomUtils.getDistanceFrom(metaAtom, currentLocation))
   );
 
-  const sortedVisibleAtoms = atomUtils.sortByDistanceFrom(
-    whatsAroundMetaAtoms,
-    lastWhatsAroundLocation
-  );
   const lastAtomUrisUpdateDate = useSelector(state =>
     getIn(state, ["owner", "lastWhatsAroundUpdateTime"])
   );
@@ -116,7 +114,7 @@ export default function PageMap() {
     lastAtomUrisUpdateDate &&
     wonLabelUtils.relativeTime(globalLastUpdateDate, lastAtomUrisUpdateDate);
 
-  const hasVisibleAtoms = sortedVisibleAtoms.length > 0;
+  const hasVisibleAtoms = whatsAroundMetaAtoms && whatsAroundMetaAtoms.size > 0;
   const showSlideIns = useSelector(viewSelectors.showSlideIns(history));
   const showModalDialog = useSelector(viewSelectors.showModalDialog);
 
@@ -488,7 +486,7 @@ export default function PageMap() {
           (hasVisibleAtoms ? (
             <div className="ownermap__content">
               <WonAtomCardGrid
-                atoms={sortedVisibleAtoms}
+                atoms={whatsAroundMetaAtoms}
                 currentLocation={lastWhatsAroundLocation}
                 showHolder={true}
                 showIndicators={false}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
@@ -3,13 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { actionCreators } from "../../actions/actions.js";
 import * as generalSelectors from "../../redux/selectors/general-selectors.js";
 import * as atomUtils from "../../redux/utils/atom-utils.js";
-import {
-  get,
-  getIn,
-  sortByDate,
-  generateLink,
-  getQueryParams,
-} from "../../utils.js";
+import { get, getIn, generateLink, getQueryParams } from "../../utils.js";
 import * as processSelectors from "../../redux/selectors/process-selectors.js";
 import * as accountUtils from "../../redux/utils/account-utils.js";
 import * as useCaseUtils from "../../usecase-utils.js";
@@ -103,6 +97,13 @@ export default function PageOverview() {
       useCase === OTHERIDENTIFIER
         ? get(whatsNewAtomsGroupedByUseCaseIdentifier, undefined)
         : get(whatsNewAtomsGroupedByUseCaseIdentifier, useCase);
+
+    const sortedVisibleAtoms =
+      visibleAtoms &&
+      visibleAtoms
+        .toOrderedMap()
+        .sortBy(atom => atomUtils.getLastUpdateDate(atom))
+        .reverse();
     const visibleAtomsSize = visibleAtoms ? visibleAtoms.size : 0;
 
     overviewContentElement = (
@@ -150,7 +151,7 @@ export default function PageOverview() {
             <div className="owneroverview__usecases__usecase">
               <div className="owneroverview__usecases__usecase__atoms">
                 <WonAtomCardGrid
-                  atoms={sortByDate(visibleAtoms)}
+                  atoms={sortedVisibleAtoms}
                   currentLocation={currentLocation}
                   showIndicators={false}
                   showHolder={true}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
@@ -44,7 +44,7 @@ export default function PageOverview() {
     );
 
   const whatsNewUseCaseIdentifierArray = whatsNewAtoms
-    .map(atom => getIn(atom, ["matchedUseCase", "identifier"]))
+    .map(atom => atomUtils.getMatchedUseCaseIdentifier(atom))
     .filter(identifier => !!identifier)
     .toSet()
     .toArray();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/pages/react/overview.jsx
@@ -1,9 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { actionCreators } from "../../actions/actions.js";
 import * as generalSelectors from "../../redux/selectors/general-selectors.js";
 import * as atomUtils from "../../redux/utils/atom-utils.js";
-import { getIn, sortByDate } from "../../utils.js";
+import {
+  get,
+  getIn,
+  sortByDate,
+  generateLink,
+  getQueryParams,
+} from "../../utils.js";
 import * as processSelectors from "../../redux/selectors/process-selectors.js";
 import * as accountUtils from "../../redux/utils/account-utils.js";
 import * as useCaseUtils from "../../usecase-utils.js";
@@ -20,19 +26,30 @@ import WonFooter from "../../components/footer";
 
 import "~/style/_overview.scss";
 import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
-import { useHistory } from "react-router-dom";
+import { useHistory, Link } from "react-router-dom";
+
+const OTHERIDENTIFIER = "_other";
 
 export default function PageOverview() {
   const history = useHistory();
+  const { useCase } = getQueryParams(history.location);
   const dispatch = useDispatch();
   const debugModeEnabled = useSelector(viewSelectors.isDebugModeEnabled);
-  const [open, setOpen] = useState([]);
+  const accountState = useSelector(generalSelectors.getAccountState);
+  const currentLocation = useSelector(generalSelectors.getCurrentLocation);
+  const showSlideIns = useSelector(viewSelectors.showSlideIns(history));
+  const showModalDialog = useSelector(viewSelectors.showModalDialog);
+  const isOwnerAtomUrisLoading = useSelector(
+    processSelectors.isProcessingWhatsNew
+  );
+  const globalLastUpdateTime = useSelector(
+    generalSelectors.selectLastUpdateTime
+  );
 
   const whatsNewAtomsUnfiltered = useSelector(
     generalSelectors.getWhatsNewAtoms
   );
 
-  const accountState = useSelector(generalSelectors.getAccountState);
   const whatsNewAtoms = whatsNewAtomsUnfiltered
     .filter(metaAtom => atomUtils.isActive(metaAtom))
     .filter(
@@ -43,86 +60,32 @@ export default function PageOverview() {
         !accountUtils.isAtomOwned(accountState, metaAtomUri)
     );
 
-  const whatsNewUseCaseIdentifierArray = whatsNewAtoms
-    .map(atom => atomUtils.getMatchedUseCaseIdentifier(atom))
-    .filter(identifier => !!identifier)
-    .toSet()
-    .toArray();
+  const whatsNewAtomsGroupedByUseCaseIdentifier =
+    whatsNewAtoms &&
+    whatsNewAtoms
+      .groupBy(atom => atomUtils.getMatchedUseCaseIdentifier(atom))
+      .toOrderedMap()
+      .sortBy(
+        (_, ucIdentifier) => useCaseUtils.getUseCaseLabel(ucIdentifier) || "zzz"
+      );
 
-  const sortedVisibleAtoms = sortByDate(whatsNewAtoms, "creationDate");
   const lastAtomUrisUpdateDate = useSelector(state =>
     getIn(state, ["owner", "lastWhatsNewUpdateTime"])
   );
 
-  const isOwnerAtomUrisLoading = useSelector(
-    processSelectors.isProcessingWhatsNew
-  );
   const isOwnerAtomUrisToLoad =
     !lastAtomUrisUpdateDate && !isOwnerAtomUrisLoading;
 
   const isLoggedIn = accountUtils.isLoggedIn(accountState);
-  const currentLocation = useSelector(generalSelectors.getCurrentLocation);
-  const globalLastUpdateTime = useSelector(
-    generalSelectors.selectLastUpdateTime
-  );
   const friendlyLastAtomUrisUpdateTimestamp =
     lastAtomUrisUpdateDate &&
     wonLabelUtils.relativeTime(globalLastUpdateTime, lastAtomUrisUpdateDate);
-  const sortedVisibleAtomsSize = sortedVisibleAtoms
-    ? sortedVisibleAtoms.length
-    : 0;
-  const hasVisibleAtoms = sortedVisibleAtomsSize > 0;
-  const showSlideIns = useSelector(viewSelectors.showSlideIns(history));
-  const showModalDialog = useSelector(viewSelectors.showModalDialog);
 
   useEffect(() => {
     if (isOwnerAtomUrisToLoad) {
       dispatch(actionCreators.atoms__fetchWhatsNew());
     }
   });
-
-  function hasOtherAtoms() {
-    return !!whatsNewAtoms.find(atom => !atomUtils.hasMatchedUseCase(atom));
-  }
-  function getOtherAtomsSize() {
-    const useCaseAtoms = whatsNewAtoms.filter(
-      atom => !atomUtils.hasMatchedUseCase(atom)
-    );
-    return useCaseAtoms ? useCaseAtoms.size : 0;
-  }
-
-  function getAtomsSizeByUseCase(ucIdentifier) {
-    const useCaseAtoms = whatsNewAtoms.filter(
-      atom => atomUtils.getMatchedUseCaseIdentifier(atom) === ucIdentifier
-    );
-    return useCaseAtoms ? useCaseAtoms.size : 0;
-  }
-
-  function getSortedVisibleAtomsByUseCase(ucIdentifier) {
-    const useCaseAtoms = whatsNewAtoms.filter(
-      atom => atomUtils.getMatchedUseCaseIdentifier(atom) === ucIdentifier
-    );
-    return sortByDate(useCaseAtoms, "creationDate") || [];
-  }
-
-  function getSortedVisibleOtherAtoms() {
-    const useCaseAtoms = whatsNewAtoms.filter(
-      atom => !atomUtils.hasMatchedUseCase(atom)
-    );
-    return sortByDate(useCaseAtoms, "creationDate") || [];
-  }
-
-  function isUseCaseExpanded(ucIdentifier) {
-    return open.includes(ucIdentifier);
-  }
-
-  function toggleUseCase(ucIdentifier) {
-    setOpen(
-      isUseCaseExpanded(ucIdentifier)
-        ? open.filter(element => ucIdentifier !== element)
-        : open.concat(ucIdentifier)
-    );
-  }
 
   function reload() {
     if (!isOwnerAtomUrisLoading) {
@@ -133,24 +96,35 @@ export default function PageOverview() {
     }
   }
 
-  return (
-    <section className={!isLoggedIn ? "won-signed-out" : ""}>
-      {showModalDialog && <WonModalDialog />}
-      <WonTopnav pageTitle="What's New" />
-      {isLoggedIn && <WonMenu />}
-      <WonToasts />
-      {showSlideIns && <WonSlideIn />}
+  let overviewContentElement;
+  if (useCase) {
+    const useCaseIcon = useCaseUtils.getUseCaseIcon(useCase);
+    const visibleAtoms =
+      useCase === OTHERIDENTIFIER
+        ? get(whatsNewAtomsGroupedByUseCaseIdentifier, undefined)
+        : get(whatsNewAtomsGroupedByUseCaseIdentifier, useCase);
+    const visibleAtomsSize = visibleAtoms ? visibleAtoms.size : 0;
+
+    overviewContentElement = (
       <main className="owneroverview">
-        <div className="owneroverview__header">
+        <div
+          className={
+            "owneroverview__header " +
+            (useCaseIcon ? " owneroverview__header--withIcon " : "")
+          }
+        >
+          {useCaseIcon ? (
+            <svg className="owneroverview__header__icon">
+              <use xlinkHref={useCaseIcon} href={useCaseIcon} />
+            </svg>
+          ) : (
+            undefined
+          )}
           <div className="owneroverview__header__title">
-            {"What's new? "}
-            {!isOwnerAtomUrisLoading &&
-              hasVisibleAtoms &&
-              !whatsNewUseCaseIdentifierArray && (
-                <span className="owneroverview__header__title__count">
-                  {"(" + sortedVisibleAtomsSize + ")"}
-                </span>
-              )}
+            {useCaseUtils.getUseCaseLabel(useCase)}
+            <span className="owneroverview__header__title__count">
+              {`(${visibleAtomsSize})`}
+            </span>
           </div>
           <div className="owneroverview__header__updated">
             {isOwnerAtomUrisLoading ? (
@@ -171,97 +145,19 @@ export default function PageOverview() {
             </button>
           </div>
         </div>
-        {hasVisibleAtoms ? (
+        {visibleAtomsSize > 0 ? (
           <div className="owneroverview__usecases">
-            {whatsNewUseCaseIdentifierArray.map((ucIdentifier, index) => (
-              <div
-                className="owneroverview__usecases__usecase"
-                key={ucIdentifier + "-" + index}
-              >
-                <div
-                  className="owneroverview__usecases__usecase__header clickable"
-                  onClick={() => toggleUseCase(ucIdentifier)}
-                >
-                  {useCaseUtils.getUseCaseIcon(ucIdentifier) && (
-                    <svg className="owneroverview__usecases__usecase__header__icon">
-                      <use
-                        xlinkHref={useCaseUtils.getUseCaseIcon(ucIdentifier)}
-                        href={useCaseUtils.getUseCaseIcon(ucIdentifier)}
-                      />
-                    </svg>
-                  )}
-                  <div className="owneroverview__usecases__usecase__header__title">
-                    {useCaseUtils.getUseCaseLabel(ucIdentifier)}
-                    <span className="owneroverview__usecases__usecase__header__title__count">
-                      {"(" + getAtomsSizeByUseCase(ucIdentifier) + ")"}
-                    </span>
-                  </div>
-                  <svg
-                    className={
-                      "owneroverview__usecases__usecase__header__carret " +
-                      (isUseCaseExpanded(ucIdentifier)
-                        ? " owneroverview__usecases__usecase__header__carret--expanded "
-                        : " owneroverview__usecases__usecase__header__carret--collapsed ")
-                    }
-                  >
-                    <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
-                  </svg>
-                </div>
-                {isUseCaseExpanded(ucIdentifier) && (
-                  <div className="owneroverview__usecases__usecase__atoms">
-                    <WonAtomCardGrid
-                      atoms={getSortedVisibleAtomsByUseCase(ucIdentifier)}
-                      currentLocation={currentLocation}
-                      showIndicators={false}
-                      showHolder={true}
-                      showCreate={false}
-                    />
-                  </div>
-                )}
+            <div className="owneroverview__usecases__usecase">
+              <div className="owneroverview__usecases__usecase__atoms">
+                <WonAtomCardGrid
+                  atoms={sortByDate(visibleAtoms)}
+                  currentLocation={currentLocation}
+                  showIndicators={false}
+                  showHolder={true}
+                  showCreate={false}
+                />
               </div>
-            ))}
-            {hasOtherAtoms() && (
-              <div className="owneroverview__usecases__usecase">
-                {whatsNewUseCaseIdentifierArray && (
-                  <div
-                    className="owneroverview__usecases__usecase__header clickable"
-                    onClick={() => toggleUseCase(undefined)}
-                  >
-                    <div className="owneroverview__usecases__usecase__header__title">
-                      Other
-                      <span className="owneroverview__usecases__usecase__header__title__count">
-                        {"(" + getOtherAtomsSize() + ")"}
-                      </span>
-                    </div>
-                    <svg
-                      className={
-                        "owneroverview__usecases__usecase__header__carret " +
-                        (isUseCaseExpanded(undefined)
-                          ? " owneroverview__usecases__usecase__header__carret--expanded "
-                          : " owneroverview__usecases__usecase__header__carret--collapsed ")
-                      }
-                    >
-                      <use
-                        xlinkHref={ico16_arrow_down}
-                        href={ico16_arrow_down}
-                      />
-                    </svg>
-                  </div>
-                )}
-
-                {isUseCaseExpanded(undefined) && (
-                  <div className="owneroverview__usecases__usecase__atoms">
-                    <WonAtomCardGrid
-                      atoms={getSortedVisibleOtherAtoms()}
-                      currentLocation={currentLocation}
-                      showIndicators={false}
-                      showHolder={true}
-                      showCreate={false}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
+            </div>
           </div>
         ) : (
           <div className="owneroverview__noresults">
@@ -271,6 +167,94 @@ export default function PageOverview() {
           </div>
         )}
       </main>
+    );
+  } else {
+    const useCaseIdentifierElements = [];
+    whatsNewAtomsGroupedByUseCaseIdentifier &&
+      whatsNewAtomsGroupedByUseCaseIdentifier.map((atoms, ucIdentifier) => {
+        const useCaseIcon = useCaseUtils.getUseCaseIcon(ucIdentifier);
+
+        useCaseIdentifierElements.push(
+          <div
+            className="owneroverview__usecases__usecase"
+            key={ucIdentifier || OTHERIDENTIFIER}
+          >
+            <Link
+              className="owneroverview__usecases__usecase__header clickable"
+              to={location =>
+                generateLink(
+                  location,
+                  { useCase: ucIdentifier || OTHERIDENTIFIER },
+                  "/overview",
+                  false
+                )
+              }
+            >
+              {useCaseIcon && (
+                <svg className="owneroverview__usecases__usecase__header__icon">
+                  <use xlinkHref={useCaseIcon} href={useCaseIcon} />
+                </svg>
+              )}
+              <div className="owneroverview__usecases__usecase__header__title">
+                {useCaseUtils.getUseCaseLabel(ucIdentifier) || "Other"}
+                <span className="owneroverview__usecases__usecase__header__title__count">
+                  {`(${atoms ? atoms.size : 0})`}
+                </span>
+              </div>
+              <svg className="owneroverview__usecases__usecase__header__carret">
+                <use xlinkHref={ico16_arrow_down} href={ico16_arrow_down} />
+              </svg>
+            </Link>
+          </div>
+        );
+      });
+
+    overviewContentElement = (
+      <main className="owneroverview">
+        <div className="owneroverview__header">
+          <div className="owneroverview__header__title">{"What's new?"}</div>
+          <div className="owneroverview__header__updated">
+            {isOwnerAtomUrisLoading ? (
+              <div className="owneroverview__header__updated__loading hide-in-responsive">
+                Loading...
+              </div>
+            ) : (
+              <div className="owneroverview__header__updated__time hide-in-responsive">
+                {"Updated: " + friendlyLastAtomUrisUpdateTimestamp}
+              </div>
+            )}
+            <button
+              className="owneroverview__header__updated__reload won-button--filled secondary"
+              onClick={reload}
+              disabled={isOwnerAtomUrisLoading}
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+        {useCaseIdentifierElements.length > 0 ? (
+          <div className="owneroverview__usecases">
+            {useCaseIdentifierElements}
+          </div>
+        ) : (
+          <div className="owneroverview__noresults">
+            <span className="owneroverview__noresults__label">
+              Nothing new found.
+            </span>
+          </div>
+        )}
+      </main>
+    );
+  }
+
+  return (
+    <section className={!isLoggedIn ? "won-signed-out" : ""}>
+      {showModalDialog && <WonModalDialog />}
+      <WonTopnav pageTitle="What's New" />
+      {isLoggedIn && <WonMenu />}
+      <WonToasts />
+      {showSlideIns && <WonSlideIn />}
+      {overviewContentElement}
       <WonFooter />
     </section>
   );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/parse-atom.js
@@ -357,23 +357,23 @@ function extractLastModifiedDate(atomJsonLd) {
 
 function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
   if (atomImm && detailsToParse) {
-    const atomContent = get(atomImm, "content");
-    const seeksBranch = get(atomImm, "seeks");
+    const atomContent = atomUtils.getContent(atomImm);
+    const seeksBranch = atomUtils.getSeeks(atomImm);
 
     const title = get(atomContent, "title");
     const seeksTitle = get(seeksBranch, "title");
 
     if (atomUtils.isServiceAtom(atomImm) || atomUtils.isPersona(atomImm)) {
-      return getIn(atomImm, ["content", "personaName"]);
+      return get(atomContent, "personaName");
     }
 
-    if (getIn(atomImm, ["matchedUseCase", "identifier"]) === "pokemonGoRaid") {
+    if (atomUtils.getMatchedUseCaseIdentifier(atomImm) === "pokemonGoRaid") {
       let raidReadable;
       let locationReadable;
       let gymReadable;
 
       const raidDetail = "pokemonRaid";
-      const raidValueImm = getIn(atomImm, ["content", raidDetail]);
+      const raidValueImm = get(atomContent, raidDetail);
       if (raidValueImm && detailsToParse[raidDetail]) {
         raidReadable = detailsToParse[raidDetail].generateHumanReadable({
           value: raidValueImm.toJS(),
@@ -382,7 +382,7 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
       }
 
       const locationDetail = "location";
-      const locationValueImm = getIn(atomImm, ["content", locationDetail]);
+      const locationValueImm = get(atomContent, locationDetail);
       if (locationValueImm && detailsToParse[locationDetail]) {
         locationReadable = detailsToParse[locationDetail].generateHumanReadable(
           {
@@ -393,7 +393,7 @@ function getHumanReadableStringFromAtom(atomImm, detailsToParse) {
       }
 
       const gymDetail = "pokemonGymInfo";
-      const gymValueImm = getIn(atomImm, ["content", gymDetail]);
+      const gymValueImm = get(atomContent, gymDetail);
       if (gymValueImm && detailsToParse[gymDetail]) {
         gymReadable = detailsToParse[gymDetail].generateHumanReadable({
           value: gymValueImm.toJS(),

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/reduce-connections.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/reduce-connections.js
@@ -11,6 +11,7 @@ import {
 import * as connectionUtils from "../../redux/utils/connection-utils";
 import * as messageUtils from "../../redux/utils/message-utils";
 import { addAtomStub } from "./reduce-atoms";
+import * as atomUtils from "~/app/redux/utils/atom-utils";
 
 export function storeConnectionsData(allAtomsInState, connectionsToStore) {
   if (connectionsToStore && connectionsToStore.size > 0) {
@@ -105,7 +106,7 @@ export function markConnectionAsRead(allAtomsInState, connectionUri) {
 export function markConnectionAsRated(allAtomsInState, connectionUri) {
   let atom =
     connectionUri && getAtomByConnectionUri(allAtomsInState, connectionUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -135,7 +136,7 @@ export function markConnectionAsRated(allAtomsInState, connectionUri) {
 export function getAtomByConnectionUri(allAtomsInState, connectionUri) {
   return (
     get(allAtomsInState, extractAtomUriFromConnectionUri(connectionUri)) ||
-    allAtomsInState.find(atom => getIn(atom, ["connections", connectionUri]))
+    allAtomsInState.find(atom => atomUtils.getConnection(atom, connectionUri))
   );
 }
 
@@ -342,7 +343,7 @@ export function setMultiSelectType(
         [atomUri, "connections", connectionUri, "messages"],
         messageUtils.sortMessages(
           messages.map(msg => {
-            msg = getIn(msg, ["viewState", "isSelected"])
+            msg = messageUtils.isMessageSelected(msg)
               ? msg.setIn(["viewState", "isSelected"], false)
               : msg;
             return msg;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/reduce-messages.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/atom-reducer/reduce-messages.js
@@ -3,6 +3,7 @@ import { markUriAsRead, isUriRead } from "../../won-localstorage.js";
 import { markConnectionAsRead } from "./reduce-connections.js";
 import { addAtomStub } from "./reduce-atoms.js";
 import vocab from "../../service/vocab.js";
+import * as atomUtils from "../../redux/utils/atom-utils.js";
 import * as connectionUtils from "../../redux/utils/connection-utils.js";
 import * as messageUtils from "../../redux/utils/message-utils.js";
 import {
@@ -299,7 +300,7 @@ export function addMessage(
       ) => {
         const allConnections =
           allAtomsInState &&
-          allAtomsInState.flatMap(atom => get(atom, "connections"));
+          allAtomsInState.flatMap(atom => atomUtils.getConnections(atom));
 
         return allConnections
           .filter(conn => connectionUtils.isConnected(conn))
@@ -327,8 +328,8 @@ export function addMessage(
           connections.map((conn, connUri) => {
             const atomUri = get(
               get(allAtomsInState, extractAtomUriFromConnectionUri(connUri)) ||
-                allAtomsInState.find(
-                  atom => !!getIn(atom, ["connections", connUri])
+                allAtomsInState.find(atom =>
+                  atomUtils.getConnection(atom, connUri)
                 ),
               "uri"
             );
@@ -405,7 +406,7 @@ export function markMessageAsSelected(
   isSelected
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
 
@@ -443,7 +444,7 @@ export function markMessageAsCollapsed(
   isCollapsed
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
 
@@ -508,7 +509,7 @@ export function markMessageExpandAllReferences(
   isExpanded
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
 
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
@@ -526,10 +527,7 @@ export function markMessageExpandAllReferences(
     return allAtomsInState;
   }
 
-  const expandedReferences = getIn(message, [
-    "viewState",
-    "expandedReferences",
-  ]);
+  const expandedReferences = messageUtils.getExpandedReferences(message);
 
   if (!expandedReferences) {
     console.error(
@@ -577,7 +575,7 @@ export function markMessageExpandReferences(
   reference
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
 
@@ -616,7 +614,7 @@ export function markMessageShowActions(
   showActions
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
 
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
@@ -655,7 +653,7 @@ export function markMessageAsRead(
   read = true
 ) {
   const atom = get(allAtomsInState, atomUri);
-  const connection = getIn(atom, ["connections", connectionUri]);
+  const connection = atomUtils.getConnection(atom, connectionUri);
 
   let messages = connectionUtils.getMessages(connection);
   const message = get(messages, messageUri);
@@ -714,7 +712,7 @@ export function markMessageAsRejected(
   rejected
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   let message = get(messages, messageUri);
 
@@ -833,7 +831,7 @@ export function markMessageAsRetracted(
   retracted
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   let message = get(messages, messageUri);
 
@@ -949,7 +947,7 @@ export function markMessageAsClaimed(
   claimed
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -1018,7 +1016,7 @@ export function markMessageAsAgreed(
   isAgreedOn
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -1087,7 +1085,7 @@ export function markMessageAsProposed(
   proposed
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -1147,7 +1145,7 @@ export function markMessageAsAccepted(
   accepted
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   let message = get(messages, messageUri);
 
@@ -1216,7 +1214,7 @@ export function markMessageAsCancelled(
   cancelled
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -1295,7 +1293,7 @@ export function markMessageAsCancellationPending(
   cancellationPending
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
 
   if (!connection) {
     console.error(
@@ -1357,7 +1355,7 @@ export function updateMessageStatus(
   atomUri
 ) {
   let atom = get(allAtomsInState, atomUri);
-  let connection = getIn(atom, ["connections", connectionUri]);
+  let connection = atomUtils.getConnection(atom, connectionUri);
   let messages = connectionUtils.getMessages(connection);
   let message = get(messages, messageUri);
 
@@ -1375,7 +1373,7 @@ export function updateMessageStatus(
   }
 
   //Check if there is any "positive" messageStatus, we assume that we do not want to display this message "fully"
-  const agreementData = get(connection, "agreementData");
+  const agreementData = connectionUtils.getAgreementData(connection);
 
   const isProposed = !!getIn(agreementData, [
     "proposedMessageUris",

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -202,7 +202,7 @@ export const getAllChatConnections = createSelector(
       )
       .toOrderedMap()
       .sortBy(conn => {
-        const lastUpdateDate = get(conn, "lastUpdateDate");
+        const lastUpdateDate = connectionUtils.getLastUpdateDate(conn);
         return lastUpdateDate && lastUpdateDate.getTime();
       })
       .reverse()

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -549,32 +549,6 @@ export function getSeeksSocketsWithKeysReset(atomImm) {
   return undefined;
 }
 
-/**
- * Sorts the elements by distance from given location (default order is ascending)
- * @param elementsImm elements from state that need to be returned as a sorted array
- * @param location given location to calculate the distance from
- * @param order if "DESC" then the order will be descending, everything else resorts to the default sort of ascending order
- * @returns {*} sorted Elements array
- */
-export function sortByDistanceFrom(atomsImm, location, order = "ASC") {
-  let sortedAtoms = atomsImm && atomsImm.toArray();
-
-  if (sortedAtoms) {
-    sortedAtoms.sort(function(a, b) {
-      const bDist = getDistanceFrom(b, location);
-      const aDist = getDistanceFrom(a, location);
-
-      if (order === "DESC") {
-        return bDist - aDist;
-      } else {
-        return aDist - bDist;
-      }
-    });
-  }
-
-  return sortedAtoms;
-}
-
 function getSocketKeysReset(socketsImm) {
   //TODO: Needs to be generic somehow, otherwise every socket that is added would not be able to be reset correctly
   return socketsImm.mapKeys(key => key.substr(key.lastIndexOf("#")));

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -22,6 +22,33 @@ export function getState(atom) {
   return get(atom, "state");
 }
 
+export function getFakePersonaName(atom) {
+  return get(atom, "fakePersonaName");
+}
+
+export function getLastUpdateDate(atom) {
+  return get(atom, "lastUpdateDate");
+}
+
+export function getCreationDate(atom) {
+  return get(atom, "creationDate");
+}
+
+export function getModifiedDate(atom) {
+  return get(atom, "modifiedDate");
+}
+
+export function isBeingCreated(atom) {
+  return get(atom, "isBeingCreated");
+}
+
+export function getContent(atom) {
+  return get(atom, "content");
+}
+
+export function getSeeks(atom) {
+  return get(atom, "seeks");
+}
 /**
  * Determines if a given atom is a Inactive
  * @param atom
@@ -64,19 +91,20 @@ export function matchesDefinition(atom, useCaseDefinition) {
  * @returns {any}
  */
 export function getTitle(atom, externalDataState, separator = ", ") {
-  const title = getIn(atom, ["content", "title"]);
+  const atomContent = getContent(atom);
+  const title = get(atomContent, "title");
   if (title) {
     return title;
   }
 
-  const personaName = getIn(atom, ["content", "personaName"]);
+  const personaName = get(atomContent, "personaName");
 
   if (personaName) {
     return personaName;
   }
 
-  const eventObjectAboutUris = getIn(atom, ["content", "eventObjectAboutUris"]);
-  const classifiedAs = getIn(atom, ["content", "classifiedAs"]);
+  const eventObjectAboutUris = get(atomContent, "eventObjectAboutUris");
+  const classifiedAs = get(atomContent, "classifiedAs");
 
   const wikiDataHumanReadable = [];
 
@@ -131,7 +159,7 @@ export function getReactions(atom, socketType) {
 }
 
 export function hasMatchedUseCase(atom) {
-  return !!getIn(atom, ["matchedUseCase", "identifier"]);
+  return !!getMatchedUseCaseIdentifier(atom);
 }
 
 export function hasImages(atom) {
@@ -139,12 +167,7 @@ export function hasImages(atom) {
 }
 
 export function hasLocation(atom) {
-  return (
-    !!getIn(atom, ["content", "jobLocation"]) ||
-    !!getIn(atom, ["content", "location"]) ||
-    !!getIn(atom, ["seeks", "jobLocation"]) ||
-    !!getIn(atom, ["seeks", "location"])
-  );
+  return !!getLocation(atom);
 }
 
 /**
@@ -155,15 +178,15 @@ export function hasLocation(atom) {
  * @returns {*}
  */
 export function getLocation(atom) {
-  if (hasLocation(atom)) {
-    return (
-      getIn(atom, ["content", "jobLocation"]) ||
-      getIn(atom, ["content", "location"]) ||
-      getIn(atom, ["seeks", "jobLocation"]) ||
-      getIn(atom, ["seeks", "location"])
-    );
-  }
-  return undefined;
+  const atomContent = getContent(atom);
+  const atomSeeks = getSeeks(atom);
+
+  return (
+    get(atomContent, "jobLocation") ||
+    get(atomContent, "location") ||
+    get(atomSeeks, "jobLocation") ||
+    get(atomSeeks, "location")
+  );
 }
 
 /**
@@ -220,15 +243,18 @@ export function getDistanceFrom(atom, location) {
 }
 
 export function getImages(atom) {
-  return getIn(atom, ["content", "images"]);
+  const atomContent = getContent(atom);
+  return get(atomContent, "images");
 }
 
 export function getImageUrl(atom) {
-  return getIn(atom, ["content", "imageUrl"]);
+  const atomContent = getContent(atom);
+  return get(atomContent, "imageUrl");
 }
 
 export function getSeeksImages(atom) {
-  return getIn(atom, ["seeks", "images"]);
+  const atomSeeks = getSeeks(atom);
+  return get(atomSeeks, "images");
 }
 
 /**
@@ -271,8 +297,8 @@ export function getDefaultImage(atom) {
  * @param atom
  */
 export function getDefaultPersonaImage(atom) {
-  if (hasImages(atom) && isPersona(atom)) {
-    const contentImages = getIn(atom, ["content", "images"]);
+  if (isPersona(atom) && hasImages(atom)) {
+    const contentImages = getImages(atom);
 
     if (contentImages) {
       const defaultImage = contentImages.find(image => get(image, "default"));
@@ -291,33 +317,30 @@ export function getDefaultPersonaImage(atom) {
  * @returns {*|boolean}
  */
 export function isInvisibleAtom(atom) {
-  return (
-    getIn(atom, ["content", "flags"]) &&
-    getIn(atom, ["content", "flags"]).contains(
-      vocab.WONMATCH.NoHintForCounterpartCompacted
-    )
-  );
+  const atomContent = getContent(atom);
+  const flags = get(atomContent, "flags");
+  return flags && flags.contains(vocab.WONMATCH.NoHintForCounterpartCompacted);
 }
 
 export function isPersona(atom) {
-  return (
-    getIn(atom, ["content", "type"]) &&
-    getIn(atom, ["content", "type"]).has(vocab.WON.PersonaCompacted)
-  );
+  const atomContent = getContent(atom);
+  const types = get(atomContent, "type");
+
+  return types && types.has(vocab.WON.PersonaCompacted);
 }
 
 export function isServiceAtom(atom) {
-  return (
-    getIn(atom, ["content", "type"]) &&
-    getIn(atom, ["content", "type"]).has(vocab.BOT.ServiceAtomCompacted)
-  );
+  const atomContent = getContent(atom);
+  const types = get(atomContent, "type");
+
+  return types && types.has(vocab.BOT.ServiceAtomCompacted);
 }
 
 export function isAtom(atom) {
-  return (
-    getIn(atom, ["content", "type"]) &&
-    getIn(atom, ["content", "type"]).has(vocab.WON.AtomCompacted)
-  );
+  const atomContent = getContent(atom);
+  const types = get(atomContent, "type");
+
+  return types && types.has(vocab.WON.AtomCompacted);
 }
 
 export function hasChatSocket(atom) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/connection-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/connection-utils.js
@@ -14,6 +14,18 @@ export function getTargetAtomUri(connection) {
   return get(connection, "targetAtomUri");
 }
 
+export function getTargetConnectionUri(connection) {
+  return get(connection, "targetConnectionUri");
+}
+
+export function getLastUpdateDate(connection) {
+  return get(connection, "lastUpdateDate");
+}
+
+export function getMultiSelectType(connection) {
+  return get(connection, "multiSelectType");
+}
+
 export function getSocketUri(connection) {
   return get(connection, "socketUri");
 }
@@ -48,6 +60,26 @@ export function isClosed(connection) {
 
 export function isUnread(connection) {
   return !!get(connection, "unread");
+}
+
+export function getAgreementData(connection) {
+  return get(connection, "agreementData");
+}
+
+export function getAgreementDataset(connection) {
+  return get(connection, "agreementDataset");
+}
+
+export function getPetriNetData(connection) {
+  return get(connection, "petriNetData");
+}
+
+export function showPetriNetData(connection) {
+  return get(connection, "showPetriNetData");
+}
+
+export function showAgreementData(connection) {
+  return get(connection, "showAgreementData");
 }
 
 export function hasSocketUris(connection, socketUri, targetSocketUri) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/message-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/message-utils.js
@@ -180,6 +180,14 @@ export function getContent(msg) {
   return get(msg, "content");
 }
 
+export function hasText(msg) {
+  return !!getText(msg);
+}
+
+export function getText(msg) {
+  return get(getContent(msg), "text");
+}
+
 export function isSystemMessage(msg) {
   return get(msg, "systemMessage");
 }

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/usecase-utils.js
@@ -708,11 +708,11 @@ export function isHoldable(useCaseImm) {
 }
 
 export function getUseCaseLabel(identifier) {
-  return getIn(useCasesImm, [identifier, "label"]);
+  return identifier && getIn(useCasesImm, [identifier, "label"]);
 }
 
 export function getUseCaseIcon(identifier) {
-  const iconImm = getIn(useCasesImm, [identifier, "icon"]);
+  const iconImm = identifier && getIn(useCasesImm, [identifier, "icon"]);
   return iconImm && iconImm.toJS();
 }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -7,16 +7,6 @@ import fakeNames from "./fakeNames.json";
  * Created by ksinger on 01.09.2015.
  */
 
-export function dispatchEvent(elem, eventName, eventData) {
-  let event = undefined;
-  if (eventData) {
-    event = new CustomEvent(eventName, { detail: eventData });
-  } else {
-    event = new Event(eventName);
-  }
-  elem.dispatchEvent(event);
-}
-
 export function getPathname(location) {
   return location && location.pathname;
 }
@@ -347,22 +337,6 @@ export function getIn(obj, path) {
 }
 
 /**
- * zipWith :: (a -> b -> c) -> [a] -> [b] -> [c]
- * e.g. zipWith((x,y)=>x-y, [8,9,3], [3,2]) // => [5,7]
- * @param f
- * @param xs
- * @param ys
- */
-export function zipWith(f, xs, ys) {
-  return Array.from(
-    {
-      length: Math.min(xs.length, ys.length),
-    },
-    (_, i) => f(xs[i], ys[i])
-  );
-}
-
-/**
  * Filters given Map of connections by occurence of a given searchText Object { value: searchString }
  * check only looks into the humanReadable of the atom(s)
  * @param connectionsImm connections map to apply filter on
@@ -466,36 +440,6 @@ export function filterAtomsBySearchValue(
     );
   }
   return allAtomsImm;
-}
-
-/**
- * Sorts the elements by Selector (default order is ascending)
- * @param elementsImm elements from state that need to be returned as a sorted array
- * @param selector selector for the date that will be used to sort the elements (default is "lastUpdateDate")
- * @param order if "ASC" then the order will be ascending, everything else resorts to the default sort of descending order
- * @returns {*} sorted Elements array
- */
-export function sortBy(elementsImm, selector = elem => elem, order = "ASC") {
-  let sortedElements = elementsImm && elementsImm.toArray();
-
-  if (sortedElements) {
-    sortedElements.sort(function(a, b) {
-      const bValue = b && selector(b);
-      const aValue = a && selector(a);
-
-      if (order === "ASC") {
-        if (aValue < bValue) return -1;
-        if (aValue > bValue) return 1;
-        return 0;
-      } else {
-        if (bValue < aValue) return -1;
-        if (bValue > aValue) return 1;
-        return 0;
-      }
-    });
-  }
-
-  return sortedElements;
 }
 
 export function generateHexColor(text) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/utils.js
@@ -363,36 +363,6 @@ export function zipWith(f, xs, ys) {
 }
 
 /**
- * Sorts the elements by Date (default order is descending)
- * @param elementsImm elements from state that need to be returned as a sorted array
- * @param selector selector for the date that will be used to sort the elements (default is "lastUpdateDate")
- * @param order if "ASC" then the order will be ascending, everything else resorts to the default sort of descending order
- * @returns {*} sorted Elements array
- */
-export function sortByDate(
-  elementsImm,
-  selector = "lastUpdateDate",
-  order = "DESC"
-) {
-  let sortedElements = elementsImm && elementsImm.toArray();
-
-  if (sortedElements) {
-    sortedElements.sort(function(a, b) {
-      const bDate = b.get(selector) && b.get(selector).getTime();
-      const aDate = a.get(selector) && a.get(selector).getTime();
-
-      if (order === "ASC") {
-        return aDate - bDate;
-      } else {
-        return bDate - aDate;
-      }
-    });
-  }
-
-  return sortedElements;
-}
-
-/**
  * Filters given Map of connections by occurence of a given searchText Object { value: searchString }
  * check only looks into the humanReadable of the atom(s)
  * @param connectionsImm connections map to apply filter on

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -10,6 +10,12 @@ export const rdfTextfieldHelpText =
   "for prefixes that will be added automatically. E.g." +
   `\`<${vocab.WONMSG.uriPlaceholder.event}> con:text "hello world!". \``;
 
+export const noParsableContentPlaceholder =
+  "«This message couldn't be displayed as it didn't contain," +
+  "any parsable content! " +
+  'Click on the "Show raw RDF data"-button in ' +
+  'the footer of the page to see the "raw" message-data.»';
+
 const labels = deepFreeze({
   connectionState: {
     [vocab.WON.Suggested]: "Suggested",

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_footer.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_footer.scss
@@ -72,13 +72,14 @@ won-footer {
 
     .footer__linksmobile {
       grid-area: footerLinks;
-      display: flex;
+      display: grid;
       font-size: $smallFontSize;
-      align-items: center;
-      flex-direction: column;
+      justify-items: center;
+      grid-template-columns: 1fr 1fr;
 
       &__link:visited,
       &__link {
+        padding: 0.5rem;
         cursor: pointer;
         color: $won-subtitle-gray;
         text-decoration: none;

--- a/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
+++ b/webofneeds/won-owner-webapp/src/main/webapp/style/_overview.scss
@@ -19,14 +19,29 @@ main.owneroverview {
     grid-gap: 0.5rem;
     border-bottom: $thinGrayBorder;
     padding: 0.5rem;
+
+    &--withIcon {
+      grid-template-columns: min-content 1fr min-content;
+    }
+
     @media (min-width: $maxContentWidth) {
       padding-right: 0;
     }
     align-items: center;
 
+    &__icon {
+      @include fixed-square($iconSize);
+      --local-primary: #{$won-primary-text-color};
+    }
+
     &__title {
       font-size: $mediumFontSize;
       font-weight: 300;
+
+      &__count {
+        display: inline-block;
+        margin-left: 0.25rem;
+      }
     }
 
     &__updated {
@@ -77,6 +92,7 @@ main.owneroverview {
         grid-template-areas: "ouch_icon ouch_title ouch_carret";
         border-bottom: $thinGrayBorder;
         padding: 0.5rem;
+        color: $won-primary-text-color;
         @media (min-width: $maxContentWidth) {
           padding-right: 0;
         }
@@ -110,14 +126,7 @@ main.owneroverview {
             --local-primary: #{$won-primary-color};
           }
 
-          &--expanded {
-            transform: rotate(-180deg);
-            transition: all linear 0.2s;
-          }
-
-          &--collapsed {
-            transition: all linear 0.2s;
-          }
+          transform: rotate(-90deg);
         }
       }
 

--- a/webofneeds/won-owner-webapp/src/main/webapp/template.ejs
+++ b/webofneeds/won-owner-webapp/src/main/webapp/template.ejs
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width">
+  <meta name="Description" content="Web of Needs">
   <link rel="icon" type="image/png" href="skin/current/images/logo.png">
   <title>Web of Needs</title>
 </head>


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- Currently a ServiceAtom can't be modified if the content has changed

## What is the new behavior?
- Refactors sorting from Array sorting to ImmutableJS map sorting
- Change UX of "What's New" Page from expandable useCases to single visible UseCase (makes back interaction better)
- Refactor connection-message to use internal components, to make the code somewhat simpler (or at least tried to do so)
- Implements ServiceAtom Modification in ServiceAtomBehaviour for BotFramework
- Refactor viewer components from classes to functions
- FIX whitescreen of death for price picker (and any picker that accesses this in the generateHumanReadable function of the detail)
- FIX additionalContent icon in chat-textfield

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
Added two (simple) changes to improve lighthouse rating (larger tap target size in mobile footer, adds description meta tag to template.ejs)