### PR TITLE
Differentiated error handling while rematching

### DIFF
--- a/webofneeds/won-auth/src/main/java/won/auth/rest/AuthEnabledLinkedDataRestClient.java
+++ b/webofneeds/won-auth/src/main/java/won/auth/rest/AuthEnabledLinkedDataRestClient.java
@@ -118,16 +118,16 @@ public class AuthEnabledLinkedDataRestClient extends LinkedDataRestClientHttps {
         } catch (RestClientException e) {
             // first, let's see if we can answer the request from loaded ontologies:
             if (e instanceof HttpClientErrorException) {
-                throw new LinkedDataFetchingException(MessageFormat.format(
+                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
                                 "Caught a HttpClientErrorException exception trying to obtain token from {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpClientErrorException) e).getResponseBodyAsString()),
-                                e, resourceURI, ((HttpClientErrorException) e).getRawStatusCode());
+                                e, ((HttpClientErrorException) e).getRawStatusCode());
             }
             if (e instanceof HttpServerErrorException) {
-                throw new LinkedDataFetchingException(MessageFormat.format(
+                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
                                 "Caught a HttpServerErrorException exception trying to obtain token from {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpServerErrorException) e).getResponseBodyAsString()),
-                                e, resourceURI, ((HttpServerErrorException) e).getRawStatusCode());
+                                e, ((HttpServerErrorException) e).getRawStatusCode());
             }
             throw new LinkedDataFetchingException(resourceURI,
                             MessageFormat.format(

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LDRequestForbiddenWwwAuthenticateException.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LDRequestForbiddenWwwAuthenticateException.java
@@ -36,26 +36,26 @@ public class LDRequestForbiddenWwwAuthenticateException extends LinkedDataFetchi
 
     public LDRequestForbiddenWwwAuthenticateException(String message, URI resourceUri, int statusCode,
                     String wwwAuthenticateHeaderValue) {
-        super(message, resourceUri, statusCode);
+        super(resourceUri, message, statusCode);
         this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
     }
 
     public LDRequestForbiddenWwwAuthenticateException(String message, Throwable cause, URI resourceUri,
                     int statusCode, String wwwAuthenticateHeaderValue) {
-        super(message, cause, resourceUri, statusCode);
+        super(resourceUri, message, cause, statusCode);
         this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
     }
 
     public LDRequestForbiddenWwwAuthenticateException(Throwable cause, URI resourceUri, int statusCode,
                     String wwwAuthenticateHeaderValue) {
-        super(cause, resourceUri, statusCode);
+        super(resourceUri, cause, statusCode);
         this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
     }
 
     public LDRequestForbiddenWwwAuthenticateException(String message, Throwable cause, boolean enableSuppression,
                     boolean writableStackTrace, URI resourceUri, int statusCode,
                     String wwwAuthenticateHeaderValue) {
-        super(message, cause, enableSuppression, writableStackTrace, resourceUri, statusCode);
+        super(message, resourceUri, cause, enableSuppression, writableStackTrace, statusCode);
         this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
     }
 }

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataFetchingException.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataFetchingException.java
@@ -1,13 +1,25 @@
 package won.protocol.rest;
 
+import org.springframework.http.HttpStatus;
+
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Exception thrown by methods trying to access a specific linked data resource.
+ * The resource is always present in the exception, optionally, the http status
+ * code is provided as well.
+ * <p>
+ * Some Subclasses are available for specific cases such as Forbidden and
+ * Unauthorized.
+ * </p>
+ */
 public class LinkedDataFetchingException extends RuntimeException {
     // The URI of the resource that could not be fetched
     private URI resourceUri;
-    private Optional<Integer> statusCode = Optional.empty();
+    private Integer statusCode = null;
 
     public LinkedDataFetchingException(URI resourceUri) {
         this(resourceUri, MessageFormat.format("Error fetching linked data for {0}", resourceUri), null);
@@ -15,6 +27,7 @@ public class LinkedDataFetchingException extends RuntimeException {
 
     public LinkedDataFetchingException(URI resourceUri, String message, Throwable cause) {
         super(message, cause);
+        Objects.requireNonNull(resourceUri);
         this.resourceUri = resourceUri;
     }
 
@@ -28,33 +41,38 @@ public class LinkedDataFetchingException extends RuntimeException {
 
     public LinkedDataFetchingException(URI resourceUri, int statusCode) {
         this.resourceUri = resourceUri;
-        this.statusCode = Optional.of(statusCode);
+        this.statusCode = statusCode;
+        Objects.requireNonNull(resourceUri);
     }
 
-    public LinkedDataFetchingException(String message, URI resourceUri, int statusCode) {
+    public LinkedDataFetchingException(URI resourceUri, String message, int statusCode) {
         super(message);
+        Objects.requireNonNull(resourceUri);
         this.resourceUri = resourceUri;
-        this.statusCode = Optional.of(statusCode);
+        this.statusCode = statusCode;
     }
 
-    public LinkedDataFetchingException(String message, Throwable cause, URI resourceUri,
+    public LinkedDataFetchingException(URI resourceUri, String message, Throwable cause,
                     int statusCode) {
         super(message, cause);
+        Objects.requireNonNull(resourceUri);
         this.resourceUri = resourceUri;
-        this.statusCode = Optional.of(statusCode);
+        this.statusCode = statusCode;
     }
 
-    public LinkedDataFetchingException(Throwable cause, URI resourceUri, int statusCode) {
+    public LinkedDataFetchingException(URI resourceUri, Throwable cause, int statusCode) {
         super(cause);
+        Objects.requireNonNull(resourceUri);
         this.resourceUri = resourceUri;
-        this.statusCode = Optional.of(statusCode);
+        this.statusCode = statusCode;
     }
 
-    public LinkedDataFetchingException(String message, Throwable cause, boolean enableSuppression,
-                    boolean writableStackTrace, URI resourceUri, int statusCode) {
+    public LinkedDataFetchingException(String message, URI resourceUri, Throwable cause, boolean enableSuppression,
+                    boolean writableStackTrace, int statusCode) {
         super(message, cause, enableSuppression, writableStackTrace);
+        Objects.requireNonNull(resourceUri);
         this.resourceUri = resourceUri;
-        this.statusCode = Optional.of(statusCode);
+        this.statusCode = statusCode;
     }
 
     public URI getResourceUri() {
@@ -62,76 +80,71 @@ public class LinkedDataFetchingException extends RuntimeException {
     }
 
     public Optional<Integer> getStatusCode() {
-        return statusCode;
+        return Optional.ofNullable(statusCode);
     }
 
     public static class ForbiddenAuthMethodProvided extends LinkedDataFetchingException {
         private String wwwAuthenticateHeaderValue;
 
         public ForbiddenAuthMethodProvided(URI resourceUri, String wwwAuthenticateHeaderValue) {
-            super(resourceUri);
+            super(resourceUri, HttpStatus.FORBIDDEN.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public ForbiddenAuthMethodProvided(URI resourceUri, String message, Throwable cause,
                         String wwwAuthenticateHeaderValue) {
-            super(resourceUri, message, cause);
+            super(resourceUri, message, cause, HttpStatus.FORBIDDEN.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public ForbiddenAuthMethodProvided(URI resourceUri, String message, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, message);
+            super(resourceUri, message, HttpStatus.FORBIDDEN.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public ForbiddenAuthMethodProvided(URI resourceUri, Throwable cause, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, cause);
-            this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
-        }
-
-        public ForbiddenAuthMethodProvided(URI resourceUri, int statusCode, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, statusCode);
+            super(resourceUri, cause, HttpStatus.FORBIDDEN.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
     }
 
     public static class Forbidden extends LinkedDataFetchingException {
         public Forbidden(URI resourceUri) {
-            super(resourceUri);
+            super(resourceUri, HttpStatus.FORBIDDEN.value());
         }
 
         public Forbidden(URI resourceUri, String message, Throwable cause) {
-            super(resourceUri, message, cause);
+            super(resourceUri, message, cause, HttpStatus.FORBIDDEN.value());
         }
 
         public Forbidden(URI resourceUri, String message) {
-            super(resourceUri, message);
+            super(resourceUri, message, HttpStatus.FORBIDDEN.value());
         }
 
         public Forbidden(URI resourceUri, Throwable cause) {
-            super(resourceUri, cause);
-        }
-
-        public Forbidden(URI resourceUri, int statusCode) {
-            super(resourceUri, statusCode);
+            super(resourceUri, cause, HttpStatus.FORBIDDEN.value());
         }
     }
 
     public static class Unauthorized extends LinkedDataFetchingException {
         public Unauthorized(URI resourceUri) {
-            super(resourceUri);
+            super(resourceUri, HttpStatus.UNAUTHORIZED.value());
         }
 
         public Unauthorized(URI resourceUri, String message, Throwable cause) {
-            super(resourceUri, message, cause);
+            super(resourceUri, message, cause, HttpStatus.UNAUTHORIZED.value());
         }
 
         public Unauthorized(URI resourceUri, String message) {
-            super(resourceUri, message);
+            super(resourceUri, message, HttpStatus.UNAUTHORIZED.value());
         }
 
         public Unauthorized(URI resourceUri, Throwable cause) {
-            super(resourceUri, cause);
+            super(resourceUri, cause, HttpStatus.UNAUTHORIZED.value());
         }
 
         public Unauthorized(URI resourceUri, int statusCode) {
@@ -143,28 +156,27 @@ public class LinkedDataFetchingException extends RuntimeException {
         private String wwwAuthenticateHeaderValue;
 
         public UnauthorizedAuthMethodProvided(URI resourceUri, String wwwAuthenticateHeaderValue) {
-            super(resourceUri);
+            super(resourceUri, HttpStatus.UNAUTHORIZED.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public UnauthorizedAuthMethodProvided(URI resourceUri, String message, Throwable cause,
                         String wwwAuthenticateHeaderValue) {
-            super(resourceUri, message, cause);
+            super(resourceUri, message, cause, HttpStatus.UNAUTHORIZED.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public UnauthorizedAuthMethodProvided(URI resourceUri, String message, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, message);
+            super(resourceUri, message, HttpStatus.UNAUTHORIZED.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
 
         public UnauthorizedAuthMethodProvided(URI resourceUri, Throwable cause, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, cause);
-            this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
-        }
-
-        public UnauthorizedAuthMethodProvided(URI resourceUri, int statusCode, String wwwAuthenticateHeaderValue) {
-            super(resourceUri, statusCode);
+            super(resourceUri, cause, HttpStatus.UNAUTHORIZED.value());
+            Objects.requireNonNull(wwwAuthenticateHeaderValue);
             this.wwwAuthenticateHeaderValue = wwwAuthenticateHeaderValue;
         }
     }

--- a/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
+++ b/webofneeds/won-core/src/main/java/won/protocol/rest/LinkedDataRestClient.java
@@ -155,16 +155,16 @@ public abstract class LinkedDataRestClient {
                 }
             }
             if (e instanceof HttpClientErrorException) {
-                throw new LinkedDataFetchingException(MessageFormat.format(
+                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
                                 "Caught a HttpClientErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpClientErrorException) e).getResponseBodyAsString()),
-                                e, resourceURI, ((HttpClientErrorException) e).getRawStatusCode());
+                                e, ((HttpClientErrorException) e).getRawStatusCode());
             }
             if (e instanceof HttpServerErrorException) {
-                throw new LinkedDataFetchingException(MessageFormat.format(
+                throw new LinkedDataFetchingException(resourceURI, MessageFormat.format(
                                 "Caught a HttpServerErrorException exception, for {0}. Underlying error message is: {1}, response Body: {2}",
                                 resourceURI, e.getMessage(), ((HttpServerErrorException) e).getResponseBodyAsString()),
-                                e, resourceURI, ((HttpServerErrorException) e).getRawStatusCode());
+                                e, ((HttpServerErrorException) e).getRawStatusCode());
             }
             throw new LinkedDataFetchingException(resourceURI,
                             MessageFormat.format("Caught a clientHandler exception, "

--- a/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
+++ b/webofneeds/won-matcher-service/src/main/java/won/matcher/service/rematch/service/RematchSparqlService.java
@@ -270,7 +270,7 @@ public class RematchSparqlService extends SparqlService {
     private void handleLinkedDataFetchingException(String atomUri, LinkedDataFetchingException e) {
         if (e.getStatusCode().isPresent()) {
             HttpStatus status = HttpStatus.valueOf(e.getStatusCode().get());
-            if (status == HttpStatus.GONE || status == HttpStatus.FORBIDDEN) {
+            if (status == HttpStatus.GONE) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Rematching {}: got response status {}, removing resource from index",
                                     atomUri,


### PR DESCRIPTION
<!-- Adapted from  https://github.com/ionic-team/ionic/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Affected Tests have been added/altered (for bug fixes / features)
- [x] Docs have been reviewed and added/updated if needed (for bug fixes / features)
- [x] Build was run locally and `mvn install` succeeds

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The matcher-service removes an atom from the rematching index only if it gets a 410 response. Attempts that fail with other errors are not registered as rematch attempts and are therefore checked for rematching at the next rematch tick (every 60s). This leads to constantly rematching atoms with 401 or 403 responses, flooding the node with requests.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The matcher-service removes an atom from the rematching index if it gets a 410 response and registers a rematch attempt for any other error response (4xx or 5xx), thus the usual back-off strategy is followed. This allows for dealing with temporary unavailability or changing access rights for the matcher.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
