### PR TITLE
Grant access rights to WoN nodes

### DIFF
--- a/webofneeds/won-auth/src/main/java/won/auth/WonAclEvaluator.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/WonAclEvaluator.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.auth.check.AtomNodeChecker;
 import won.auth.check.ConnectionTargetCheck;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.check.WonAclEvaluationException;
 import won.auth.model.*;
 import won.auth.support.AseMerger;
@@ -30,12 +30,12 @@ public class WonAclEvaluator {
     public static final long DEFAULT_TOKEN_EXPIRES_AFTER_SECONDS = 3600;
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final Set<Authorization> authorizations;
-    private final TargetAtomCheckEvaluator targetAtomCheckEvaluator;
+    private final ConnectionTargetCheckEvaluator targetAtomCheckEvaluator;
     private final AtomNodeChecker atomNodeChecker;
     private final WebIdKeyLoader webIdKeyLoader;
 
     public WonAclEvaluator(Set<Authorization> authorizations,
-                    TargetAtomCheckEvaluator targetAtomCheckEvaluator,
+                    ConnectionTargetCheckEvaluator targetAtomCheckEvaluator,
                     AtomNodeChecker atomNodeChecker,
                     WebIdKeyLoader webIdKeyLoader) {
         this.authorizations = authorizations;
@@ -205,7 +205,7 @@ public class WonAclEvaluator {
                                 return aer;
                             } catch (Exception e) {
                                 throw new WonAclEvaluationException(
-                                                String.format("Evaluating the following authorzation (node %s) causes exception\n%s",
+                                                String.format("Evaluating the following authorization (node %s) causes exception\n%s",
                                                                 auth.getNode(), AuthUtils.toRdfString(auth)),
                                                 e);
                             }

--- a/webofneeds/won-auth/src/main/java/won/auth/WonAclEvaluatorFactory.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/WonAclEvaluatorFactory.java
@@ -6,7 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import won.auth.check.AtomNodeChecker;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.model.Authorization;
 import won.cryptography.rdfsign.WebIdKeyLoader;
 import won.shacl2java.Shacl2JavaInstanceFactory;
@@ -20,7 +20,7 @@ public class WonAclEvaluatorFactory {
     protected Shacl2JavaInstanceFactory instanceFactory = AuthUtils.instanceFactory();
     protected Shapes shapes;
     @Autowired
-    protected TargetAtomCheckEvaluator targetAtomCheckEvaluator;
+    protected ConnectionTargetCheckEvaluator targetAtomCheckEvaluator;
     @Autowired
     protected AtomNodeChecker atomNodeChecker;
     @Autowired
@@ -30,7 +30,7 @@ public class WonAclEvaluatorFactory {
     }
 
     public WonAclEvaluatorFactory(
-                    TargetAtomCheckEvaluator targetAtomCheckEvaluator,
+                    ConnectionTargetCheckEvaluator targetAtomCheckEvaluator,
                     AtomNodeChecker atomNodeChecker,
                     WebIdKeyLoader webIdKeyLoader) {
         this.targetAtomCheckEvaluator = targetAtomCheckEvaluator;

--- a/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
@@ -1,26 +1,31 @@
 package won.auth.check;
 
-import won.auth.model.*;
+import won.auth.model.ConnectionState;
 
 import java.net.URI;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-public class TargetAtomCheck {
+public class ConnectionTargetCheck {
     private URI atom;
     private URI requestedTarget;
     private Set<URI> allowedSockets;
     private Set<URI> allowedSocketTypes;
     private Set<URI> allowedConnectionStates;
+    private boolean isWonNodeCheck = false;
 
-    public TargetAtomCheck(URI atom, URI requestedTarget) {
+    public ConnectionTargetCheck(URI atom, URI requestedTarget) {
         this.atom = atom;
         this.requestedTarget = requestedTarget;
     }
 
-    public TargetAtomCheck clone() {
-        TargetAtomCheck clone = new TargetAtomCheck(atom, requestedTarget);
+    public ConnectionTargetCheck clone() {
+        ConnectionTargetCheck clone = new ConnectionTargetCheck(atom, requestedTarget);
         clone.atom = atom;
+        clone.isWonNodeCheck = isWonNodeCheck;
         clone.requestedTarget = requestedTarget;
         clone.allowedSockets = new HashSet<>(getAllowedSockets());
         clone.allowedSocketTypes = new HashSet<>(getAllowedSocketTypes());
@@ -34,6 +39,14 @@ public class TargetAtomCheck {
 
     public URI getRequestedTarget() {
         return requestedTarget;
+    }
+
+    public boolean isWonNodeCheck() {
+        return isWonNodeCheck;
+    }
+
+    public void setWonNodeCheck(boolean wonNodeCheck) {
+        isWonNodeCheck = wonNodeCheck;
     }
 
     public Set<URI> getAllowedSockets() {
@@ -117,25 +130,6 @@ public class TargetAtomCheck {
         }
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        TargetAtomCheck that = (TargetAtomCheck) o;
-        return Objects.equals(atom, that.atom) &&
-                        Objects.equals(requestedTarget, that.requestedTarget) &&
-                        Objects.equals(allowedSockets, that.allowedSockets) &&
-                        Objects.equals(allowedSocketTypes, that.allowedSocketTypes) &&
-                        Objects.equals(allowedConnectionStates, that.allowedConnectionStates);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(atom, requestedTarget, allowedSockets, allowedSocketTypes, allowedConnectionStates);
-    }
-
     public void intersectAllowedConnectionStates(Set<URI> allowedConnectionStates) {
         if (allowedConnectionStates != null) {
             this.allowedConnectionStates.retainAll(allowedConnectionStates);
@@ -150,10 +144,34 @@ public class TargetAtomCheck {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionTargetCheck that = (ConnectionTargetCheck) o;
+        return isWonNodeCheck == that.isWonNodeCheck &&
+                        Objects.equals(atom, that.atom) &&
+                        Objects.equals(requestedTarget, that.requestedTarget) &&
+                        Objects.equals(allowedSockets, that.allowedSockets) &&
+                        Objects.equals(allowedSocketTypes, that.allowedSocketTypes) &&
+                        Objects.equals(allowedConnectionStates, that.allowedConnectionStates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(atom, requestedTarget, allowedSockets, allowedSocketTypes, allowedConnectionStates,
+                        isWonNodeCheck);
+    }
+
+    @Override
     public String toString() {
         return "TargetAtomCheck{" +
                         "atom=" + atom +
                         ", requestorAtom=" + requestedTarget +
+                        ", isWonNodeAllowed=" + isWonNodeCheck +
                         ", allowedSockets=" + allowedSockets +
                         ", allowedSocketTypes=" + allowedSocketTypes +
                         ", allowedConnectionStates=" + allowedConnectionStates +

--- a/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
@@ -171,7 +171,7 @@ public class ConnectionTargetCheck {
         return "TargetAtomCheck{" +
                         "atom=" + atom +
                         ", requestorAtom=" + requestedTarget +
-                        ", isWonNodeAllowed=" + isWonNodeCheck +
+                        ", isWonNodeCheck=" + isWonNodeCheck +
                         ", allowedSockets=" + allowedSockets +
                         ", allowedSocketTypes=" + allowedSocketTypes +
                         ", allowedConnectionStates=" + allowedConnectionStates +

--- a/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheck.java
@@ -130,15 +130,15 @@ public class ConnectionTargetCheck {
         }
     }
 
-    public void intersectAllowedConnectionStates(Set<URI> allowedConnectionStates) {
+    public void addAllowedConnectionStates(Set<URI> allowedConnectionStates) {
         if (allowedConnectionStates != null) {
-            this.allowedConnectionStates.retainAll(allowedConnectionStates);
+            this.allowedConnectionStates.addAll(allowedConnectionStates);
         }
     }
 
-    public void intersectAllowedConnectionStatesCS(Set<ConnectionState> connectionStates) {
+    public void addAllowedConnectionStatesCS(Set<ConnectionState> connectionStates) {
         if (connectionStates != null) {
-            intersectAllowedConnectionStates(connectionStates
+            addAllowedConnectionStates(connectionStates
                             .stream().map(ConnectionState::getValue).collect(Collectors.toSet()));
         }
     }

--- a/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheckEvaluator.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/ConnectionTargetCheckEvaluator.java
@@ -1,5 +1,5 @@
 package won.auth.check;
 
-public interface TargetAtomCheckEvaluator {
+public interface ConnectionTargetCheckEvaluator {
     public boolean isRequestorAllowedTarget(ConnectionTargetCheck check);
 }

--- a/webofneeds/won-auth/src/main/java/won/auth/check/TargetAtomCheckEvaluator.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/TargetAtomCheckEvaluator.java
@@ -1,5 +1,5 @@
 package won.auth.check;
 
 public interface TargetAtomCheckEvaluator {
-    public boolean isRequestorAllowedTarget(TargetAtomCheck check);
+    public boolean isRequestorAllowedTarget(ConnectionTargetCheck check);
 }

--- a/webofneeds/won-auth/src/main/java/won/auth/check/impl/AcceptAll.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/impl/AcceptAll.java
@@ -1,12 +1,12 @@
 package won.auth.check.impl;
 
-import won.auth.check.TargetAtomCheck;
+import won.auth.check.ConnectionTargetCheck;
 import won.auth.check.TargetAtomCheckEvaluator;
 import won.auth.check.TokenValidator;
 
 public class AcceptAll implements TargetAtomCheckEvaluator, TokenValidator {
     @Override
-    public boolean isRequestorAllowedTarget(TargetAtomCheck check) {
+    public boolean isRequestorAllowedTarget(ConnectionTargetCheck check) {
         return true;
     }
 

--- a/webofneeds/won-auth/src/main/java/won/auth/check/impl/AcceptAll.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/check/impl/AcceptAll.java
@@ -1,10 +1,10 @@
 package won.auth.check.impl;
 
 import won.auth.check.ConnectionTargetCheck;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.check.TokenValidator;
 
-public class AcceptAll implements TargetAtomCheckEvaluator, TokenValidator {
+public class AcceptAll implements ConnectionTargetCheckEvaluator, TokenValidator {
     @Override
     public boolean isRequestorAllowedTarget(ConnectionTargetCheck check) {
         return true;

--- a/webofneeds/won-auth/src/main/java/won/auth/support/ConnectionTargetCheckGenerator.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/support/ConnectionTargetCheckGenerator.java
@@ -4,7 +4,10 @@ import won.auth.check.ConnectionTargetCheck;
 import won.auth.model.*;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ConnectionTargetCheckGenerator extends DefaultTreeExpressionVisitor {
     private Deque<ConnectionTargetCheck> checks = new ArrayDeque<>();
@@ -39,7 +42,7 @@ public class ConnectionTargetCheckGenerator extends DefaultTreeExpressionVisitor
         if (other instanceof TargetAtomContainer) {
             TargetAtomContainer tac = (TargetAtomContainer) other;
             if (tac.getTargetAtom() != null) {
-                collectTargetAtomCheck(tac);
+                collectConnectionTargetCheck(tac);
             }
         }
     }
@@ -49,16 +52,13 @@ public class ConnectionTargetCheckGenerator extends DefaultTreeExpressionVisitor
             TargetAtomContainer tac = (TargetAtomContainer) other;
             if (tac.getTargetWonNode() != null) {
                 checks.peek().setWonNodeCheck(true);
-                collectTargetAtomCheck(tac);
+                collectConnectionTargetCheck(tac);
             }
         }
     }
 
-    public void collectTargetAtomCheck(TargetAtomContainer node) {
+    public void collectConnectionTargetCheck(TargetAtomContainer node) {
         ConnectionTargetCheck collected = checks.peek().clone();
-        if (collected.getAllowedConnectionStates().isEmpty()) {
-            collected.setAllowedConnectionStatesCS(Collections.singleton(ConnectionState.CONNECTED));
-        }
         this.connectionTargetChecks.add(collected);
     }
 
@@ -92,7 +92,7 @@ public class ConnectionTargetCheckGenerator extends DefaultTreeExpressionVisitor
         if (inherited.isEmpty()) {
             check.setAllowedConnectionStatesCS(other.getConnectionStates());
         } else {
-            check.intersectAllowedConnectionStatesCS(other.getConnectionStates());
+            check.addAllowedConnectionStatesCS(other.getConnectionStates());
         }
         processPossibleTargetAtom(other);
         processPossibleTargetWonNode(other);

--- a/webofneeds/won-auth/src/main/java/won/auth/support/ConnectionTargetCheckGenerator.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/support/ConnectionTargetCheckGenerator.java
@@ -1,17 +1,17 @@
 package won.auth.support;
 
-import won.auth.check.TargetAtomCheck;
+import won.auth.check.ConnectionTargetCheck;
 import won.auth.model.*;
 
 import java.net.URI;
 import java.util.*;
 
-public class TargetAtomCheckGenerator extends DefaultTreeExpressionVisitor {
-    private Deque<TargetAtomCheck> checks = new ArrayDeque<>();
-    private Set<TargetAtomCheck> targetAtomChecks = new HashSet<>();
+public class ConnectionTargetCheckGenerator extends DefaultTreeExpressionVisitor {
+    private Deque<ConnectionTargetCheck> checks = new ArrayDeque<>();
+    private Set<ConnectionTargetCheck> connectionTargetChecks = new HashSet<>();
 
-    public TargetAtomCheckGenerator(URI atom, URI candidateAtom) {
-        TargetAtomCheck rootCheck = new TargetAtomCheck(atom, candidateAtom);
+    public ConnectionTargetCheckGenerator(URI atom, URI candidateAtom) {
+        ConnectionTargetCheck rootCheck = new ConnectionTargetCheck(atom, candidateAtom);
         checks.push(rootCheck);
     }
 
@@ -31,8 +31,8 @@ public class TargetAtomCheckGenerator extends DefaultTreeExpressionVisitor {
         }
     }
 
-    public Set<TargetAtomCheck> getTargetAtomChecks() {
-        return targetAtomChecks;
+    public Set<ConnectionTargetCheck> getConnectionTargetChecks() {
+        return connectionTargetChecks;
     }
 
     public void processPossibleTargetAtom(TreeExpression other) {
@@ -44,37 +44,50 @@ public class TargetAtomCheckGenerator extends DefaultTreeExpressionVisitor {
         }
     }
 
+    public void processPossibleTargetWonNode(TreeExpression other) {
+        if (other instanceof TargetAtomContainer) {
+            TargetAtomContainer tac = (TargetAtomContainer) other;
+            if (tac.getTargetWonNode() != null) {
+                checks.peek().setWonNodeCheck(true);
+                collectTargetAtomCheck(tac);
+            }
+        }
+    }
+
     public void collectTargetAtomCheck(TargetAtomContainer node) {
-        TargetAtomCheck collected = checks.peek().clone();
+        ConnectionTargetCheck collected = checks.peek().clone();
         if (collected.getAllowedConnectionStates().isEmpty()) {
             collected.setAllowedConnectionStatesCS(Collections.singleton(ConnectionState.CONNECTED));
         }
-        this.targetAtomChecks.add(collected);
+        this.connectionTargetChecks.add(collected);
     }
 
     @Override
     protected void onBeginVisit(ConnectionsExpression other) {
-        TargetAtomCheck check = checks.peek();
+        ConnectionTargetCheck check = checks.peek();
         check.setAllowedConnectionStatesCS(other.getConnectionStates());
         processPossibleTargetAtom(other);
+        processPossibleTargetWonNode(other);
     }
 
     @Override
     protected void onBeginVisit(SocketExpression other) {
-        TargetAtomCheck check = checks.peek();
+        ConnectionTargetCheck check = checks.peek();
         check.setAllowedSockets(other.getSocketIris());
         check.setAllowedSocketTypes(other.getSocketTypes());
         processPossibleTargetAtom(other);
+        processPossibleTargetWonNode(other);
     }
 
     @Override
     protected void onBeginVisit(AseRoot other) {
         processPossibleTargetAtom(other);
+        processPossibleTargetWonNode(other);
     }
 
     @Override
     protected void onBeginVisit(ConnectionExpression other) {
-        TargetAtomCheck check = checks.peek();
+        ConnectionTargetCheck check = checks.peek();
         Set<URI> inherited = check.getAllowedConnectionStates();
         if (inherited.isEmpty()) {
             check.setAllowedConnectionStatesCS(other.getConnectionStates());
@@ -82,5 +95,6 @@ public class TargetAtomCheckGenerator extends DefaultTreeExpressionVisitor {
             check.intersectAllowedConnectionStatesCS(other.getConnectionStates());
         }
         processPossibleTargetAtom(other);
+        processPossibleTargetWonNode(other);
     }
 }

--- a/webofneeds/won-auth/src/test/java/won/auth/GrantedOperationsTest.java
+++ b/webofneeds/won-auth/src/test/java/won/auth/GrantedOperationsTest.java
@@ -97,7 +97,7 @@ public class GrantedOperationsTest {
     public void testSet1() throws IOException {
         Shacl2JavaInstanceFactory factory = AuthUtils.instanceFactory();
         Shapes atomDataShapes = loadShapes(atomDataShapesDef);
-        ModelBasedTargetAtomCheckEvaluator targetAtomChecker = new ModelBasedTargetAtomCheckEvaluator(
+        ModelBasedConnectionTargetCheckEvaluator targetAtomChecker = new ModelBasedConnectionTargetCheckEvaluator(
                         atomDataShapes,
                         "won.auth.test.model");
         ModelBasedAtomNodeChecker atomNodeChecker = new ModelBasedAtomNodeChecker(atomDataShapes,

--- a/webofneeds/won-auth/src/test/java/won/auth/ModelBasedConnectionTargetCheckEvaluator.java
+++ b/webofneeds/won-auth/src/test/java/won/auth/ModelBasedConnectionTargetCheckEvaluator.java
@@ -5,7 +5,7 @@ import org.apache.jena.shacl.Shapes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import won.auth.check.ConnectionTargetCheck;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.test.model.Atom;
 import won.auth.test.model.Connection;
 import won.auth.test.model.Socket;
@@ -18,12 +18,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ModelBasedTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
+public class ModelBasedConnectionTargetCheckEvaluator implements ConnectionTargetCheckEvaluator {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     Shacl2JavaInstanceFactory instanceFactory;
     Shacl2JavaInstanceFactory.Accessor accessor = null;
 
-    public ModelBasedTargetAtomCheckEvaluator(Shapes shapes, String packageName) {
+    public ModelBasedConnectionTargetCheckEvaluator(Shapes shapes, String packageName) {
         this.instanceFactory = new Shacl2JavaInstanceFactory(shapes, packageName);
     }
 

--- a/webofneeds/won-auth/src/test/java/won/auth/ModelBasedTargetAtomCheckEvaluator.java
+++ b/webofneeds/won-auth/src/test/java/won/auth/ModelBasedTargetAtomCheckEvaluator.java
@@ -4,7 +4,7 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.shacl.Shapes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import won.auth.check.TargetAtomCheck;
+import won.auth.check.ConnectionTargetCheck;
 import won.auth.check.TargetAtomCheckEvaluator;
 import won.auth.test.model.Atom;
 import won.auth.test.model.Connection;
@@ -36,7 +36,7 @@ public class ModelBasedTargetAtomCheckEvaluator implements TargetAtomCheckEvalua
     }
 
     @Override
-    public boolean isRequestorAllowedTarget(TargetAtomCheck check) {
+    public boolean isRequestorAllowedTarget(ConnectionTargetCheck check) {
         Optional<Atom> atomOpt = accessor.getInstanceOfType(check.getAtom().toString(), Atom.class);
         if (!atomOpt.isPresent()) {
             logger.debug("No data found for atom {} ", check.getAtom());
@@ -75,7 +75,10 @@ public class ModelBasedTargetAtomCheckEvaluator implements TargetAtomCheckEvalua
                         .anyMatch(c -> c
                                         .getTargetAtom()
                                         .getNode().toString()
-                                        .equals(check.getRequestedTarget().toString()));
+                                        .equals(check.getRequestedTarget().toString())
+                                        || (check.isWonNodeCheck()
+                                                        && check.getRequestedTarget()
+                                                                        .equals(c.getTargetAtom().getWonNode())));
         if (logger.isDebugEnabled()) {
             logger.debug("{} target atom {} in connections' targetAtoms", foundIt ? "found" : "did not find",
                             check.getRequestedTarget());

--- a/webofneeds/won-auth/src/test/java/won/auth/WonAclEvaluatorTest.java
+++ b/webofneeds/won-auth/src/test/java/won/auth/WonAclEvaluatorTest.java
@@ -98,8 +98,8 @@ public class WonAclEvaluatorTest {
     public void testWonAcl_fail() throws IOException {
         Shapes shapes = loadShapes(shapesDef);
         Shapes atomDataShapes = loadShapes(atomDataShapesDef);
-        ModelBasedTargetAtomCheckEvaluator targetAtomChecker = withDurationLog("initializing TargetAtomChecker",
-                        () -> new ModelBasedTargetAtomCheckEvaluator(atomDataShapes,
+        ModelBasedConnectionTargetCheckEvaluator targetAtomChecker = withDurationLog("initializing TargetAtomChecker",
+                        () -> new ModelBasedConnectionTargetCheckEvaluator(atomDataShapes,
                                         "won.auth.test.model"));
         ModelBasedAtomNodeChecker atomNodeChecker = new ModelBasedAtomNodeChecker(atomDataShapes,
                         "won.auth.test.model");
@@ -121,7 +121,8 @@ public class WonAclEvaluatorTest {
     public void testWonAcl_ok() throws IOException {
         Shapes shapes = loadShapes(shapesDef);
         Shapes atomDataShapes = loadShapes(atomDataShapesDef);
-        ModelBasedTargetAtomCheckEvaluator targetAtomChecker = new ModelBasedTargetAtomCheckEvaluator(atomDataShapes,
+        ModelBasedConnectionTargetCheckEvaluator targetAtomChecker = new ModelBasedConnectionTargetCheckEvaluator(
+                        atomDataShapes,
                         "won.auth.test.model");
         ModelBasedAtomNodeChecker atomNodeChecker = new ModelBasedAtomNodeChecker(atomDataShapes,
                         "won.auth.test.model");
@@ -143,7 +144,8 @@ public class WonAclEvaluatorTest {
     public void testWonAcl_spec() throws IOException {
         Shapes shapes = loadShapes(shapesDef);
         Shapes atomDataShapes = loadShapes(atomDataShapesDef);
-        ModelBasedTargetAtomCheckEvaluator targetAtomChecker = new ModelBasedTargetAtomCheckEvaluator(atomDataShapes,
+        ModelBasedConnectionTargetCheckEvaluator targetAtomChecker = new ModelBasedConnectionTargetCheckEvaluator(
+                        atomDataShapes,
                         "won.auth.test.model");
         ModelBasedAtomNodeChecker atomNodeChecker = new ModelBasedAtomNodeChecker(atomDataShapes,
                         "won.auth.test.model");
@@ -167,7 +169,8 @@ public class WonAclEvaluatorTest {
     public void testWonAcl_domain_spec() throws IOException {
         Shapes shapes = loadShapes(shapesDef);
         Shapes atomDataShapes = loadShapes(atomDataShapesDef);
-        ModelBasedTargetAtomCheckEvaluator targetAtomChecker = new ModelBasedTargetAtomCheckEvaluator(atomDataShapes,
+        ModelBasedConnectionTargetCheckEvaluator targetAtomChecker = new ModelBasedConnectionTargetCheckEvaluator(
+                        atomDataShapes,
                         "won.auth.test.model");
         ModelBasedAtomNodeChecker atomNodeChecker = new ModelBasedAtomNodeChecker(atomDataShapes,
                         "won.auth.test.model");
@@ -189,7 +192,7 @@ public class WonAclEvaluatorTest {
 
     private void evaluateTest(Shapes shapes, Shapes atomDataShapes,
                     WonAclEvaluatorTestFactory evaluatorFactory,
-                    ModelBasedTargetAtomCheckEvaluator targetAtomChecker,
+                    ModelBasedConnectionTargetCheckEvaluator targetAtomChecker,
                     Resource resource,
                     DecisionValue accessDenied)
                     throws IOException {
@@ -212,7 +215,7 @@ public class WonAclEvaluatorTest {
 
     private void evaluateTestWithSpec(Shapes shapes, Shapes atomDataShapes,
                     WonAclEvaluatorTestFactory evaluatorFactory,
-                    ModelBasedTargetAtomCheckEvaluator targetAtomChecker,
+                    ModelBasedConnectionTargetCheckEvaluator targetAtomChecker,
                     ModelBasedAtomNodeChecker atomNodeChecker, Graph graph,
                     Resource resource)
                     throws IOException {

--- a/webofneeds/won-auth/src/test/java/won/auth/WonAclEvaluatorTestFactory.java
+++ b/webofneeds/won-auth/src/test/java/won/auth/WonAclEvaluatorTestFactory.java
@@ -2,7 +2,7 @@ package won.auth;
 
 import org.apache.jena.graph.Graph;
 import won.auth.check.AtomNodeChecker;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.model.Authorization;
 import won.auth.model.OperationRequest;
 import won.cryptography.rdfsign.WebIdKeyLoader;
@@ -14,7 +14,7 @@ public class WonAclEvaluatorTestFactory extends WonAclEvaluatorFactory {
     private Shacl2JavaInstanceFactory.Accessor accessor = null;
 
     public WonAclEvaluatorTestFactory(
-                    TargetAtomCheckEvaluator targetAtomCheckEvaluator,
+                    ConnectionTargetCheckEvaluator targetAtomCheckEvaluator,
                     AtomNodeChecker atomNodeChecker, WebIdKeyLoader webIdKeyLoader) {
         super(targetAtomCheckEvaluator, atomNodeChecker, webIdKeyLoader);
     }

--- a/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-010.ttl
+++ b/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-010.ttl
@@ -35,7 +35,7 @@ atom1:bsConn1
     a                   won:Connection ;
     won:targetAtom      ex:atom2 ;
     won:socket          atom1:buddySocket ;
-    won:connectionState won:RequestSent .
+    won:connectionState won:Connected .
 
 ex:atom2
     a           won:Atom ;
@@ -45,13 +45,12 @@ ex:atom2
 <#authorization>
     a            auth:Authorization ;
     auth:grantee [ auth:socket [ auth:socketType  wx-buddy:BuddySocket ;
-                                 auth:targetAtom  [ ] ;
                                  auth:connections
                                                   [ auth:connection
-                                                          [ auth:connectionState
+                                                          [   auth:targetAtom  [ ] ;
+                                                              auth:connectionState
                                                                   won:RequestSent, won:RequestReceived ] ] ] ] ;
-    auth:grant   [ auth:atomState won:Active ;
-                   auth:operation auth:anyOperation ] .
+    auth:grant   [ auth:operation auth:anyOperation ] .
 
 <#request>
     a                 auth:OperationRequest ;

--- a/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-011.ttl
+++ b/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-011.ttl
@@ -45,11 +45,8 @@ ex:atom2
 <#authorization>
     a            auth:Authorization ;
     auth:grantee [ auth:socket [ auth:socketType  wx-buddy:BuddySocket ;
-                                 auth:targetAtom  [ ] ;
-                                 auth:connections
-                                                  [ auth:connection
-                                                          [ auth:connectionState
-                                                                  won:RequestSent, won:RequestReceived ] ] ] ] ;
+                                 auth:connections [ auth:connection [ auth:targetAtom      [ ] ;
+                                                                      auth:connectionState won:Connected ] ] ] ] ;
     auth:grant   [ auth:atomState won:Active ;
                    auth:operation auth:anyOperation ] .
 

--- a/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-012.ttl
+++ b/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-012.ttl
@@ -75,9 +75,9 @@ ex:atom4
     auth:grantee [ auth:socket [ auth:socketType  wx-buddy:BuddySocket ;
                                  auth:connections [ auth:connection [ auth:targetAtom      [ ] ;
                                                                       auth:connectionState won:Closed ] ] ] ;
-# requires state won:Connected
-                   auth:socket [ auth:socketType ex:ExSocketDef ;
-                                 auth:targetAtom [ ] ] ] ;
+                   auth:socket [ auth:socketType  ex:ExSocketDef ;
+                                 auth:connections [ auth:connectionState won:Connected ;
+                                                    auth:targetAtom      [ ] ] ] ] ;
     auth:grant   [ auth:atomState won:Active ;
                    auth:operation auth:anyOperation ] .
 

--- a/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-013.ttl
+++ b/webofneeds/won-auth/src/test/resources/won/opreq/fail/opreq-013.ttl
@@ -72,8 +72,7 @@ ex:atom4
 
 <#authorization>
     a            auth:Authorization ;
-    auth:grantee [ auth:targetAtom [ ] ;
-#allows connected - but none here are
+    auth:grantee [
                    auth:socket     [ auth:socketIri   atom1:bsConn1 ;
                                      auth:connections [ auth:connection [ auth:targetAtom      [ ] ;
                                                                           auth:connectionState
@@ -81,12 +80,9 @@ ex:atom4
                    auth:socket     [ auth:socketType  wx-buddy:BuddySocket ;
                                      auth:connections [ auth:connection [ auth:targetAtom      [ ] ;
                                                                           auth:connectionState won:Connected ] ] ] ;
-# requires state won:Connected
-                   auth:socket [ auth:socketType ex:ExSocketDef ;
-                                 auth:targetAtom [ ] ;
-                                 auth:connections [auth:connectionState won:RequestSent ] ; # target atom is at socket level
-                               ]
-                 ] ;
+                   auth:socket     [ auth:socketType  ex:ExSocketDef ;
+                                     auth:connections [ auth:targetAtom      [ ] ;
+                                                        auth:connectionState won:Connected ] ] ] ;
     auth:grant   [ auth:atomState won:Active ;
                    auth:operation auth:anyOperation ] .
 

--- a/webofneeds/won-auth/src/test/resources/won/opreq/spec/opreq-027.ttl
+++ b/webofneeds/won-auth/src/test/resources/won/opreq/spec/opreq-027.ttl
@@ -1,0 +1,129 @@
+@base             <https://example.com/test/atom1> .
+@prefix ex:       <https://example.com/test/> .
+@prefix auth:     <https://w3id.org/won/auth#> .
+@prefix won:      <https://w3id.org/won/core#> .
+@prefix chat:     <https://w3id.org/won/ext/chat#> .
+@prefix wx-buddy: <https://w3id.org/won/ext/buddy#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix atom1:    <http://example.org/test/atom1#> .
+@prefix atom2:    <http://example.org/test/atom2#> .
+@prefix atom3:    <http://example.org/test/atom3#> .
+@prefix msg:      <https://w3id.org/won/message#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdfg:     <http://www.w3.org/2004/04/trix/rdfg-1/> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:expectedResult1
+    a                       auth:ExpectedAclEvalResult ;
+    auth:decision           auth:accessGranted ;
+    auth:requestedOperation <#request1> .
+
+ex:expectedResult2
+    a                       auth:ExpectedAclEvalResult ;
+    auth:decision           auth:accessDenied ;
+    auth:requestedOperation <#request2> .
+
+ex:expectedResult3
+    a                       auth:ExpectedAclEvalResult ;
+    auth:decision           auth:accessDenied ;
+    auth:requestedOperation <#request3> .
+
+# Atom is connectable on socket layer
+
+<#authorization>
+    a            auth:Authorization ;
+    auth:grant   [ auth:graph [ auth:operation auth:opRead ;
+                                auth:graphType auth:keyGraph ] ] ;
+    auth:grantee [ auth:targetWonNode [ ] ] .
+
+<#request1>
+    a                 auth:OperationRequest ;
+    auth:operation    auth:opRead ;
+    auth:requestor    ex:node2 ;
+    auth:reqAtom      ex:atom1 ;
+    auth:reqPosition  auth:positionAtomGraph ;
+    auth:reqGraph     atom1:key ;
+    auth:reqGraphType auth:keyGraph .
+
+<#request2>
+    a                 auth:OperationRequest ;
+    auth:operation    auth:opRead ;
+    auth:requestor    ex:node3 ;
+    auth:reqAtom      ex:atom1 ;
+    auth:reqPosition  auth:positionAtomGraph ;
+    auth:reqGraph     atom1:key ;
+    auth:reqGraphType auth:keyGraph .
+
+<#request3>
+    a                 auth:OperationRequest ;
+    auth:operation    auth:opRead ;
+    auth:requestor    ex:node2 ;
+    auth:reqAtom      ex:atom1 ;
+    auth:reqPosition  auth:positionAtomGraph ;
+    auth:reqGraph     atom1:content ;
+    auth:reqGraphType auth:contentGraph .
+
+# Persona 1
+
+ex:atom1
+    a                    won:Atom ;
+    won:socket           atom1:buddySocket ;
+    won:state            won:Active ;
+    won:messageContainer atom1:msg ;
+    won:wonNode          ex:node .
+
+
+atom1:buddySocket
+    a                    won:Socket ;
+    won:socketDefinition wx-buddy:BuddySocket ;
+    won:connections      atom1:conns .
+
+atom1:conns
+    a           won:ConnectionContainer ;
+    rdfs:member atom1:conn12 .
+
+atom1:conn12
+    a                   won:Connection ;
+    won:socket          atom1:buddySocket ;
+    won:targetAtom      ex:atom2 ;
+    won:connectionState won:Connected .
+
+# Atom 2 - holdable
+
+ex:atom2
+    a                    won:Atom ;
+    won:socket           atom2:buddySocket ;
+    won:state            won:Active ;
+    won:messageContainer atom2:msg ;
+    won:wonNode          ex:node2 .
+
+atom2:buddySocket
+    a                    won:Socket ;
+    won:socketDefinition wx-buddy:BuddySocket ;
+    won:connections      atom2:conns .
+
+atom2:conns
+    a           won:ConnectionContainer ;
+    rdfs:member atom2:conn21 .
+
+atom2:conn21
+    a                   won:Connection ;
+    won:socket          atom2:buddySocket ;
+    won:targetAtom      ex:atom1 ;
+    won:connectionState won:Connected .
+
+# Atom 3 - not holdable
+
+ex:atom3
+    a                    won:Atom ;
+    won:socket           atom3:buddySocket ;
+    won:state            won:Active ;
+    won:messageContainer atom3:msg ;
+    won:wonNode          ex:node3 .
+
+atom3:buddySocket
+    a                    won:Socket ;
+    won:socketDefinition wx-buddy:BuddySocket .
+
+

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -286,11 +286,11 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.state in :allowedStates ")
     boolean existsWithAtomAndTargetAtomPrefixAndStates(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates);
 
     @Query("select case when (count(con) > 0) then true else false end "
@@ -306,11 +306,11 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.typeURI in :allowedSocketTypes ")
     boolean existsWithAtomAndTargetAtomPrefixAndSocketTypes(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes);
 
     @Query("select case when (count(con) > 0) then true else false end "
@@ -326,11 +326,11 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomPrefixAndSockets(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedSockets") Collection<URI> allowedSockets);
 
     @Query("select case when (count(con) > 0) then true else false end "
@@ -348,12 +348,12 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.state in :allowedStates "
                     + "and con.typeURI in :allowedSocketTypes ")
     boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypes(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes);
 
@@ -372,12 +372,12 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.state in :allowedStates "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSockets(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates,
                     @Param("allowedSockets") Collection<URI> allowedSockets);
 
@@ -396,12 +396,12 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.typeURI in :allowedSocketTypes "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomPrefixAndSocketTypesAndSockets(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
                     @Param("allowedSockets") Collection<URI> allowedSockets);
 
@@ -422,13 +422,13 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
-                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 "
                     + "and con.state in :allowedStates "
                     + "and con.typeURI in :allowedSocketTypes "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypesAndSockets(
                     @Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("targetAtomPrefix") String targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
                     @Param("allowedSockets") Collection<URI> allowedSockets);

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -269,6 +269,11 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     boolean existsWithAtomAndTargetAtom(@Param("fromAtom") URI fromAtom, @Param("toAtom") URI toAtom);
 
     @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where con.atomURI = :fromAtom and con.targetAtomURI like concat(:targetAtomPrefix,'%')")
+    boolean existsWithAtomAndTargetAtomPrefix(@Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix);
+
+    @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
                     + "and con.targetAtomURI = :toAtom "
@@ -276,6 +281,16 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     boolean existsWithAtomAndTargetAtomAndStates(
                     @Param("fromAtom") URI fromAtom,
                     @Param("toAtom") URI toAtom,
+                    @Param("allowedStates") Collection<ConnectionState> allowedStates);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.state in :allowedStates ")
+    boolean existsWithAtomAndTargetAtomPrefixAndStates(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates);
 
     @Query("select case when (count(con) > 0) then true else false end "
@@ -291,11 +306,31 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.typeURI in :allowedSocketTypes ")
+    boolean existsWithAtomAndTargetAtomPrefixAndSocketTypes(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
                     + "and con.targetAtomURI = :toAtom "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomAndSockets(
                     @Param("fromAtom") URI fromAtom,
                     @Param("toAtom") URI toAtom,
+                    @Param("allowedSockets") Collection<URI> allowedSockets);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.socketURI in :allowedSockets ")
+    boolean existsWithAtomAndTargetAtomPrefixAndSockets(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
                     @Param("allowedSockets") Collection<URI> allowedSockets);
 
     @Query("select case when (count(con) > 0) then true else false end "
@@ -307,6 +342,18 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     boolean existsWithAtomAndTargetAtomAndStatesAndSocketTypes(
                     @Param("fromAtom") URI fromAtom,
                     @Param("toAtom") URI toAtom,
+                    @Param("allowedStates") Collection<ConnectionState> allowedStates,
+                    @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.state in :allowedStates "
+                    + "and con.typeURI in :allowedSocketTypes ")
+    boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypes(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes);
 
@@ -325,12 +372,36 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "
                     + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.state in :allowedStates "
+                    + "and con.socketURI in :allowedSockets ")
+    boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSockets(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
+                    @Param("allowedStates") Collection<ConnectionState> allowedStates,
+                    @Param("allowedSockets") Collection<URI> allowedSockets);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
                     + "and con.targetAtomURI = :toAtom "
                     + "and con.typeURI in :allowedSocketTypes "
                     + "and con.socketURI in :allowedSockets ")
     boolean existsWithAtomAndTargetAtomAndSocketTypesAndSockets(
                     @Param("fromAtom") URI fromAtom,
                     @Param("toAtom") URI toAtom,
+                    @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
+                    @Param("allowedSockets") Collection<URI> allowedSockets);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.typeURI in :allowedSocketTypes "
+                    + "and con.socketURI in :allowedSockets ")
+    boolean existsWithAtomAndTargetAtomPrefixAndSocketTypesAndSockets(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
                     @Param("allowedSockets") Collection<URI> allowedSockets);
 
@@ -344,6 +415,20 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     boolean existsWithAtomAndTargetAtomAndStatesAndSocketTypesAndSockets(
                     @Param("fromAtom") URI fromAtom,
                     @Param("toAtom") URI toAtom,
+                    @Param("allowedStates") Collection<ConnectionState> allowedStates,
+                    @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
+                    @Param("allowedSockets") Collection<URI> allowedSockets);
+
+    @Query("select case when (count(con) > 0) then true else false end "
+                    + "from Connection con where "
+                    + "con.atomURI = :fromAtom "
+                    + "and con.targetAtomURI like concat(:targetAtomPrefix,'%')"
+                    + "and con.state in :allowedStates "
+                    + "and con.typeURI in :allowedSocketTypes "
+                    + "and con.socketURI in :allowedSockets ")
+    boolean existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypesAndSockets(
+                    @Param("fromAtom") URI fromAtom,
+                    @Param("targetAtomPrefix") URI targetAtomPrefix,
                     @Param("allowedStates") Collection<ConnectionState> allowedStates,
                     @Param("allowedSocketTypes") Collection<URI> allowedSocketTypes,
                     @Param("allowedSockets") Collection<URI> allowedSockets);

--- a/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/repository/ConnectionRepository.java
@@ -269,9 +269,10 @@ public interface ConnectionRepository extends WonRepository<Connection> {
     boolean existsWithAtomAndTargetAtom(@Param("fromAtom") URI fromAtom, @Param("toAtom") URI toAtom);
 
     @Query("select case when (count(con) > 0) then true else false end "
-                    + "from Connection con where con.atomURI = :fromAtom and con.targetAtomURI like concat(:targetAtomPrefix,'%')")
+                    + "from Connection con where con.atomURI = :fromAtom "
+                    + "and LOCATE (:targetAtomPrefix, con.targetAtomURI) = 1 ")
     boolean existsWithAtomAndTargetAtomPrefix(@Param("fromAtom") URI fromAtom,
-                    @Param("targetAtomPrefix") URI targetAtomPrefix);
+                    @Param("targetAtomPrefix") String targetAtomPrefix);
 
     @Query("select case when (count(con) > 0) then true else false end "
                     + "from Connection con where "

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
@@ -597,10 +597,10 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
         } catch (URISyntaxException e) {
             logger.warn("could not remove fragment from uri {} when generating cache key, using it as-is", resource, e);
         }
-        // using spaces in the null placeholder to make it impossible to inject a
-        // requesterWebID URI that is equal to the
-        // null place holder (because an URI can't have spaces).
-        return resourceForCacheKey.toString() + (requesterWebID == null ? " (no Web ID)" : requesterWebID.toString());
+        // use space to separate the URIS
+        // use space in the null placeholder to make it impossible to inject a
+        // requesterWebID URI that is equal to the null place holder (because an URI can't have spaces).
+        return resourceForCacheKey.toString() + " " + (requesterWebID == null ? " (no Web ID)" : requesterWebID.toString());
     }
 
     public enum CacheControlFlag {

--- a/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/util/linkeddata/CachingLinkedDataSource.java
@@ -440,7 +440,7 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
 
     /**
      * Performs the actual request via the linkedDataRestClient.
-     * 
+     *
      * @param resource
      * @param requesterWebID
      * @param headers
@@ -599,8 +599,10 @@ public class CachingLinkedDataSource extends LinkedDataSourceBase implements Lin
         }
         // use space to separate the URIS
         // use space in the null placeholder to make it impossible to inject a
-        // requesterWebID URI that is equal to the null place holder (because an URI can't have spaces).
-        return resourceForCacheKey.toString() + " " + (requesterWebID == null ? " (no Web ID)" : requesterWebID.toString());
+        // requesterWebID URI that is equal to the null place holder (because an URI
+        // can't have spaces).
+        return resourceForCacheKey.toString() + " "
+                        + (requesterWebID == null ? " (no Web ID)" : requesterWebID.toString());
     }
 
     public enum CacheControlFlag {

--- a/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
+++ b/webofneeds/won-cryptography/src/main/java/won/cryptography/rdfsign/WonVerifier.java
@@ -1,6 +1,23 @@
 package won.cryptography.rdfsign;
 
-import static won.cryptography.rdfsign.WonSigner.*;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
+import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
+import io.ipfs.multibase.Base58;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import won.protocol.message.WonMessage;
+import won.protocol.message.WonSignatureData;
+import won.protocol.util.Prefixer;
+import won.protocol.util.RdfUtils;
+import won.protocol.util.WonMessageUriHelper;
+import won.protocol.util.WonRdfUtils;
+import won.protocol.vocabulary.WONMSG;
 
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
@@ -12,25 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.GraphCollection;
-import de.uni_koblenz.aggrimm.icp.crypto.sign.graph.SignatureData;
-import io.ipfs.multibase.Base58;
-import won.protocol.message.WonMessage;
-import won.protocol.message.WonSignatureData;
-import won.protocol.util.Prefixer;
-import won.protocol.util.RdfUtils;
-import won.protocol.util.WonMessageUriHelper;
-import won.protocol.util.WonRdfUtils;
-import won.protocol.vocabulary.WONMSG;
+import static won.cryptography.rdfsign.WonSigner.SIGNING_ALGORITHM_PROVIDER;
 
 /**
  * User: ypanchenko Date: 15.07.2014
@@ -129,7 +128,7 @@ public class WonVerifier {
             PublicKey publicKey = publicKeys.get(wonSignatureData.getVerificationCertificateUri());
             if (publicKey == null) {
                 verificationState.setVerificationFailed(wonSignatureData.getSignatureUri(),
-                                "No public key found for " + wonSignatureData.getSignatureUri());
+                                "No public key found for " + wonSignatureData.getVerificationCertificateUri());
                 if (logger.isDebugEnabled()) {
                     logger.debug("offending message:\n" + RdfUtils.toString(Prefixer.setPrefixes(dataset)));
                 }

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -66,7 +66,7 @@
 	 	node2: check webid of node1 -> request descriptor of node1 (using webid of node2)
 	 	...
 	 -->
-	<sec:http request-matcher="regex" pattern="/(resource|data|page)/?(\?.+)?$"
+	<sec:http request-matcher="regex" pattern="/(resource|data|page)/?$"
 			  entry-point-ref="authorizationEntryPoint">
 		<sec:headers defaults-disabled="true">
 			<sec:cache-control/>
@@ -75,7 +75,7 @@
 			<sec:frame-options/>
 			<sec:xss-protection/>
 		</sec:headers>
-		<sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/>
+		<sec:intercept-url pattern="/(resource|data|page)/?$" access="permitAll"/>
 		<sec:csrf disabled="true"/>
 	</sec:http>
 
@@ -99,7 +99,7 @@
 		<sec:custom-filter ref="wonAclAuthTokenFilter" after="X509_FILTER"/>
 		<!-- we allow self-signed certificates that need not be webids -->
 		<!--sec:intercept-url pattern=".*" access="hasRole('ROLE_CLIENT_CERTIFICATE_PRESENTED')"/-->
-		<!--sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/ disabled and moved to separate http element-->
+		<sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/><!-- required for register -->
 		<sec:intercept-url pattern="/(resource|data|page)/(atom)/?(\?.+)?$" access="permitAll"/>
 		<sec:intercept-url pattern="/(resource|data|page)/(atom|msg)/[^\?]+(\?.+)?$"
 						   access="hasRole('ROLE_WEBID') or hasRole('ROLE_CLIENT_CERTIFICATE') or isAnonymous()"/>

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -116,7 +116,7 @@
 	<bean id="webIdUserDetailsService" class="won.node.springsecurity.UserDetailsService"/>
 	<bean id="wonAclAccessDecisionVoter" class="won.node.springsecurity.acl.WonAclAccessDecisionVoter"/>
 	<bean id="wonAclEvaluatorFactory" class="won.auth.WonAclEvaluatorFactory"/>
-	<bean id="targetAtomCheckEvaluator" class="won.node.springsecurity.acl.WonTargetAtomCheckEvaluator"/>
+	<bean id="targetAtomCheckEvaluator" class="won.node.springsecurity.acl.WonConnectionTargetCheckEvaluator"/>
 	<bean id="ldFetchingAtomNodeChecker" class="won.auth.check.impl.LDFetchingAtomNodeChecker"/>
 	<bean id="atomNodeChecker" class="won.node.springsecurity.acl.NodeBasedAtomNodeChecker" primary="true"/>
 

--- a/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
+++ b/webofneeds/won-node-webapp/src/main/resources/spring/node-context.xml
@@ -55,6 +55,30 @@
     restricted access, we want to verify the WebID and we want no client-side caching. For public access, the WebID
     verification step is not needed, and we can be more open about caching.
      -->
+
+	<!-- specific config for WoN node descriptor: requires no authentication, webids are not checked
+	 	This is required so that other nodes can verify requests that this node sends using its own
+	 	webid. If the requestor's webid was checked before responding with the node descriptor, we
+	 	would cause a deadlock:
+	 	node1: request to node2 (using webid of node1)
+	 	node2: check webid of node1 -> request descriptor of node1 (using webid of node2)
+	 	node1: check webid of node2 -> request descriptor of node2 (using webid of node1)
+	 	node2: check webid of node1 -> request descriptor of node1 (using webid of node2)
+	 	...
+	 -->
+	<sec:http request-matcher="regex" pattern="/(resource|data|page)/?(\?.+)?$"
+			  entry-point-ref="authorizationEntryPoint">
+		<sec:headers defaults-disabled="true">
+			<sec:cache-control/>
+			<sec:content-type-options/>
+			<sec:hsts/>
+			<sec:frame-options/>
+			<sec:xss-protection/>
+		</sec:headers>
+		<sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/>
+		<sec:csrf disabled="true"/>
+	</sec:http>
+
 	<!-- slightly different config for cases in which a client certificate is sufficient (but the webID will not be
     checked
      -->
@@ -75,7 +99,7 @@
 		<sec:custom-filter ref="wonAclAuthTokenFilter" after="X509_FILTER"/>
 		<!-- we allow self-signed certificates that need not be webids -->
 		<!--sec:intercept-url pattern=".*" access="hasRole('ROLE_CLIENT_CERTIFICATE_PRESENTED')"/-->
-		<sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/>
+		<!--sec:intercept-url pattern="/(resource|data|page)/?(\?.+)?$" access="permitAll"/ disabled and moved to separate http element-->
 		<sec:intercept-url pattern="/(resource|data|page)/(atom)/?(\?.+)?$" access="permitAll"/>
 		<sec:intercept-url pattern="/(resource|data|page)/(atom|msg)/[^\?]+(\?.+)?$"
 						   access="hasRole('ROLE_WEBID') or hasRole('ROLE_CLIENT_CERTIFICATE') or isAnonymous()"/>

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/AclChecker.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/AclChecker.java
@@ -35,7 +35,7 @@ public class AclChecker extends AbstractCamelProcessor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        URI atomUri = WonCamelHelper.getRecipientAtomURIRequired(exchange);
+        URI recipientAtomUri = WonCamelHelper.getRecipientAtomURIRequired(exchange);
         WonMessage message = WonCamelHelper.getMessageRequired(exchange);
         if (message.getMessageType().isCreateAtom()) {
             // no checks required for a create message
@@ -55,7 +55,7 @@ public class AclChecker extends AbstractCamelProcessor {
                 return;
             }
         }
-        Atom atom = atomService.getAtomRequired(atomUri);
+        Atom atom = atomService.getAtomForMessageRequired(message, direction);
         Optional<Graph> aclGraph = atom.getAclGraph();
         if (aclGraph.isEmpty()) {
             // no checks if no acl present
@@ -80,7 +80,7 @@ public class AclChecker extends AbstractCamelProcessor {
             }
         }
         OperationRequest operationRequest = OperationRequest.builder()
-                        .setReqAtom(atomUri)
+                        .setReqAtom(atom.getAtomURI())
                         .setReqAtomState(AuthUtils.toAuthAtomState(atom.getState()))
                         .setRequestor(requestor)
                         .build();

--- a/webofneeds/won-node/src/main/java/won/node/camel/processor/general/RoutingInfoExtractor.java
+++ b/webofneeds/won-node/src/main/java/won/node/camel/processor/general/RoutingInfoExtractor.java
@@ -1,16 +1,15 @@
 package won.node.camel.processor.general;
 
-import static won.node.camel.service.WonCamelHelper.*;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.beans.factory.annotation.Autowired;
+import won.protocol.message.WonMessage;
+import won.protocol.service.MessageRoutingInfoService;
 
 import java.net.URI;
 import java.util.Optional;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import won.protocol.message.WonMessage;
-import won.protocol.service.MessageRoutingInfoService;
+import static won.node.camel.service.WonCamelHelper.*;
 
 public class RoutingInfoExtractor implements Processor {
     @Autowired
@@ -21,12 +20,12 @@ public class RoutingInfoExtractor implements Processor {
         WonMessage message = getMessageRequired(exchange);
         URI atom = messageRoutingInfoService.recipientAtom(message)
                         .orElseThrow(() -> new IllegalArgumentException(
-                                        "Cannot dertermine recipient atom for message " + message.getMessageURI()));
+                                        "Cannot determine recipient atom for message " + message.getMessageURI()));
         // the sender node is not there in the case of hint messages.
         Optional<URI> senderNode = messageRoutingInfoService.senderNode(message);
         URI recipientNode = messageRoutingInfoService.recipientNode(message)
                         .orElseThrow(() -> new IllegalArgumentException(
-                                        "Cannot dertermine node for response message "
+                                        "Cannot determine node for response message "
                                                         + message.getMessageURI()));
         if (senderNode.isPresent()) {
             putSenderNodeURI(exchange, senderNode.get());

--- a/webofneeds/won-node/src/main/java/won/node/service/persistence/AtomService.java
+++ b/webofneeds/won-node/src/main/java/won/node/service/persistence/AtomService.java
@@ -136,7 +136,7 @@ public class AtomService {
         if (atomURI != null) {
             return getAtomRequired(atomURI);
         } else {
-            throw new WonMessageProcessingException("Could not obtain atom URI from messsage " + msg.getMessageURI());
+            throw new WonMessageProcessingException("Could not obtain atom URI from message " + msg.getMessageURI());
         }
     }
 

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonAclAccessDecisionVoter.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonAclAccessDecisionVoter.java
@@ -15,7 +15,7 @@ import won.auth.AuthUtils;
 import won.auth.WonAclEvaluator;
 import won.auth.WonAclEvaluatorFactory;
 import won.auth.check.AtomNodeChecker;
-import won.auth.check.TargetAtomCheckEvaluator;
+import won.auth.check.ConnectionTargetCheckEvaluator;
 import won.auth.model.*;
 import won.cryptography.rdfsign.WebIdKeyLoader;
 import won.cryptography.service.CryptographyService;
@@ -47,7 +47,7 @@ public class WonAclAccessDecisionVoter implements AccessDecisionVoter<FilterInvo
     private static final String anonymousUserPrincipal = "anonymousUser";
     // the aclEvaluator is not thread-safe, each thread needs its own.
     @Autowired
-    private TargetAtomCheckEvaluator targetAtomCheckEvaluator;
+    private ConnectionTargetCheckEvaluator targetAtomCheckEvaluator;
     @Autowired
     private AtomNodeChecker atomNodeChecker;
     @Autowired

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonTargetAtomCheckEvaluator.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonTargetAtomCheckEvaluator.java
@@ -30,7 +30,7 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
                         | RESTRICTS_SOCKETS] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypesAndSockets(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedConnectionStates().stream()
                                                                         .map(ConnectionState::fromURI).collect(toSet()),
                                                         check.getAllowedSocketTypes(),
@@ -40,7 +40,7 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
                         | RESTRICTS_SOCKET_TYPES] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypes(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedConnectionStates().stream()
                                                                         .map(ConnectionState::fromURI).collect(toSet()),
                                                         check.getAllowedSocketTypes());
@@ -49,7 +49,7 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
                         | RESTRICTS_SOCKETS] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndStatesAndSockets(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedConnectionStates().stream()
                                                                         .map(ConnectionState::fromURI).collect(toSet()),
                                                         check.getAllowedSockets());
@@ -57,7 +57,7 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
                         | RESTRICTS_CONNECTION_STATES] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndStates(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedConnectionStates().stream()
                                                                         .map(ConnectionState::fromURI)
                                                                         .collect(toSet()));
@@ -66,20 +66,20 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
                         | RESTRICTS_SOCKETS] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndSocketTypesAndSockets(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedSocketTypes(),
                                                         check.getAllowedSockets());
         evaluators[WON_NODE_CHECK
                         | RESTRICTS_SOCKET_TYPES] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndSocketTypes(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedSocketTypes());
         evaluators[WON_NODE_CHECK
                         | RESTRICTS_SOCKETS] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomPrefixAndSockets(
                                                         check.getAtom(),
-                                                        check.getRequestedTarget(),
+                                                        check.getRequestedTarget().toString(),
                                                         check.getAllowedSockets());
         evaluators[RESTRICTS_CONNECTION_STATES
                         | RESTRICTS_SOCKET_TYPES

--- a/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonTargetAtomCheckEvaluator.java
+++ b/webofneeds/won-node/src/main/java/won/node/springsecurity/acl/WonTargetAtomCheckEvaluator.java
@@ -3,7 +3,7 @@ package won.node.springsecurity.acl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import won.auth.check.TargetAtomCheck;
+import won.auth.check.ConnectionTargetCheck;
 import won.auth.check.TargetAtomCheckEvaluator;
 import won.protocol.model.ConnectionState;
 import won.protocol.repository.ConnectionRepository;
@@ -18,12 +18,71 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
     private static final int RESTRICTS_SOCKETS = 1;
     private static final int RESTRICTS_SOCKET_TYPES = 2;
     private static final int RESTRICTS_CONNECTION_STATES = 4;
+    private static final int WON_NODE_CHECK = 8;
     @Autowired
     private ConnectionRepository connectionRepository;
-    private TargetAtomCheckEvaluator[] evaluators = new TargetAtomCheckEvaluator[8];
+    private TargetAtomCheckEvaluator[] evaluators = new TargetAtomCheckEvaluator[16];
 
     public WonTargetAtomCheckEvaluator() {
-        evaluators[RESTRICTS_CONNECTION_STATES | RESTRICTS_SOCKET_TYPES
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_CONNECTION_STATES
+                        | RESTRICTS_SOCKET_TYPES
+                        | RESTRICTS_SOCKETS] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypesAndSockets(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedConnectionStates().stream()
+                                                                        .map(ConnectionState::fromURI).collect(toSet()),
+                                                        check.getAllowedSocketTypes(),
+                                                        check.getAllowedSockets());
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_CONNECTION_STATES
+                        | RESTRICTS_SOCKET_TYPES] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndStatesAndSocketTypes(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedConnectionStates().stream()
+                                                                        .map(ConnectionState::fromURI).collect(toSet()),
+                                                        check.getAllowedSocketTypes());
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_CONNECTION_STATES
+                        | RESTRICTS_SOCKETS] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndStatesAndSockets(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedConnectionStates().stream()
+                                                                        .map(ConnectionState::fromURI).collect(toSet()),
+                                                        check.getAllowedSockets());
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_CONNECTION_STATES] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndStates(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedConnectionStates().stream()
+                                                                        .map(ConnectionState::fromURI)
+                                                                        .collect(toSet()));
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_SOCKET_TYPES
+                        | RESTRICTS_SOCKETS] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndSocketTypesAndSockets(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedSocketTypes(),
+                                                        check.getAllowedSockets());
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_SOCKET_TYPES] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndSocketTypes(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedSocketTypes());
+        evaluators[WON_NODE_CHECK
+                        | RESTRICTS_SOCKETS] = check -> connectionRepository
+                                        .existsWithAtomAndTargetAtomPrefixAndSockets(
+                                                        check.getAtom(),
+                                                        check.getRequestedTarget(),
+                                                        check.getAllowedSockets());
+        evaluators[RESTRICTS_CONNECTION_STATES
+                        | RESTRICTS_SOCKET_TYPES
                         | RESTRICTS_SOCKETS] = check -> connectionRepository
                                         .existsWithAtomAndTargetAtomAndStatesAndSocketTypesAndSockets(
                                                         check.getAtom(),
@@ -71,14 +130,15 @@ public class WonTargetAtomCheckEvaluator implements TargetAtomCheckEvaluator {
     }
 
     @Override
-    public boolean isRequestorAllowedTarget(TargetAtomCheck check) {
+    public boolean isRequestorAllowedTarget(ConnectionTargetCheck check) {
         boolean restrictsConnectionStates = isPresent(check.getAllowedConnectionStates());
         boolean restrictsSocketTypes = isPresent(check.getAllowedSocketTypes());
         boolean restrictsSockets = isPresent(check.getAllowedSockets());
         int rcs = restrictsConnectionStates ? RESTRICTS_CONNECTION_STATES : 0;
         int rst = restrictsSocketTypes ? RESTRICTS_SOCKET_TYPES : 0;
         int rs = restrictsSockets ? RESTRICTS_SOCKETS : 0;
-        int evaluatorIndex = rcs | rst | rs;
+        int wnc = check.isWonNodeCheck() ? WON_NODE_CHECK : 0;
+        int evaluatorIndex = wnc | rcs | rst | rs;
         TargetAtomCheckEvaluator evaluator = evaluators[evaluatorIndex];
         if (logger.isDebugEnabled()) {
             logger.debug("Using evaluator with index {} (rcs:{}, rst:{}, rs:{}) ",

--- a/webofneeds/won-vocab/src/main/resources/ontology/won-auth.ttl
+++ b/webofneeds/won-vocab/src/main/resources/ontology/won-auth.ttl
@@ -119,6 +119,14 @@ auth:targetAtomPropertyShape
     sh:node          auth:targetAtomExpressionShape ;
     sh:minCount      1 .
 
+auth:targetWonNodePropertyShape
+    rdfs:isDefinedBy auth: ;
+    a                sh:PropertyShape ;
+    sh:path          auth:targetWonNode ;
+    sh:maxCount      1 ;
+    sh:node          auth:targetWonNodeExpressionShape ;
+    sh:minCount      1 .
+
 auth:expiresAfterPropertyShape
     rdfs:isDefinedBy auth: ;
     a                sh:PropertyShape ;
@@ -200,7 +208,7 @@ auth:aseRootShape
     sh:ignoredProperties ( auth:atomState auth:graph auth:atomMessages auth:atomMessage auth:socket
                            auth:connections
                            auth:connection auth:connectionMessages auth:connectionMessage
-                           auth:operation auth:targetAtom rdfs:label rdfs:comment rdfs:isDefinedBy ) ;
+                           auth:operation auth:targetAtom auth:targetWonNode rdfs:label rdfs:comment rdfs:isDefinedBy ) ;
     sh:nodeKind          sh:BlankNodeOrIRI ;
     sh:or                ( [ sh:property auth:atomStatePropertyShape ]
                            [ sh:property auth:graphPropertyShape ]
@@ -212,7 +220,8 @@ auth:aseRootShape
                            [ sh:property auth:connectionMessagesPropertyShape ]
                            [ sh:property auth:connectionMessagePropertyShape ]
                            [ sh:property auth:operationPropertyShape ]
-                           [ sh:property auth:targetAtomPropertyShape ] ) .
+                           [ sh:property auth:targetAtomPropertyShape ]
+                           [ sh:property auth:targetWonNodePropertyShape ] ) .
 
 
 auth:atomStateShape
@@ -276,7 +285,7 @@ auth:socketExpressionShape
     sh:closed            true ;
     sh:ignoredProperties ( auth:connections
                            auth:connection auth:connectionMessages auth:connectionMessage
-                           auth:operation auth:targetAtom auth:socketType auth:socketIri
+                           auth:operation auth:targetAtom auth:targetWonNode auth:socketType auth:socketIri
                            auth:inherit ) ;
     sh:targetObjectsOf   auth:socket ;
     auth:asePosition     auth:positionSocket ;
@@ -290,6 +299,7 @@ auth:socketExpressionShape
                            [ sh:property auth:connectionMessagesPropertyShape ]
                            [ sh:property auth:connectionMessagePropertyShape ]
                            [ sh:property auth:targetAtomPropertyShape ]
+                           [ sh:property auth:targetWonNodePropertyShape ]
                            [ sh:property auth:operationPropertyShape ] ) .
 
 # Definition 11 (connections expression)
@@ -300,7 +310,7 @@ auth:connectionsExpressionShape
                          auth:TargetAtomContainerShape ;
     sh:closed            true ;
     sh:ignoredProperties ( auth:connection auth:connectionMessages auth:connectionMessage
-                           auth:operation auth:targetAtom auth:socketType auth:socketIri
+                           auth:operation auth:targetAtom auth:targetWonNode auth:socketType auth:socketIri
                            auth:connectionState
                            auth:inherit ) ;
     auth:asePosition     auth:positionConnections ;
@@ -312,6 +322,7 @@ auth:connectionsExpressionShape
                            [ sh:property auth:connectionMessagesPropertyShape ]
                            [ sh:property auth:connectionMessagePropertyShape ]
                            [ sh:property auth:targetAtomPropertyShape ]
+                           [ sh:property auth:targetWonNodePropertyShape ]
                            [ sh:property auth:operationPropertyShape ] ) .
 
 # Definition 12 (connection expression)
@@ -322,7 +333,7 @@ auth:connectionExpressionShape
                          auth:TargetAtomContainerShape ;
     sh:closed            true ;
     sh:ignoredProperties ( auth:connectionMessages auth:connectionMessage
-                           auth:operation auth:targetAtom auth:connectionState auth:inherit ) ;
+                           auth:operation auth:targetAtom auth:targetWonNode auth:connectionState auth:inherit ) ;
     sh:targetObjectsOf   auth:connection ;
     auth:asePosition     auth:positionConnection ;
     sh:or                ( [ sh:property auth:inheritPropertyShape ]
@@ -331,6 +342,8 @@ auth:connectionExpressionShape
                            [ sh:property auth:connectionMessagesPropertyShape ]
                            [ sh:property auth:connectionMessagePropertyShape ]
                            [ sh:property auth:targetAtomPropertyShape ]
+                           [ sh:property auth:targetWonNodePropertyShape ]
+                           [ sh:property auth:targetWonNodePropertyShape ]
                            [ sh:property auth:operationPropertyShape ] ) .
 
 auth:connectionStateShape
@@ -353,6 +366,15 @@ auth:targetAtomExpressionShape
     sh:ignoredProperties ( auth:atom ) ;
     sh:or                ( [ sh:nodeKind sh:BlankNode ]
                            [ sh:node auth:atomExpressionShape ] ) .
+
+# TODO: describe
+
+auth:targetWonNodeExpressionShape
+    rdfs:isDefinedBy   auth: ;
+    a                  sh:NodeShape ;
+    sh:closed          true ;
+    sh:targetObjectsOf auth:targetWonNode ;
+    sh:nodeKind        sh:BlankNode .
 
 # Definition 14 (connection messages expression)
 
@@ -1004,7 +1026,7 @@ auth:operationRequestor
     rdfs:isDefinedBy auth: ;
     a                owl:NamedIndividual, auth:RelativeAtomExpression ;
     rdfs:label       "operationRequestor" ;
-    rdfs:comment     """Placeholder for the uri of the atom that requests an operation. In the case of bearer
+    rdfs:comment     """Placeholder for the uri of the atom or node that requests an operation. In the case of bearer
     authentication, there is no operationRequestor; arguably, one could use the token's subject claim, but that
     would extend additional trust to the issuer of the token."""@en .
 
@@ -1180,6 +1202,15 @@ auth:targetAtom
                        "Identifies target atoms of connections that are direct or transitive targetNodes of the expression's focus nodes."@en ;
     rdfs:label         "targetAtom" .
 
+auth:targetWonNode
+    rdfs:isDefinedBy   auth: ;
+    rdfs:subPropertyOf auth:AseLeafObjectProperty ;
+    a                  owl:ObjectProperty ;
+    rdfs:domain        auth:AtomStructureExpression ;
+    rdfs:comment
+                       "Identifies target WoN nodes of connections that are direct or transitive targetNodes of the expression's focus nodes."@en ;
+    rdfs:label         "targetWonNode" .
+
 auth:atomState
     rdfs:isDefinedBy   auth: ;
     a                  owl:ObjectProperty ;
@@ -1284,7 +1315,7 @@ auth:connectionMessage
     rdfs:subPropertyOf auth:AseBranchProperty ;
     rdfs:domain        [ a           owl:Class ;
                          owl:unionOf ( auth:AseRoot auth:SocketExpression auth:ConnectionsExpression
-                                     auth:ConnectionExpression auth:ConnectionMessagesExpression ) ] ;
+                                       auth:ConnectionExpression auth:ConnectionMessagesExpression ) ] ;
     rdfs:range         auth:ConnectionMessageExpression ;
     rdfs:label         "connectionMessage" ;
     rdfs:comment       """Used in the ASE root, socket, connections, connection, or connection messages expressions to specify
@@ -1446,10 +1477,12 @@ auth:expiresAfter
 auth:nodeSigned
     rdfs:isDefinedBy auth: ;
     a                owl:DatatypeProperty ;
-    rdfs:domain      [ a owl:Class ; owl:unionOf (auth:TokenSpecification auth:TokenShape ) ];
+    rdfs:domain      [ a           owl:Class ;
+                       owl:unionOf ( auth:TokenSpecification auth:TokenShape ) ] ;
     rdfs:range       xsd:boolean ;
     rdfs:label       "nodeSigned" ;
-    rdfs:comment     "If `true` or missing in an [auth:TokenSpecification], tokens are issued on behalf of [won:Atom]s by the [won:Node], and signed with the node's key. If `false`, tokens issued by an atom have to be signed using the atom's key. The latter is a much more complex process as the atom's key is only known to the owner applications controlling that atom; such tokens cannot be produced by the WoN node alone. If used in an [auth:TokenShape]the property instructs the token verification algorithm on which key to verify the signature against. By default, i.e., if this property is not used, tokens are assumed to be signed by the WoN node."@en .
+    rdfs:comment
+                     "If `true` or missing in an [auth:TokenSpecification], tokens are issued on behalf of [won:Atom]s by the [won:Node], and signed with the node's key. If `false`, tokens issued by an atom have to be signed using the atom's key. The latter is a much more complex process as the atom's key is only known to the owner applications controlling that atom; such tokens cannot be produced by the WoN node alone. If used in an [auth:TokenShape]the property instructs the token verification algorithm on which key to verify the signature against. By default, i.e., if this property is not used, tokens are assumed to be signed by the WoN node."@en .
 
 auth:tokenIss
     rdfs:isDefinedBy auth: ;
@@ -1562,6 +1595,15 @@ auth:grantsForConnStateConnected
                                          auth:connectionState won:Connected ] ] ;
     rdfs:label       "grantsForConnStateConnected" ;
     rdfs:comment     "Implicit authorization for established connections"@en .
+
+auth:grantReadKeyToConnectionTargetNodes
+    rdfs:isDefinedBy auth: ;
+    a                auth:Authorization, owl:NamedIndividual ;
+    auth:grant       [ auth:graph [ auth:graphType auth:keyGraph ] ] ;
+    auth:grantee     [ auth:connection [ auth:targetWonNode [ ] ] ] ;
+    rdfs:label       "grantReadKeyToConnectionTargetNodes" ;
+    rdfs:comment     """Implicit authorization granting the WoN node hosting an atom that we we have a connection
+    with access to our key graph so the node can verify messages we send."""@en .
 
 # Operations
 


### PR DESCRIPTION
* new auth property: auth:targetWonNode
* change TargetATomCheck to ConnectionTargetCheck, it's either checking the target atom or the won node of the target atom
* add a test case
* add an implicit Authorization: if local atom A has a connection to atom B on a remote node, allow that node to see the key graph of atom A.

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
WoN messaging across WoN nodes is not possible. The receiving node cannot verify the incoming message as it does not (necessarily) have access to the sending atom's public key. 

In addition to that, the nodes enter a deadlock trying  to verify each other's WebID. 

## What is the new behavior?
We add the option to allow ACL grants to won nodes, defined as the `target WoN node` of a `connection`, and we add an implicit Authorization giving any won node read access to an atom's key if that atom has a connection to any atom on that WoN node.

Access to the node descriptor is possible without checking a WebID first, so as to avoid a deadlock when a node wants to check another node's WebID using its own webID.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Can be tested with green/blue test system.
