### PR TITLE
Remove test for owned atoms

### DIFF
--- a/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
+++ b/webofneeds/won-owner-webapp/src/main/java/won/owner/web/websocket/WonWebSocketHandler.java
@@ -64,7 +64,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.Duration;
-import java.util.*;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -387,18 +390,6 @@ public class WonWebSocketHandler extends TextWebSocketHandler
         UserAtom userAtom = getAtomOfUser(user, atomUri);
         if (userAtom == null) {
             logger.debug("not sending notification to user: atom uri not specified");
-            return;
-        }
-        UserAtom senderAtom = getAtomOfUser(user, wonMessage.getSenderAtomURI());
-        boolean allSendersOwned = wonMessage
-                        .getHeadAndForwarded(true)
-                        .getAllMessages()
-                        .stream()
-                        .map(m -> m.getSenderAtomURI())
-                        .filter(Objects::nonNull)
-                        .allMatch(uri -> getAtomOfUser(user, uri) != null);
-        if (allSendersOwned) {
-            logger.debug("not sending notification to user: sender and recipient atoms are controlled by same user.");
             return;
         }
         String textMsg = WonRdfUtils.MessageUtils.getTextMessage(wonMessage);


### PR DESCRIPTION
Before sending a push notification, we used to check if the sending atom and the recipient atom belong to the same user. This check does not seem to work for group chats (in which messages are forwarded by the group atom). We remove this check as the overall experience is better without it.

<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [ ] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Fixes: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
