### PR TITLE
Feat datareload2

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -141,7 +141,7 @@ const actionHierarchy = {
     storeUriFailed: INJ_DEFAULT,
     removeDeleted: INJ_DEFAULT,
     markAsLoaded: INJ_DEFAULT,
-    markConnectionContainerToLoad: INJ_DEFAULT,
+    markConnectionContainersToLoad: INJ_DEFAULT,
 
     fetchToken: {
       success: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/actions/actions.js
@@ -141,7 +141,8 @@ const actionHierarchy = {
     storeUriFailed: INJ_DEFAULT,
     removeDeleted: INJ_DEFAULT,
     markAsLoaded: INJ_DEFAULT,
-    markConnectionContainerAsLoaded: INJ_DEFAULT,
+    markConnectionContainerToLoad: INJ_DEFAULT,
+
     fetchToken: {
       success: INJ_DEFAULT,
       failure: INJ_DEFAULT,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-card.jsx
@@ -27,6 +27,7 @@ export default function WonAtomCard({
   const isSkeleton =
     atomUtils.isBeingCreated(atom) ||
     processUtils.hasAtomFailedToLoad(processState, atomUri) ||
+    processUtils.isAtomLoading(processState, atomUri) ||
     processUtils.isAtomFetchNecessary(processState, atomUri, atom);
 
   const matchedUseCase = atomUtils.getMatchedUseCaseIdentifier(atom);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-content.jsx
@@ -440,6 +440,7 @@ export default function WonAtomContent({
   }
 }
 WonAtomContent.propTypes = {
+  atomUri: PropTypes.string.isRequired,
   atom: PropTypes.object.isRequired,
   relevantConnectionsMap: PropTypes.object.isRequired,
   visibleTab: PropTypes.string.isRequired,
@@ -601,7 +602,6 @@ function WonAtomContentSingleConnectSockets({
   );
 }
 WonAtomContentSingleConnectSockets.propTypes = {
-  atomUri: PropTypes.string.isRequired,
   atom: PropTypes.object.isRequired,
   reactions: PropTypes.object.isRequired,
   relevantSingleConnectConnectionsMap: PropTypes.object.isRequired,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header-big.jsx
@@ -105,7 +105,8 @@ export default function WonAtomHeaderBig({
     isSenderAtomFetchNecessary ||
     isSenderHolderFetchNecessary ||
     isTargetAtomFetchNecessary ||
-    isTargetHolderFetchNecessary
+    isTargetHolderFetchNecessary ||
+    atomLoading
   ) {
     const onChange = isVisible => {
       if (isVisible) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-header.jsx
@@ -105,7 +105,12 @@ export default function WonAtomHeader({
     orgAtom
   );
 
-  if (isAtomFetchNecessary || isHolderFetchNecessary || isOrgFetchNecessary) {
+  if (
+    isAtomFetchNecessary ||
+    isHolderFetchNecessary ||
+    isOrgFetchNecessary ||
+    atomLoading
+  ) {
     //Loading View
 
     atomHeaderIcon = <div className="ah__icon__skeleton" />;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-tag-header.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/atom-tag-header.jsx
@@ -64,7 +64,7 @@ export default function WonAtomTagHeader({ atom, toLink, onClick, className }) {
     holderAtom
   );
 
-  if (isAtomFetchNecessary || isHolderFetchNecessary) {
+  if (isAtomFetchNecessary || isHolderFetchNecessary || atomLoading) {
     //Loading View
 
     atomHeaderContent = (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/skeleton-card.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/cards/skeleton-card.jsx
@@ -27,6 +27,7 @@ export default function WonSkeletonCard({
     atomUri
   );
   const atomToLoad = processUtils.isAtomToLoad(processState, atomUri) || !atom;
+  const atomLoading = processUtils.isAtomLoading(processState, atomUri);
 
   const isAtomFetchNecessary =
     !atomInCreation &&
@@ -94,8 +95,9 @@ export default function WonSkeletonCard({
   return (
     <won-skeleton-card
       class={
-        (isAtomFetchNecessary || atomInCreation ? " won-is-loading " : "") +
-        (atomToLoad ? "won-is-toload" : "")
+        (isAtomFetchNecessary || atomLoading || atomInCreation
+          ? " won-is-loading "
+          : "") + (atomToLoad ? "won-is-toload" : "")
       }
     >
       {cardIconSkeleton}

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/socket-add-atom.jsx
@@ -363,14 +363,6 @@ export default function WonSocketAddAtom({
       );
     }
   }
-  const specificLabels =
-    addToAtom &&
-    addToSocketType &&
-    wonLabelUtils.getAtomSocketPickerLabel(
-      addToAtom,
-      addToSocketType,
-      isAddToAtomOwned
-    );
   return (
     <won-socket-add-atom>
       <div className="wsaa__header">
@@ -378,11 +370,11 @@ export default function WonSocketAddAtom({
           <use xlinkHref={ico36_close} href={ico36_close} />
         </svg>
         <div className="wsaa__header__label">
-          {specificLabels
-            ? `${specificLabels}`
-            : `Pick an Atom to ${
-                isAddToAtomOwned ? "add" : "connect"
-              } to the ${wonLabelUtils.getSocketTabLabel(addToSocketType)}`}
+          {wonLabelUtils.getSocketPickerLabel(
+            addToAtom,
+            addToSocketType,
+            isAddToAtomOwned
+          )}
         </div>
       </div>
       <div className="wsaa__content">

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -108,20 +108,19 @@ export default function WonTopnav({ pageTitle }) {
    * Crawler for externalDataUris (e.g. wikidata uris)
    * this is used to fetch every wikidata uri that is not yet in the state
    */
-  // TODO: FIX ME (LOOPS)
-  // const externalDataUrisToLoad = useSelector(
-  //   generalSelectors.getExternalDataUrisToLoad
-  // );
-  // useEffect(
-  //   () => {
-  //     if (externalDataUrisToLoad && externalDataUrisToLoad.size > 0) {
-  //       externalDataUrisToLoad.map(entityUri => {
-  //         dispatch(actionCreators.externalData__fetchWikiData(entityUri));
-  //       });
-  //     }
-  //   },
-  //   [externalDataUrisToLoad]
-  // );
+  const externalDataUrisToLoad = useSelector(
+    generalSelectors.getExternalDataUrisToLoad
+  );
+  useEffect(
+    () => {
+      if (externalDataUrisToLoad && externalDataUrisToLoad.size > 0) {
+        externalDataUrisToLoad.map(entityUri => {
+          dispatch(actionCreators.externalData__fetchWikiData(entityUri));
+        });
+      }
+    },
+    [externalDataUrisToLoad]
+  );
 
   /*
   * Crawler to see if RequestCredentials for ConnectionContainers appeared

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -18,6 +18,7 @@ import ico_loading_anim from "~/images/won-icons/ico_loading_anim.svg";
 import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
 import { Link, useHistory } from "react-router-dom";
 import WonAtomIcon from "~/app/components/atom-icon";
+import Immutable from "immutable";
 
 export default function WonTopnav({ pageTitle }) {
   const history = useHistory();
@@ -42,6 +43,10 @@ export default function WonTopnav({ pageTitle }) {
 
   const connectionContainersToCrawl = useSelector(
     generalSelectors.getConnectionContainersToCrawl
+  );
+
+  const connectionContainersWithUnusedCredentials = useSelector(
+    processSelectors.getUnusedRequestCredentialsForConnectionContainer
   );
 
   const hasUnreads = useSelector(
@@ -85,11 +90,6 @@ export default function WonTopnav({ pageTitle }) {
 
   useEffect(
     () => {
-      console.debug(
-        "connectionContainersToCrawl: ",
-        connectionContainersToCrawl ? connectionContainersToCrawl.toJS() : {}
-      );
-
       if (connectionContainersToCrawl && connectionContainersToCrawl.size > 0) {
         connectionContainersToCrawl.map((connectionContainerState, atomUri) => {
           console.debug("connectionContainerState: ", connectionContainerState);
@@ -100,6 +100,28 @@ export default function WonTopnav({ pageTitle }) {
       }
     },
     [connectionContainersToCrawl]
+  );
+
+  useEffect(
+    () => {
+      if (
+        connectionContainersWithUnusedCredentials &&
+        connectionContainersWithUnusedCredentials.size > 0
+      ) {
+        connectionContainersWithUnusedCredentials.map(
+          (connectionContainerState, atomUri) => {
+            //TODO: FIXME THIS MIGHT BE THE WRONG POSITION
+            dispatch({
+              type: actionCreators.atoms.markConnectionContainerToLoad,
+              payload: Immutable.fromJS({
+                uri: atomUri,
+              }),
+            });
+          }
+        );
+      }
+    },
+    [connectionContainersWithUnusedCredentials]
   );
 
   function toggleSlideIns() {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -37,14 +37,6 @@ export default function WonTopnav({ pageTitle }) {
   const isSignUpView = currentPath === "/signup";
   const showLoadingIndicator = useSelector(processSelectors.isLoading);
 
-  const connectionContainersToCrawl = useSelector(
-    generalSelectors.getConnectionContainersToCrawl
-  );
-
-  const atomUrisWithUnusedCredentialsForConnectionContainer = useSelector(
-    processSelectors.getAtomUrisWithUnusedRequestCredentialsForConnectionContainer
-  );
-
   const hasUnreads = useSelector(
     state =>
       generalSelectors.hasUnassignedUnpinnedAtomUnreads(state) ||
@@ -96,6 +88,9 @@ export default function WonTopnav({ pageTitle }) {
   * this is used to fetch every connection Container with the appropriate credentials in order to display all the content
   * available to the user
   */
+  const connectionContainersToCrawl = useSelector(
+    generalSelectors.getConnectionContainersToCrawl
+  );
   useEffect(
     () => {
       if (connectionContainersToCrawl && connectionContainersToCrawl.size > 0) {
@@ -109,10 +104,32 @@ export default function WonTopnav({ pageTitle }) {
     [connectionContainersToCrawl]
   );
 
+  /**
+   * Crawler for externalDataUris (e.g. wikidata uris)
+   * this is used to fetch every wikidata uri that is not yet in the state
+   */
+  // TODO: FIX ME (LOOPS)
+  // const externalDataUrisToLoad = useSelector(
+  //   generalSelectors.getExternalDataUrisToLoad
+  // );
+  // useEffect(
+  //   () => {
+  //     if (externalDataUrisToLoad && externalDataUrisToLoad.size > 0) {
+  //       externalDataUrisToLoad.map(entityUri => {
+  //         dispatch(actionCreators.externalData__fetchWikiData(entityUri));
+  //       });
+  //     }
+  //   },
+  //   [externalDataUrisToLoad]
+  // );
+
   /*
   * Crawler to see if RequestCredentials for ConnectionContainers appeared
   * This is used to mark connection containers as "toLoad" in order to refetch them
   */
+  const atomUrisWithUnusedCredentialsForConnectionContainer = useSelector(
+    processSelectors.getAtomUrisWithUnusedRequestCredentialsForConnectionContainer
+  );
   useEffect(
     () => {
       if (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -18,7 +18,6 @@ import ico_loading_anim from "~/images/won-icons/ico_loading_anim.svg";
 import ico16_arrow_down from "~/images/won-icons/ico16_arrow_down.svg";
 import { Link, useHistory } from "react-router-dom";
 import WonAtomIcon from "~/app/components/atom-icon";
-import Immutable from "immutable";
 
 export default function WonTopnav({ pageTitle }) {
   const history = useHistory();
@@ -45,9 +44,9 @@ export default function WonTopnav({ pageTitle }) {
     generalSelectors.getConnectionContainersToCrawl
   );
 
-  const connectionContainersWithUnusedCredentials = useSelector(
-    processSelectors.getUnusedRequestCredentialsForConnectionContainer
-  );
+  // const connectionContainersWithUnusedCredentials = useSelector(
+  //   processSelectors.getUnusedRequestCredentialsForConnectionContainer
+  // );
 
   const hasUnreads = useSelector(
     state =>
@@ -102,27 +101,32 @@ export default function WonTopnav({ pageTitle }) {
     [connectionContainersToCrawl]
   );
 
-  useEffect(
-    () => {
-      if (
-        connectionContainersWithUnusedCredentials &&
-        connectionContainersWithUnusedCredentials.size > 0
-      ) {
-        connectionContainersWithUnusedCredentials.map(
-          (connectionContainerState, atomUri) => {
-            //TODO: FIXME THIS MIGHT BE THE WRONG POSITION
-            dispatch({
-              type: actionCreators.atoms.markConnectionContainerToLoad,
-              payload: Immutable.fromJS({
-                uri: atomUri,
-              }),
-            });
-          }
-        );
-      }
-    },
-    [connectionContainersWithUnusedCredentials]
-  );
+  // FIXME: This effect causes the App to break (loops seemingly endlessly)
+  // useEffect(
+  //   () => {
+  //     if (
+  //       connectionContainersWithUnusedCredentials &&
+  //       connectionContainersWithUnusedCredentials.size > 0
+  //     ) {
+  //       connectionContainersWithUnusedCredentials.map(
+  //         (connectionContainerState, atomUri) => {
+  //           console.debug(
+  //             "there are Unused credentials for connContainer of: ",
+  //             atomUri,
+  //             " credentials: ",
+  //             connectionContainerState
+  //           );
+  //           dispatch(
+  //             actionCreators.atoms__markConnectionContainerToLoad({
+  //               uri: atomUri,
+  //             })
+  //           );
+  //         }
+  //       );
+  //     }
+  //   },
+  //   [connectionContainersWithUnusedCredentials]
+  // );
 
   function toggleSlideIns() {
     hideMenu();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/components/topnav.jsx
@@ -44,9 +44,9 @@ export default function WonTopnav({ pageTitle }) {
     generalSelectors.getConnectionContainersToCrawl
   );
 
-  // const connectionContainersWithUnusedCredentials = useSelector(
-  //   processSelectors.getUnusedRequestCredentialsForConnectionContainer
-  // );
+  const connectionContainersWithUnusedCredentials = useSelector(
+    processSelectors.getUnusedRequestCredentialsForConnectionContainer
+  );
 
   const hasUnreads = useSelector(
     state =>
@@ -101,32 +101,31 @@ export default function WonTopnav({ pageTitle }) {
     [connectionContainersToCrawl]
   );
 
-  // FIXME: This effect causes the App to break (loops seemingly endlessly)
-  // useEffect(
-  //   () => {
-  //     if (
-  //       connectionContainersWithUnusedCredentials &&
-  //       connectionContainersWithUnusedCredentials.size > 0
-  //     ) {
-  //       connectionContainersWithUnusedCredentials.map(
-  //         (connectionContainerState, atomUri) => {
-  //           console.debug(
-  //             "there are Unused credentials for connContainer of: ",
-  //             atomUri,
-  //             " credentials: ",
-  //             connectionContainerState
-  //           );
-  //           dispatch(
-  //             actionCreators.atoms__markConnectionContainerToLoad({
-  //               uri: atomUri,
-  //             })
-  //           );
-  //         }
-  //       );
-  //     }
-  //   },
-  //   [connectionContainersWithUnusedCredentials]
-  // );
+  useEffect(
+    () => {
+      if (
+        connectionContainersWithUnusedCredentials &&
+        connectionContainersWithUnusedCredentials.size > 0
+      ) {
+        connectionContainersWithUnusedCredentials.map(
+          (unusedCredentials, atomUri) => {
+            console.debug(
+              "there are Unused credentials for connContainer of: ",
+              atomUri,
+              " credentials: ",
+              unusedCredentials.toJS()
+            );
+            dispatch(
+              actionCreators.atoms__markConnectionContainerToLoad({
+                uri: atomUri,
+              })
+            );
+          }
+        );
+      }
+    },
+    [connectionContainersWithUnusedCredentials]
+  );
 
   function toggleSlideIns() {
     hideMenu();

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -378,12 +378,11 @@ export default function(processState = initialState, action = {}) {
       const remainingRequestCredentials = get(
         action.payload,
         "allRequestCredentials"
-      ).filter(
-        requestCredentials =>
-          !processUtils.isUsedCredentialsUnsuccessfully(
-            updatedFetchTokenRequests,
-            requestCredentials
-          )
+      ).filterNot(requestCredentials =>
+        processUtils.isUsedCredentialsUnsuccessfully(
+          updatedFetchTokenRequests,
+          requestCredentials
+        )
       );
 
       console.debug(
@@ -425,12 +424,11 @@ export default function(processState = initialState, action = {}) {
       const remainingRequestCredentials = get(
         action.payload,
         "allRequestCredentials"
-      ).filter(
-        requestCredentials =>
-          !processUtils.isUsedCredentialsUnsuccessfully(
-            updatedAtomRequests,
-            requestCredentials
-          )
+      ).filterNot(requestCredentials =>
+        processUtils.isUsedCredentialsUnsuccessfully(
+          updatedAtomRequests,
+          requestCredentials
+        )
       );
 
       return updateAtomProcess(processState, atomUri, {
@@ -452,12 +450,11 @@ export default function(processState = initialState, action = {}) {
       const remainingRequestCredentials = get(
         action.payload,
         "allRequestCredentials"
-      ).filter(
-        requestCredentials =>
-          !processUtils.isUsedCredentials(
-            updatedConnectionContainerRequests,
-            requestCredentials
-          )
+      ).filterNot(requestCredentials =>
+        processUtils.isUsedCredentials(
+          updatedConnectionContainerRequests,
+          requestCredentials
+        )
       );
 
       return updateConnectionContainerProcess(processState, atomUri, {
@@ -731,12 +728,11 @@ export default function(processState = initialState, action = {}) {
       const remainingRequestCredentials = get(
         action.payload,
         "allRequestCredentials"
-      ).filter(
-        requestCredentials =>
-          !processUtils.isUsedCredentials(
-            updatedConnectionContainerRequests,
-            requestCredentials
-          )
+      ).filterNot(requestCredentials =>
+        processUtils.isUsedCredentials(
+          updatedConnectionContainerRequests,
+          requestCredentials
+        )
       );
 
       console.debug(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -447,13 +447,22 @@ export default function(processState = initialState, action = {}) {
       });
     }
 
-    case actionTypes.atoms.markConnectionContainerToLoad: {
-      const atomUri = getUri(action.payload);
-      console.debug("markConnectionContainerToLoad: ", atomUri);
+    case actionTypes.atoms.markConnectionContainersToLoad: {
+      const atomUris = get(action.payload, "uris");
 
-      return updateConnectionContainerProcess(processState, atomUri, {
-        toLoad: true,
-      });
+      if (atomUris && atomUris.size > 0) {
+        atomUris.map(atomUri => {
+          processState = updateConnectionContainerProcess(
+            processState,
+            atomUri,
+            {
+              toLoad: true,
+            }
+          );
+        });
+      }
+
+      return processState;
     }
 
     case actionTypes.connections.storeUriFailed: {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -469,6 +469,15 @@ export default function(processState = initialState, action = {}) {
       });
     }
 
+    case actionTypes.atoms.markConnectionContainerToLoad: {
+      const atomUri = getUri(action.payload);
+      console.debug("markConnectionContainerToLoad: ", atomUri);
+
+      return updateConnectionContainerProcess(processState, atomUri, {
+        toLoad: true,
+      });
+    }
+
     case actionTypes.connections.storeUriFailed: {
       const connUri = get(action.payload, "connUri");
       const request = get(action.payload, "request");
@@ -853,17 +862,6 @@ export default function(processState = initialState, action = {}) {
       let atomUri = getUri(action.payload);
 
       return updateAtomProcess(processState, atomUri, {
-        toLoad: false,
-        failedToLoad: false,
-        loading: false,
-        loaded: true,
-      });
-    }
-
-    case actionTypes.atoms.markConnectionContainerAsLoaded: {
-      let atomUri = getUri(action.payload);
-
-      return updateConnectionContainerProcess(processState, atomUri, {
         toLoad: false,
         failedToLoad: false,
         loading: false,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/reducers/process-reducer.js
@@ -375,25 +375,6 @@ export default function(processState = initialState, action = {}) {
         .getFetchTokenRequests(processState, atomUri, tokenScopeUri)
         .push(request);
 
-      const remainingRequestCredentials = get(
-        action.payload,
-        "allRequestCredentials"
-      ).filterNot(requestCredentials =>
-        processUtils.isUsedCredentialsUnsuccessfully(
-          updatedFetchTokenRequests,
-          requestCredentials
-        )
-      );
-
-      console.debug(
-        "remainingRequestCredentials to fetch TokenScopeUri",
-        tokenScopeUri,
-        " from ",
-        atomUri,
-        " -> ",
-        remainingRequestCredentials.size
-      );
-
       return updateFetchTokenProcess(processState, atomUri, tokenScopeUri, {
         requests: updatedFetchTokenRequests,
       });

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -542,12 +542,6 @@ export const getConnectionContainersToCrawl = createSelector(
           .filter(
             atom => !processUtils.isAtomToLoad(processState, getUri(atom))
           )
-          .map(atom =>
-            processUtils.getConnectionContainerStatus(
-              processState,
-              getUri(atom)
-            )
-          )
       );
     }
 
@@ -557,9 +551,6 @@ export const getConnectionContainersToCrawl = createSelector(
         .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
         .filter(atom =>
           processUtils.isConnectionContainerToLoad(processState, getUri(atom))
-        )
-        .map(atom =>
-          processUtils.getConnectionContainerStatus(processState, getUri(atom))
         );
 
     if (
@@ -574,9 +565,6 @@ export const getConnectionContainersToCrawl = createSelector(
       .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
       .filter(atom =>
         processUtils.isConnectionContainerToLoad(processState, getUri(atom))
-      )
-      .map(atom =>
-        processUtils.getConnectionContainerStatus(processState, getUri(atom))
       );
 
     if (
@@ -593,9 +581,6 @@ export const getConnectionContainersToCrawl = createSelector(
         .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
         .filter(atom =>
           processUtils.isConnectionContainerToLoad(processState, getUri(atom))
-        )
-        .map(atom =>
-          processUtils.getConnectionContainerStatus(processState, getUri(atom))
         );
 
     if (

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -650,14 +650,13 @@ export const getExternalDataUrisToLoad = createSelector(
   getExternalDataState,
   (allAtoms, processState, externalDataState) =>
     allAtoms
+      .filterNot(atom => processUtils.isAtomToLoad(processState, getUri(atom)))
       .map(atom => getIn(atom, ["content", "eventObjectAboutUris"]))
-      .filter(entityUri =>
-        processUtils.isExternalDataFetchNecessary(
-          processState,
-          entityUri,
-          get(externalDataState, entityUri)
-        )
-      )
       .flatten()
       .toSet()
+      .filter(entityUri => !!entityUri)
+      .filterNot(entityUri => !!get(externalDataState, entityUri))
+      .filterNot(entityUri =>
+        processUtils.isExternalDataLoading(processState, entityUri)
+      )
 );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -539,8 +539,8 @@ export const getConnectionContainersToCrawl = createSelector(
         ownedPinnedAtoms &&
         ownedPinnedAtoms
           .filter(atom => getUri(atom) === activePinnedAtomUri)
-          .filter(
-            atom => !processUtils.isAtomToLoad(processState, getUri(atom))
+          .filterNot(atom =>
+            processUtils.isAtomToLoad(processState, getUri(atom))
           )
       );
     }
@@ -548,7 +548,9 @@ export const getConnectionContainersToCrawl = createSelector(
     const ownedPinnedAtomsConnectionContainersToCrawl =
       ownedPinnedAtoms &&
       ownedPinnedAtoms
-        .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
+        .filterNot(atom =>
+          processUtils.isAtomToLoad(processState, getUri(atom))
+        )
         .filter(atom =>
           processUtils.isConnectionContainerToLoad(processState, getUri(atom))
         );
@@ -562,7 +564,7 @@ export const getConnectionContainersToCrawl = createSelector(
     }
 
     const ownedAtomsConnectionContainersToCrawl = ownedAtoms
-      .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
+      .filterNot(atom => processUtils.isAtomToLoad(processState, getUri(atom)))
       .filter(atom =>
         processUtils.isConnectionContainerToLoad(processState, getUri(atom))
       );
@@ -578,7 +580,9 @@ export const getConnectionContainersToCrawl = createSelector(
     const atomsConnectionContainersToCrawl =
       atoms &&
       atoms
-        .filter(atom => !processUtils.isAtomToLoad(processState, getUri(atom)))
+        .filterNot(atom =>
+          processUtils.isAtomToLoad(processState, getUri(atom))
+        )
         .filter(atom =>
           processUtils.isConnectionContainerToLoad(processState, getUri(atom))
         );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/general-selectors.js
@@ -643,3 +643,21 @@ export const getPossibleRequestCredentialsForAtom = atomUri =>
       return Immutable.fromJS(possibleRequestCredentials);
     }
   );
+
+export const getExternalDataUrisToLoad = createSelector(
+  getAtoms,
+  getProcessState,
+  getExternalDataState,
+  (allAtoms, processState, externalDataState) =>
+    allAtoms
+      .map(atom => getIn(atom, ["content", "eventObjectAboutUris"]))
+      .filter(entityUri =>
+        processUtils.isExternalDataFetchNecessary(
+          processState,
+          entityUri,
+          get(externalDataState, entityUri)
+        )
+      )
+      .flatten()
+      .toSet()
+);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
@@ -98,7 +98,12 @@ export const getAllAtomRequests = createSelector(
     get(processState, ["atoms"]).map(atom => get(atom, "requests"))
 );
 
-export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
+/**
+ * Returns a Set of AtomUris where there are unused Credentials left for connectionContainer fetches
+ * That way we can indicate or induce a refetch of the connectionContainer in order to get all the data
+ * available
+ */
+export const getAtomUrisWithUnusedRequestCredentialsForConnectionContainer = createSelector(
   state => state,
   getProcessState,
   state => get(state, "atoms"),
@@ -121,4 +126,6 @@ export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
       .filter(
         requestCredentials => requestCredentials && requestCredentials.size > 0
       )
+      .keySeq()
+      .toSet()
 );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
@@ -110,7 +110,7 @@ export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
           processUtils.isConnectionContainerLoading(processState, atomUri)
       )
       .map((_, atomUri) => {
-        const priorRequests = getConnectionContainerRequests(atomUri);
+        const priorRequests = getConnectionContainerRequests(atomUri)(state);
         return getPossibleRequestCredentialsForAtom(atomUri)(state).filterNot(
           requestCredentials =>
             processUtils.isUsedCredentials(priorRequests, requestCredentials)

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
@@ -4,6 +4,7 @@
 import { get } from "../../utils.js";
 import * as processUtils from "../utils/process-utils.js";
 import { createSelector } from "reselect";
+import { getPossibleRequestCredentialsForAtom } from "~/app/redux/selectors/general-selectors";
 
 const getProcessState = createSelector(
   state => get(state, "process"),
@@ -95,4 +96,21 @@ export const getAllAtomRequests = createSelector(
   getProcessState,
   processState =>
     get(processState, ["atoms"]).map(atom => get(atom, "requests"))
+);
+
+export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
+  state => state,
+  state => get(state, "atoms"),
+  (state, atoms) =>
+    atoms
+      .map((_, atomUri) => {
+        const priorRequests = getConnectionContainerRequests(atomUri);
+        return getPossibleRequestCredentialsForAtom(atomUri)(state).filterNot(
+          requestCredentials =>
+            processUtils.isUsedCredentials(priorRequests, requestCredentials)
+        );
+      })
+      .filter(
+        requestCredentials => requestCredentials && requestCredentials.size > 0
+      )
 );

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
@@ -104,10 +104,12 @@ export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
   state => get(state, "atoms"),
   (state, processState, atoms) =>
     atoms
-      .filterNot(
-        (_, atomUri) =>
-          processUtils.isConnectionContainerToLoad(processState, atomUri) ||
-          processUtils.isConnectionContainerLoading(processState, atomUri)
+      .filter((_, atomUri) => processUtils.isAtomLoaded(processState, atomUri))
+      .filterNot((_, atomUri) =>
+        processUtils.isConnectionContainerToLoad(processState, atomUri)
+      )
+      .filterNot((_, atomUri) =>
+        processUtils.isConnectionContainerLoading(processState, atomUri)
       )
       .map((_, atomUri) => {
         const priorRequests = getConnectionContainerRequests(atomUri)(state);

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/selectors/process-selectors.js
@@ -100,9 +100,15 @@ export const getAllAtomRequests = createSelector(
 
 export const getUnusedRequestCredentialsForConnectionContainer = createSelector(
   state => state,
+  getProcessState,
   state => get(state, "atoms"),
-  (state, atoms) =>
+  (state, processState, atoms) =>
     atoms
+      .filterNot(
+        (_, atomUri) =>
+          processUtils.isConnectionContainerToLoad(processState, atomUri) ||
+          processUtils.isConnectionContainerLoading(processState, atomUri)
+      )
       .map((_, atomUri) => {
         const priorRequests = getConnectionContainerRequests(atomUri);
         return getPossibleRequestCredentialsForAtom(atomUri)(state).filterNot(

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/state-store.js
@@ -372,11 +372,15 @@ export const fetchConnectionsContainerAndDispatch = (
         requestCredentials
       )
       .then(connectionsWithStateAndSocket => {
+        const connectionsWithNonDeletedAtoms = connectionsWithStateAndSocket.filter(
+          conn => !isUriDeleted(conn.uri)
+        );
+
         dispatch({
           type: actionTypes.connections.storeMetaConnections,
           payload: Immutable.fromJS({
             atomUri: atomUri,
-            connections: connectionsWithStateAndSocket,
+            connections: connectionsWithNonDeletedAtoms,
             allRequestCredentials: generalSelectors.getPossibleRequestCredentialsForAtom(
               atomUri
             )(state),
@@ -387,10 +391,9 @@ export const fetchConnectionsContainerAndDispatch = (
           }),
         });
         if (isOwned) {
-          const activeConnectionUris = connectionsWithStateAndSocket
+          const activeConnectionUris = connectionsWithNonDeletedAtoms
             .filter(
               conn =>
-                !isUriDeleted(conn.uri) &&
                 conn.connectionState !== vocab.WON.Closed &&
                 conn.connectionState !== vocab.WON.Suggested
             )

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -237,6 +237,15 @@ export function getReactions(atom, socketType) {
   return socketType ? get(possibleReactions, socketType) : possibleReactions;
 }
 
+/**
+ * Returns the Label defined in the UseCase/Reaction
+ * @param atom
+ * @param labelType - which label you want (e.g. default, addNew, picker...)
+ * @param isOwned - if the atom in question is Owned or not
+ * @param addToSocketType
+ * @param socketType
+ * @returns {undefined|*}
+ */
 export function getReactionLabel(
   atom,
   labelType,

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/atom-utils.js
@@ -237,68 +237,29 @@ export function getReactions(atom, socketType) {
   return socketType ? get(possibleReactions, socketType) : possibleReactions;
 }
 
-export function getReactionLabels(atom, addToSocketType, socketType) {
-  let labels = {
-    owned: {
-      default: [],
-      addNew: [],
-      picker: [],
-    },
-    nonOwned: {
-      default: [],
-      addNew: [],
-      picker: [],
-    },
-  };
+export function getReactionLabel(
+  atom,
+  labelType,
+  isOwned,
+  addToSocketType,
+  socketType
+) {
   const reactions = getReactions(atom, addToSocketType);
   if (reactions && reactions.size > 0) {
     if (socketType) {
-      const typeReactions = get(reactions, socketType);
-      const reactionLabels = get(typeReactions, "labels");
-      return {
-        owned: {
-          default: getIn(reactionLabels, ["owned", "default"]),
-          addNew: getIn(reactionLabels, ["owned", "addNew"]),
-          picker: getIn(reactionLabels, ["owned", "picker"]),
-        },
-        nonOwned: {
-          default: getIn(reactionLabels, ["nonOwned", "default"]),
-          addNew: getIn(reactionLabels, ["nonOwned", "addNew"]),
-          picker: getIn(reactionLabels, ["nonOwned", "picker"]),
-        },
-      };
+      return getIn(reactions, [
+        socketType,
+        "labels",
+        isOwned ? "owned" : "nonOwned",
+        labelType,
+      ]);
     } else {
-      reactions.map(reaction => {
-        const reactionLabels = get(reaction, "labels");
-        if (reactionLabels) {
-          labels.owned.default.push(
-            getIn(reactionLabels, ["owned", "default"])
-          );
-          labels.owned.addNew.push(getIn(reactionLabels, ["owned", "addNew"]));
-          labels.owned.picker.push(getIn(reactionLabels, ["owned", "picker"]));
-          labels.nonOwned.default.push(
-            getIn(reactionLabels, ["nonOwned", "default"])
-          );
-          labels.nonOwned.addNew.push(
-            getIn(reactionLabels, ["nonOwned", "addNew"])
-          );
-          labels.nonOwned.picker.push(
-            getIn(reactionLabels, ["nonOwned", "picker"])
-          );
-        }
-      });
-      return {
-        owned: {
-          default: labels.owned.default.join(" / "),
-          addNew: labels.owned.addNew.join(" / "),
-          picker: labels.owned.picker.join(" / "),
-        },
-        nonOwned: {
-          default: labels.nonOwned.default.join(" / "),
-          addNew: labels.nonOwned.addNew.join(" / "),
-          picker: labels.nonOwned.picker.join(" / "),
-        },
-      };
+      return reactions
+        .map(reaction =>
+          getIn(reaction, ["labels", isOwned ? "owned" : "nonOwned", labelType])
+        )
+        .filter(label => !!label)
+        .join(" / ");
     }
   }
   return undefined;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/process-utils.js
@@ -170,11 +170,6 @@ export function hasConnectionContainerFailedToLoad(process, atomUri) {
   );
 }
 
-//TODO REFACTOR NAME!
-export function getConnectionContainerStatus(process, atomUri) {
-  return atomUri && getIn(process, ["connectionContainers", atomUri]);
-}
-
 export function isConnectionContainerLoading(process, atomUri) {
   return (
     atomUri && getIn(process, ["connectionContainers", atomUri, "loading"])

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/process-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/redux/utils/process-utils.js
@@ -517,8 +517,9 @@ function getRequestForSameCredentials(priorRequests, requestCredentials) {
   const scope = get(requestCredentials, "scope");
   const requesterWebId = get(requestCredentials, "requesterWebId");
 
+  let foundRequest = undefined;
   if (priorRequests && priorRequests.size > 0 && requestCredentials) {
-    return priorRequests.find(
+    foundRequest = priorRequests.find(
       request =>
         requestTokenFromAtomUri
           ? getIn(request, ["requestCredentials", "obtainedFrom", "scope"]) ===
@@ -532,7 +533,7 @@ function getRequestForSameCredentials(priorRequests, requestCredentials) {
             requesterWebId
     );
   }
-  return undefined;
+  return foundRequest;
 }
 
 export function isUsedCredentials(priorRequests, requestCredentials) {

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -215,6 +215,25 @@ export function getSocketItemLabels(targetSocketType, socketTypes) {
   return socketTypeLabels.join("/");
 }
 
+export function getSocketPickerLabel(
+  addToAtom,
+  addToSocketType,
+  isAddToAtomOwned
+) {
+  const specificLabels =
+    addToAtom &&
+    addToSocketType &&
+    getAtomSocketPickerLabel(addToAtom, addToSocketType, isAddToAtomOwned);
+
+  if (specificLabels) {
+    return specificLabels;
+  } else {
+    return `Pick an Atom to ${
+      isAddToAtomOwned ? "add" : "connect"
+    } to the ${getSocketTabLabel(addToSocketType)}`;
+  }
+}
+
 export function getAddNewSocketItemLabel(
   isAddToOwned,
   addToUseCase,
@@ -314,7 +333,7 @@ export function generateAddButtonLabel(
   }
 }
 
-export function getAtomSocketDefaultLabel(atom, socketType, isOwned) {
+function getAtomSocketDefaultLabel(atom, socketType, isOwned) {
   const labels = atomUtils.getReactionLabels(atom, socketType);
   if (labels) {
     return isOwned ? labels.owned.default : labels.nonOwned.default;
@@ -322,12 +341,7 @@ export function getAtomSocketDefaultLabel(atom, socketType, isOwned) {
   return undefined;
 }
 
-export function getAtomSocketAddNewLabel(
-  atom,
-  addToSocketType,
-  socketType,
-  isOwned
-) {
+function getAtomSocketAddNewLabel(atom, addToSocketType, socketType, isOwned) {
   const labels = atomUtils.getReactionLabels(atom, addToSocketType, socketType);
   if (labels) {
     return isOwned ? labels.owned.addNew : labels.nonOwned.addNew;
@@ -335,7 +349,7 @@ export function getAtomSocketAddNewLabel(
   return undefined;
 }
 
-export function getAtomSocketPickerLabel(atom, socketType, isOwned) {
+function getAtomSocketPickerLabel(atom, socketType, isOwned) {
   const labels = atomUtils.getReactionLabels(atom, socketType);
   if (labels) {
     return isOwned ? labels.owned.picker : labels.nonOwned.picker;

--- a/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/app/won-label-utils.js
@@ -223,7 +223,12 @@ export function getSocketPickerLabel(
   const specificLabels =
     addToAtom &&
     addToSocketType &&
-    getAtomSocketPickerLabel(addToAtom, addToSocketType, isAddToAtomOwned);
+    atomUtils.getReactionLabel(
+      addToAtom,
+      "picker",
+      isAddToAtomOwned,
+      addToSocketType
+    );
 
   if (specificLabels) {
     return specificLabels;
@@ -245,7 +250,13 @@ export function getAddNewSocketItemLabel(
   const specificLabels =
     atom &&
     addToSocketType &&
-    getAtomSocketAddNewLabel(atom, addToSocketType, socketType, isAddToOwned);
+    atomUtils.getReactionLabel(
+      atom,
+      "addNew",
+      isAddToOwned,
+      addToSocketType,
+      socketType
+    );
   if (specificLabels) {
     return specificLabels;
   } else if (addToUseCase === "organization" && ucIdentifier === "persona") {
@@ -301,7 +312,13 @@ export function generateAddButtonLabel(
   const specificLabels =
     targetAtom &&
     targetSocketType &&
-    getAtomSocketDefaultLabel(targetAtom, targetSocketType, isAtomOwned);
+    atomUtils.getReactionLabel(
+      targetAtom,
+      "default",
+      isAtomOwned,
+      targetSocketType
+    );
+
   if (specificLabels) {
     return specificLabels;
   } else {
@@ -331,30 +348,6 @@ export function generateAddButtonLabel(
       senderReactions
     );
   }
-}
-
-function getAtomSocketDefaultLabel(atom, socketType, isOwned) {
-  const labels = atomUtils.getReactionLabels(atom, socketType);
-  if (labels) {
-    return isOwned ? labels.owned.default : labels.nonOwned.default;
-  }
-  return undefined;
-}
-
-function getAtomSocketAddNewLabel(atom, addToSocketType, socketType, isOwned) {
-  const labels = atomUtils.getReactionLabels(atom, addToSocketType, socketType);
-  if (labels) {
-    return isOwned ? labels.owned.addNew : labels.nonOwned.addNew;
-  }
-  return undefined;
-}
-
-function getAtomSocketPickerLabel(atom, socketType, isOwned) {
-  const labels = atomUtils.getReactionLabels(atom, socketType);
-  if (labels) {
-    return isOwned ? labels.owned.picker : labels.nonOwned.picker;
-  }
-  return undefined;
 }
 
 function generateDefaultButtonLabel(

--- a/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-role.js
+++ b/webofneeds/won-owner-webapp/src/main/webapp/config/usecases/uc-role.js
@@ -34,6 +34,18 @@ export const role = {
     [vocab.WXSCHEMA.OrganizationRoleOfSocketCompacted]: {
       [vocab.WXSCHEMA.MemberSocketCompacted]: {
         useCaseIdentifiers: ["organization"],
+        labels: {
+          owned: {
+            default: "Organization",
+            addNew: "Add to New Organization",
+            picker: "Pick a Organization to join",
+          },
+          nonOwned: {
+            default: "Organization",
+            addNew: "Add to New Organization",
+            picker: "Pick a Organization to join",
+          },
+        },
         refuseNonOwned: true,
       },
     },


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [X] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- Currently we run into a loop when fetching Connection Containers
- We also do not fetch connectionContainers again if the initial Amount of possibilities has been reached -> no data reload even if more requestCredentials would be available
- the label generation was using a lot of unnecessary state retrievals
- atom in state loading did not always show the skeleton/loading card


## What is the new behavior?
- the fetch loop has been removed
- connContainers are loaded again if new requestCredentials "arise"
- label generation is simplified
- atom loading ui is displayed appropriately for atom-cards

## Does this introduce a breaking change?

- [ ] Yes
- [X] No