### PR TITLE
Use WebIDs in owner webapp to fetch owned atoms

### DIFF
--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClientHttps.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClientHttps.java
@@ -67,7 +67,7 @@ public class LinkedDataRestClientHttps extends LinkedDataRestClient {
         RestTemplate template;
         try {
             if (logger.isDebugEnabled()) {
-                logger.debug("creating rest template for webID {} ", webID == null ? "[none provided]" : webID);
+                logger.debug("creating rest template for webID {} ", webID);
             }
             String actualPrivateKeyAlias = keyPairAliasDerivationStrategy.getAliasForAtomUri(webID);
             if (actualPrivateKeyAlias == null) {
@@ -79,7 +79,8 @@ public class LinkedDataRestClientHttps extends LinkedDataRestClient {
                             this.trustStoreService.getUnderlyingKeyStore(), this.trustStrategy, readTimeout,
                             connectionTimeout, true);
             if (logger.isDebugEnabled()) {
-                logger.debug("rest template for webID {} created", webID == null ? "[none provided]" : webID);
+                logger.debug("rest template for webID {} created (privateKeyAlias actually used: {})", webID,
+                                actualPrivateKeyAlias);
             }
             // we add our DatasetConverter before any other converter because the jackson
             // converter feels responsible for "application/*+json" (which matches

--- a/webofneeds/won-docker/deploy/local_build/logback-config/logback.xml
+++ b/webofneeds/won-docker/deploy/local_build/logback-config/logback.xml
@@ -27,9 +27,8 @@
     <!-- avoid logging Exceptions with stack traces on WARN level when JMS Connection is broken -->
     <logger name="org.apache.camel.component.jms.reply.TemporaryQueueReplyManager" level="ERROR"/>
     <logger name="org.springframework.jms.connection.CachingConnectionFactory" level="ERROR"/>
-    <logger name="org.springframework" level="info"/>
+    <logger name="org.springframework" level="debug"/>
     <logger name="org.springframework.security" level="info"/>
-    <logger name="org.springframework" level="debug" />
     <logger name="won.node" level="debug"/>
     <logger name="won" level="debug"/>
     <logger name="won.shacl2java" level="info" />

--- a/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
+++ b/webofneeds/won-owner/src/main/resources/spring/component/linkeddatasource/owner-linkeddatasource.xml
@@ -26,6 +26,7 @@
     </bean>
 
     <bean id="linkedDataSourceOnBehalfOfAtom" class="won.auth.linkeddata.AuthEnabledLinkedDataSource">
+        <qualifier value="onBehalfOfAtom" />
         <property name="linkedDataRestClient" ref="linkedDataRestClientOnBehalfOfAtom"/>
         <property name="sharedCache" value="false"/>
     </bean>


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If your atoms are not publicly readable, the owner webapp breaks

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

the owner webapp should handle private atoms just fine

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
